### PR TITLE
chore: add bug/feature issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug Report
+description: Report a bug — include reproduction steps so we can fix it fast
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting! Please fill in as much detail as you can.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly.
+      placeholder: "When I click X, Y happens instead of Z."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions so we can reproduce the issue.
+      placeholder: |
+        1. Run `pnpm dev`
+        2. Open http://localhost:3003
+        3. Click "New Chat"
+        4. See error in console
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened?
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, browser, etc.
+      placeholder: |
+        - OS: macOS 15.2 / Ubuntu 24.04 / Windows 11
+        - Node: v22.x
+        - Browser: Chrome 130
+        - pnpm: 9.x
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Paste error logs or attach screenshots if relevant.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Discussion
+    url: https://github.com/zts212653/clowder-ai/discussions
+    about: Ask questions or start a discussion

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "Feature: "
+labels: ["feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature IDs (F001, F002, ...) are assigned by **maintainers**, not by contributors.
+        Just describe what you want — we'll handle the numbering.
+        See [CONTRIBUTING.md](https://github.com/zts212653/clowder-ai/blob/main/CONTRIBUTING.md) for details.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the pain point or opportunity.
+      placeholder: "I want to deploy on Windows but the setup script only supports macOS/Linux."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Include examples if possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What other approaches did you think about? Why not those?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Screenshots, links to related issues, competitive examples, etc.


### PR DESCRIPTION
## Summary
- **Bug report template**: structured form with repro steps, environment, logs
- **Feature request template**: problem/solution/alternatives — includes note that F-numbers are assigned by maintainers
- **Config**: enable blank issues + link to Discussions

## Why
First batch of beta tester issues (#12, #14, #15, #16, #18) came in without consistent structure. Templates will guide contributors to provide the info we need upfront.

Also reinforces the F-numbering rule from the updated CONTRIBUTING.md — feature template explicitly says "F-numbers assigned by maintainers, not contributors."

## Test plan
- [ ] Verify templates appear when creating new issue on GitHub
- [ ] Verify bug template pre-fills bug label
- [ ] Verify feature template pre-fills feature label

🐱 布偶猫/宪宪