### PR TITLE
fix: restore original CONTRIBUTING.md overwritten by sync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,16 @@
 # Contributing to Clowder AI
 
-Thank you for your interest in contributing to Clowder AI! This guide will help you get started.
+[English](#english) | [中文](#中文)
+
+---
+
+<a id="english"></a>
 
 ## For Beta Testers (Internal Preview)
 
-You have **Read** access to this repo. Here's how to contribute:
+You have **Write** access to this repo, but `main` is protected — all changes go through **Pull Requests**.
 
-### Step-by-step: Submit a PR
+### Quick Start: Submit a PR
 
 ```bash
 # 1. Fork this repo (click "Fork" button on GitHub, or use gh cli)
@@ -39,147 +43,318 @@ gh pr create --repo zts212653/clowder-ai
 - Open an [Issue](https://github.com/zts212653/clowder-ai/issues) — please include reproduction steps for bugs
 - Check [pinned issues](https://github.com/zts212653/clowder-ai/issues) for current focus areas
 
-### What you CAN do with Read access
-
-- Clone, pull, and read all code
-- Fork and submit Pull Requests
-- Open and comment on Issues
-- Participate in Discussions
-
 ### Runtime ports
 
 The default ports are `3003` (API) and `3004` (Frontend). See [SETUP.md](SETUP.md) for full configuration.
 
 ---
 
-## Code of Conduct
+## How Contributing Works Here
 
-Be respectful, constructive, and collaborative. We welcome contributors of all experience levels.
+Most open source projects say: "write code, open a PR." Clowder works differently.
 
-## Getting Started
+In the age of AI-assisted development, **code is cheap. Alignment is expensive.** Your AI team can generate thousands of lines in minutes — but if the intent is wrong, all that code is waste.
 
-### Prerequisites
+> Clowder is not a code-only repository.
+> For non-trivial changes, the primary contribution is the **intent**: the feature note, protocol update, or design decision that explains what should change and why. Code, tests, and references are how that intent becomes real.
 
-- Node.js 20+
-- pnpm 9+
-- Redis 7+ (for full test suite; basic tests work without it)
-- At least one AI provider API key (Anthropic, OpenAI, or Google)
-
-### Development Setup
-
-See [SETUP.md](SETUP.md) for the full runtime configuration matrix, optional integrations, and design tooling requirements.
-
-```bash
-# Clone the repository
-git clone https://github.com/zts212653/clowder-ai.git
-cd clowder-ai
-
-# Install dependencies
-pnpm install
-
-# Build shared packages (required before other packages)
-pnpm --filter @cat-cafe/shared build
-
-# Run the public test suite
-pnpm --filter @cat-cafe/api run test:public
-
-# Run lint checks
-pnpm check
-```
-
-### Project Structure
-
-| Directory | Purpose |
-|-----------|---------|
-| `packages/api/` | Backend API server (agent routing, MCP, sessions) |
-| `packages/web/` | Frontend Mission Hub (Next.js) |
-| `packages/shared/` | Shared TypeScript types and utilities |
-| `packages/mcp-server/` | MCP server for agent tool integration |
-| `cat-cafe-skills/` | Modular skill definitions |
-| `scripts/` | Development and build utilities |
-
-### After Modifying `packages/shared`
-
-Always rebuild shared types after changes:
-
-```bash
-pnpm --filter @cat-cafe/shared build
-```
-
-Other packages depend on the compiled `.d.ts` files.
-
-## Submitting Changes
-
-### Pull Request Process
-
-1. **Fork** the repository and create a feature branch
-2. **Write tests** for new functionality (we practice TDD)
-3. **Run quality checks** before submitting:
-   ```bash
-   pnpm check          # Lint (Biome)
-   pnpm -r build       # Build all packages
-   pnpm --filter @cat-cafe/api run test:public  # Public test suite
-   ```
-4. **Open a PR** with a clear description of what and why
-5. **Wait for review** — at least one maintainer review is required
-
-### PR Guidelines
-
-- **Title**: Use conventional commits format: `feat(scope):`, `fix(scope):`, `docs:`, etc.
-- **Description**: Explain what changed and why. Link to relevant issues.
-- **Tests**: New features must include tests. Bug fixes should include a regression test.
-- **Size**: Prefer small, focused PRs over large ones.
-
-### Commit Messages
-
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+### The Contribution Flow
 
 ```
-feat(api): add webhook support for external notifications
-fix(web): resolve thread sidebar scroll position on reload
-docs: update Quick Start with Redis configuration
-test(api): add coverage for concurrent session creation
+1. Intent          You have an idea or found a problem
+      ↓
+2. Feature Doc     Write a Fxxx-slug.md following the template
+      ↓
+3. Discussion      Open a PR with just the doc — get alignment on intent
+      ↓
+4. Execution       Implement against the doc's Acceptance Criteria
+      ↓
+5. Verification    Does the result match the doc? Evidence, not confidence.
 ```
 
-## Code Quality Standards
+**Step 3 is the most important.** A merged Feature Doc means the community agrees on the *what* and *why*. Implementation follows naturally.
 
-### Hard Requirements
+### What's a Feature Doc?
 
-- **No `any` type** in TypeScript (use `unknown` + type guards)
-- **File size**: 200 lines warning, 350 lines hard limit
-- **Directory size**: 15 files warning, 25 files hard limit
-- **New features must have tests**
-- **Biome lint must pass** (`pnpm check`)
+A Feature Doc (`docs/features/Fxxx-slug.md`) is a structured document that captures:
 
-### Style
+- **Why** — the problem, the motivation, who it's for
+- **What** — the design, broken into phases
+- **Acceptance Criteria** — how we know it's done (checkboxes, not vibes)
+- **Refs** — research, prior art, design mockups, user feedback that led here
 
-- We use [Biome](https://biomejs.dev/) for linting and formatting
-- Run `pnpm check:fix` to auto-fix most issues
-- TypeScript strict mode is enabled
+The Feature Doc is the **single source of truth** for what gets built. Code is a byproduct.
 
-## Path Ownership
+Use the template at `docs/features/TEMPLATE.md`. Required frontmatter:
 
-Different parts of the codebase have different contribution expectations:
+```yaml
+---
+feature_ids: [F{NNN}]
+related_features: []
+topics: []
+doc_kind: spec
+created: YYYY-MM-DD
+---
+```
 
-| Path | Ownership | PR Requirements |
-|------|-----------|----------------|
-| `packages/api/src/` | Core | 2 reviewer approvals |
-| `packages/web/src/` | Core | 1 reviewer approval |
-| `packages/shared/` | Core | 2 reviewer approvals (affects all packages) |
-| `cat-cafe-skills/` | Core | 1 reviewer + skill test validation |
-| `scripts/` | Utility | 1 reviewer approval |
-| `docs/` | Community | 1 reviewer approval |
+**Refs matter more than you think.** A Feature Doc with good refs — competitive analysis, user quotes, design explorations — gives the implementing team (human or AI) the context to make good micro-decisions without asking you every 5 minutes.
 
-## Reporting Issues
+### What Counts as a Contribution
 
-- Use GitHub Issues for bug reports and feature requests
-- Include reproduction steps for bugs
-- For security vulnerabilities, see [SECURITY.md](SECURITY.md)
+| Type | What It Looks Like |
+|------|--------------------|
+| **Feature proposal** | A new `Fxxx-slug.md` with Why/What/AC |
+| **Design feedback** | Comment on an existing Feature Doc PR — challenge assumptions, suggest alternatives |
+| **Research / Refs** | Add context to an existing feature — competitive analysis, user research, technical spikes |
+| **Bug report** | Issue with reproduction steps — becomes a Feature Doc if non-trivial |
+| **Code implementation** | PR that implements against a merged Feature Doc's AC |
+| **Vision alignment** | "This feature doesn't match the Five Principles because..." |
 
-## Questions?
+4 out of 6 contribution types involve **no code at all**.
 
-Open a [Discussion](https://github.com/zts212653/clowder-ai/discussions) for questions, ideas, or general conversation.
+### PR Types
 
-## License
+Not every PR is the same. Different changes have different requirements:
 
-By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+| PR Type | What It Is | What's Required |
+|---------|-----------|-----------------|
+| **Patch** | Small bug fix, typo, test gap | Code + tests. No Feature Doc needed. |
+| **Feature** | New capability or behavior change | Feature Doc **first** (merged or in same PR), then code + tests + evidence |
+| **Protocol** | Changes to rules, skills, workflows, refs | The document **is** the contribution. Code is supporting. |
+| **Adapter** | New agent integration | Contract spec + example config + verification steps + code |
+
+**Rule of thumb:** if your change affects the README roadmap, it needs a Feature Doc.
+
+### What Makes a Contribution Complete
+
+For non-trivial changes, a complete contribution has four layers:
+
+| Layer | What It Is | Example |
+|-------|-----------|---------|
+| **Intent** | Feature Doc / proposal / design note | `docs/features/F042-info-architecture.md` |
+| **Implementation** | Code + tests | `packages/api/src/...` + test files |
+| **Operation** | Refs, guides, config examples, README updates | `docs/decisions/`, config samples |
+| **Evidence** | Proof it works | Screenshots, test output, logs, regression proof |
+
+Missing intent? We can't tell if this is the right direction.
+Missing refs? Others can't build on your work.
+Missing evidence? We can't verify it's done.
+
+### Source of Truth
+
+When in doubt about what's authoritative:
+
+| What | Where |
+|------|-------|
+| Feature behavior and direction | `docs/features/` |
+| Collaboration rules and workflows | `cat-cafe-skills/refs/` |
+| Architecture decisions | `docs/decisions/` |
+| Active work | `docs/BACKLOG.md` |
+
+If code and docs disagree, **fix the doc first, then align the code**. Docs lead, code follows.
+
+### Merge Rules
+
+| Change Size | What You Need |
+|-------------|---------------|
+| **Small** (patch, typo, test fix) | Code + tests |
+| **Medium** (behavior change, new endpoint) | Code + tests + related doc updates |
+| **Large** (new feature, protocol change) | Feature Doc merged **first**, then implementation PR |
+
+**README roadmap changes must sync with feature status.** Marketing does not get to run ahead of reality.
+
+### Review: Intent First, Code Second
+
+When reviewing PRs:
+
+1. **Does this match a Feature Doc?** Code without a Feature Doc is unanchored.
+2. **Are the Acceptance Criteria met?** Check the boxes with evidence.
+3. **Does it align with the Five Principles?** Especially P1 (face the final state) and P5 (verified = done).
+4. **Then** look at code quality.
+
+### The Five Principles
+
+Every contribution should respect these:
+
+| # | Principle | Meaning |
+|---|-----------|---------|
+| P1 | Face the final state | Every step is foundation, not scaffolding |
+| P2 | Co-creators, not puppets | Hard constraints are the floor; above it, release autonomy |
+| P3 | Direction > speed | Uncertain? Stop, search, ask, confirm, then execute |
+| P4 | Single source of truth | Every concept defined in exactly one place |
+| P5 | Verified = done | Evidence talks, not confidence |
+
+### Getting Started
+
+1. Read the [README](README.md) to understand what Clowder is
+2. Browse `docs/features/` to see existing Feature Docs
+3. Check `docs/BACKLOG.md` for the active feature list
+4. Look at `docs/decisions/` for past architectural decisions
+5. Open an issue or draft a Feature Doc PR
+6. Sign the [CLA](CLA.md) on your first PR (the bot will guide you)
+
+### Code Style (When You Do Write Code)
+
+- **TypeScript** with strict mode
+- **Biome** for formatting and linting (`pnpm check` / `pnpm check:fix`)
+- **pnpm** for package management
+- Files under 350 lines (warning at 200)
+- No `any` types
+- Run `pnpm lint` before submitting
+
+---
+
+<a id="中文"></a>
+
+## 如何为 Clowder 贡献
+
+大多数开源项目说："写代码，提 PR。" Clowder 不一样。
+
+在 AI 辅助开发的时代，**代码不值钱，对齐才值钱。** AI 团队几分钟能生成上千行代码 — 但如果意图错了，这些代码就全是废品。
+
+> Clowder 不是一个纯代码仓库。
+> 对于非 trivial 的改动，贡献的主体是**意图**：解释应该改什么、为什么改的功能文档、协议更新或设计决策。代码、测试和参考文档是让意图变成现实的手段。
+
+### 贡献流程
+
+```
+1. 意图          你有一个想法，或发现了一个问题
+      ↓
+2. Feature Doc   按模板写一个 Fxxx-slug.md
+      ↓
+3. 讨论          开一个只包含文档的 PR — 在意图层面对齐
+      ↓
+4. 执行          按文档的验收标准实现
+      ↓
+5. 验证          结果和文档一致吗？靠证据，不靠自信
+```
+
+**第 3 步最重要。** 一个被 merge 的 Feature Doc 意味着社区在 *做什么* 和 *为什么做* 上达成了共识。实现是自然而然的事。
+
+### Feature Doc 是什么？
+
+Feature Doc（`docs/features/Fxxx-slug.md`）是一个结构化文档，包含：
+
+- **Why** — 问题是什么、动机是什么、为谁而做
+- **What** — 设计方案，按阶段拆分
+- **验收标准（AC）** — 怎么判断做完了（用 checkbox，不用感觉）
+- **Refs** — 调研、竞品分析、设计稿、促成这个功能的用户反馈
+
+Feature Doc 是**唯一真相源**。代码是它的产物。
+
+使用 `docs/features/TEMPLATE.md` 模板。必要的 frontmatter：
+
+```yaml
+---
+feature_ids: [F{NNN}]
+related_features: []
+topics: []
+doc_kind: spec
+created: YYYY-MM-DD
+---
+```
+
+**Refs 比你想象的重要。** 一份带着好 refs 的 Feature Doc — 竞品分析、用户原话、设计探索 — 让实现团队（人或 AI）能自主做出好的微决策，不用每 5 分钟来问你一次。
+
+### 什么算贡献
+
+| 类型 | 形式 |
+|------|------|
+| **功能提案** | 一个新的 `Fxxx-slug.md`，包含 Why/What/AC |
+| **设计反馈** | 在已有 Feature Doc PR 上留言 — 质疑假设、提出替代方案 |
+| **调研 / Refs** | 为已有功能补充上下文 — 竞品分析、用户研究、技术探针 |
+| **Bug 报告** | 带复现步骤的 Issue — 非 trivial 的会变成 Feature Doc |
+| **代码实现** | 对照已 merge 的 Feature Doc AC 的 PR |
+| **愿景对齐** | "这个功能不符合五条原理，因为……" |
+
+6 种贡献类型里有 4 种**完全不涉及代码**。
+
+### PR 类型
+
+不是每个 PR 都一样。不同改动有不同的要求：
+
+| PR 类型 | 适用场景 | 需要什么 |
+|---------|---------|---------|
+| **Patch** | 小 bug 修复、文案修正、测试补洞 | 代码 + 测试。不需要 Feature Doc。 |
+| **Feature** | 新能力或行为变更 | **先有** Feature Doc（已 merge 或在同一 PR），再上代码 + 测试 + 证据 |
+| **Protocol** | 改规则、技能、工作流、参考文档 | 文档**本身就是**贡献主体。代码是配套。 |
+| **Adapter** | 接入新 Agent | 契约规格 + 示例配置 + 验证步骤 + 代码 |
+
+**经验法则：** 如果你的改动会影响 README 路线图，就需要 Feature Doc。
+
+### 完整贡献的四个层次
+
+对于非 trivial 的改动，一个完整的贡献有四层：
+
+| 层次 | 内容 | 示例 |
+|------|------|------|
+| **意图** | Feature Doc / 提案 / 设计说明 | `docs/features/F042-info-architecture.md` |
+| **实现** | 代码 + 测试 | `packages/api/src/...` + 测试文件 |
+| **运维** | 参考文档、指南、配置示例、README 更新 | `docs/decisions/`、配置样例 |
+| **证据** | 证明它真的能用 | 截图、测试输出、日志、回归证明 |
+
+缺意图？我们无法判断方向对不对。
+缺参考文档？别人接不上你的工作。
+缺证据？我们无法验证做没做完。
+
+### 真相源层级
+
+拿不准什么说了算时：
+
+| 什么 | 在哪 |
+|------|------|
+| 功能行为和方向 | `docs/features/` |
+| 协作规则和工作流 | `cat-cafe-skills/refs/` |
+| 架构决策 | `docs/decisions/` |
+| 活跃工作 | `docs/BACKLOG.md` |
+
+如果代码和文档冲突，**先修文档，再对齐代码**。文档领路，代码跟随。
+
+### 合并规则
+
+| 改动规模 | 需要什么 |
+|---------|---------|
+| **小**（patch、文案、测试补洞） | 代码 + 测试 |
+| **中**（行为变更、新接口） | 代码 + 测试 + 相关文档更新 |
+| **大**（新功能、协议变更） | Feature Doc **先 merge**，再提实现 PR |
+
+**README 路线图的改动必须同步 Feature 状态。** Marketing 不允许跑在现实前面。
+
+### Review：先看意图，再看代码
+
+Review PR 时的优先级：
+
+1. **有对应的 Feature Doc 吗？** 没有 Feature Doc 的代码是没有锚的。
+2. **验收标准达成了吗？** 用证据勾 checkbox。
+3. **符合五条第一性原理吗？** 尤其是 P1（面向终态）和 P5（可验证才算完成）。
+4. **然后**再看代码质量。
+
+### 五条第一性原理
+
+每个贡献都应该尊重这些原则：
+
+| # | 原理 | 一句话 |
+|---|------|-------|
+| P1 | 面向终态，不绕路 | 每步是基座不是脚手架 |
+| P2 | 共创伙伴，不是木头人 | 硬约束是底线，底线上释放主观能动性 |
+| P3 | 方向正确 > 执行速度 | 不确定就停 → 搜 → 问 → 确认 → 再动手 |
+| P4 | 单一真相源 | 每个概念只在一处定义 |
+| P5 | 可验证才算完成 | 证据说话，不是信心说话 |
+
+### 从哪开始
+
+1. 读 [README](README.md) 了解 Clowder 是什么
+2. 浏览 `docs/features/` 看看现有的 Feature Doc
+3. 看 `docs/BACKLOG.md` 了解当前活跃的功能列表
+4. 翻翻 `docs/decisions/` 看看过去的架构决策
+5. 开一个 Issue 或直接提一个 Feature Doc 的 PR
+6. 首次提 PR 时签署 [CLA](CLA.md)（bot 会自动引导）
+
+### 代码规范（当你确实要写代码时）
+
+- **TypeScript** 严格模式
+- **Biome** 格式化和 lint（`pnpm check` / `pnpm check:fix`）
+- **pnpm** 包管理
+- 文件不超过 350 行（200 行开始警告）
+- 禁止 `any` 类型
+- 提交前跑 `pnpm lint`


### PR DESCRIPTION
## Summary
- Sync commit `44f2bbd` replaced the hand-crafted 317-line CONTRIBUTING (intent-first philosophy, Feature Doc flow, bilingual EN/CN, CLA guide) with a generic 133-line version
- Restores original from `82330a0` + adds beta tester quick start section at top
- Sync script already fixed in cat-cafe (`2f314886`) to exclude CONTRIBUTING.md from rsync

[布偶猫🐾]