### PR TITLE
fix: visible error on process_restart sweep (#77)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/StartupReconciler.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/StartupReconciler.ts
@@ -9,7 +9,9 @@
  */
 
 import type { CatId } from '@cat-cafe/shared';
-import type { IInvocationRecordStore } from '../../stores/ports/InvocationRecordStore.js';
+import type { IInvocationRecordStore, InvocationRecord } from '../../stores/ports/InvocationRecordStore.js';
+import type { AppendMessageInput } from '../../stores/ports/MessageStore.js';
+import type { AgentMessage } from '../../types.js';
 import type { TaskProgressStore } from './TaskProgressStore.js';
 
 export interface StartupSweepResult {
@@ -17,6 +19,7 @@ export interface StartupSweepResult {
   running: number;
   queued: number;
   taskProgressCleared: number;
+  notifiedThreads: number;
   durationMs: number;
 }
 
@@ -25,12 +28,26 @@ interface ReconcilerLog {
   warn(msg: string): void;
 }
 
+/** Minimal message-append interface (subset of IMessageStore). */
+interface MessageAppender {
+  append(msg: AppendMessageInput): unknown;
+}
+
+/** Minimal broadcast interface (subset of SocketManager). */
+interface AgentMessageBroadcaster {
+  broadcastAgentMessage(message: AgentMessage, threadId: string): void;
+}
+
 export interface StartupReconcilerDeps {
   invocationRecordStore: IInvocationRecordStore;
   taskProgressStore: TaskProgressStore;
   log: ReconcilerLog;
   /** Only sweep records created before this timestamp (prevents sweeping new invocations from current process). */
   processStartAt?: number;
+  /** #77: Optional — post visible error messages to affected threads. */
+  messageStore?: MessageAppender;
+  /** #77: Optional — push real-time WebSocket notification to frontend. */
+  socketManager?: AgentMessageBroadcaster;
 }
 
 type ScanStore = IInvocationRecordStore & { scanByStatus(status: string): Promise<string[]> };
@@ -53,26 +70,42 @@ export class StartupReconciler {
     // biome-ignore lint/complexity/useLiteralKeys: TS index signature requires bracket access
     if (!('scanByStatus' in store) || typeof (store as Record<string, unknown>)['scanByStatus'] !== 'function') {
       this.deps.log.info('[startup-reconciler] Memory mode — no orphans to sweep');
-      return { swept: 0, running: 0, queued: 0, taskProgressCleared: 0, durationMs: Date.now() - start };
+      return {
+        swept: 0,
+        running: 0,
+        queued: 0,
+        taskProgressCleared: 0,
+        notifiedThreads: 0,
+        durationMs: Date.now() - start,
+      };
     }
 
     const scanStore = store as ScanStore;
-    const { running, taskProgressCleared } = await this.sweepRunning(scanStore, this.deps.processStartAt);
-    const queued = await this.sweepStaleQueued(scanStore);
+    const affectedThreads = new Map<string, CatId[]>();
+    const { running, taskProgressCleared } = await this.sweepRunning(
+      scanStore,
+      this.deps.processStartAt,
+      affectedThreads,
+    );
+    const queued = await this.sweepStaleQueued(scanStore, affectedThreads);
+
+    // #77: Notify affected threads with a visible error message
+    const notifiedThreads = await this.notifyAffectedThreads(affectedThreads);
 
     const swept = running + queued;
     const durationMs = Date.now() - start;
     this.deps.log.info(
       `[startup-reconciler] Sweep complete: ${swept} orphans (${running} running, ${queued} stale queued), ` +
-        `${taskProgressCleared} task-progress cleared, ${durationMs}ms`,
+        `${taskProgressCleared} task-progress cleared, ${notifiedThreads} threads notified, ${durationMs}ms`,
     );
-    return { swept, running, queued, taskProgressCleared, durationMs };
+    return { swept, running, queued, taskProgressCleared, notifiedThreads, durationMs };
   }
 
   /** Sweep all running records — restart = all child processes dead. */
   private async sweepRunning(
     store: ScanStore,
-    cutoff?: number,
+    cutoff: number | undefined,
+    affectedThreads: Map<string, CatId[]>,
   ): Promise<{ running: number; taskProgressCleared: number }> {
     let running = 0;
     let taskProgressCleared = 0;
@@ -91,6 +124,7 @@ export class StartupReconciler {
         });
         if (updated) {
           running++;
+          this.trackAffectedThread(affectedThreads, record);
           taskProgressCleared += await this.clearTaskProgress(record.threadId, record.targetCats);
         }
       } catch (err) {
@@ -101,7 +135,7 @@ export class StartupReconciler {
   }
 
   /** Sweep stale queued records (created > threshold ago). */
-  private async sweepStaleQueued(store: ScanStore): Promise<number> {
+  private async sweepStaleQueued(store: ScanStore, affectedThreads: Map<string, CatId[]>): Promise<number> {
     let queued = 0;
     const ids = await store.scanByStatus('queued');
     const staleThreshold = Date.now() - STALE_QUEUED_THRESHOLD_MS;
@@ -115,12 +149,63 @@ export class StartupReconciler {
           expectedStatus: 'queued',
           error: 'process_restart',
         });
-        if (updated) queued++;
+        if (updated) {
+          queued++;
+          this.trackAffectedThread(affectedThreads, record);
+        }
       } catch (err) {
         this.deps.log.warn(`[startup-reconciler] Failed to sweep queued invocation ${id}: ${String(err)}`);
       }
     }
     return queued;
+  }
+
+  /** Collect affected threadId → catIds for post-sweep notification. */
+  private trackAffectedThread(map: Map<string, CatId[]>, record: InvocationRecord): void {
+    const existing = map.get(record.threadId) ?? [];
+    for (const catId of record.targetCats) {
+      if (!existing.includes(catId)) existing.push(catId);
+    }
+    map.set(record.threadId, existing);
+  }
+
+  /** #77: Post a visible error message to each affected thread. */
+  private async notifyAffectedThreads(affectedThreads: Map<string, CatId[]>): Promise<number> {
+    if (affectedThreads.size === 0) return 0;
+    const { messageStore, socketManager } = this.deps;
+    if (!messageStore && !socketManager) return 0;
+
+    let notified = 0;
+    for (const [threadId, catIds] of affectedThreads) {
+      try {
+        const catLabel = catIds.length === 1 ? catIds[0] : `${catIds.length} cats`;
+        const content = `Service restarted — interrupted in-progress request (${catLabel}). Please resend your message.`;
+
+        if (messageStore) {
+          await messageStore.append({
+            threadId,
+            userId: 'system',
+            catId: null,
+            content,
+            mentions: [],
+            timestamp: Date.now(),
+          });
+        }
+
+        if (socketManager) {
+          const errorCatId = catIds[0] ?? ('system' as CatId);
+          socketManager.broadcastAgentMessage(
+            { type: 'error', catId: errorCatId, error: content, isFinal: true, timestamp: Date.now() },
+            threadId,
+          );
+        }
+
+        notified++;
+      } catch (err) {
+        this.deps.log.warn(`[startup-reconciler] Failed to notify thread ${threadId}: ${String(err)}`);
+      }
+    }
+    return notified;
   }
 
   /** Best-effort clear task progress for all target cats. */

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -774,6 +774,8 @@ async function main(): Promise<void> {
       taskProgressStore,
       log: app.log,
       processStartAt: PROCESS_START_AT,
+      messageStore,
+      socketManager: socketManager ?? undefined,
     });
     try {
       await reconciler.reconcileOrphans();

--- a/packages/api/test/startup-reconciler.test.js
+++ b/packages/api/test/startup-reconciler.test.js
@@ -368,6 +368,102 @@ describe('StartupReconciler', () => {
     assert.ok(result.durationMs >= 0);
   });
 
+  // #77: Notification tests
+  test('#77: posts visible error message to affected threads', async () => {
+    const r1 = makeRecord({ id: 'n1', threadId: 'thread-a', status: 'running', targetCats: ['opus'] });
+    const r2 = makeRecord({ id: 'n2', threadId: 'thread-b', status: 'running', targetCats: ['codex'] });
+    store.seed(r1);
+    store.seed(r2);
+
+    const appendedMessages = [];
+    const messageStore = {
+      append(msg) {
+        appendedMessages.push(msg);
+        return { ...msg, id: `msg-${appendedMessages.length}` };
+      },
+    };
+
+    const broadcastedMessages = [];
+    const socketManager = {
+      broadcastAgentMessage(msg, threadId) {
+        broadcastedMessages.push({ msg, threadId });
+      },
+    };
+
+    const reconciler = new StartupReconciler({
+      invocationRecordStore: store,
+      taskProgressStore,
+      log,
+      messageStore,
+      socketManager,
+    });
+
+    const result = await reconciler.reconcileOrphans();
+
+    assert.equal(result.notifiedThreads, 2, 'should notify 2 threads');
+    assert.equal(appendedMessages.length, 2, 'should append 2 messages');
+    assert.equal(broadcastedMessages.length, 2, 'should broadcast 2 messages');
+
+    // Verify message content
+    const msgA = appendedMessages.find((m) => m.threadId === 'thread-a');
+    assert.ok(msgA, 'thread-a should have a message');
+    assert.equal(msgA.userId, 'system');
+    assert.equal(msgA.catId, null);
+    assert.ok(msgA.content.includes('opus'), 'message should mention affected cat');
+    assert.ok(msgA.content.includes('restart') || msgA.content.includes('interrupted'), 'message should explain restart');
+
+    // Verify broadcast
+    const bcA = broadcastedMessages.find((b) => b.threadId === 'thread-a');
+    assert.ok(bcA);
+    assert.equal(bcA.msg.type, 'error');
+    assert.equal(bcA.msg.isFinal, true);
+  });
+
+  test('#77: deduplicates notifications per thread', async () => {
+    // Two invocations in the same thread
+    const r1 = makeRecord({ id: 'dup1', threadId: 'thread-x', status: 'running', targetCats: ['opus'] });
+    const r2 = makeRecord({ id: 'dup2', threadId: 'thread-x', status: 'running', targetCats: ['codex'] });
+    store.seed(r1);
+    store.seed(r2);
+
+    const appendedMessages = [];
+    const messageStore = {
+      append(msg) {
+        appendedMessages.push(msg);
+        return { ...msg, id: `msg-${appendedMessages.length}` };
+      },
+    };
+
+    const reconciler = new StartupReconciler({
+      invocationRecordStore: store,
+      taskProgressStore,
+      log,
+      messageStore,
+    });
+
+    const result = await reconciler.reconcileOrphans();
+
+    assert.equal(result.notifiedThreads, 1, 'only 1 thread notification despite 2 invocations');
+    assert.equal(appendedMessages.length, 1, 'only 1 message appended');
+    assert.ok(appendedMessages[0].content.includes('2 cats'), 'message should mention 2 cats');
+  });
+
+  test('#77: no notification when messageStore/socketManager not provided', async () => {
+    store.seed(makeRecord({ id: 'quiet1', status: 'running' }));
+
+    const reconciler = new StartupReconciler({
+      invocationRecordStore: store,
+      taskProgressStore,
+      log,
+      // no messageStore, no socketManager
+    });
+
+    const result = await reconciler.reconcileOrphans();
+
+    assert.equal(result.notifiedThreads, 0);
+    assert.equal(result.running, 1, 'still sweeps even without notification deps');
+  });
+
   test('does not sweep running records created after processStartAt', async () => {
     const processStartAt = Date.now() - 5_000; // 5 sec ago
     // Old orphan: created before process started → should be swept


### PR DESCRIPTION
## Summary
- **StartupReconciler** now posts a visible system message to each affected thread when sweeping orphaned invocations after a process restart
- Broadcasts a WebSocket `error` event so connected clients see the notification in real-time
- Deduplicates notifications per thread (multiple swept invocations in the same thread → one message listing all affected cats)
- Backward compatible: `messageStore` and `socketManager` are optional deps

## Changes
- `StartupReconciler.ts` — added `notifyAffectedThreads()`, `trackAffectedThread()`, extended deps interface
- `index.ts` — wired `messageStore` and `socketManager` into reconciler instantiation
- `startup-reconciler.test.js` — 3 new tests (14 total, all passing)

## Test plan
- [x] `node --test packages/api/test/startup-reconciler.test.js` — 14/14 pass
- [x] `pnpm lint` — clean
- [x] `pnpm check` — clean
- [ ] Manual: trigger a `tsx watch` restart while a request is in-flight → verify system message appears in thread

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)