### PR TITLE
feat(#29): add hover tooltip to thread list items

### DIFF
--- a/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
@@ -88,12 +88,21 @@ export function ThreadItem({
     }
   }, [onRename, draftTitle, title, id]);
 
+  // #29: Build tooltip with full title + participants + time
+  const displayTitle = title ?? (id === 'default' ? '大厅' : '未命名对话');
+  const participantNames = participants.map((catId) => getCatById(catId)?.displayName ?? catId).join(', ');
+  const tooltipLines = [displayTitle];
+  if (participantNames) tooltipLines.push(`参与: ${participantNames}`);
+  tooltipLines.push(formatRelativeTime(lastActiveAt, false));
+  const tooltip = tooltipLines.join('\n');
+
   return (
     <div
       className={`group relative ${indented ? 'pl-7 pr-3' : 'px-3'} py-2.5 border-b border-gray-50 transition-colors cursor-pointer ${
         isActive ? 'bg-owner-bg' : 'hover:bg-gray-50'
       }`}
       onClick={() => onSelect(id)}
+      title={tooltip}
     >
       {/* Title row */}
       <div className="flex items-start justify-between gap-1 mb-1">


### PR DESCRIPTION
## Summary
- Adds native HTML `title` tooltip to thread sidebar items
- Shows: full thread title, participant cat names, and last active time
- No extra dependencies — uses browser native tooltip

## Changes
- `ThreadItem.tsx`: Compute tooltip string from title + participants + time, add `title` attribute to root div

Closes #29

## Test plan
- [ ] Hover over a thread item in the sidebar — tooltip shows full title + participants + time
- [ ] Verify truncated titles are fully readable in tooltip
- [ ] Default thread ("大厅") shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)