### PR TITLE
feat(web): show thread summary tooltip on hover (#36)

### DIFF
--- a/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
@@ -25,6 +25,8 @@ export interface ThreadItemProps {
   threadState?: ThreadState;
   indented?: boolean;
   preferredCats?: string[];
+  /** Thread memory summary shown on hover */
+  summary?: string;
 }
 
 export function ThreadItem({
@@ -44,6 +46,7 @@ export function ThreadItem({
   threadState,
   indented,
   preferredCats,
+  summary,
 }: ThreadItemProps) {
   const { getCatById } = useCatData();
   const canDelete = id !== 'default' && onDelete;
@@ -94,6 +97,7 @@ export function ThreadItem({
         isActive ? 'bg-owner-bg' : 'hover:bg-gray-50'
       }`}
       onClick={() => onSelect(id)}
+      title={summary || undefined}
     >
       {/* Title row */}
       <div className="flex items-start justify-between gap-1 mb-1">

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -570,6 +570,7 @@ export function ThreadSidebar({ onClose, className, onBootcampClick }: ThreadSid
                             threadState={getThreadState(t.id)}
                             indented
                             preferredCats={t.preferredCats}
+                            summary={t.threadMemory?.summary}
                           />
                         ))}
                       </SectionGroup>
@@ -615,6 +616,7 @@ export function ThreadSidebar({ onClose, className, onBootcampClick }: ThreadSid
                     threadState={getThreadState(t.id)}
                     indented={group.type === 'project'}
                     preferredCats={t.preferredCats}
+                    summary={t.threadMemory?.summary}
                   />
                 ))}
               </SectionGroup>

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-item-tooltip.test.ts
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-item-tooltip.test.ts
@@ -1,0 +1,78 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ThreadItem } from '../ThreadItem';
+
+vi.mock('@/hooks/useCatData', () => ({
+  useCatData: () => ({
+    getCatById: () => null,
+    cats: [],
+  }),
+}));
+
+describe('ThreadItem hover tooltip (#36)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it('shows summary as title attribute when provided', () => {
+    act(() => {
+      root.render(
+        React.createElement(ThreadItem, {
+          id: 'thread-1',
+          title: 'Test thread',
+          participants: [],
+          lastActiveAt: Date.now(),
+          isActive: false,
+          onSelect: vi.fn(),
+          summary: 'This is the thread summary text',
+        }),
+      );
+    });
+
+    const item = container.querySelector('[title="This is the thread summary text"]');
+    expect(item).not.toBeNull();
+  });
+
+  it('does not set title attribute when summary is absent', () => {
+    act(() => {
+      root.render(
+        React.createElement(ThreadItem, {
+          id: 'thread-2',
+          title: 'Another thread',
+          participants: [],
+          lastActiveAt: Date.now(),
+          isActive: false,
+          onSelect: vi.fn(),
+        }),
+      );
+    });
+
+    // The outer div should not have a title attribute (except on action buttons)
+    const outerDiv = container.firstElementChild;
+    expect(outerDiv).not.toBeNull();
+    expect(outerDiv?.getAttribute('title')).toBeNull();
+  });
+});

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -249,6 +249,8 @@ export interface Thread {
   deletedAt?: number | null;
   /** F087: CVO Bootcamp onboarding state. */
   bootcampState?: BootcampStateV1;
+  /** F065: Rolling thread memory with summary */
+  threadMemory?: { v: 1; summary: string };
 }
 
 /** F087: Bootcamp state for CVO onboarding threads */


### PR DESCRIPTION
## Summary
- Add `threadMemory` field to frontend `Thread` type in `chat-types.ts`
- Pass `threadMemory.summary` as `summary` prop to `ThreadItem`
- Render summary as native `title` attribute on the thread item container — hovering shows the tooltip

## Changes
- `packages/web/src/stores/chat-types.ts` — add `threadMemory?: { v: 1; summary: string }` to `Thread`
- `packages/web/src/components/ThreadSidebar/ThreadItem.tsx` — add `summary` prop, render as `title`
- `packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx` — pass `t.threadMemory?.summary` in all 2 grouped render sites
- New test: `thread-item-tooltip.test.ts`

## Test plan
- [x] 2 new tests: tooltip present when summary provided, absent when not
- [x] All 37 existing ThreadSidebar tests pass
- [x] Biome lint: no new warnings
- [ ] Manual: hover over threads with memory — tooltip should appear

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)