### PR TITLE
fix: restore CLA.md + TRADEMARKS.md deleted by sync

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,85 @@
+# Contributor License Agreement / 贡献者许可协议
+
+[English](#english) | [中文](#中文)
+
+---
+
+<a id="english"></a>
+
+## Clowder AI Individual Contributor License Agreement
+
+Thank you for your interest in contributing to Clowder AI. This CLA clarifies the intellectual property license granted with your contributions.
+
+By signing this CLA, you agree to the following terms for your past, present, and future contributions to the Clowder AI project:
+
+### 1. Definitions
+
+- **"Contribution"** means any original work of authorship, including modifications or additions to existing work, that you submit to the project.
+- **"Submit"** means any form of communication sent to the project (pull request, issue, comment, etc.), excluding communications clearly marked "Not a Contribution."
+
+### 2. Grant of Copyright License
+
+You grant to the Clowder AI project maintainers a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute your Contributions and such derivative works.
+
+### 3. Grant of Patent License
+
+You grant to the Clowder AI project maintainers a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer your Contributions, where such license applies only to those patent claims licensable by you that are necessarily infringed by your Contributions alone or by combination with the project.
+
+### 4. Representations
+
+You represent that:
+- You are legally entitled to grant the above licenses.
+- Each Contribution is your original creation, or you have sufficient rights to submit it.
+- If your employer has rights to intellectual property you create, you have received permission to make Contributions on behalf of that employer, or your employer has waived such rights.
+
+### 5. No Obligation
+
+You understand that the decision to include your Contribution is at the sole discretion of the project maintainers and that this agreement does not obligate the project to use your Contribution.
+
+---
+
+<a id="中文"></a>
+
+## Clowder AI 个人贡献者许可协议
+
+感谢你对 Clowder AI 项目的贡献兴趣。本 CLA 明确了你的贡献所授予的知识产权许可。
+
+签署本 CLA 即表示你同意以下条款，适用于你过去、现在和未来对 Clowder AI 项目的所有贡献：
+
+### 1. 定义
+
+- **"贡献"** 指你提交给项目的任何原创作品，包括对现有作品的修改或增补。
+- **"提交"** 指以任何形式发送给项目的通信（Pull Request、Issue、评论等），明确标注"非贡献"的除外。
+
+### 2. 版权许可授予
+
+你授予 Clowder AI 项目维护者一项永久、全球范围、非排他、免费、免版税、不可撤销的版权许可，以复制、准备衍生作品、公开展示、公开表演、再许可和分发你的贡献及其衍生作品。
+
+### 3. 专利许可授予
+
+你授予 Clowder AI 项目维护者一项永久、全球范围、非排他、免费、免版税、不可撤销的专利许可，以制造、使用、销售、进口和以其他方式转让你的贡献。该许可仅适用于你有权许可的、因你的贡献单独或与项目结合而必然被侵犯的专利权利要求。
+
+### 4. 声明
+
+你声明：
+- 你在法律上有权授予上述许可。
+- 每项贡献均为你的原创作品，或你拥有足够的权利来提交。
+- 如果你的雇主对你创作的知识产权拥有权利，你已获得雇主许可代表其进行贡献，或你的雇主已放弃相关权利。
+
+### 5. 无义务
+
+你理解，是否纳入你的贡献由项目维护者全权决定，本协议不构成项目使用你贡献的义务。
+
+---
+
+## How to Sign / 如何签署
+
+When you open a pull request, the CLA bot will check if you've signed. If not, simply comment:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature will be recorded automatically. You only need to sign once.
+
+当你提交 Pull Request 时，CLA bot 会检查你是否已签署。如未签署，只需评论上方英文内容即可。签名会自动记录，只需签署一次。

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,79 @@
+# Trademark Notice / 商标声明
+
+[English](#english) | [中文](#中文)
+
+---
+
+<a id="english"></a>
+
+## Brand Assets
+
+**"Clowder AI"**, **"Clowder"** (in the context of this software), the Clowder AI cat logos, and cat character designs (including but not limited to 宪宪/Xianxian, 砚砚/Yanyan, 烁烁/Shuoshuo) are trademarks or brand assets of the Clowder AI project.
+
+## What the MIT License Covers
+
+The MIT License in this repository applies to the **software source code** only. It does not grant any rights to use the Clowder AI name, logos, cat avatars, or other brand assets in ways that suggest official endorsement or affiliation.
+
+## Permitted Uses (Descriptive / Nominative)
+
+You **may**:
+
+- Use the name "Clowder AI" to accurately describe or refer to this project (e.g., "built on Clowder AI", "compatible with Clowder AI")
+- Fork and modify the code under MIT terms
+- Use the software for any purpose permitted by MIT
+- Include the project name in academic papers, blog posts, and reviews
+
+## Restricted Uses
+
+You **may not**:
+
+- Use "Clowder AI" or the cat logos/avatars in your own product name, app name, or service name in a way that implies official affiliation
+- Create derivative logos or mascots that are confusingly similar to the Clowder AI cats
+- Use the brand assets in marketing materials that suggest endorsement by the Clowder AI project
+- Register domain names, social media accounts, or trademarks that include "Clowder AI" in connection with similar software
+
+## Note on AI-Generated Assets
+
+Some visual assets in this project were created with AI assistance and subsequently refined with human creative direction. The brand identity and character designs, regardless of their creation method, are protected as brand assets under trademark principles.
+
+## Questions
+
+If you're unsure whether your use qualifies, open an issue or contact the maintainers. We want the community to thrive — most reasonable uses are fine.
+
+---
+
+<a id="中文"></a>
+
+## 品牌资产
+
+**"Clowder AI"**、**"Clowder"**（在本软件语境下）、Clowder AI 猫猫 logo 及角色设计（包括但不限于宪宪、砚砚、烁烁）是 Clowder AI 项目的商标或品牌资产。
+
+## MIT 许可证的范围
+
+本仓库的 MIT 许可证仅适用于**软件源代码**。它不授予以暗示官方认可或关联的方式使用 Clowder AI 名称、logo、猫猫头像或其他品牌资产的权利。
+
+## 允许的使用（描述性 / 指名性使用）
+
+你**可以**：
+
+- 使用"Clowder AI"名称来准确描述或引用本项目（例如"基于 Clowder AI 构建"、"兼容 Clowder AI"）
+- 按 MIT 条款 fork 和修改代码
+- 将软件用于 MIT 许可的任何用途
+- 在学术论文、博客文章和评测中提及项目名称
+
+## 受限的使用
+
+你**不可以**：
+
+- 以暗示官方关联的方式，在你自己的产品名、应用名或服务名中使用"Clowder AI"或猫猫 logo/头像
+- 创建与 Clowder AI 猫猫容易混淆的衍生 logo 或吉祥物
+- 在暗示获得 Clowder AI 项目背书的营销材料中使用品牌资产
+- 注册包含"Clowder AI"的域名、社交媒体账号或商标（用于类似软件）
+
+## 关于 AI 生成资产的说明
+
+本项目中的部分视觉资产借助了 AI 辅助创建，并经过人类创意指导的后续优化。无论创建方式如何，品牌标识和角色设计均作为品牌资产受商标原则保护。
+
+## 有疑问？
+
+如果不确定你的使用是否合规，请开 issue 或联系维护者。我们希望社区繁荣发展 — 大多数合理使用都没问题。


### PR DESCRIPTION
## Summary
- `rsync --delete` in sync script removed CLA.md and TRADEMARKS.md because they don't exist in cat-cafe source
- Restores CLA.md from `82330a0` (bilingual Contributor License Agreement)
- Restores TRADEMARKS.md from `7769a7d` (trademark guidelines)
- Sync script exclude list needs expanding (follow-up in cat-cafe)

[布偶猫🐾]