### PR TITLE
fix: pnpm start defaults to local direct startup

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -193,6 +193,7 @@ pnpm hindsight:stop     # Shut down
 pnpm start              # Start everything (Redis + API + Frontend)
 pnpm start --memory     # No Redis, in-memory mode
 pnpm start --quick      # Skip rebuild, use existing dist/
+pnpm runtime:start      # Advanced: start via git worktree (production/maintainer mode)
 
 pnpm check              # Biome lint + format check
 pnpm check:fix          # Auto-fix lint issues
@@ -408,6 +409,7 @@ pnpm hindsight:stop     # 关闭
 pnpm start              # 启动全部（Redis + API + 前端）
 pnpm start --memory     # 无 Redis，纯内存模式
 pnpm start --quick      # 跳过重编译，用已有 dist/
+pnpm runtime:start      # 高级：通过 git worktree 启动（生产/维护者模式）
 
 pnpm check              # Biome lint + 格式检查
 pnpm check:fix          # 自动修复 lint 问题

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "description": "三只 AI 猫猫的协作空间",
   "scripts": {
     "init": "./scripts/init-cafe.sh",
-    "start": "./scripts/runtime-worktree.sh start",
-    "start:direct": "./scripts/start-dev.sh",
+    "start": "./scripts/start-dev.sh",
     "runtime:init": "./scripts/runtime-worktree.sh init",
     "runtime:sync": "./scripts/runtime-worktree.sh sync",
     "runtime:start": "./scripts/runtime-worktree.sh start",

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -51,6 +51,12 @@ done
 
 # 加载环境变量 (放最前面，后续函数需要端口号)
 # 默认读取 .env；.env.local 仅用于 DARE 相关白名单键，避免全量覆盖引发配置漂移。
+# 首次启动自动从 .env.example 创建 .env
+if [ ! -f .env ] && [ -f .env.example ]; then
+    echo -e "${YELLOW}  首次启动，从 .env.example 创建 .env...${NC}"
+    cp .env.example .env
+    echo -e "${GREEN}  ✓ .env 已创建，可按需编辑${NC}"
+fi
 if [ -f .env ]; then
     set -a
     source .env
@@ -328,15 +334,16 @@ setup_storage() {
             STARTED_REDIS=true
             print_redis_runtime_info
         else
-            echo -e "${RED}  ✗ Redis 启动失败${NC}"
-            echo -e "${RED}    使用 --memory 标志允许内存模式启动${NC}"
-            exit 1
+            echo -e "${YELLOW}  ⚠ Redis 启动失败，自动降级到内存模式${NC}"
+            echo -e "${YELLOW}    提示: 安装 Redis 可持久化数据 (brew install redis)${NC}"
+            unset REDIS_URL
+            export MEMORY_STORE=1
         fi
     else
-        echo -e "${RED}  ✗ Redis 未安装${NC}"
-        echo -e "${YELLOW}    安装: brew install redis${NC}"
-        echo -e "${RED}    使用 --memory 标志允许内存模式启动${NC}"
-        exit 1
+        echo -e "${YELLOW}  ⚠ Redis 未安装，自动降级到内存模式${NC}"
+        echo -e "${YELLOW}    提示: 安装 Redis 可持久化数据 (brew install redis)${NC}"
+        unset REDIS_URL
+        export MEMORY_STORE=1
     fi
 }
 


### PR DESCRIPTION
## Summary
- `pnpm start` now runs `start-dev.sh` directly (simpler for new users)
- `pnpm runtime:start` preserved for advanced worktree mode
- Removed redundant `start:direct` script alias
- Auto-create `.env` from `.env.example` on first run
- Auto-fallback to memory mode when Redis unavailable

## Test plan
- [ ] `pnpm start` launches API + Frontend directly
- [ ] First run without `.env` auto-creates it from `.env.example`
- [ ] Without Redis installed, auto-falls back to memory mode (no error exit)
- [ ] `pnpm runtime:start` still works for advanced users

Closes #50

Generated with Claude Code