### PR TITLE
fix: fallback to upstream when Anthropic proxy is unreachable

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -10,6 +10,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createConnection } from 'node:net';
 import { resolve } from 'node:path';
 import { type CatId, type ContextHealth, catRegistry, type MessageContent } from '@cat-cafe/shared';
 import { isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
@@ -64,6 +65,28 @@ function registerProxyUpstream(projectRoot: string, slug: string, targetUrl: str
   upstreams[slug] = targetUrl;
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
   writeFileSync(filePath, `${JSON.stringify(upstreams, null, 2)}\n`);
+}
+
+async function isLocalProxyReachable(portRaw: string, timeoutMs = 250): Promise<boolean> {
+  const port = Number.parseInt(portRaw, 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return false;
+
+  return await new Promise((resolveReady) => {
+    const socket = createConnection({ host: '127.0.0.1', port });
+    let settled = false;
+
+    const settle = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolveReady(ok);
+    };
+
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => settle(true));
+    socket.once('timeout', () => settle(false));
+    socket.once('error', () => settle(false));
+  });
 }
 
 /**
@@ -469,7 +492,15 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
             if (proxyEnabled) {
               const slug = deriveProxySlug(profile.id);
               registerProxyUpstream(projectRoot, slug, profile.baseUrl);
-              callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL = `http://127.0.0.1:${proxyPort}/${slug}`;
+              const proxyBaseUrl = `http://127.0.0.1:${proxyPort}/${slug}`;
+              if (await isLocalProxyReachable(proxyPort)) {
+                callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL = proxyBaseUrl;
+              } else {
+                callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL = profile.baseUrl;
+                console.warn(
+                  `[invoke-single-cat] Anthropic proxy unreachable at 127.0.0.1:${proxyPort}, fallback to upstream`,
+                );
+              }
             } else {
               callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL = profile.baseUrl;
             }

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6,6 +6,7 @@
 import './helpers/setup-cat-registry.js';
 import assert from 'node:assert/strict';
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { before, describe, it, mock } from 'node:test';
@@ -2381,6 +2382,141 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_PROFILE_MODE, 'api_key');
     assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL, 'https://api.root.example');
     assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_API_KEY, 'sk-root-profile');
+  });
+
+  it('F062 proxy-fallback: uses upstream baseUrl when local proxy is unreachable', async () => {
+    const { createProviderProfile } = await import('../dist/config/provider-profiles.js');
+    const root = await mkdtemp(join(tmpdir(), 'f062-proxy-fallback-'));
+    const apiDir = join(root, 'packages', 'api');
+    await mkdir(apiDir, { recursive: true });
+    await writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf-8');
+
+    await createProviderProfile(root, {
+      provider: 'anthropic',
+      name: 'proxy-fallback',
+      mode: 'api_key',
+      baseUrl: 'https://api.fallback.example',
+      apiKey: 'sk-proxy-fallback',
+      setActive: true,
+    });
+
+    // Pick a known-free port, then close it to force ECONNREFUSED.
+    const tmpServer = createServer();
+    await new Promise((resolve, reject) => {
+      tmpServer.once('error', reject);
+      tmpServer.listen(0, '127.0.0.1', resolve);
+    });
+    const closedPort = String(tmpServer.address().port);
+    await new Promise((resolve, reject) => {
+      tmpServer.close((err) => (err ? reject(err) : resolve()));
+    });
+
+    const optionsSeen = [];
+    const service = {
+      async *invoke(_prompt, options) {
+        optionsSeen.push(options ?? {});
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = makeDeps();
+    const previousCwd = process.cwd();
+    const previousProxyEnabled = process.env.ANTHROPIC_PROXY_ENABLED;
+    const previousProxyPort = process.env.ANTHROPIC_PROXY_PORT;
+    try {
+      process.env.ANTHROPIC_PROXY_ENABLED = '1';
+      process.env.ANTHROPIC_PROXY_PORT = closedPort;
+      process.chdir(apiDir);
+      await collect(
+        invokeSingleCat(deps, {
+          catId: 'opus',
+          service,
+          prompt: 'test',
+          userId: 'user-f062-proxy-fallback',
+          threadId: 'thread-f062-proxy-fallback',
+          isLastCat: true,
+        }),
+      );
+    } finally {
+      process.chdir(previousCwd);
+      if (previousProxyEnabled === undefined) delete process.env.ANTHROPIC_PROXY_ENABLED;
+      else process.env.ANTHROPIC_PROXY_ENABLED = previousProxyEnabled;
+      if (previousProxyPort === undefined) delete process.env.ANTHROPIC_PROXY_PORT;
+      else process.env.ANTHROPIC_PROXY_PORT = previousProxyPort;
+      await rm(root, { recursive: true, force: true });
+    }
+
+    const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
+    assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_PROFILE_MODE, 'api_key');
+    assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL, 'https://api.fallback.example');
+    assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_API_KEY, 'sk-proxy-fallback');
+  });
+
+  it('F062 proxy-fallback: keeps proxy baseUrl when local proxy is reachable', async () => {
+    const { createProviderProfile } = await import('../dist/config/provider-profiles.js');
+    const root = await mkdtemp(join(tmpdir(), 'f062-proxy-reachable-'));
+    const apiDir = join(root, 'packages', 'api');
+    await mkdir(apiDir, { recursive: true });
+    await writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf-8');
+
+    await createProviderProfile(root, {
+      provider: 'anthropic',
+      name: 'proxy-reachable',
+      mode: 'api_key',
+      baseUrl: 'https://api.proxy.example',
+      apiKey: 'sk-proxy-reachable',
+      setActive: true,
+    });
+
+    const proxyServer = createServer((socket) => socket.destroy());
+    await new Promise((resolve, reject) => {
+      proxyServer.once('error', reject);
+      proxyServer.listen(0, '127.0.0.1', resolve);
+    });
+    const proxyPort = String(proxyServer.address().port);
+
+    const optionsSeen = [];
+    const service = {
+      async *invoke(_prompt, options) {
+        optionsSeen.push(options ?? {});
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = makeDeps();
+    const previousCwd = process.cwd();
+    const previousProxyEnabled = process.env.ANTHROPIC_PROXY_ENABLED;
+    const previousProxyPort = process.env.ANTHROPIC_PROXY_PORT;
+    try {
+      process.env.ANTHROPIC_PROXY_ENABLED = '1';
+      process.env.ANTHROPIC_PROXY_PORT = proxyPort;
+      process.chdir(apiDir);
+      await collect(
+        invokeSingleCat(deps, {
+          catId: 'opus',
+          service,
+          prompt: 'test',
+          userId: 'user-f062-proxy-reachable',
+          threadId: 'thread-f062-proxy-reachable',
+          isLastCat: true,
+        }),
+      );
+    } finally {
+      await new Promise((resolve, reject) => {
+        proxyServer.close((err) => (err ? reject(err) : resolve()));
+      });
+      process.chdir(previousCwd);
+      if (previousProxyEnabled === undefined) delete process.env.ANTHROPIC_PROXY_ENABLED;
+      else process.env.ANTHROPIC_PROXY_ENABLED = previousProxyEnabled;
+      if (previousProxyPort === undefined) delete process.env.ANTHROPIC_PROXY_PORT;
+      else process.env.ANTHROPIC_PROXY_PORT = previousProxyPort;
+      await rm(root, { recursive: true, force: true });
+    }
+
+    const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
+    assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_PROFILE_MODE, 'api_key');
+    assert.match(callbackEnv.CAT_CAFE_ANTHROPIC_BASE_URL, new RegExp(`^http://127\\.0\\.0\\.1:${proxyPort}/`));
+    assert.equal(callbackEnv.CAT_CAFE_ANTHROPIC_API_KEY, 'sk-proxy-reachable');
   });
 
   it('F062-fix: skips auto-seal for api_key mode when context health is approx', async () => {


### PR DESCRIPTION
## Summary
- add proxy reachability check before forcing Anthropic `api_key` traffic through local proxy
- fallback to `profile.baseUrl` when `127.0.0.1:${ANTHROPIC_PROXY_PORT}` is unreachable
- keep current proxy path behavior when proxy is reachable
- add regression tests for both fallback and reachable cases

## Why
`@opus` repeatedly failed with:
- `API Error: Unable to connect to API (ECONNREFUSED)`
- `Claude CLI: CLI 异常退出 (code: 1, signal: none)`

Root cause: `api_key` mode rewrote base URL to local proxy even when proxy port was down.

Closes #46

## Validation
- `pnpm --filter @cat-cafe/api run build`
- `cd packages/api && node --test test/invoke-single-cat.test.js`
