### PR TITLE
fix: add title tooltips to icon-only buttons (#18)

### DIFF
--- a/packages/web/src/components/CatCafeHub.tsx
+++ b/packages/web/src/components/CatCafeHub.tsx
@@ -309,7 +309,7 @@ export function CatCafeHub() {
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-4 pb-3" style={{ flexShrink: 0 }}>
           <h2 className="text-base font-bold text-gray-900">Cat Caf&eacute; Hub</h2>
-          <button onClick={closeHub} className="text-gray-400 hover:text-gray-600 text-lg">
+          <button onClick={closeHub} className="text-gray-400 hover:text-gray-600 text-lg" title="关闭" aria-label="关闭">
             &times;
           </button>
         </div>

--- a/packages/web/src/components/ChatContainerHeader.tsx
+++ b/packages/web/src/components/ChatContainerHeader.tsx
@@ -40,6 +40,7 @@ export function ChatContainerHeader({
         <button
           onClick={onToggleSidebar}
           className="p-1 rounded-lg hover:bg-owner-light transition-colors mr-1"
+          title={sidebarOpen ? '收起侧栏' : '展开侧栏'}
           aria-label={sidebarOpen ? 'Hide sidebar' : 'Show sidebar'}
         >
           <svg className="w-5 h-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor">
@@ -85,6 +86,7 @@ export function ChatContainerHeader({
         <button
           onClick={onOpenMobileStatus}
           className="p-1 rounded-lg hover:bg-owner-light transition-colors ml-1 lg:hidden"
+          title="打开状态面板"
           aria-label="打开状态面板"
         >
           <svg className="w-5 h-5 text-gray-500" viewBox="0 0 20 20" fill="currentColor">

--- a/packages/web/src/components/ChatInputActionButton.tsx
+++ b/packages/web/src/components/ChatInputActionButton.tsx
@@ -105,6 +105,7 @@ export function ChatInputActionButton({
         <button
           onClick={() => onStop()}
           className="p-2 rounded-lg bg-red-500/80 text-white hover:bg-red-600 transition-colors"
+          title="停止生成"
           aria-label="Stop generation"
         >
           <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
@@ -119,6 +120,7 @@ export function ChatInputActionButton({
         <button
           onClick={() => onStop()}
           className="p-3 rounded-xl bg-red-500 text-white hover:bg-red-600 transition-colors"
+          title="停止生成"
           aria-label="Stop generation"
         >
           <svg className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
@@ -129,12 +131,13 @@ export function ChatInputActionButton({
         <button
           onClick={voice.stopRecording}
           className="p-3 rounded-xl bg-red-500 text-white hover:bg-red-600 transition-colors animate-pulse"
+          title="停止录音"
           aria-label="Stop recording"
         >
           <StopRecordingIcon className="w-5 h-5" />
         </button>
       ) : voice.state === 'transcribing' ? (
-        <button disabled className="p-3 rounded-xl bg-gray-300 text-white cursor-wait" aria-label="Transcribing">
+        <button disabled className="p-3 rounded-xl bg-gray-300 text-white cursor-wait" title="转写中" aria-label="Transcribing">
           <LoadingIcon className="w-5 h-5" />
         </button>
       ) : isQueueMode && onQueueSend ? (
@@ -172,6 +175,7 @@ export function ChatInputActionButton({
           onClick={onSend}
           disabled={isSendDisabled}
           className="p-3 rounded-xl bg-owner-primary text-white hover:bg-owner-dark disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          title="发送消息"
           aria-label="Send message"
         >
           <SendIcon className="w-5 h-5" />

--- a/packages/web/src/components/ImagePreview.tsx
+++ b/packages/web/src/components/ImagePreview.tsx
@@ -38,6 +38,7 @@ export function ImagePreview({ files, onRemove }: ImagePreviewProps) {
             <button
               onClick={() => onRemove(i)}
               className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-red-500 text-white text-xs flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+              title={`移除 ${file.name}`}
               aria-label={`Remove ${file.name}`}
             >
               x

--- a/packages/web/src/components/ParallelStatusBar.tsx
+++ b/packages/web/src/components/ParallelStatusBar.tsx
@@ -115,6 +115,7 @@ export function ParallelStatusBar({ onStop }: { onStop?: () => void }) {
           <button
             onClick={() => onStop()}
             className="ml-auto flex items-center gap-1 px-2.5 py-1 rounded-full bg-red-50 text-red-500 hover:bg-red-100 hover:text-red-600 transition-colors text-xs font-medium"
+            title="停止所有猫猫"
             aria-label="Stop all cats"
             data-testid="parallel-stop-button"
           >

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -283,6 +283,7 @@ function QueueEntryRow({
           <button
             onClick={() => onMove(entry.id, 'up')}
             className="p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
+            title="上移"
             aria-label="Move up"
           >
             <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
@@ -298,6 +299,7 @@ function QueueEntryRow({
           <button
             onClick={() => onMove(entry.id, 'down')}
             className="p-0.5 text-gray-400 hover:text-gray-600 transition-colors"
+            title="下移"
             aria-label="Move down"
           >
             <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor">
@@ -326,6 +328,7 @@ function QueueEntryRow({
       <button
         onClick={() => onRemove(entry.id)}
         className="p-1 text-gray-400 hover:text-red-500 transition-colors shrink-0"
+        title="撤回"
         aria-label="撤回"
       >
         <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">

--- a/packages/web/src/components/ToastContainer.tsx
+++ b/packages/web/src/components/ToastContainer.tsx
@@ -45,7 +45,7 @@ function ToastCard({ toast }: { toast: ToastItem }) {
           <p className="text-sm font-medium text-gray-800 truncate">{toast.title}</p>
           <p className="text-xs text-gray-500 mt-0.5 line-clamp-2">{toast.message}</p>
         </div>
-        <button onClick={dismiss} className="text-gray-300 hover:text-gray-500 flex-shrink-0 p-0.5">
+        <button onClick={dismiss} className="text-gray-300 hover:text-gray-500 flex-shrink-0 p-0.5" title="关闭" aria-label="关闭">
           <svg className="w-3.5 h-3.5" viewBox="0 0 14 14" fill="currentColor">
             <path d="M4.293 4.293a1 1 0 011.414 0L7 5.586l1.293-1.293a1 1 0 111.414 1.414L8.414 7l1.293 1.293a1 1 0 01-1.414 1.414L7 8.414 5.707 9.707a1 1 0 01-1.414-1.414L5.586 7 4.293 5.707a1 1 0 010-1.414z" />
           </svg>

--- a/packages/web/src/components/VoteConfigModal.tsx
+++ b/packages/web/src/components/VoteConfigModal.tsx
@@ -77,7 +77,7 @@ export function VoteConfigModal({
         {/* Header */}
         <div className="px-5 py-4 border-b border-gray-100 flex items-center justify-between">
           <h2 className="text-base font-semibold text-cafe-black">发起投票</h2>
-          <button type="button" onClick={onCancel} className="text-gray-400 hover:text-gray-600 transition-colors p-1">
+          <button type="button" onClick={onCancel} className="text-gray-400 hover:text-gray-600 transition-colors p-1" title="关闭" aria-label="关闭">
             <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 20 20" fill="currentColor">
               <path
                 fillRule="evenodd"
@@ -131,6 +131,7 @@ export function VoteConfigModal({
                       type="button"
                       onClick={() => removeOption(i)}
                       className="text-gray-400 hover:text-red-500 transition-colors px-1"
+                      title={`删除选项 ${i + 1}`}
                       aria-label={`删除选项 ${i + 1}`}
                     >
                       <svg aria-hidden="true" className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">

--- a/packages/web/src/components/rich/AudioBlock.tsx
+++ b/packages/web/src/components/rich/AudioBlock.tsx
@@ -111,6 +111,7 @@ export function AudioBlock({ block, catId }: { block: RichAudioBlock; catId?: st
           onClick={toggle}
           className={`flex items-center gap-2 rounded-2xl px-3 py-1.5 transition-colors cursor-pointer ${colors.bg} hover:opacity-80`}
           style={{ width: `${barWidth}px` }}
+          title={playing ? '暂停语音' : '播放语音'}
           aria-label={playing ? '暂停语音' : '播放语音'}
         >
           {/* Speaker / sound wave icon */}
@@ -182,6 +183,7 @@ export function AudioBlock({ block, catId }: { block: RichAudioBlock; catId?: st
       <button
         onClick={toggle}
         className="flex-shrink-0 w-8 h-8 rounded-full bg-blue-500 hover:bg-blue-600 text-white flex items-center justify-center transition-colors"
+        title={playing ? '暂停' : '播放'}
         aria-label={playing ? 'Pause' : 'Play'}
       >
         {playing ? (


### PR DESCRIPTION
## Summary
- Adds `title` attributes to 19 icon-only buttons across 9 components
- Improves discoverability for users unfamiliar with icon meanings
- Enhances accessibility by providing hover text descriptions

## Components changed
CatCafeHub, ChatContainerHeader, ChatInputActionButton, ImagePreview, ParallelStatusBar, QueuePanel, ToastContainer, VoteConfigModal, AudioBlock

Closes #18

🐾 Generated via Cat Café Hotfix Lane