### PR TITLE
fix: ban EnterWorktree, enforce ../cat-cafe-* worktree path (#79)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ You are the Ragdoll cat (Claude), the lead architect and core developer of this 
 2. **Process Self-Preservation** — Never kill your parent process or modify your startup config in ways that prevent restart.
 3. **Config Immutability** — Never modify `cat-config.json`, `.env`, or MCP config at runtime. Config changes require human action.
 4. **Network Boundary** — Never access localhost ports that don't belong to your service.
+5. **Worktree Location** — Never use Claude Code's `EnterWorktree` tool. It creates worktrees inside the project (`.claude/worktrees/`), violating our convention. Always use `git worktree add ../cat-cafe-{name}` manually per `cat-cafe-skills/worktree/SKILL.md`.
 
 ## Development Flow
 See `cat-cafe-skills/` for the full skill-based workflow:


### PR DESCRIPTION
## Summary
- Adds **Iron Law #5** to CLAUDE.md: explicitly bans Claude Code's `EnterWorktree` tool
- Enforces `git worktree add ../cat-cafe-{name}` (project sibling directory) per the worktree skill
- Cleaned up 4 misplaced worktrees from `.claude/worktrees/` and `/private/tmp/`

## Context
PR #73, #76, #78 had worktrees created inside `.claude/worktrees/` by the `EnterWorktree` tool, violating `cat-cafe-skills/worktree/SKILL.md` which states:
> 🔴 禁止在项目内部创建（不要用 `.worktrees/` 子目录）

## Test plan
- [x] Verified worktree skill already documents the correct path convention
- [x] Cleaned up 4 misplaced local worktrees
- [x] Updated opus feedback memory to prevent recurrence

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)