### PR TITLE
fix(CI): narrow workflow triggers to code paths [砚砚/GPT-52🐾]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,18 +3,28 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'designs/**'
-      - 'assets/**'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'packages/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig*.json'
+      - 'biome.json'
+      - 'cat-config.json'
   pull_request:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - '*.md'
-      - 'designs/**'
-      - 'assets/**'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'packages/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'tsconfig*.json'
+      - 'biome.json'
+      - 'cat-config.json'
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## What
- switch CI from broad `paths-ignore` rules to a code-only `paths` allowlist
- stop burning Actions minutes on docs, root markdown, designs, and most skill markdown edits

## Why
- our private beta repo does not need a full CI run for every documentation-only change
- code, config, workflow, and script changes should still keep the gate

## Included trigger paths
- `.github/workflows/ci.yml`
- `packages/**`
- `scripts/**`
- `package.json`
- `pnpm-lock.yaml`
- `pnpm-workspace.yaml`
- `tsconfig*.json`
- `biome.json`
- `cat-config.json`

## Notes
- this intentionally excludes `docs/**`, root `*.md`, `designs/**`, `assets/**`, and most `cat-cafe-skills/**/*.md` changes
- CI still runs for real code and build-affecting config changes