### PR TITLE
fix(web): reset scroll refs on thread switch (#35)

### DIFF
--- a/packages/web/src/hooks/__tests__/useChatHistory-scroll-reset.test.ts
+++ b/packages/web/src/hooks/__tests__/useChatHistory-scroll-reset.test.ts
@@ -117,9 +117,13 @@ describe('useChatHistory scroll reset on thread switch (#35)', () => {
       root.render(React.createElement(RealisticHost, { threadId: 'thread-a' }));
     });
 
-    // Spy on scrollIntoView on the end sentinel div (messagesEndRef target)
+    // Spy on scrollIntoView on the end sentinel div (messagesEndRef target).
+    // Record the currentThreadId at each call to prove scroll fires on the right thread.
     const endDiv = container.querySelector('div');
-    const scrollSpy = vi.fn();
+    const callThreadIds: string[] = [];
+    const scrollSpy = vi.fn(() => {
+      callThreadIds.push(useChatStore.getState().currentThreadId);
+    });
     if (endDiv) endDiv.scrollIntoView = scrollSpy;
 
     // Switch to thread-b — this triggers the real sequence:
@@ -143,5 +147,14 @@ describe('useChatHistory scroll reset on thread switch (#35)', () => {
 
     // Verify scrollIntoView was called (proving scroll-to-bottom fired)
     expect(scrollSpy).toHaveBeenCalled();
+
+    // Critical: verify that EVERY scrollIntoView call happened while the
+    // store was synced to thread-b (the target thread), not on stale thread-a data.
+    // This is the core invariant: scroll must not fire before setCurrentThread restores
+    // the correct messages.
+    expect(callThreadIds.length).toBeGreaterThan(0);
+    for (const tid of callThreadIds) {
+      expect(tid).toBe('thread-b');
+    }
   });
 });

--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -515,10 +515,12 @@ export function useChatHistory(threadId: string) {
     // Thread switch or initial load — scroll to bottom.
     // scrollToBottomRef is set by the threadId change effect and survives
     // across render cycles until consumed here with actual new-thread messages.
-    // Only consume when the store is synced to the target thread (avoids consuming
-    // the flag on a stale render before setCurrentThread restores cached messages).
+    // Gate ALL scroll-to-bottom paths on storeReady: the store's currentThreadId
+    // must match the target thread. This prevents consuming the flag (or the
+    // prevCount===0 sentinel) on a stale render before setCurrentThread restores
+    // cached messages for the new thread.
     const storeReady = useChatStore.getState().currentThreadId === scrollTargetThreadRef.current;
-    if ((scrollToBottomRef.current && storeReady) || prevCount === 0) {
+    if (storeReady && (scrollToBottomRef.current || prevCount === 0)) {
       scrollToBottomRef.current = false;
       messagesEndRef.current?.scrollIntoView({ behavior: 'auto' });
       return;


### PR DESCRIPTION
## Summary
- Reset `prevCountRef`, `prevFirstIdRef`, and `scrollSnapshotRef` when `threadId` changes in `useChatHistory`
- This ensures thread switch always scrolls to the latest messages instead of landing mid-conversation
- Added test covering the cached-thread-restore scroll scenario

## Root Cause
When `setCurrentThread` restores cached messages, the message count goes directly from Thread A's N to Thread B's M — never passing through 0. The scroll-to-bottom trigger (`prevCount === 0`) was therefore never true on thread switch.

## Test plan
- [x] All 20 `useChatHistory` tests pass (19 existing + 1 new)
- [x] Biome lint: no new warnings
- [x] TypeScript: no new errors
- [ ] Manual: click between threads with many messages — should always land at the bottom

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)