### PR TITLE
fix(#27): save/restore scroll position on thread switch

### DIFF
--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -523,8 +523,12 @@ export function useChatHistory(threadId: string) {
       restoreScrollRef.current = false;
       const savedTop = scrollPositionsRef.current.get(threadId);
       if (savedTop !== undefined) {
+        const restoreThread = threadId;
         requestAnimationFrame(() => {
-          el.scrollTop = savedTop;
+          // Guard: skip if thread changed during the frame (fast A→B→C switch)
+          if (threadIdRef.current === restoreThread) {
+            el.scrollTop = savedTop;
+          }
         });
         return;
       }


### PR DESCRIPTION
## Summary
- Fixes thread switching causing the chat panel to jump/reset scroll position
- `useChatHistory` now maintains a per-thread `Map<threadId, scrollTop>` ref
- On thread leave: saves current `scrollTop` to the map
- On thread return: restores saved `scrollTop` via `requestAnimationFrame`
- Resets `prevCountRef`/`prevFirstIdRef` on switch to prevent false prepend/append detection

Closes #27

## Test plan
- [ ] Open two threads with many messages, scroll to middle of each
- [ ] Switch between them — scroll position should be preserved
- [ ] First visit to a new thread should still scroll to bottom
- [ ] Scrolling up to load history (prepend) should still maintain position
- [ ] New incoming messages (append) should still smooth-scroll to bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)