### PR TITLE
feat(F128): cat_cafe_propose_thread — proposal-first thread creation

### DIFF
--- a/cat-cafe-skills/manifest.yaml
+++ b/cat-cafe-skills/manifest.yaml
@@ -443,6 +443,29 @@ skills:
     sop_step: null
     merged_from: null
 
+  # ── Thread 编排 ──
+  thread-orchestration:
+    description: >
+      大任务的主动拆解与多 thread 并行编排。
+      Use when: 任务涉及 2+ 个独立可交付子任务，需要不同猫参与、不同 thread 并行推进。
+      Not for: 单一任务（直接做）、已有 thread 之间的被动协调（用 cross-thread-sync）、单 session 内 subagent 并行（用 parallel-execution）。
+      Output: 子 thread 创建 + 选猫 + 各 thread 交付 + 主 thread 汇聚报告。
+    triggers:
+      - "拆任务"
+      - "分 thread"
+      - "并行推进"
+      - "开多个 thread"
+      - "thread orchestration"
+      - "任务分解"
+    not_for:
+      - "单一任务（直接做）"
+      - "被动跨 thread 协调（用 cross-thread-sync）"
+      - "单 session 内 subagent 并行（用 parallel-execution）"
+    output: "子 thread 创建 + 选猫 + 各 thread 交付 + 主 thread 汇聚报告"
+    next: ["worktree", "tdd", "quality-gate"]
+    sop_step: null
+    merged_from: null
+
   # ── 深度调研 ──
   deep-research:
     description: >

--- a/cat-cafe-skills/thread-orchestration/SKILL.md
+++ b/cat-cafe-skills/thread-orchestration/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: thread-orchestration
+description: >
+  大任务的主动拆解与多 thread 并行编排。
+  Use when: 任务涉及 2+ 个独立可交付子任务，需要不同猫参与、不同 thread 并行推进。
+  Not for: 单一任务（直接做）、已有 thread 之间的被动协调（用 cross-thread-sync）、单 session 内 subagent 并行（CLI 内置能力）。
+  Output: 子 thread 创建 + 选猫 + 各 thread 交付 + 主 thread 汇聚报告。
+triggers:
+  - "拆任务"
+  - "分 thread"
+  - "并行推进"
+  - "开多个 thread"
+  - "thread orchestration"
+  - "任务分解"
+---
+
+# Thread Orchestration — 多 Thread 并行编排
+
+**核心理念**：一个 thread 对应一个独立可交付的工作单元。主 thread 是指挥部，子 thread 是战场。
+
+## 何时触发
+
+```
+任务可以拆成多个独立子任务？
+  → 子任务之间有代码依赖？ → 串行（先完成依赖项）
+  → 子任务独立？ → 本 skill：开 thread 并行推进
+只有一个任务？ → 不需要本 skill，直接做
+```
+
+## 五步流程
+
+### Step 1: 拆解 — 识别独立可交付单元
+
+**判定标准**：两个子任务能否由不同猫在不同 worktree 里同时做？能 → 独立。
+
+拆解时明确每个子任务的：
+- **Scope**: 改哪些文件/模块
+- **交付物**: 代码 + 测试 + 文档（具体到文件）
+- **验收条件**: 怎么算完（测试绿 / lint 过 / review 通过）
+
+### Step 2: 提议 Thread — 每个子任务一个提议（用户审批后才创建）
+
+**重要：cat 不直接创建 thread。** 调用 `cat_cafe_propose_thread` 创建一个**提议卡片**，等用户在 source thread 里点"批准"，后端才真正创建 thread。
+
+```
+→ cat_cafe_propose_thread(
+    title: "简洁描述任务目标",
+    reason: "为什么这个子任务值得自己一个 thread（必填）",
+    preferredCats: ["执行猫", "review猫"]
+  )
+```
+
+**返回值**：`{ proposalId, status: "pending" }` —— **不是 threadId**。Thread 还未存在，不要尝试 `cross_post` 到一个尚未批准的 proposal。
+
+**命名规则**：`[优先级/批次] 动词 + 对象`
+- 例："P1 功能完善：Web UI + Semantic Scholar + API 降级"
+- 例："P2 工程质量：CI/CD + Linting"
+
+**提议后**：继续主 thread 的工作，等用户批准。批准后用户会在新 thread 里出现，此时再 cross_post 给被分配的猫。
+
+### Step 3: 选猫 — 按任务性质匹配能力
+
+| 任务性质 | 适合的猫 | 理由 |
+|---------|---------|------|
+| 代码实现 | 架构猫（自己）或快速编码猫 | 产出代码 |
+| 代码 Review | 缅因猫系（审查专长） | 跨家族 review |
+| UI/体验/文案 | 暹罗猫系（审美专长） | 设计视角 |
+| 架构决策 | 布偶猫 Opus 4.5 / 缅因猫 GPT | 深度思考 |
+| 确定性执行 | 狸花猫 | 零信任验证 |
+
+**铁律**：同一子任务的实现和 review 不能是同一只猫（no self-review）。
+
+用户批准 proposal 后，新 thread 出现在 sidebar。此时在新 thread 里发任务描述 + 分工提议。**必须包含主 thread ID**，这是子 thread 识别归属的唯一可靠来源：
+
+```
+→ cat_cafe_cross_post_message(
+    threadId: "<sub_thread_id>",
+    content: "## 主 Thread\nID: <main_thread_id>\n标题: <main_thread_title>\n\n## 任务描述\n...\n## 分工提议\n...\n\n⚠️ 完成后请回报主 thread，不要回报其他 thread\n@codex 请确认"
+  )
+```
+
+**铁律**：每个子 thread 的**第一条消息**必须包含 `## 主 Thread` header，后续猫进入子 thread 时可据此定位汇报目标。
+
+### Step 4: 并行执行 — Worktree 隔离
+
+**每个 thread 的代码改动应使用独立 worktree**，避免文件冲突。
+
+thread 内的执行遵循已有 skill：
+- 写代码 → `tdd`
+- 完成后自检 → `quality-gate`
+- 请 review → `request-review` + `cross-cat-handoff`（五件套）
+- 收到反馈 → `receive-review`
+
+**加速手段**：thread 内可用 CLI 内置的 subagent 并行模式加速实现，但 review 必须由其他猫完成。
+
+### Step 5: 汇聚 — 确认门禁 + 串行推进
+
+**铁律：子 thread 达到里程碑时，必须立刻通知主 thread 并等待确认。**
+
+#### 5a: 待 commit — 通知主 thread 等确认
+
+子 thread 完成开发 + 自检后，**不要直接 commit**，而是：
+
+```
+→ cat_cafe_cross_post_message(
+    threadId: "<main_thread_id>",     ← 从第一条消息的 ## 主 Thread 获取
+    content: "## [子任务名] — 待确认 commit\n\n| 子项 | 状态 | 关键产出 |\n|------|------|---------|\n| ... | ✅ | 一句话 |\n\n验证：测试 X/X pass, lint 0 errors\n请确认是否 commit + push"
+  )
+```
+
+**等主 thread 确认后再 commit。** 主 thread 可能会要求修改后再 commit。
+
+#### 5b: 确认后 — 串行触发
+
+如果有串行依赖（B 依赖 A），主 thread 确认 A commit 后：
+1. A commit + push（或 merge 到 main）
+2. 主 thread 通知 B 的子 thread："A 已合入，可以开始"
+3. B 从 main 拉取 A 的改动后开工
+
+```
+A 完成 → 通知主 thread → 确认 commit → A merge
+                                         ↓
+                              主 thread 通知 B → B 拉 main → B 开工
+```
+
+#### 5c: 全部完成 — 汇总报告
+
+所有子 thread 完成后，主 thread 汇总：
+
+```markdown
+## 编排汇总
+
+| 子 Thread | 任务 | 状态 | PR |
+|-----------|------|------|----|
+| thread-xxx | ... | ✅ merged | #xx |
+| thread-yyy | ... | ✅ merged | #yy |
+
+下一步：[无 / 集成测试 / 部署]
+```
+
+**不要让 team lead 自己去子 thread 查进度。**
+
+## 依赖管理
+
+| 场景 | 处理 |
+|------|------|
+| 子任务完全独立 | 并行，各自 worktree |
+| B 依赖 A 的产出 | A 先做，A merge 到 main 后 B 从 main 拉 |
+| A 和 B 改同一文件 | 不要并行！串行处理，或重新拆分 scope |
+| 多个 thread 都要改共享状态 | 走 `cross-thread-sync` 的 Claim 协议 |
+
+## Quick Reference
+
+```
+拆解 → 提议 thread → 等用户批准 → 选猫(含主 Thread ID) → 并行执行 → 待 commit 通知 → 确认 → 串行触发 → 汇总
+
+主 thread = 指挥部（拆 + 提议 + 确认 + 收）
+子 thread = 战场（做 + review + 等确认）— 仅在用户批准 proposal 后存在
+Proposal = 卡片（cat 提议 → 用户审核/编辑/批准 → 后端创建 thread）
+第一条消息 = 必须含 ## 主 Thread（ID + 标题）
+Worktree = 隔离（不冲突）
+汇报 = 及时 + 等确认（不让 team lead 追，也不越权 commit）
+```
+
+## Common Mistakes
+
+| 错误 | 后果 | 修法 |
+|------|------|------|
+| 在主 thread 里直接改代码 | 子 thread 看不到过程，审计困难 | 代码改动必须在子 thread + worktree |
+| 子 thread 完成不通知主 thread | team lead 要自己查 | 完成/阻塞时立刻 cross-post 回主 thread |
+| 多 thread 在同一 worktree 改代码 | 文件冲突 | 每个 thread 用独立 worktree |
+| 只拉同家族猫 | 缺少多元视角 | 按任务性质跨家族选猫 |
+| 拆得太细（1 个小文件 = 1 个 thread） | 编排开销 > 收益 | 相关小任务合并到同一 thread |
+| 忘记在子 thread 发任务描述 | 被拉的猫不知道干啥 | 建 thread 后立刻发 scope + 分工 |
+| 子 thread 第一条消息没写主 Thread ID | 猫汇报到错误的 thread | 第一条消息必须含 `## 主 Thread` header |
+| 子 thread 完成直接 commit 不等确认 | team lead 失去控制权 | 待 commit 时通知主 thread 等确认 |
+| 把 propose 返回的 proposalId 当成 threadId 用 | cross_post 到不存在的 thread | propose 不创建 thread，只有 user 批准后才有 threadId。等批准事件再发首条消息 |
+| 提议一个 proposal 后立刻假设 thread 存在 | 后续操作全失败 | 必须等用户在 proposal 卡片上点"批准"。批准前继续主 thread 工作 |
+
+## 和其他 Skill 的区别
+
+| Skill | 层级 | 方向 | 核心区别 |
+|-------|------|------|---------|
+| **thread-orchestration** | 跨 thread | 主动拆解 → 分发 → 汇聚 | 全生命周期编排 |
+| CLI subagent 并行 | session 内 | subagent 并行（CLI 内置） | 不涉及 thread、不涉及其他猫 |
+| `cross-thread-sync` | 跨 thread | 被动发现 → 通知 → 协调 | 响应式，不主动建 thread |
+| `cross-cat-handoff` | 猫对猫 | 一次性交接 | 点对点，不涉及多 thread 编排 |
+
+## 下一步
+
+- 子 thread 内写代码 → `worktree` → `tdd`
+- 子 thread 完成自检 → `quality-gate`
+- 子 thread 请 review → `request-review`
+- 子 thread merge → `merge-gate`
+- 子 thread 之间有冲突 → `cross-thread-sync`

--- a/designs/F128-thread-hierarchy-sidebar.pen
+++ b/designs/F128-thread-hierarchy-sidebar.pen
@@ -1,0 +1,884 @@
+{
+  "version": "2.9",
+  "children": [
+    {
+      "type": "frame",
+      "id": "bi8Au",
+      "x": 0,
+      "y": 0,
+      "name": "Frame",
+      "clip": true,
+      "width": 800,
+      "height": 600,
+      "fill": "#FFFFFF",
+      "layout": "none"
+    },
+    {
+      "type": "frame",
+      "id": "ChqC2",
+      "x": 0,
+      "y": 0,
+      "name": "Thread Hierarchy Sidebar",
+      "width": 280,
+      "fill": "#FFFFFF",
+      "stroke": {
+        "align": "inside",
+        "thickness": {
+          "right": 1
+        },
+        "fill": "#E5E7EB"
+      },
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "nSGzu",
+          "name": "Sidebar Header",
+          "width": "fill_container",
+          "padding": [
+            12,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "6vU1E",
+              "name": "logo",
+              "fill": "#1F2937",
+              "content": "Cat Café",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "PtGNO",
+              "name": "newBtn",
+              "width": 24,
+              "height": 24,
+              "fill": "#F3F4F6",
+              "cornerRadius": 4,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "SiJrW",
+                  "name": "plusIcon",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "lucide",
+                  "fill": "#6B7280"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Mom3K",
+          "name": "Search Box",
+          "width": "fill_container",
+          "fill": "#F9FAFB",
+          "cornerRadius": 6,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E5E7EB"
+          },
+          "gap": 8,
+          "padding": [
+            6,
+            12
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "E6828",
+              "name": "searchIcon",
+              "width": 14,
+              "height": 14,
+              "iconFontName": "search",
+              "iconFontFamily": "lucide",
+              "fill": "#9CA3AF"
+            },
+            {
+              "type": "text",
+              "id": "T1G3V",
+              "name": "searchText",
+              "fill": "#9CA3AF",
+              "content": "搜索对话...",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "wwA5X",
+          "name": "divider1",
+          "fill": "#F3F4F6",
+          "width": "fill_container",
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "I8G0x",
+          "name": "Project Section",
+          "width": "fill_container",
+          "layout": "vertical",
+          "padding": [
+            4,
+            0
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "BCNAQ",
+              "name": "Section Header",
+              "width": "fill_container",
+              "gap": 6,
+              "padding": [
+                6,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "LbL3u",
+                  "name": "chevron",
+                  "rotation": 90,
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "chevron-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9CA3AF"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "k0aYD",
+                  "name": "folderIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "folder",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9CA3AF"
+                },
+                {
+                  "type": "text",
+                  "id": "1twM9",
+                  "name": "sectionLabel",
+                  "fill": "#6B7280",
+                  "content": "clowder-ai",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "text",
+                  "id": "OL0R5",
+                  "name": "sectionCount",
+                  "fill": "#D1D5DB",
+                  "content": "5",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "eHtSJ",
+              "name": "Thread List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CcCEE",
+                  "name": "Thread: Regular",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "W7Nj3",
+                      "name": "t1avatar",
+                      "width": 20,
+                      "height": 20,
+                      "fill": "#9B7EBD",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "e91Cw",
+                          "name": "t1avatarTxt",
+                          "fill": "#FFFFFF",
+                          "content": "宪",
+                          "fontFamily": "Inter",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vnvG7",
+                      "name": "t1info",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JR3WJ",
+                          "name": "t1title",
+                          "fill": "#374151",
+                          "content": "Pencil MCP 对接",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "uk9T5",
+                          "name": "t1time",
+                          "fill": "#9CA3AF",
+                          "content": "刚刚",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Kd0vg",
+                  "name": "Thread: Parent (expanded)",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Ie4mc",
+                      "name": "Parent Row",
+                      "width": "fill_container",
+                      "fill": "#F5F3FF",
+                      "cornerRadius": 4,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "mHTZz",
+                          "name": "parentChevron",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#7C3AED"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3Uhi4",
+                          "name": "parentAvatar",
+                          "width": 20,
+                          "height": 20,
+                          "fill": "#9B7EBD",
+                          "cornerRadius": 10,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "3Xglr",
+                              "name": "parentAvatarTxt",
+                              "fill": "#FFFFFF",
+                              "content": "宪",
+                              "fontFamily": "Inter",
+                              "fontSize": 9,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "I6n1N",
+                          "name": "parentInfo",
+                          "width": "fill_container",
+                          "layout": "vertical",
+                          "gap": 2,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "7LaOn",
+                              "name": "parentTitle",
+                              "fill": "#374151",
+                              "content": "🧶 Thread Orchestration 实现",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "OdWGI",
+                              "name": "parentMeta",
+                              "gap": 6,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "OW3Nq",
+                                  "name": "parentTime",
+                                  "fill": "#9CA3AF",
+                                  "content": "2 分钟前",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "8lugl",
+                                  "name": "parentBadge",
+                                  "fill": "#EDE9FE",
+                                  "cornerRadius": 8,
+                                  "padding": [
+                                    1,
+                                    6
+                                  ],
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Qzg00",
+                                      "name": "parentBadgeTxt",
+                                      "fill": "#7C3AED",
+                                      "content": "3 子线程",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 10,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gmVmK",
+                      "name": "Children Container",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "padding": [
+                        0,
+                        0,
+                        0,
+                        20
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "LXdT3",
+                          "name": "Child Thread 1",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            12,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KdyTy",
+                              "name": "c1line",
+                              "width": 12,
+                              "height": 16,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "rectangle",
+                                  "id": "w2Xwq",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "c1lineV",
+                                  "fill": "#D1D5DB",
+                                  "width": 1,
+                                  "height": 16
+                                },
+                                {
+                                  "type": "rectangle",
+                                  "id": "AuV74",
+                                  "x": 0,
+                                  "y": 8,
+                                  "name": "c1lineH",
+                                  "fill": "#D1D5DB",
+                                  "width": 12,
+                                  "height": 1
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Vme0w",
+                              "name": "c1avatar",
+                              "width": 18,
+                              "height": 18,
+                              "fill": "#5B8C5A",
+                              "cornerRadius": 9,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TbusD",
+                                  "name": "c1avatarTxt",
+                                  "fill": "#FFFFFF",
+                                  "content": "砚",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 8,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "F8f2o",
+                              "name": "c1info",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 1,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "zb0KE",
+                                  "name": "c1title",
+                                  "fill": "#4B5563",
+                                  "content": "后端 API 实现",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "NcVIY",
+                                  "name": "c1time",
+                                  "fill": "#9CA3AF",
+                                  "content": "5 分钟前 · @codex",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "iDWav",
+                          "name": "Child Thread 2",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            12,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "knsDa",
+                              "name": "c2line",
+                              "width": 12,
+                              "height": 16,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "rectangle",
+                                  "id": "zZl17",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "c2lineV",
+                                  "fill": "#D1D5DB",
+                                  "width": 1,
+                                  "height": 16
+                                },
+                                {
+                                  "type": "rectangle",
+                                  "id": "MWAGS",
+                                  "x": 0,
+                                  "y": 8,
+                                  "name": "c2lineH",
+                                  "fill": "#D1D5DB",
+                                  "width": 12,
+                                  "height": 1
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Q1mfP",
+                              "name": "c2avatar",
+                              "width": 18,
+                              "height": 18,
+                              "fill": "#5B9BD5",
+                              "cornerRadius": 9,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "AgXi5",
+                                  "name": "c2avatarTxt",
+                                  "fill": "#FFFFFF",
+                                  "content": "烁",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 8,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "4Vppj",
+                              "name": "c2info",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 1,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "b88Ws",
+                                  "name": "c2title",
+                                  "fill": "#4B5563",
+                                  "content": "UI 设计审查",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "UEbZZ",
+                                  "name": "c2time",
+                                  "fill": "#9CA3AF",
+                                  "content": "8 分钟前 · @gemini",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Z1nRL",
+                          "name": "Child Thread 3 (last)",
+                          "width": "fill_container",
+                          "gap": 8,
+                          "padding": [
+                            6,
+                            12,
+                            6,
+                            8
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "9IQAh",
+                              "name": "c3line",
+                              "width": 12,
+                              "height": 16,
+                              "layout": "none",
+                              "children": [
+                                {
+                                  "type": "rectangle",
+                                  "id": "wrPYp",
+                                  "x": 0,
+                                  "y": 8,
+                                  "name": "c3lineH",
+                                  "fill": "#D1D5DB",
+                                  "width": 12,
+                                  "height": 1
+                                },
+                                {
+                                  "type": "rectangle",
+                                  "id": "3RUa4",
+                                  "x": 0,
+                                  "y": 0,
+                                  "name": "c3lineCorner",
+                                  "fill": "#D1D5DB",
+                                  "width": 1,
+                                  "height": 9
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rE7lR",
+                              "name": "c3avatar",
+                              "width": 18,
+                              "height": 18,
+                              "fill": "#9B7EBD",
+                              "cornerRadius": 9,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "RzSjk",
+                                  "name": "c3avatarTxt",
+                                  "fill": "#FFFFFF",
+                                  "content": "宪",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 8,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ZlsG5",
+                              "name": "c3info",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 1,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Y02mq",
+                                  "name": "c3title",
+                                  "fill": "#4B5563",
+                                  "content": "前端组件开发",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Dr1TW",
+                                  "name": "c3time",
+                                  "fill": "#9CA3AF",
+                                  "content": "12 分钟前 · @opus",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "qrfXL",
+                  "name": "Thread: Parent (collapsed)",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "gap": 6,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "s3jWw",
+                      "name": "colChevron",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevron-right",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9CA3AF"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EAEcs",
+                      "name": "colAvatar",
+                      "width": 20,
+                      "height": 20,
+                      "fill": "#5B8C5A",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SIpLn",
+                          "name": "colAvatarTxt",
+                          "fill": "#FFFFFF",
+                          "content": "砚",
+                          "fontFamily": "Inter",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "s4Bw6",
+                      "name": "colInfo",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QfGrz",
+                          "name": "colTitle",
+                          "fill": "#374151",
+                          "content": "🔧 Bug 修复 #116",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "MIOOH",
+                          "name": "colMeta",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "9Qh7q",
+                              "name": "colTime",
+                              "fill": "#9CA3AF",
+                              "content": "30 分钟前",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "URuZv",
+                              "name": "colBadge",
+                              "fill": "#F3F4F6",
+                              "cornerRadius": 8,
+                              "padding": [
+                                1,
+                                6
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "uOnmD",
+                                  "name": "colBadgeTxt",
+                                  "fill": "#6B7280",
+                                  "content": "2 子线程",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 10,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Jdu4F",
+                  "name": "Thread: Regular 2",
+                  "width": "fill_container",
+                  "cornerRadius": 4,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "nCWjm",
+                      "name": "t3avatar",
+                      "width": 20,
+                      "height": 20,
+                      "fill": "#D4A76A",
+                      "cornerRadius": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "CA4Xo",
+                          "name": "t3avatarTxt",
+                          "fill": "#FFFFFF",
+                          "content": "狸",
+                          "fontFamily": "Inter",
+                          "fontSize": 9,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uOz6Y",
+                      "name": "t3info",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "69A81",
+                          "name": "t3title",
+                          "fill": "#374151",
+                          "content": "审计日志追踪",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "2GuwQ",
+                          "name": "t3time",
+                          "fill": "#9CA3AF",
+                          "content": "1 小时前",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -39,7 +39,7 @@ created: 2026-02-26
 | F119 | 谁是卧底 — 坏猫战术推理游戏 #2 | spec | Ragdoll | internal | [F119](features/F119-who-is-spy-game.md) |
 | F124 | Apple Ecosystem × Cat Café 语音交互系统 — iOS/watchOS/AirPods | spec | Ragdoll | internal | [F124](features/F124-apple-ecosystem-voice-interaction.md) |
 | F126 | 四肢控制面 — Cat Café Limb Control Plane | in-progress | Ragdoll | internal | [F126](features/F126-limb-control-plane.md) |
-| F128 | Cat-Proposed Thread Creation — 猫猫提议创建 Thread | spec | 待定 | community [#82](https://github.com/zts212653/clowder-ai/issues/82) | [F128](features/F128-cat-create-thread.md) |
+| F128 | Cat Thread Proposal — 猫提议新 thread，用户审批后创建（含提案卡片 + 审批端点） | spec | Ragdoll | community [#82](https://github.com/zts212653/clowder-ai/issues/82) | [F128](features/F128-cat-create-thread.md) |
 | F129 | Pack System — Multi-Agent 共创世界的 Mod 生态 | in-progress | Ragdoll | internal | [F129](features/F129-pack-system-multi-agent-mod.md) |
 | F138 | Cat Café Video Studio — AI 视频制作管线 | spec | 金渐层 | internal | [F138](features/F138-video-studio.md) |
 | F143 | Hostable Agent Runtime — 统一宿主抽象 | spec | Ragdoll | internal | [F143](features/F143-hostable-agent-runtime.md) |

--- a/docs/features/F128-cat-create-thread.md
+++ b/docs/features/F128-cat-create-thread.md
@@ -1,137 +1,264 @@
 ---
 feature_ids: [F128]
-related_features: [F108, F050]
-related_decisions: [ADR-035]
-topics: [mcp, thread, autonomy, orchestration, community, approval, rich-block]
+related_features: []
+topics: [mcp, autonomy, proposal-flow]
 doc_kind: spec
-created: 2026-03-19
-source: community
-community_issue: https://github.com/zts212653/clowder-ai/issues/82
-community_pr: https://github.com/zts212653/clowder-ai/pull/85
+created: 2026-03-14
+updated: 2026-05-22
 ---
 
-# F128: Cat-Proposed Thread Creation — 猫猫提议创建 Thread
+# F128: Cat Thread Proposal (formerly "Cat-Initiated Thread Creation")
 
-> **Status**: spec | **Source**: clowder-ai #82 (bouillipx) / PR #85 | **Priority**: P2
-> **Design correction (2026-05-22)**: supersedes direct `cat_cafe_create_thread` with Proposal-First flow per ADR-035.
+> **Status**: spec v2 | **Owner**: opus | **Priority**: P1
+> **v1 archived**: direct-create semantics rejected by maintainer 2026-05-22 (#85, #82)
 
 ## Why
 
-猫目前无法帮助team lead准备新 thread。当话题需要独立上下文时（如新 issue 调查、子任务分配），猫只能口头请求team lead去前端手动创建，打断了自主工作流。
+Cats cannot create threads programmatically. When a topic needs its own thread, the cat has to ask the owner to do it in the frontend, breaking autonomous workflow.
 
-> 发现场景（issue #82）：team lead要求"新开一个 thread"，但猫没有 API 可调，只能等team lead手动操作。
+Encountered during #79: owner asked to "新开一个 thread" for the worktree location fix, but the cat had no API to do so.
 
-但直接给猫暴露 `cat_cafe_create_thread` 也不对。Thread 是用户可见、持久化、会改变工作空间结构的对象；猫可以起草创建信息，但不应悄悄创建。F128 的产品目标不是"猫绕过team lead创建 thread"，而是：
+## Product correction (2026-05-22, from #85 maintainer review)
 
-> 猫猫把新 thread 的信息填好，以卡片形式展示；team lead确认或编辑后，系统再创建。
+Threads are user-visible persistent workspace structure. Cats must **not** silently create them. The accepted flow is **proposal-first**:
+
+```
+cat proposes thread (prefilled card) → user reviews / edits / approves → backend creates thread
+```
+
+Direct `cat_cafe_create_thread` semantics are rejected. The replacement is `cat_cafe_propose_thread`.
 
 ## What
 
-### Phase A: Thread Proposal API + Rich Block（核心）
+### Single PR scope — propose flow end-to-end
 
-- `cat_cafe_propose_thread` MCP callback tool
-  - `POST /api/callbacks/thread-proposals` callback route（auth + zod schema）
-  - 必填：`title`（trim 后 1-200 字符）
-  - 必填：`why`（猫猫为什么建议新开 thread）
-  - 可选：`initialMessage`（创建后要投递到新 thread 的第一条消息）
-  - 可选：`preferredCats`（指定 thread 的默认猫）
-  - 可选：`parentThreadId`（默认从 invocation 当前 thread 推导）
-  - 可选：`projectPath`（默认继承 parent thread）
-  - 返回 `{ proposalId }`，不返回 `threadId`，因为此阶段尚未创建 thread
-- Thread proposal rich block
-  - 插入当前 thread，展示标题、原因、父 thread、默认猫、初始消息
-  - team lead可编辑字段
-  - 操作：Create / Edit / Dismiss
-- `POST /api/thread-proposals/:proposalId/approve`
-  - 必须由用户 principal 调用，不能由猫 callback token 自批
-  - 使用 idempotency key，重复点击不会创建重复 thread
-  - 校验 `parentThreadId` 归属与 `projectPath` 权限
-  - 创建成功后返回 `{ threadId }`
-- `POST /api/thread-proposals/:proposalId/reject`
-  - 更新卡片状态，不产生 thread
-- WebSocket `thread_created` 事件
-  - 新 thread 实时推送到前端 sidebar
-  - 源 thread proposal 卡片更新为 created 状态
-- `parentThreadId` 数据模型 — Thread 接口新增字段，Redis 维护 `thread:{parentId}:children` sorted set 二级索引
-- `getChildThreads(parentThreadId)` — 父 thread 发现子 thread
-- Audit trail
-  - 新 thread metadata 记录 `createdFromProposalId` / `sourceThreadId` / `approvedBy` / `approvedAt`
-  - 源 thread 自动追加系统消息：已创建子 thread，并链接到新 thread
-  - 新 thread 自动追加 seed message，说明来源与初始任务
+Owner decision (2026-05-22, mid-spec): do **not** split — proposal-first is a single coherent feature that's only useful end-to-end. The PR ships:
 
-### Phase B: 前端层级 UI + Proposal Card（需设计稿）
+| Layer | Scope |
+|-------|-------|
+| **Backend** | `RedisProposalStore`, `cat_cafe_propose_thread` MCP tool, `POST /api/callbacks/propose-thread` (cat auth), `POST /api/proposals/:id/approve` & `/reject` (user auth), audit fields, tests |
+| **Frontend** | Proposal card rendered in the source thread (reuses rich `card` block kind) with prefilled editable fields and Approve / Edit / Reject buttons; status transitions reflected via `proposal_updated` WS event |
+| **Prompt + skill** | `MCP_TOOLS_SECTION` updated for propose semantics; `thread-orchestration` skill rewritten for propose-first flow |
 
-- Thread proposal card 设计稿
-  - 紧凑态：标题 + why + Create / Dismiss
-  - 展开态：可编辑 title / preferredCats / initialMessage / projectPath
-  - Created 状态：显示 thread link
-  - Rejected 状态：保留审计但降低视觉权重
-- Sidebar 可折叠展开子 thread 树形展示
-- 树形连接线（├──/└──）+ 猫头像 + @handle 标签
-- 展开/收起状态 localStorage 持久化
-- **前置条件**：需 .pen 设计稿 + ThreadSidebar 重构（当前 727 行，超 350 行硬上限）
+### Deferred (NOT in this PR)
 
-### Phase C: Thread Orchestration Skill
+**Hierarchy sidebar UI** (parent/child tree rendering): kept on disk as v1 design reference, but explicitly **out of scope** here. Reason: between v1's `ThreadSidebar` and `main`, F190 console restructure reorganized the sidebar; layering hierarchy onto the v1 component shape would either revert F190 or create a hybrid that's worse than either. A separate follow-up will design hierarchy UI against the post-F190 sidebar shape if still desired. The backend `parentThreadId` field + `getChildThreads()` are kept so the hierarchy follow-up has the data it needs.
 
-- 文档化"拆解→建 thread→分猫→并行→汇聚"编排模式
-- 适配项目 skill manifest 体系
-- 明确要求：猫猫只能 propose，不直接 create
-- 明确何时不该 propose：当前 thread 内即可回答、只是临时子任务、用户已拒绝过同类提案
+## Backend design
 
-## Product Guardrail（ADR-035）
+### Proposal lifecycle
 
-F128 遵循 ADR-035 Proposal-First Agent Actions：
+```
+   propose (cat)            approve (user)            create (system)
+   ──────────►   pending   ──────────────►   approved   ────────►  thread created
+                    │
+                    │ reject (user)
+                    ▼
+                rejected
+```
 
-| 决策点 | F128 规则 |
-|--------|-----------|
-| 猫猫能否直接创建 thread | 默认不能 |
-| 猫猫能做什么 | 起草 thread proposal rich block |
-| 谁确认 | team lead或具备 thread create 权限的用户 |
-| 谁执行创建 | 后端使用用户确认上下文执行 |
-| 如何追踪 | proposalId + sourceThreadId + approvedBy + threadId 双向链接 |
-| 可否 trusted auto-create | 后续 settings opt-in，默认关闭 |
+### Data model — `Proposal`
+
+```ts
+interface ThreadProposal {
+  proposalId: string;          // UUID
+  status: 'pending' | 'approved' | 'rejected';
+
+  // Source / lineage
+  sourceThreadId: string;      // thread the cat was running in
+  sourceInvocationId: string;  // for audit / traceability
+  sourceCatId: CatId;          // cat that proposed
+
+  // Prefilled fields (editable by user before approve)
+  title: string;
+  reason: string;              // why cat thinks a new thread is needed
+  parentThreadId?: string;     // defaults to sourceThreadId, user can change
+  preferredCats?: CatId[];
+  initialMessage?: string;     // optional first message body for new thread
+  projectPath: string;         // inherited from source thread
+
+  // Audit
+  createdBy: string;           // userId from invocation record
+  createdAt: number;           // unix ms
+
+  // Approval outcome
+  approvedBy?: string;
+  approvedAt?: number;
+  createdThreadId?: string;    // backfilled when thread is created on approve
+
+  // Rejection outcome
+  rejectedBy?: string;
+  rejectedAt?: number;
+  rejectionReason?: string;
+}
+```
+
+### Storage — `RedisProposalStore`
+
+Following `RedisPendingRequestStore` / `RedisAuthorizationAuditStore` patterns:
+
+| Key | Type | Purpose |
+|-----|------|---------|
+| `proposal:{proposalId}` | hash | proposal fields |
+| `proposals:user:{userId}` | sorted set (score=createdAt) | user's proposals for dashboard |
+| `proposals:pending:{userId}` | sorted set (score=createdAt) | fast filter for pending UI |
+| `proposals:thread:{threadId}` | sorted set | proposals proposed in a thread (for card re-render lookup) |
+
+Approve transitions `status: pending → approved` and moves out of `proposals:pending:{userId}`.
+
+### Endpoints
+
+#### Cat side — `POST /api/callbacks/propose-thread` (cat callback auth)
+
+Body (Zod schema):
+```ts
+{
+  invocationId: string;
+  callbackToken: string;
+  title: string;             // .trim().min(1).max(200)
+  reason: string;            // .trim().min(1).max(1000)
+  preferredCats?: CatId[];   // max 10
+  initialMessage?: string;   // .max(4000)
+  parentThreadId?: string;   // auto-inferred from record.threadId if omitted
+  clientRequestId?: string;  // idempotency key
+}
+```
+
+Behavior:
+1. `registry.verify` + `registry.isLatest` guard (parity with `create_thread` v1)
+2. Idempotency: if `clientRequestId` is seen, return cached `proposalId`
+3. Auto-fill `sourceThreadId = record.threadId`, `parentThreadId = parentThreadId ?? sourceThreadId`, `projectPath = sourceThread.projectPath`
+4. Ownership check: if `parentThreadId` explicitly provided, verify it belongs to `record.userId` (403 otherwise)
+5. Create proposal row (status=pending)
+6. Emit a `proposal_created` WebSocket event scoped to the user → frontend renders the card in `sourceThreadId`
+7. Return `{ proposalId, status: 'pending' }`
+
+**This route does NOT create a thread.**
+
+#### User side — `POST /api/proposals/:proposalId/approve` (user auth via `resolveUserId`)
+
+Body (optional edits):
+```ts
+{
+  title?: string;
+  parentThreadId?: string;
+  preferredCats?: CatId[];
+  initialMessage?: string;
+}
+```
+
+Behavior:
+1. Resolve `userId` from `X-Cat-Cafe-User` (user auth)
+2. Load proposal; verify `proposal.createdBy === userId` (ownership; cross-user rejection)
+3. Idempotency: if already `approved`, return cached `{ threadId: proposal.createdThreadId }`
+4. If `rejected`, return 409 conflict
+5. Apply user edits to in-memory copy (do not mutate proposal record's prefilled fields beyond `approvedBy/approvedAt`)
+6. Validate `parentThreadId` ownership if provided/changed
+7. Create thread via `threadStore.create(userId, finalTitle, projectPath, finalParentThreadId, finalPreferredCats)`
+8. If `initialMessage` present, post it to the new thread as the user
+9. Update proposal: `status=approved, approvedBy, approvedAt, createdThreadId`
+10. Emit WebSocket events: `thread_created` (for sidebar) + `proposal_updated` (for card status flip)
+11. Return `{ threadId, proposalId, status: 'approved' }`
+
+#### User side — `POST /api/proposals/:proposalId/reject` (user auth)
+
+Body: `{ rejectionReason?: string }`
+- Same ownership check
+- Idempotent: re-reject is no-op
+- Cannot reject after approve (409)
+- Update proposal `status=rejected, rejectedBy, rejectedAt, rejectionReason`
+- Emit `proposal_updated`
+
+### MCP tool — `cat_cafe_propose_thread`
+
+Replaces `cat_cafe_create_thread` (deleted). Tool description (drafted, refine in implementation):
+
+> Propose a new thread to the user. The user will see a card with your proposed title and reason and can approve, edit, or reject. The new thread is **not** created until the user approves. Use sparingly — only when a new dedicated thread is genuinely needed (e.g. owner explicitly asks "open a new thread", or a clearly separable long-running investigation). Returns `proposalId`. Wait for the user's decision before assuming the new thread exists.
+
+### Reused infrastructure
+
+| Reused | From | Why |
+|--------|------|-----|
+| `InvocationRegistry.verify` + `isLatest` | callback-auth | Standard cat-callback auth |
+| `resolveUserId(request)` | request-identity | Standard user auth for approve/reject |
+| Rich `card` block + `interactive.confirm` actions | chat-types.ts | Proposal card renders as existing block kind — no new frontend primitive |
+| `emitToUser` socket pattern | callbacks.ts | Same as v1's `thread_created` broadcast, just different event names |
+| `clientRequestId` idempotency cache | post-message route | Battle-tested dedup pattern |
+
+### Code to delete from v1 worktree
+
+| File | Action |
+|------|--------|
+| `callback-create-thread-routes.ts` | rename + rewrite to `callback-propose-thread-routes.ts` |
+| `callback-tools.ts: cat_cafe_create_thread` | rename to `cat_cafe_propose_thread`, return shape changes |
+| `callback-create-thread.test.js` | rewrite for propose semantics |
+| Frontend hierarchy files (`ThreadHierarchyToggle.tsx`, `thread-hierarchy.ts`, `thread-hierarchy.test.ts`, hierarchy bits in `ThreadItem.tsx` / `ThreadSidebar.tsx`) | **delete** from this PR; defer to hierarchy follow-up (will redesign post-F190) |
+| `designs/F128-thread-hierarchy-sidebar.pen` | keep on disk but mark as deferred follow-up reference; this PR needs a new `F128-proposal-card.pen` |
+| `thread-orchestration` skill | rewrite to propose-first flow (cat proposes → wait for user approval → continue) |
+
+### Code to keep / extend
+
+- `ThreadStore.parentThreadId` field + Redis secondary index for children + `getChildThreads()` — useful for hierarchy follow-up, no harm keeping
+- `SystemPromptBuilder` MCP_TOOLS_SECTION entry — update wording for propose semantics
+- `serializeThread` / `hydrateThread` parentThreadId persistence — keep
 
 ## Acceptance Criteria
 
-- [ ] AC-A1: `cat_cafe_propose_thread` 工具只创建 proposal，不创建 thread
-- [ ] AC-A2: proposal rich block 在源 thread 可见，字段可编辑
-- [ ] AC-A3: approve endpoint 必须使用用户 principal，猫 callback token 不能自批
-- [ ] AC-A4: approve 有 idempotency key，重复点击不创建重复 thread
-- [ ] AC-A5: `parentThreadId` 必须从当前 invocation 推导或校验同用户归属
-- [ ] AC-A6: 创建成功后源 thread 和新 thread 双向链接
-- [ ] AC-A7: WebSocket 推送新 thread，并更新 proposal 卡片状态
-- [ ] AC-A8: reject/dismiss 不产生 thread，但保留审计记录
-- [ ] AC-A9: skill/system prompt 明确教猫何时 propose、何时不要 propose
-- [ ] AC-A10: 测试覆盖 happy path、重复 approve、跨用户 parentThreadId、reject、proposal card state update
+### Backend
 
-## Maintainer Review 结论（2026-03-19，已被 2026-05-22 产品修正补充）
+- [ ] AC-B1: `RedisProposalStore` implements create/get/listByUser/listPending/markApproved/markRejected with proper Redis indices
+- [ ] AC-B2: `POST /api/callbacks/propose-thread` creates proposal, does NOT create thread, returns `proposalId`, supports `clientRequestId` idempotency, enforces stale guard, validates parent ownership
+- [ ] AC-B3: `cat_cafe_propose_thread` MCP tool registered with strong description; old `cat_cafe_create_thread` removed
+- [ ] AC-B4: `POST /api/proposals/:id/approve` (user auth) creates thread, is idempotent on re-approve, rejects cross-user attempts (403), conflicts on already-rejected (409), applies user edits, posts initial message if provided, writes audit fields, emits both `thread_created` + `proposal_updated`
+- [ ] AC-B5: `POST /api/proposals/:id/reject` (user auth) is idempotent, conflicts on already-approved, writes audit, emits `proposal_updated`
+- [ ] AC-B6: `Proposal` schema in shared types matches the spec model above
+- [ ] AC-B7: Tests cover: cat auth happy path, stale guard, ownership rejection, idempotency, user approve happy path, double-approve idempotency, cross-user approve 403, approve-after-reject 409, reject happy path, reject-then-approve 409, edit-on-approve applied to created thread
 
-**Reviewer**: Ragdoll (Opus) + Maine Coon (Codex)
+### Frontend
 
-社区 PR #85 整包 Take-In 不可行，原建议拆三条线：
+- [ ] AC-F1: Proposal card renders in source thread on `proposal_created` socket event (no manual refresh)
+- [ ] AC-F2: Card prefills with cat-supplied fields; user can edit `title`, `parentThreadId`, `preferredCats`, `initialMessage` before approve
+- [ ] AC-F3: Approve button POSTs to `/api/proposals/:id/approve`; on success, sidebar shows new thread (via `thread_created` WS event); card flips to `approved` state with link to created thread
+- [ ] AC-F4: Reject button POSTs to `/api/proposals/:id/reject`; card flips to `rejected` state; thread is not created
+- [ ] AC-F5: Double-click protection on Approve/Reject (rely on backend idempotency + button disable on click)
+- [ ] AC-F6: Frontend tests cover render, edit, approve happy path, reject path, status flip via WS event
 
-| 线 | 范围 | 状态 |
-|----|------|------|
-| PR-A: API + MCP | callback route, MCP tool, parentThreadId, WebSocket, tests | 修 P2 后可合入 |
-| PR-B: 前端层级 UI | ThreadHierarchyToggle, thread-hierarchy.ts, Sidebar 改动 | 需 .pen 设计稿 + Sidebar 重构 |
-| PR-C: Skill | thread-orchestration SKILL.md + manifest | 适配后单独合入 |
+### Cross-cutting
 
-### 阻塞项（PR-A 合入前需修复）
+- [ ] AC-X1: All file sizes ≤ 350 lines (split routes/components if needed)
+- [ ] AC-X2: No `any` types
+- [ ] AC-X3: `MCP_TOOLS_SECTION` updated; `thread-orchestration` skill rewritten for propose-first
+- [ ] AC-X4: `pnpm check` + `pnpm lint` + all affected tests green
 
-1. **幂等性**：`create-thread` route 无 idempotency key，callbackPost 重试会创建重复 thread
-2. **parentThreadId 所有权校验**：当前接受任意 parentThreadId，可跨用户污染 children 索引
-3. **Redis N+1**：`getChildThreads` 逐个 `this.get(id)`，应用 pipeline
+## Risks
 
-### 建议改进
+| Risk | Mitigation |
+|------|-----------|
+| Proposal spam if cat ignores tool description | Rate limit per (userId, sourceThreadId) at store level; status visible to user in dashboard |
+| Approve race (two browser tabs) | Idempotency via `proposal.status` check + Redis WATCH/MULTI or single-route serialization |
+| Initial message posting fails after thread created | Thread creation already committed; post failure surfaces in API response; user can retry |
+| Frontend renders stale proposal status (cached card) | `proposal_updated` socket event triggers re-fetch; status read from store on click, not from cached block |
+| F190 console restructure conflicts with eventual PR-3 hierarchy UI | PR-3 is explicitly deferred and will design against post-F190 sidebar |
 
-4. softDelete/delete 应清理 children 索引
-5. `IThreadStore.create()` 4 个位置参数 → 建议 options 对象
-6. 合入时 squash commits
+## Out of scope
 
-### 2026-05-22 产品修正
+- Hierarchy sidebar UI (deferred to PR-3 or absorbed by F190 follow-up)
+- Cat-side polling for proposal status (cat returns control to user after proposing; doesn't wait synchronously)
+- Bulk approve/reject UI
 
-上述 review 聚焦在 PR #85 的技术拆分与 P2 缺陷；team lead在 2026-05-22 补充了更上层的产品判断：
+## Timeline
 
-> 猫猫创建 thread 之类的能力应该弹出一个卡片，填写好创建的信息，team lead点击再创建，不是悄摸摸创建。
+| Date | Event |
+|------|-------|
+| 2026-03-14 | v1 kickoff (direct-create semantics) |
+| 2026-03-14 ~ 03-31 | v1 implementation + maintainer reviews, blocked |
+| 2026-05-22 | Maintainer correction: switch to proposal-first; spec rewritten as v2 |
+| 2026-05-22 | Owner decision: single PR (no split) — backend + card UI ship together; hierarchy sidebar deferred |
+| TBD | Implementation complete + PR opened |
 
-因此 PR-A 的方向也需从 `cat_cafe_create_thread` 调整为 `cat_cafe_propose_thread`。幂等性、所有权校验、Redis pipeline 仍然有效，但它们属于 approve 后执行阶段的技术约束；产品入口不再是猫直接创建。
+## References
+
+- GitHub issue: #82
+- v1 PR (to close after v2 lands): #85
+- Maintainer correction comments: zts212653/clowder-ai#82#issuecomment-4516585087, zts212653/clowder-ai#85#issuecomment-4516589522
+- Reuse references: `RedisPendingRequestStore`, `request_permission` flow, `InteractiveBlock` / `CardBlock` rich block primitives

--- a/docs/features/index.json
+++ b/docs/features/index.json
@@ -782,8 +782,8 @@
     },
     {
       "id": "F128",
-      "name": "Cat-Proposed Thread Creation — 猫猫提议创建 Thread",
-      "status": "spec | **Source**: clowder-ai #82 (bouillipx) / PR #85 | **Priority**: P2",
+      "name": "Cat Thread Proposal (formerly \"Cat-Initiated Thread Creation\")",
+      "status": "spec v2 | **Owner**: opus | **Priority**: P1",
       "file": "F128-cat-create-thread.md"
     },
     {

--- a/packages/api/src/domains/cats/services/context/SystemPromptBuilder.ts
+++ b/packages/api/src/domains/cats/services/context/SystemPromptBuilder.ts
@@ -304,6 +304,7 @@ MCP 工具（异步汇报；token 有效期有限）：
 - cat_cafe_generate_document: 文档生成→IM投递
 - cat_cafe_get_rich_block_rules: rich block 规则
 - cat_cafe_multi_mention: 并行拉猫讨论（先搜后问）
+- cat_cafe_propose_thread: 提议新建 thread（创建提案卡片，**不直接创建 thread**）。返回 proposalId，仅在用户审批通过后后端才创建 thread。审批前必须假设 thread 不存在，不要 cross_post。仅在owner 显式要求或确有独立 long-running 讨论需求时使用。
 
 ${RICH_BLOCK_SHORT}
 需要富呈现时优先 rich block；首次使用前先 call get_rich_block_rules。

--- a/packages/api/src/domains/cats/services/stores/factories/ProposalStoreFactory.ts
+++ b/packages/api/src/domains/cats/services/stores/factories/ProposalStoreFactory.ts
@@ -1,0 +1,15 @@
+/**
+ * F128 Proposal Store Factory
+ * REDIS_URL set → RedisProposalStore
+ * otherwise → InMemoryProposalStore
+ */
+
+import type { RedisClient } from '@cat-cafe/shared/utils';
+import type { IProposalStore } from '../ports/ProposalStore.js';
+import { InMemoryProposalStore } from '../ports/ProposalStore.js';
+import { RedisProposalStore } from '../redis/RedisProposalStore.js';
+
+export function createProposalStore(redis?: RedisClient): IProposalStore {
+  if (redis) return new RedisProposalStore(redis);
+  return new InMemoryProposalStore();
+}

--- a/packages/api/src/domains/cats/services/stores/ports/ProposalStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ProposalStore.ts
@@ -1,0 +1,253 @@
+/**
+ * F128 Proposal Store
+ * Cats propose threads; users approve/reject. Proposal is the persistent
+ * record across the propose-approve flow.
+ */
+
+import type { CatId, ProposalApproveOverrides, ThreadProposal } from '@cat-cafe/shared';
+import { generateProposalId } from '@cat-cafe/shared';
+
+export interface CreateProposalInput {
+  sourceThreadId: string;
+  sourceInvocationId: string;
+  sourceCatId: CatId;
+  title: string;
+  reason: string;
+  parentThreadId: string;
+  preferredCats: CatId[];
+  projectPath: string;
+  initialMessage?: string;
+  createdBy: string;
+  /**
+   * Optional explicit proposalId. When supplied, the store uses this value instead of
+   * generating one. Used by the propose route to reserve a dedup key BEFORE creating
+   * the proposal, ensuring losers in a concurrent retry never produce orphan records.
+   */
+  proposalId?: string;
+}
+
+export interface ClaimForApprovalInput {
+  proposalId: string;
+  approvedBy: string;
+}
+
+export interface FinalizeApprovalInput {
+  proposalId: string;
+  createdThreadId: string;
+  overrides?: ProposalApproveOverrides;
+}
+
+export interface RejectProposalInput {
+  proposalId: string;
+  rejectedBy: string;
+  rejectionReason?: string;
+}
+
+export interface IProposalStore {
+  create(input: CreateProposalInput): ThreadProposal | Promise<ThreadProposal>;
+  get(proposalId: string): ThreadProposal | null | Promise<ThreadProposal | null>;
+  listByUser(userId: string, limit?: number): ThreadProposal[] | Promise<ThreadProposal[]>;
+  listPending(userId: string, limit?: number): ThreadProposal[] | Promise<ThreadProposal[]>;
+  listByThread(threadId: string, limit?: number): ThreadProposal[] | Promise<ThreadProposal[]>;
+  /**
+   * Atomic CAS pending → approving. Returns the claimed proposal snapshot, or null if status
+   * was not pending (e.g. already approved/rejected/claimed). Caller MUST call finalizeApproval
+   * or rollbackClaim afterwards.
+   */
+  claimForApproval(input: ClaimForApprovalInput): ThreadProposal | null | Promise<ThreadProposal | null>;
+  /** CAS approving → approved. Returns updated proposal or null if status drifted. */
+  finalizeApproval(input: FinalizeApprovalInput): ThreadProposal | null | Promise<ThreadProposal | null>;
+  /**
+   * Persist `createdThreadId` on an approving proposal WITHOUT changing status.
+   * Caller invokes this immediately after threadStore.create succeeds, BEFORE
+   * finalizeApproval. This makes the partial-commit state idempotently recoverable:
+   * if the process dies between create and finalize, the proposal records which
+   * thread already exists — stale-claim recovery can then re-finalize instead of
+   * rolling back (which would cause a duplicate thread on the next approve).
+   * No-op if proposal status is not 'approving'.
+   */
+  recordCreatedThread(proposalId: string, threadId: string): void | Promise<void>;
+  /** CAS approving → pending. Used when thread creation fails after claim. */
+  rollbackClaim(proposalId: string): boolean | Promise<boolean>;
+  /** CAS pending → rejected. Returns null if status is not pending (e.g. already approving/approved). */
+  markRejected(input: RejectProposalInput): ThreadProposal | null | Promise<ThreadProposal | null>;
+  /** Idempotency: return cached proposalId for (userId, clientRequestId) if any. */
+  getDedupProposalId(userId: string, clientRequestId: string): string | null | Promise<string | null>;
+  /**
+   * Idempotency: try to reserve (userId, clientRequestId) → proposalId atomically.
+   * Returns the proposalId actually stored — caller's value if newly reserved, or the existing
+   * value if a concurrent request beat it. Use the returned value as the canonical proposalId.
+   */
+  reserveDedup(userId: string, clientRequestId: string, proposalId: string): string | Promise<string>;
+  /**
+   * Mark the proposal as visible by recording the rich-card messageId that was appended to the
+   * source thread. Until this is set, dedup fast paths must treat the proposal as in-flight
+   * and not return it as a successful prior result.
+   */
+  setCardMessageId(proposalId: string, cardMessageId: string): void | Promise<void>;
+  /**
+   * Hard delete: remove proposal record and all index entries. Used to clean up after a
+   * partial-commit failure during propose (e.g. proposal created but its card message
+   * failed to post). Idempotent — no error if the proposal is already gone.
+   */
+  delete(proposalId: string): void | Promise<void>;
+  /**
+   * Idempotency cleanup: release the dedup reservation IF it currently points at expectedProposalId.
+   * Used when `create` fails after a successful reservation, so retries can reclaim the key.
+   * No-op if the key is missing or points at a different proposalId (defensive: never wipe
+   * someone else's winning reservation).
+   */
+  releaseDedup(userId: string, clientRequestId: string, expectedProposalId: string): void | Promise<void>;
+}
+
+const DEFAULT_LIST_LIMIT = 100;
+
+/**
+ * In-memory implementation for tests and single-process dev.
+ */
+export class InMemoryProposalStore implements IProposalStore {
+  private readonly proposals: Map<string, ThreadProposal> = new Map();
+  private readonly dedupCache: Map<string, string> = new Map();
+
+  create(input: CreateProposalInput): ThreadProposal {
+    const now = Date.now();
+    const proposal: ThreadProposal = {
+      proposalId: input.proposalId ?? generateProposalId(),
+      status: 'pending',
+      sourceThreadId: input.sourceThreadId,
+      sourceInvocationId: input.sourceInvocationId,
+      sourceCatId: input.sourceCatId,
+      title: input.title,
+      reason: input.reason,
+      parentThreadId: input.parentThreadId,
+      preferredCats: [...input.preferredCats],
+      projectPath: input.projectPath,
+      createdBy: input.createdBy,
+      createdAt: now,
+      ...(input.initialMessage ? { initialMessage: input.initialMessage } : {}),
+    };
+    this.proposals.set(proposal.proposalId, proposal);
+    return cloneProposal(proposal);
+  }
+
+  get(proposalId: string): ThreadProposal | null {
+    const found = this.proposals.get(proposalId);
+    return found ? cloneProposal(found) : null;
+  }
+
+  listByUser(userId: string, limit: number = DEFAULT_LIST_LIMIT): ThreadProposal[] {
+    return this.collect((p) => p.createdBy === userId, limit);
+  }
+
+  listPending(userId: string, limit: number = DEFAULT_LIST_LIMIT): ThreadProposal[] {
+    return this.collect((p) => p.createdBy === userId && p.status === 'pending', limit);
+  }
+
+  listByThread(threadId: string, limit: number = DEFAULT_LIST_LIMIT): ThreadProposal[] {
+    return this.collect((p) => p.sourceThreadId === threadId, limit);
+  }
+
+  claimForApproval(input: ClaimForApprovalInput): ThreadProposal | null {
+    const proposal = this.proposals.get(input.proposalId);
+    if (!proposal || proposal.status !== 'pending') return null;
+    proposal.status = 'approving';
+    proposal.approvedBy = input.approvedBy;
+    proposal.claimedAt = Date.now();
+    return cloneProposal(proposal);
+  }
+
+  finalizeApproval(input: FinalizeApprovalInput): ThreadProposal | null {
+    const proposal = this.proposals.get(input.proposalId);
+    if (!proposal || proposal.status !== 'approving') return null;
+    proposal.status = 'approved';
+    proposal.approvedAt = Date.now();
+    proposal.createdThreadId = input.createdThreadId;
+    delete proposal.claimedAt;
+    if (input.overrides?.title !== undefined) proposal.title = input.overrides.title;
+    if (input.overrides?.parentThreadId !== undefined) {
+      proposal.parentThreadId = input.overrides.parentThreadId;
+    }
+    if (input.overrides?.preferredCats !== undefined) {
+      proposal.preferredCats = [...input.overrides.preferredCats];
+    }
+    if (input.overrides?.initialMessage === null) {
+      delete proposal.initialMessage;
+    } else if (typeof input.overrides?.initialMessage === 'string') {
+      proposal.initialMessage = input.overrides.initialMessage;
+    }
+    return cloneProposal(proposal);
+  }
+
+  rollbackClaim(proposalId: string): boolean {
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal || proposal.status !== 'approving') return false;
+    proposal.status = 'pending';
+    delete proposal.approvedBy;
+    delete proposal.claimedAt;
+    return true;
+  }
+
+  recordCreatedThread(proposalId: string, threadId: string): void {
+    const proposal = this.proposals.get(proposalId);
+    if (!proposal || proposal.status !== 'approving') return;
+    proposal.createdThreadId = threadId;
+  }
+
+  markRejected(input: RejectProposalInput): ThreadProposal | null {
+    const proposal = this.proposals.get(input.proposalId);
+    if (!proposal || proposal.status !== 'pending') return null;
+    proposal.status = 'rejected';
+    proposal.rejectedBy = input.rejectedBy;
+    proposal.rejectedAt = Date.now();
+    if (input.rejectionReason) proposal.rejectionReason = input.rejectionReason;
+    return cloneProposal(proposal);
+  }
+
+  getDedupProposalId(userId: string, clientRequestId: string): string | null {
+    return this.dedupCache.get(dedupKey(userId, clientRequestId)) ?? null;
+  }
+
+  reserveDedup(userId: string, clientRequestId: string, proposalId: string): string {
+    const key = dedupKey(userId, clientRequestId);
+    const existing = this.dedupCache.get(key);
+    if (existing !== undefined) return existing;
+    this.dedupCache.set(key, proposalId);
+    return proposalId;
+  }
+
+  releaseDedup(userId: string, clientRequestId: string, expectedProposalId: string): void {
+    const key = dedupKey(userId, clientRequestId);
+    if (this.dedupCache.get(key) === expectedProposalId) {
+      this.dedupCache.delete(key);
+    }
+  }
+
+  setCardMessageId(proposalId: string, cardMessageId: string): void {
+    const proposal = this.proposals.get(proposalId);
+    if (proposal) proposal.cardMessageId = cardMessageId;
+  }
+
+  delete(proposalId: string): void {
+    this.proposals.delete(proposalId);
+  }
+
+  private collect(predicate: (p: ThreadProposal) => boolean, limit: number): ThreadProposal[] {
+    const result: ThreadProposal[] = [];
+    for (const proposal of this.proposals.values()) {
+      if (predicate(proposal)) result.push(cloneProposal(proposal));
+    }
+    result.sort((a, b) => b.createdAt - a.createdAt);
+    return result.slice(0, Math.max(0, limit));
+  }
+}
+
+function dedupKey(userId: string, clientRequestId: string): string {
+  return `${userId}::${clientRequestId}`;
+}
+
+function cloneProposal(proposal: ThreadProposal): ThreadProposal {
+  return {
+    ...proposal,
+    preferredCats: [...proposal.preferredCats],
+  };
+}

--- a/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
@@ -152,6 +152,16 @@ export interface Thread {
   deletedAt?: number | null;
   /** F087: CVO Bootcamp onboarding state. */
   bootcampState?: BootcampStateV1;
+  /** F128: Parent thread ID for orchestration tracking (sub-threads report back here). */
+  parentThreadId?: string;
+  /** F128: Proposal that led to this thread being created (audit metadata). */
+  createdFromProposalId?: string;
+  /** F128: Source thread the proposal was raised in (audit metadata). */
+  sourceThreadId?: string;
+  /** F128: User who approved the proposal (audit metadata). */
+  approvedBy?: string;
+  /** F128: Unix ms when the proposal was approved (audit metadata). */
+  approvedAt?: number;
   /** F171: First-Run Quest onboarding state. */
   firstRunQuestState?: FirstRunQuestStateV1;
   /** F192 livefix: System thread kind — determines sidebar "系统" section visibility.
@@ -165,6 +175,16 @@ export interface Thread {
   preferredWorkspaceMode?: 'dev' | 'recall' | 'schedule' | 'tasks' | 'community';
   /** F187: User-defined label IDs for thread categorization. */
   labels?: string[];
+}
+
+/**
+ * F128: Audit metadata written to a thread when it is created from an approved proposal.
+ */
+export interface ThreadProposalAudit {
+  createdFromProposalId: string;
+  sourceThreadId: string;
+  approvedBy: string;
+  approvedAt: number;
 }
 
 /** F088 Phase G: Connector Hub thread state for IM command isolation. */
@@ -301,7 +321,13 @@ export interface ILabelStore {
  * Common interface for thread stores (in-memory and future Redis).
  */
 export interface IThreadStore {
-  create(userId: string, title?: string, projectPath?: string): Thread | Promise<Thread>;
+  create(
+    userId: string,
+    title?: string,
+    projectPath?: string,
+    parentThreadId?: string,
+    proposalAudit?: ThreadProposalAudit,
+  ): Thread | Promise<Thread>;
   get(threadId: string): Thread | null | Promise<Thread | null>;
   list(userId: string): Thread[] | Promise<Thread[]>;
   listByProject(userId: string, projectPath: string): Thread[] | Promise<Thread[]>;
@@ -374,6 +400,8 @@ export interface IThreadStore {
   ensureExternalRuntimeAnchorThread(runtime: ExternalRuntimeAnchorRuntime, userId: string): Thread | Promise<Thread>;
   updateLastActive(threadId: string): void | Promise<void>;
   delete(threadId: string): boolean | Promise<boolean>;
+  /** F128: List child threads that have this thread as parentThreadId. */
+  getChildThreads(parentThreadId: string): Thread[] | Promise<Thread[]>;
   /** F095 Phase D: Soft-delete — mark thread as deleted without removing data. */
   softDelete(threadId: string): boolean | Promise<boolean>;
   /** F095 Phase D: Restore a soft-deleted thread. */
@@ -421,7 +449,13 @@ export class ThreadStore implements IThreadStore {
     return `${threadId}:${catId}`;
   }
 
-  create(userId: string, title?: string, projectPath?: string): Thread {
+  create(
+    userId: string,
+    title?: string,
+    projectPath?: string,
+    parentThreadId?: string,
+    proposalAudit?: ThreadProposalAudit,
+  ): Thread {
     this.evictIfNeeded();
 
     const thread: Thread = {
@@ -432,6 +466,15 @@ export class ThreadStore implements IThreadStore {
       participants: [],
       lastActiveAt: Date.now(),
       createdAt: Date.now(),
+      ...(parentThreadId ? { parentThreadId } : {}),
+      ...(proposalAudit
+        ? {
+            createdFromProposalId: proposalAudit.createdFromProposalId,
+            sourceThreadId: proposalAudit.sourceThreadId,
+            approvedBy: proposalAudit.approvedBy,
+            approvedAt: proposalAudit.approvedAt,
+          }
+        : {}),
     };
 
     this.threads.set(thread.id, thread);
@@ -804,6 +847,17 @@ export class ThreadStore implements IThreadStore {
     this.clearActivityForThread(threadId);
     this.clearMentionRoutingFeedbackForThread(threadId);
     return this.threads.delete(threadId);
+  }
+
+  /** F128: List child threads that have this thread as parentThreadId. */
+  getChildThreads(parentThreadId: string): Thread[] {
+    const children: Thread[] = [];
+    for (const thread of this.threads.values()) {
+      if (thread.parentThreadId === parentThreadId && !thread.deletedAt) {
+        children.push(thread);
+      }
+    }
+    return children.sort((a, b) => a.createdAt - b.createdAt);
   }
 
   /** F095 Phase D: Soft-delete — mark thread as deleted. */

--- a/packages/api/src/domains/cats/services/stores/redis-keys/proposal-keys.ts
+++ b/packages/api/src/domains/cats/services/stores/redis-keys/proposal-keys.ts
@@ -1,0 +1,24 @@
+/**
+ * Redis key patterns for F128 thread proposal storage.
+ * All keys share the cat-cafe: prefix set by the Redis client.
+ */
+
+export const ProposalKeys = {
+  /** Hash with proposal fields: proposal:{proposalId} */
+  detail: (id: string) => `proposal:${id}`,
+
+  /** Sorted set of all proposal IDs for a user (score = createdAt): proposals:user:{userId} */
+  userList: (userId: string) => `proposals:user:${userId}`,
+
+  /** Sorted set of pending-only proposal IDs for a user: proposals:pending:{userId} */
+  userPending: (userId: string) => `proposals:pending:${userId}`,
+
+  /** Sorted set of proposal IDs proposed in a given source thread: proposals:thread:{threadId} */
+  threadList: (threadId: string) => `proposals:thread:${threadId}`,
+
+  /**
+   * Idempotency cache for cat propose calls: dedup:propose:{userId}:{clientRequestId} → proposalId
+   * Short TTL (minutes), strictly per-user.
+   */
+  dedup: (userId: string, clientRequestId: string) => `dedup:propose:${userId}:${clientRequestId}`,
+} as const;

--- a/packages/api/src/domains/cats/services/stores/redis-keys/thread-keys.ts
+++ b/packages/api/src/domains/cats/services/stores/redis-keys/thread-keys.ts
@@ -21,6 +21,9 @@ export const ThreadKeys = {
   /** F046 D3: One-shot suppressed mention routing feedback per cat. */
   mentionRoutingFeedback: (id: string) => `thread:${id}:mention-routing-feedback`,
 
+  /** F128: Sorted set of child thread IDs: thread:{parentId}:children */
+  children: (parentId: string) => `thread:${parentId}:children`,
+
   /** Tombstone left by hard-delete to prevent self-healing resurrection. */
   tombstone: (id: string) => `thread:${id}:tombstone`,
 } as const;

--- a/packages/api/src/domains/cats/services/stores/redis/RedisProposalStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisProposalStore.ts
@@ -1,0 +1,281 @@
+/**
+ * Redis-backed F128 Proposal store.
+ *
+ * Data structures:
+ * - Hash proposal:{proposalId} — proposal fields
+ * - SortedSet proposals:user:{userId} — all proposals for user (score=createdAt)
+ * - SortedSet proposals:pending:{userId} — pending-only ids (zrem on approve/reject)
+ * - SortedSet proposals:thread:{threadId} — proposals proposed in a thread
+ * - String dedup:propose:{userId}:{clientRequestId} → proposalId (short TTL)
+ *
+ * IMPORTANT: ioredis keyPrefix auto-prefixes ALL commands.
+ */
+
+import type { ProposalStatus, ThreadProposal } from '@cat-cafe/shared';
+import { generateProposalId } from '@cat-cafe/shared';
+import type { RedisClient } from '@cat-cafe/shared/utils';
+import type {
+  ClaimForApprovalInput,
+  CreateProposalInput,
+  FinalizeApprovalInput,
+  IProposalStore,
+  RejectProposalInput,
+} from '../ports/ProposalStore.js';
+import { ProposalKeys } from '../redis-keys/proposal-keys.js';
+import {
+  applyFinalize,
+  CAS_TRANSITION_LUA,
+  hydrateProposal,
+  RECORD_CREATED_THREAD_LUA,
+  RELEASE_DEDUP_LUA,
+  serializeProposal,
+} from './RedisProposalStoreHelpers.js';
+
+const DEFAULT_DEDUP_TTL_SECONDS = 10 * 60; // 10 minutes — idempotency key only, not user-visible state
+const DEFAULT_LIST_LIMIT = 100;
+
+export class RedisProposalStore implements IProposalStore {
+  private readonly redis: RedisClient;
+  private readonly ttlSeconds: number | null;
+  private readonly dedupTtlSeconds: number;
+
+  constructor(redis: RedisClient, options?: { ttlSeconds?: number; dedupTtlSeconds?: number }) {
+    this.redis = redis;
+    // Iron law #5 (LL-048): user-visible/recoverable state defaults to persistent (no TTL).
+    // Proposal hashes carry approval-card UI state + audit lineage (createdFromProposalId);
+    // an automatic expiry would 404 old cards, orphan pending/user/thread zset members, and
+    // erase the approval trail. TTL is only set when the caller explicitly opts in with
+    // ttlSeconds > 0.
+    const ttl = options?.ttlSeconds;
+    if (ttl !== undefined && Number.isFinite(ttl) && ttl > 0) {
+      this.ttlSeconds = Math.floor(ttl);
+    } else {
+      this.ttlSeconds = null;
+    }
+    this.dedupTtlSeconds = options?.dedupTtlSeconds ?? DEFAULT_DEDUP_TTL_SECONDS;
+  }
+
+  async create(input: CreateProposalInput): Promise<ThreadProposal> {
+    const now = Date.now();
+    const proposal: ThreadProposal = {
+      proposalId: input.proposalId ?? generateProposalId(),
+      status: 'pending',
+      sourceThreadId: input.sourceThreadId,
+      sourceInvocationId: input.sourceInvocationId,
+      sourceCatId: input.sourceCatId,
+      title: input.title,
+      reason: input.reason,
+      parentThreadId: input.parentThreadId,
+      preferredCats: [...input.preferredCats],
+      projectPath: input.projectPath,
+      createdBy: input.createdBy,
+      createdAt: now,
+      ...(input.initialMessage ? { initialMessage: input.initialMessage } : {}),
+    };
+
+    const key = ProposalKeys.detail(proposal.proposalId);
+    const pipeline = this.redis.multi();
+    pipeline.hset(key, ...this.serialize(proposal));
+    if (this.ttlSeconds) pipeline.expire(key, this.ttlSeconds);
+    pipeline.zadd(ProposalKeys.userList(proposal.createdBy), String(now), proposal.proposalId);
+    pipeline.zadd(ProposalKeys.userPending(proposal.createdBy), String(now), proposal.proposalId);
+    pipeline.zadd(ProposalKeys.threadList(proposal.sourceThreadId), String(now), proposal.proposalId);
+    await pipeline.exec();
+    return proposal;
+  }
+
+  async get(proposalId: string): Promise<ThreadProposal | null> {
+    const data = await this.redis.hgetall(ProposalKeys.detail(proposalId));
+    if (!data || !data.proposalId) return null;
+    return this.hydrate(data);
+  }
+
+  async listByUser(userId: string, limit: number = DEFAULT_LIST_LIMIT): Promise<ThreadProposal[]> {
+    return this.loadFromIndex(ProposalKeys.userList(userId), limit);
+  }
+
+  async listPending(userId: string, limit: number = DEFAULT_LIST_LIMIT): Promise<ThreadProposal[]> {
+    return this.loadFromIndex(ProposalKeys.userPending(userId), limit);
+  }
+
+  async listByThread(threadId: string, limit: number = DEFAULT_LIST_LIMIT): Promise<ThreadProposal[]> {
+    return this.loadFromIndex(ProposalKeys.threadList(threadId), limit);
+  }
+
+  async claimForApproval(input: ClaimForApprovalInput): Promise<ThreadProposal | null> {
+    const proposal = await this.get(input.proposalId);
+    if (!proposal || proposal.status !== 'pending') return null;
+    const claimedAt = Date.now();
+    const ok = await this.casTransition(proposal.proposalId, proposal.createdBy, 'pending', 'zrem', '', [
+      'status',
+      'approving',
+      'approvedBy',
+      input.approvedBy,
+      'claimedAt',
+      String(claimedAt),
+    ]);
+    if (!ok) return null;
+    return { ...proposal, status: 'approving', approvedBy: input.approvedBy, claimedAt };
+  }
+
+  async finalizeApproval(input: FinalizeApprovalInput): Promise<ThreadProposal | null> {
+    const proposal = await this.get(input.proposalId);
+    if (!proposal || proposal.status !== 'approving') return null;
+    const now = Date.now();
+    const updated = applyFinalize(proposal, input, now);
+    const pairs = this.finalizedFields(updated);
+    const ok = await this.casTransition(updated.proposalId, updated.createdBy, 'approving', 'noop', '', pairs);
+    return ok ? updated : null;
+  }
+
+  async recordCreatedThread(proposalId: string, threadId: string): Promise<void> {
+    await this.redis.eval(RECORD_CREATED_THREAD_LUA, 1, ProposalKeys.detail(proposalId), threadId);
+  }
+
+  async rollbackClaim(proposalId: string): Promise<boolean> {
+    const proposal = await this.get(proposalId);
+    if (!proposal || proposal.status !== 'approving') return false;
+    return this.casTransition(
+      proposal.proposalId,
+      proposal.createdBy,
+      'approving',
+      'zadd',
+      String(proposal.createdAt),
+      ['status', 'pending', 'approvedBy', '', 'claimedAt', '0'],
+    );
+  }
+
+  async markRejected(input: RejectProposalInput): Promise<ThreadProposal | null> {
+    const proposal = await this.get(input.proposalId);
+    if (!proposal || proposal.status !== 'pending') return null;
+    const now = Date.now();
+    const updated: ThreadProposal = {
+      ...proposal,
+      status: 'rejected',
+      rejectedBy: input.rejectedBy,
+      rejectedAt: now,
+      ...(input.rejectionReason ? { rejectionReason: input.rejectionReason } : {}),
+    };
+    const pairs = ['status', 'rejected', 'rejectedBy', input.rejectedBy, 'rejectedAt', String(now)];
+    if (input.rejectionReason) pairs.push('rejectionReason', input.rejectionReason);
+    const ok = await this.casTransition(updated.proposalId, updated.createdBy, 'pending', 'zrem', '', pairs);
+    return ok ? updated : null;
+  }
+
+  async getDedupProposalId(userId: string, clientRequestId: string): Promise<string | null> {
+    return this.redis.get(ProposalKeys.dedup(userId, clientRequestId));
+  }
+
+  /** Atomic SET NX: returns the value actually stored (newly set or existing). */
+  async reserveDedup(userId: string, clientRequestId: string, proposalId: string): Promise<string> {
+    const key = ProposalKeys.dedup(userId, clientRequestId);
+    const result = await this.redis.set(key, proposalId, 'EX', this.dedupTtlSeconds, 'NX');
+    if (result === 'OK') return proposalId;
+    const existing = await this.redis.get(key);
+    return existing ?? proposalId;
+  }
+
+  /**
+   * Mark the proposal as visible: persist the rich-card messageId. Until this is set,
+   * dedup fast paths return 503 retryable so callers don't act on a phantom proposalId.
+   */
+  async setCardMessageId(proposalId: string, cardMessageId: string): Promise<void> {
+    await this.redis.hset(ProposalKeys.detail(proposalId), 'cardMessageId', cardMessageId);
+  }
+
+  /**
+   * Hard delete: remove proposal hash + all index entries. Idempotent.
+   * Used to clean up after propose's card append fails so retries can re-create a visible card.
+   */
+  async delete(proposalId: string): Promise<void> {
+    const proposal = await this.get(proposalId);
+    const pipeline = this.redis.multi();
+    pipeline.del(ProposalKeys.detail(proposalId));
+    if (proposal) {
+      pipeline.zrem(ProposalKeys.userList(proposal.createdBy), proposalId);
+      pipeline.zrem(ProposalKeys.userPending(proposal.createdBy), proposalId);
+      pipeline.zrem(ProposalKeys.threadList(proposal.sourceThreadId), proposalId);
+    }
+    await pipeline.exec();
+  }
+
+  /**
+   * Release a previously reserved dedup key IF it still points at expectedProposalId.
+   * Uses a small Lua script for atomic compare-and-delete so we never wipe a sibling's
+   * reservation if a different winner has already replaced the key.
+   */
+  async releaseDedup(userId: string, clientRequestId: string, expectedProposalId: string): Promise<void> {
+    await this.redis.eval(RELEASE_DEDUP_LUA, 1, ProposalKeys.dedup(userId, clientRequestId), expectedProposalId);
+  }
+
+  private async casTransition(
+    proposalId: string,
+    userId: string,
+    expectedStatus: ProposalStatus,
+    pendingIndexAction: 'zrem' | 'zadd' | 'noop',
+    zaddScore: string,
+    fieldPairs: string[],
+  ): Promise<boolean> {
+    const result = (await this.redis.eval(
+      CAS_TRANSITION_LUA,
+      2,
+      ProposalKeys.detail(proposalId),
+      ProposalKeys.userPending(userId),
+      proposalId,
+      expectedStatus,
+      pendingIndexAction,
+      zaddScore,
+      ...fieldPairs,
+    )) as number;
+    return result === 1;
+  }
+
+  private finalizedFields(updated: ThreadProposal): string[] {
+    const fields: string[] = [
+      'status',
+      'approved',
+      'approvedAt',
+      String(updated.approvedAt ?? 0),
+      'claimedAt',
+      '0',
+      'title',
+      updated.title,
+      'parentThreadId',
+      updated.parentThreadId,
+      'preferredCats',
+      JSON.stringify(updated.preferredCats),
+    ];
+    if (updated.createdThreadId) fields.push('createdThreadId', updated.createdThreadId);
+    if (updated.initialMessage !== undefined) {
+      fields.push('initialMessage', updated.initialMessage);
+    } else {
+      fields.push('initialMessage', '');
+    }
+    return fields;
+  }
+
+  private async loadFromIndex(indexKey: string, limit: number): Promise<ThreadProposal[]> {
+    const ids = await this.redis.zrevrange(indexKey, 0, Math.max(0, limit - 1));
+    if (ids.length === 0) return [];
+    const pipeline = this.redis.pipeline();
+    for (const id of ids) pipeline.hgetall(ProposalKeys.detail(id));
+    const results = await pipeline.exec();
+    if (!results) return [];
+    const records: ThreadProposal[] = [];
+    for (const [err, data] of results) {
+      if (err || !data || typeof data !== 'object') continue;
+      const d = data as Record<string, string>;
+      if (!d.proposalId) continue;
+      records.push(hydrateProposal(d));
+    }
+    return records;
+  }
+
+  private serialize(proposal: ThreadProposal): string[] {
+    return serializeProposal(proposal);
+  }
+
+  private hydrate(data: Record<string, string>): ThreadProposal {
+    return hydrateProposal(data);
+  }
+}

--- a/packages/api/src/domains/cats/services/stores/redis/RedisProposalStoreHelpers.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisProposalStoreHelpers.ts
@@ -1,0 +1,148 @@
+/**
+ * F128 RedisProposalStore — extracted helpers (Lua + serialize/hydrate + overrides).
+ * Split out of RedisProposalStore.ts to keep both files under the 350-line hard limit (AC-X1).
+ */
+
+import type { CatId, ProposalApproveOverrides, ProposalStatus, ThreadProposal } from '@cat-cafe/shared';
+import type { FinalizeApprovalInput } from '../ports/ProposalStore.js';
+
+/**
+ * CAS Lua: atomically check current status matches expected → HSET fields + ZREM/ZADD pending index.
+ * KEYS[1] = proposal:{id}, KEYS[2] = proposals:pending:{userId}
+ * ARGV[1] = proposalId
+ * ARGV[2] = expected status (e.g. "pending")
+ * ARGV[3] = pending-index action: "zrem" | "zadd" | "noop"
+ * ARGV[4] = score for zadd (createdAt), required when action="zadd"
+ * ARGV[5..N] = HSET field/value pairs
+ * Returns 1 on success, 0 if current status doesn't match expected.
+ */
+export const CAS_TRANSITION_LUA = `
+local current = redis.call('HGET', KEYS[1], 'status')
+if current ~= ARGV[2] then
+  return 0
+end
+local fields = {}
+for i = 5, #ARGV do
+  fields[#fields + 1] = ARGV[i]
+end
+if #fields > 0 then
+  redis.call('HSET', KEYS[1], unpack(fields))
+end
+if ARGV[3] == 'zrem' then
+  redis.call('ZREM', KEYS[2], ARGV[1])
+elseif ARGV[3] == 'zadd' then
+  redis.call('ZADD', KEYS[2], ARGV[4], ARGV[1])
+end
+return 1
+`;
+
+/** SET NX style release: delete dedup key only if value matches expected. */
+export const RELEASE_DEDUP_LUA = `
+local current = redis.call('GET', KEYS[1])
+if current == ARGV[1] then
+  redis.call('DEL', KEYS[1])
+end
+return 1
+`;
+
+/** Conditional HSET: write createdThreadId only if proposal status is still 'approving'. */
+export const RECORD_CREATED_THREAD_LUA = `
+local current = redis.call('HGET', KEYS[1], 'status')
+if current == 'approving' then
+  redis.call('HSET', KEYS[1], 'createdThreadId', ARGV[1])
+end
+return 1
+`;
+
+export function serializeProposal(proposal: ThreadProposal): string[] {
+  const fields: string[] = [
+    'proposalId',
+    proposal.proposalId,
+    'status',
+    proposal.status,
+    'sourceThreadId',
+    proposal.sourceThreadId,
+    'sourceInvocationId',
+    proposal.sourceInvocationId,
+    'sourceCatId',
+    proposal.sourceCatId,
+    'title',
+    proposal.title,
+    'reason',
+    proposal.reason,
+    'parentThreadId',
+    proposal.parentThreadId,
+    'preferredCats',
+    JSON.stringify(proposal.preferredCats),
+    'projectPath',
+    proposal.projectPath,
+    'createdBy',
+    proposal.createdBy,
+    'createdAt',
+    String(proposal.createdAt),
+  ];
+  if (proposal.initialMessage) fields.push('initialMessage', proposal.initialMessage);
+  if (proposal.cardMessageId) fields.push('cardMessageId', proposal.cardMessageId);
+  return fields;
+}
+
+export function hydrateProposal(data: Record<string, string>): ThreadProposal {
+  const preferredCats = parseCatArray(data.preferredCats);
+  const initialMessage = data.initialMessage && data.initialMessage.length > 0 ? data.initialMessage : undefined;
+  const proposal: ThreadProposal = {
+    proposalId: data.proposalId!,
+    status: (data.status ?? 'pending') as ProposalStatus,
+    sourceThreadId: data.sourceThreadId!,
+    sourceInvocationId: data.sourceInvocationId!,
+    sourceCatId: data.sourceCatId! as CatId,
+    title: data.title!,
+    reason: data.reason!,
+    parentThreadId: data.parentThreadId!,
+    preferredCats,
+    projectPath: data.projectPath!,
+    createdBy: data.createdBy!,
+    createdAt: parseInt(data.createdAt!, 10),
+  };
+  if (initialMessage) proposal.initialMessage = initialMessage;
+  if (data.approvedBy) proposal.approvedBy = data.approvedBy;
+  if (data.approvedAt) proposal.approvedAt = parseInt(data.approvedAt, 10);
+  if (data.createdThreadId) proposal.createdThreadId = data.createdThreadId;
+  if (data.rejectedBy) proposal.rejectedBy = data.rejectedBy;
+  if (data.rejectedAt) proposal.rejectedAt = parseInt(data.rejectedAt, 10);
+  if (data.rejectionReason) proposal.rejectionReason = data.rejectionReason;
+  if (data.cardMessageId) proposal.cardMessageId = data.cardMessageId;
+  const claimedAt = parseInt(data.claimedAt ?? '0', 10);
+  if (claimedAt > 0) proposal.claimedAt = claimedAt;
+  return proposal;
+}
+
+export function applyFinalize(proposal: ThreadProposal, input: FinalizeApprovalInput, now: number): ThreadProposal {
+  const updated: ThreadProposal = {
+    ...proposal,
+    status: 'approved',
+    approvedAt: now,
+    createdThreadId: input.createdThreadId,
+  };
+  applyOverrides(updated, input.overrides);
+  return updated;
+}
+
+export function applyOverrides(proposal: ThreadProposal, overrides: ProposalApproveOverrides | undefined): void {
+  if (!overrides) return;
+  if (overrides.title !== undefined) proposal.title = overrides.title;
+  if (overrides.parentThreadId !== undefined) proposal.parentThreadId = overrides.parentThreadId;
+  if (overrides.preferredCats !== undefined) proposal.preferredCats = [...overrides.preferredCats];
+  if (overrides.initialMessage === null) delete proposal.initialMessage;
+  else if (typeof overrides.initialMessage === 'string') proposal.initialMessage = overrides.initialMessage;
+}
+
+function parseCatArray(raw: string | undefined): CatId[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === 'string').map((entry) => entry as CatId);
+  } catch {
+    return [];
+  }
+}

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -158,7 +158,13 @@ export class RedisThreadStore implements IThreadStore {
     }
   }
 
-  async create(userId: string, title?: string, projectPath?: string): Promise<Thread> {
+  async create(
+    userId: string,
+    title?: string,
+    projectPath?: string,
+    parentThreadId?: string,
+    proposalAudit?: import('../ports/ThreadStore.js').ThreadProposalAudit,
+  ): Promise<Thread> {
     const now = Date.now();
     const thread: Thread = {
       id: generateThreadId(),
@@ -168,6 +174,15 @@ export class RedisThreadStore implements IThreadStore {
       participants: [],
       lastActiveAt: now,
       createdAt: now,
+      ...(parentThreadId ? { parentThreadId } : {}),
+      ...(proposalAudit
+        ? {
+            createdFromProposalId: proposalAudit.createdFromProposalId,
+            sourceThreadId: proposalAudit.sourceThreadId,
+            approvedBy: proposalAudit.approvedBy,
+            approvedAt: proposalAudit.approvedAt,
+          }
+        : {}),
     };
 
     const key = ThreadKeys.detail(thread.id);
@@ -179,6 +194,14 @@ export class RedisThreadStore implements IThreadStore {
     pipeline.zadd(ThreadKeys.userList(userId), String(now), thread.id);
     if (this.ttlSeconds !== null) {
       pipeline.expire(ThreadKeys.userList(userId), this.ttlSeconds);
+    }
+    // F128: Maintain parent→children secondary index
+    if (parentThreadId) {
+      const childrenKey = ThreadKeys.children(parentThreadId);
+      pipeline.zadd(childrenKey, String(now), thread.id);
+      if (this.ttlSeconds !== null) {
+        pipeline.expire(childrenKey, this.ttlSeconds);
+      }
     }
     await pipeline.exec();
 
@@ -612,6 +635,32 @@ export class RedisThreadStore implements IThreadStore {
     }
   }
 
+  /** F128: List child threads that have this thread as parentThreadId. Pipeline to avoid N+1. */
+  async getChildThreads(parentThreadId: string): Promise<Thread[]> {
+    const childIds = await this.redis.zrange(ThreadKeys.children(parentThreadId), 0, -1);
+    if (!childIds.length) return [];
+    // Pipeline: fetch all thread hashes + participant sets in one round-trip
+    const pipeline = this.redis.multi();
+    for (const id of childIds) {
+      pipeline.hgetall(ThreadKeys.detail(id));
+      pipeline.smembers(ThreadKeys.participants(id));
+    }
+    const results = await pipeline.exec();
+    if (!results) return [];
+    const children: Thread[] = [];
+    for (let i = 0; i < childIds.length; i++) {
+      const dataResult = results[i * 2];
+      const membersResult = results[i * 2 + 1];
+      if (!dataResult || dataResult[0]) continue; // error
+      const data = dataResult[1] as Record<string, string>;
+      if (!data || !data.id) continue;
+      const thread = this.hydrateThread(data);
+      thread.participants = ((membersResult?.[1] as string[]) ?? []) as import('@cat-cafe/shared').CatId[];
+      if (!thread.deletedAt) children.push(thread);
+    }
+    return children;
+  }
+
   /** F095 Phase D: Soft-delete — set deletedAt timestamp. */
   async softDelete(threadId: string): Promise<boolean> {
     if (threadId === DEFAULT_THREAD_ID) return false;
@@ -622,6 +671,11 @@ export class RedisThreadStore implements IThreadStore {
     const existingDeletedAt = await this.redis.hget(key, 'deletedAt');
     if (existingDeletedAt && parseInt(existingDeletedAt, 10) > 0) return false;
     await this.redis.hset(key, 'deletedAt', String(Date.now()));
+    // P3-4: Remove from parent's children index
+    const parentId = await this.redis.hget(key, 'parentThreadId');
+    if (parentId) {
+      await this.redis.zrem(ThreadKeys.children(parentId), threadId);
+    }
     await this.applyKeyRetention([key]);
     return true;
   }
@@ -634,6 +688,19 @@ export class RedisThreadStore implements IThreadStore {
     const existingDeletedAt = await this.redis.hget(key, 'deletedAt');
     if (!existingDeletedAt || parseInt(existingDeletedAt, 10) <= 0) return false;
     await this.redis.hset(key, 'deletedAt', '0');
+    // P2 (Codex review): softDelete strips the child from its parent's children ZSET; restore
+    // must put it back so getChildThreads() stays consistent after a soft-delete/restore cycle.
+    const [parentId, createdAt] = await Promise.all([
+      this.redis.hget(key, 'parentThreadId'),
+      this.redis.hget(key, 'createdAt'),
+    ]);
+    if (parentId) {
+      const score = createdAt && parseInt(createdAt, 10) > 0 ? createdAt : String(Date.now());
+      await this.redis.zadd(ThreadKeys.children(parentId), score, threadId);
+      if (this.ttlSeconds !== null) {
+        await this.redis.expire(ThreadKeys.children(parentId), this.ttlSeconds);
+      }
+    }
     await this.applyKeyRetention([key]);
     return true;
   }
@@ -953,6 +1020,23 @@ export class RedisThreadStore implements IThreadStore {
     if (thread.bootcampState) {
       result.bootcampState = JSON.stringify(thread.bootcampState);
     }
+    // F128: Parent thread for orchestration tracking
+    if (thread.parentThreadId) {
+      result.parentThreadId = thread.parentThreadId;
+    }
+    // F128: Proposal audit metadata (only present on threads created via approve flow)
+    if (thread.createdFromProposalId) {
+      result.createdFromProposalId = thread.createdFromProposalId;
+    }
+    if (thread.sourceThreadId) {
+      result.sourceThreadId = thread.sourceThreadId;
+    }
+    if (thread.approvedBy) {
+      result.approvedBy = thread.approvedBy;
+    }
+    if (thread.approvedAt) {
+      result.approvedAt = String(thread.approvedAt);
+    }
     if (thread.firstRunQuestState) {
       result.firstRunQuestState = JSON.stringify(thread.firstRunQuestState);
     }
@@ -1050,6 +1134,24 @@ export class RedisThreadStore implements IThreadStore {
       } catch {
         /* ignore malformed JSON */
       }
+    }
+    // F128: Parent thread for orchestration tracking
+    if (data.parentThreadId) {
+      result.parentThreadId = data.parentThreadId;
+    }
+    // F128: Proposal audit metadata
+    if (data.createdFromProposalId) {
+      result.createdFromProposalId = data.createdFromProposalId;
+    }
+    if (data.sourceThreadId) {
+      result.sourceThreadId = data.sourceThreadId;
+    }
+    if (data.approvedBy) {
+      result.approvedBy = data.approvedBy;
+    }
+    const approvedAt = parseInt(data.approvedAt ?? '0', 10);
+    if (approvedAt > 0) {
+      result.approvedAt = approvedAt;
     }
     if (data.firstRunQuestState) {
       try {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -87,6 +87,7 @@ import { createLabelStore } from './domains/cats/services/stores/factories/Label
 import { createMemoryStore } from './domains/cats/services/stores/factories/MemoryStoreFactory.js';
 import { createMessageStore } from './domains/cats/services/stores/factories/MessageStoreFactory.js';
 import { createPendingRequestStore } from './domains/cats/services/stores/factories/PendingRequestStoreFactory.js';
+import { createProposalStore } from './domains/cats/services/stores/factories/ProposalStoreFactory.js';
 import { createPushSubscriptionStore } from './domains/cats/services/stores/factories/PushSubscriptionStoreFactory.js';
 import { createReadStateStore } from './domains/cats/services/stores/factories/ReadStateStoreFactory.js';
 import { createSummaryStore } from './domains/cats/services/stores/factories/SummaryStoreFactory.js';
@@ -179,6 +180,7 @@ import {
   projectSetupRoute,
   projectsBootstrapRoutes,
   projectsRoutes,
+  proposalRoutes,
   pushRoutes,
   queueRoutes,
   quotaRoutes,
@@ -470,6 +472,7 @@ async function main(): Promise<void> {
   const sessionStore = redis ? new SessionStore(redis) : undefined;
   const deliveryCursorStore = new DeliveryCursorStore(sessionStore);
   const threadStore = createThreadStore(redis);
+  const proposalStore = createProposalStore(redis);
   // F155 B-4/B-6: Guide state is runtime-only (in-memory, resets on restart)
   const { InMemoryGuideSessionStore } = await import('./domains/guides/GuideSessionRepository.js');
   const guideSessionStore = new InMemoryGuideSessionStore();
@@ -1596,6 +1599,7 @@ async function main(): Promise<void> {
     threadStore,
     sessionChainStore,
     runtimeSessionStore,
+    proposalStore,
     agentRegistry,
     router,
     invocationRecordStore,
@@ -1669,6 +1673,15 @@ async function main(): Promise<void> {
     socketManager,
   });
   await app.register(threadExportRoutes, { threadStore });
+  await app.register(proposalRoutes, {
+    proposalStore,
+    threadStore,
+    messageStore,
+    socketManager,
+    router,
+    invocationQueue,
+    queueProcessor,
+  });
   // F142: shared connector binding store — reused by threadCatsRoutes AND connector gateway
   const { RedisConnectorThreadBindingStore } = await import(
     './infrastructure/connectors/RedisConnectorThreadBindingStore.js'

--- a/packages/api/src/routes/callback-propose-thread-routes.ts
+++ b/packages/api/src/routes/callback-propose-thread-routes.ts
@@ -1,0 +1,327 @@
+/**
+ * F128 Cat-side propose-thread callback route.
+ *
+ * POST /api/callbacks/propose-thread
+ *   Cat-auth. Creates a Proposal (status=pending); does NOT create a thread.
+ *   Idempotent via clientRequestId.
+ *
+ * The companion approve/reject endpoints are user-authenticated and live in
+ * proposal-routes.ts.
+ */
+
+import type { CatId, RichCardBlock, ThreadProposal } from '@cat-cafe/shared';
+import { catIdSchema, generateProposalId } from '@cat-cafe/shared';
+import type { FastifyInstance } from 'fastify';
+import { z } from 'zod';
+import type { InvocationRegistry } from '../domains/cats/services/agents/invocation/InvocationRegistry.js';
+import type { IMessageStore } from '../domains/cats/services/stores/ports/MessageStore.js';
+import type { IProposalStore } from '../domains/cats/services/stores/ports/ProposalStore.js';
+import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
+import type { SocketManager } from '../infrastructure/websocket/index.js';
+import { normalizeCatIdMentionsInText } from '../utils/cat-mention-handle.js';
+import { requireCallbackAuth } from './callback-auth-prehandler.js';
+
+const proposeThreadCallbackSchema = z.object({
+  title: z.string().trim().min(1).max(200),
+  reason: z.string().trim().min(1).max(1000),
+  preferredCats: z.array(catIdSchema()).max(10).optional(),
+  initialMessage: z.string().max(4000).optional(),
+  parentThreadId: z.string().min(1).optional(),
+  clientRequestId: z.string().min(1).max(200).optional(),
+});
+
+export interface ProposeThreadDeps {
+  registry: InvocationRegistry;
+  proposalStore: IProposalStore;
+  threadStore: IThreadStore;
+  messageStore: IMessageStore;
+  socketManager: SocketManager;
+}
+
+export function buildProposalCardBlock(proposal: ThreadProposal): RichCardBlock {
+  const fields: Array<{ label: string; value: string }> = [
+    { label: '父 Thread', value: proposal.parentThreadId },
+    {
+      label: '建议成员',
+      value: proposal.preferredCats.length > 0 ? proposal.preferredCats.join(', ') : '（未指定）',
+    },
+  ];
+  if (proposal.initialMessage) fields.push({ label: '首条消息', value: proposal.initialMessage });
+  return {
+    id: `proposal-${proposal.proposalId}`,
+    kind: 'card',
+    v: 1,
+    title: `📥 提议新建 thread：${proposal.title}`,
+    bodyMarkdown: proposal.reason,
+    tone: 'info',
+    fields,
+    actions: [
+      { label: '批准并创建', action: 'propose:approve', payload: { proposalId: proposal.proposalId } },
+      { label: '驳回', action: 'propose:reject', payload: { proposalId: proposal.proposalId } },
+    ],
+  };
+}
+
+export function registerCallbackProposeThreadRoutes(app: FastifyInstance, deps: ProposeThreadDeps): void {
+  const { registry, proposalStore, threadStore, messageStore, socketManager } = deps;
+
+  app.post('/api/callbacks/propose-thread', async (request, reply) => {
+    const record = requireCallbackAuth(request, reply);
+    if (!record) return;
+
+    const parsed = proposeThreadCallbackSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.status(400);
+      return { error: 'Invalid request body', details: parsed.error.issues };
+    }
+
+    const {
+      title,
+      reason,
+      preferredCats,
+      initialMessage: rawInitialMessage,
+      parentThreadId,
+      clientRequestId,
+    } = parsed.data;
+    const invocationId = record.invocationId;
+
+    // F128: cats sometimes paste raw catIds (`@cat-rcs85pvn`) from
+    // `cat_cafe_get_thread_cats` output into `initialMessage` instead of the
+    // stable handle (`@砚砚` / `@opus46`). Raw catIds aren't in the router's
+    // mentionPatterns, so downstream `router.parseAllMentions` won't see them
+    // as mentions — dispatch then walks `preferredCats` in the wrong order.
+    // Normalize at the propose boundary so the persisted card text matches
+    // how the cat would have written @mentions in the same thread.
+    const initialMessage = rawInitialMessage ? normalizeCatIdMentionsInText(rawInitialMessage) : rawInitialMessage;
+
+    if (!(await registry.isLatest(invocationId))) {
+      return { status: 'stale_ignored' };
+    }
+
+    // Idempotency fast path: only return success if the proposal is fully VISIBLE — i.e. the
+    // rich card has been appended (cardMessageId set). For proposals where cardMessageId is
+    // missing, try a best-effort self-heal: scan the source thread for a card whose rich block
+    // id matches this proposalId, and backfill the marker. This recovers from the "card written,
+    // marker write failed" partial commit.
+    if (clientRequestId) {
+      const cached = await proposalStore.getDedupProposalId(record.userId, clientRequestId);
+      if (cached) {
+        const proposal = await proposalStore.get(cached);
+        if (proposal && proposal.cardMessageId) {
+          return { proposalId: proposal.proposalId, status: proposal.status, deduped: true };
+        }
+        if (proposal && !proposal.cardMessageId) {
+          const recoveredId = await findCardMessageInThread(messageStore, proposal.sourceThreadId, proposal.proposalId);
+          if (recoveredId) {
+            // best-effort backfill so subsequent retries skip the scan
+            try {
+              await proposalStore.setCardMessageId(proposal.proposalId, recoveredId);
+            } catch {
+              // ignore; we can still answer this request
+            }
+            return { proposalId: proposal.proposalId, status: proposal.status, deduped: true };
+          }
+          reply.status(503);
+          reply.header('retry-after', '1');
+          return {
+            error: 'Proposal in-flight (card pending); retry shortly',
+            status: 'retryable',
+          };
+        }
+        // Cached but proposal missing — winner crashed before persisting; let the
+        // SET-NX path below reclaim the dedup key.
+      }
+    }
+
+    // Resolve parent thread: explicit value (with ownership check) or source-thread fallback.
+    const sourceThread = await threadStore.get(record.threadId);
+    if (!sourceThread) {
+      reply.status(404);
+      return { error: 'Source thread not found' };
+    }
+
+    let resolvedParentThreadId = record.threadId;
+    if (parentThreadId && parentThreadId !== record.threadId) {
+      const parent = await threadStore.get(parentThreadId);
+      if (!parent || parent.createdBy !== record.userId) {
+        reply.status(403);
+        return { error: 'parentThreadId does not belong to the current user' };
+      }
+      resolvedParentThreadId = parentThreadId;
+    }
+
+    // P2: Reserve dedup BEFORE create. Pre-generate a candidate proposalId, then atomically
+    // SET NX. The loser of a concurrent retry must NOT create anything (otherwise the pending
+    // list grows by N for N concurrent retries even though they share one clientRequestId).
+    let proposalId: string;
+    let reservedDedup = false;
+    if (clientRequestId) {
+      const candidate = generateProposalId();
+      const winningId = await proposalStore.reserveDedup(record.userId, clientRequestId, candidate);
+      if (winningId !== candidate) {
+        // Loser path. Return deduped success ONLY if the winner's proposal is FULLY VISIBLE
+        // (cardMessageId set). If marker is missing, try the same source-thread self-heal as
+        // the fast path before reporting in-flight.
+        const canonical = await proposalStore.get(winningId);
+        if (canonical && !canonical.cardMessageId) {
+          const recoveredId = await findCardMessageInThread(
+            messageStore,
+            canonical.sourceThreadId,
+            canonical.proposalId,
+          );
+          if (recoveredId) {
+            try {
+              await proposalStore.setCardMessageId(canonical.proposalId, recoveredId);
+            } catch {
+              // ignore
+            }
+            return { proposalId: winningId, status: canonical.status, deduped: true };
+          }
+        }
+        if (!canonical || !canonical.cardMessageId) {
+          reply.status(503);
+          reply.header('retry-after', '1');
+          return {
+            error: canonical
+              ? 'Proposal in-flight by a concurrent request (card pending); retry shortly'
+              : 'Proposal reservation in-flight by a concurrent request; retry shortly',
+            status: 'retryable',
+          };
+        }
+        return {
+          proposalId: winningId,
+          status: canonical.status,
+          deduped: true,
+        };
+      }
+      proposalId = candidate;
+      reservedDedup = true;
+    } else {
+      proposalId = generateProposalId();
+    }
+
+    let proposal: ThreadProposal;
+    try {
+      proposal = await proposalStore.create({
+        proposalId,
+        sourceThreadId: record.threadId,
+        sourceInvocationId: invocationId,
+        sourceCatId: record.catId,
+        title,
+        reason,
+        parentThreadId: resolvedParentThreadId,
+        preferredCats: (preferredCats ?? []) as CatId[],
+        projectPath: sourceThread.projectPath,
+        createdBy: record.userId,
+        ...(initialMessage ? { initialMessage } : {}),
+      });
+    } catch (err) {
+      // Critical: if we reserved a dedup key but failed to create the proposal it points at,
+      // release the reservation so the caller's retry can claim it. Without this, the key stays
+      // a phantom pointer for the dedup TTL window.
+      if (reservedDedup && clientRequestId) {
+        try {
+          await proposalStore.releaseDedup(record.userId, clientRequestId, proposalId);
+        } catch {
+          // best-effort cleanup; surface the original error
+        }
+      }
+      throw err;
+    }
+
+    // Render the proposal as a card in the source thread so the user sees + acts on it.
+    // The card is the ONLY user-facing approval entry point (no pending dashboard fallback),
+    // so if appending it fails we must NOT leave a phantom proposal — delete it and release
+    // the dedup so retries can re-create a visible card.
+    const cardBlock = buildProposalCardBlock(proposal);
+    let stored;
+    try {
+      stored = await messageStore.append({
+        userId: record.userId,
+        catId: record.catId,
+        content: `提议新建 thread：${title}`,
+        mentions: [],
+        timestamp: Date.now(),
+        threadId: record.threadId,
+        extra: { rich: { v: 1 as const, blocks: [cardBlock] } },
+      });
+    } catch (err) {
+      try {
+        await proposalStore.delete(proposal.proposalId);
+      } catch {
+        // best-effort cleanup
+      }
+      if (reservedDedup && clientRequestId) {
+        try {
+          await proposalStore.releaseDedup(record.userId, clientRequestId, proposal.proposalId);
+        } catch {
+          // best-effort cleanup
+        }
+      }
+      throw err;
+    }
+
+    // Card is now persisted — mark the proposal as visible so the dedup fast path can return
+    // it as a successful prior result on retries. Marker write failures are degraded to a
+    // warning rather than rolling back (the card is already on the user's screen). Subsequent
+    // retries can self-heal via fast-path source-thread scan + backfill.
+    const warnings: string[] = [];
+    try {
+      await proposalStore.setCardMessageId(proposal.proposalId, stored.id);
+    } catch (err) {
+      warnings.push(`setCardMessageId failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    socketManager.broadcastToRoom(`thread:${record.threadId}`, 'connector_message', {
+      threadId: record.threadId,
+      message: {
+        id: stored.id,
+        type: 'cat',
+        catId: record.catId,
+        content: stored.content,
+        timestamp: stored.timestamp,
+        extra: stored.extra,
+      },
+    });
+    socketManager.emitToUser(record.userId, 'proposal_created', proposal);
+
+    return {
+      proposalId: proposal.proposalId,
+      status: proposal.status,
+      messageId: stored.id,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+  });
+}
+
+/**
+ * Best-effort recovery: scan a source thread for the rich card belonging to proposalId.
+ * The card's first rich block uses id `proposal-{proposalId}` (see buildProposalCardBlock),
+ * which makes the lookup deterministic without adding a new store index.
+ *
+ * Limit choice: messageStore.getByThread defaults to a small page (~50). For a self-heal
+ * scan we need a much wider window so old proposals whose marker write failed long ago can
+ * still recover after the thread accumulated more activity. SELF_HEAL_SCAN_LIMIT is set high
+ * enough to cover practically any thread (well above realistic chat lengths) without paging.
+ */
+const SELF_HEAL_SCAN_LIMIT = 10000;
+
+async function findCardMessageInThread(
+  messageStore: IMessageStore,
+  threadId: string,
+  proposalId: string,
+): Promise<string | null> {
+  try {
+    const messages = await messageStore.getByThread(threadId, SELF_HEAL_SCAN_LIMIT);
+    const target = `proposal-${proposalId}`;
+    for (const msg of messages) {
+      const blocks = msg.extra?.rich?.blocks ?? [];
+      for (const block of blocks) {
+        if (block.id === target) return msg.id;
+      }
+    }
+  } catch {
+    // self-heal is best-effort; swallow store errors
+  }
+  return null;
+}

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -64,6 +64,7 @@ import { registerCallbackLarkActionRoutes } from './callback-lark-action-routes.
 import { registerCallbackLimbRoutes } from './callback-limb-routes.js';
 import { registerCallbackMemoryRoutes } from './callback-memory-routes.js';
 import { getMultiMentionOrchestrator, registerMultiMentionRoutes } from './callback-multi-mention-routes.js';
+import { registerCallbackProposeThreadRoutes } from './callback-propose-thread-routes.js';
 import { registerCallbackQuestRoutes } from './callback-quest-routes.js';
 import { registerCallbackRuntimeSessionRoutes } from './callback-runtime-session-routes.js';
 import {
@@ -267,6 +268,8 @@ export interface CallbackRoutesOptions {
   sessionChainStore?: import('../domains/cats/services/stores/ports/SessionChainStore.js').ISessionChainStore;
   runtimeSessionStore?: IRuntimeSessionStore;
   eventAuditLog?: Pick<EventAuditLog, 'append'>;
+  /** F128: cat-side thread proposals (propose endpoint) */
+  proposalStore?: import('../domains/cats/services/stores/ports/ProposalStore.js').IProposalStore;
   /** F155 B-4: Independent guide session store */
   guideSessionStore?: import('../domains/guides/GuideSessionRepository.js').IGuideSessionStore;
   /** AgentRegistry for thread-cats MCP callback */
@@ -2226,6 +2229,17 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     registerCallbackThreadCatsRoutes(app, {
       threadStore: opts.threadStore,
       agentRegistry: opts.agentRegistry,
+    });
+  }
+
+  // F128: Cat-side thread proposal callback
+  if (opts.proposalStore && opts.threadStore) {
+    registerCallbackProposeThreadRoutes(app, {
+      registry,
+      proposalStore: opts.proposalStore,
+      threadStore: opts.threadStore,
+      messageStore: opts.messageStore,
+      socketManager,
     });
   }
 

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -48,6 +48,7 @@ export { projectsRoutes } from './projects.js';
 export { projectsBootstrapRoutes } from './projects-bootstrap.js';
 export { mkdirRoute } from './projects-mkdir.js';
 export { projectSetupRoute } from './projects-setup.js';
+export { proposalRoutes } from './proposal-routes.js';
 export { pushRoutes } from './push.js';
 export { queueRoutes } from './queue.js';
 export { quotaRoutes } from './quota.js';

--- a/packages/api/src/routes/proposal-approve-dispatch.ts
+++ b/packages/api/src/routes/proposal-approve-dispatch.ts
@@ -1,0 +1,196 @@
+import type { CatId } from '@cat-cafe/shared';
+import type { InvocationQueue } from '../domains/cats/services/agents/invocation/InvocationQueue.js';
+import type { QueueProcessor } from '../domains/cats/services/agents/invocation/QueueProcessor.js';
+import { parseIntent } from '../domains/cats/services/context/IntentParser.js';
+import type { AgentRouter } from '../domains/cats/services/index.js';
+import type { IMessageStore } from '../domains/cats/services/stores/ports/MessageStore.js';
+
+type ProposalRouter = Pick<AgentRouter, 'resolveTargetsAndIntent'>;
+type ProposalInvocationQueue = Pick<InvocationQueue, 'enqueue' | 'backfillMessageId' | 'rollbackEnqueue'>;
+type ProposalQueueProcessor = Pick<QueueProcessor, 'processNext'>;
+
+export interface ProposalInitialMessageDispatchDeps {
+  router?: ProposalRouter;
+  invocationQueue?: ProposalInvocationQueue;
+  queueProcessor?: ProposalQueueProcessor;
+}
+
+export interface AppendApprovedInitialMessageInput extends ProposalInitialMessageDispatchDeps {
+  proposalId: string;
+  userId: string;
+  threadId: string;
+  content: string;
+  /**
+   * Optional fallback targets. When the router cannot resolve any @-mention in
+   * `content` (typical case: user wrote "开玩！" as initialMessage without
+   * @-ing the proposed members), we fall back to the proposal's preferredCats
+   * so all proposed members get woken up — that's the whole point of
+   * choosing them on the proposal card.
+   */
+  preferredCats?: readonly CatId[];
+  messageStore: IMessageStore;
+}
+
+export interface AppendApprovedInitialMessageResult {
+  messageId: string;
+  warning?: string;
+}
+
+/**
+ * Build the "## 主 Thread" header that the thread-orchestration skill mandates
+ * for the first message of any sub-thread. This header lets cats inside the
+ * sub-thread locate the parent thread and report back when work is done
+ * (skill Step 5c "汇聚" — final report flow).
+ *
+ * F128: cats sometimes forget to include this header when writing
+ * `initialMessage` on the proposal card. Server injects it defensively at
+ * approve time so the fork-and-return loop never breaks on cat omission.
+ *
+ * The header is appended to the END of the user-typed content (rather than
+ * prepended) so it doesn't visually break the user's opening (greeting /
+ * game rules / topic intro). Cats reading the thread bottom-up still pick
+ * it up reliably because it stays in the first message.
+ */
+export function enrichWithParentThreadHeader(
+  content: string,
+  sourceThreadId: string,
+  sourceThreadTitle?: string | null,
+): string {
+  const titleLine = sourceThreadTitle ? `\n标题: ${sourceThreadTitle}` : '';
+  const header = [
+    '---',
+    '## 主 Thread',
+    `ID: \`${sourceThreadId}\`${titleLine}`,
+    '',
+    '完成后请由最后一棒猫 `cat_cafe_cross_post_message` 把总结回报到这个主 Thread。',
+    '（这是 thread-orchestration skill 的 Step 5c 汇聚铁律，不要忘了汇报。）',
+  ].join('\n');
+  return `${content}\n\n${header}`;
+}
+
+export async function appendApprovedInitialMessage({
+  proposalId,
+  userId,
+  threadId,
+  content,
+  preferredCats,
+  messageStore,
+  router,
+  invocationQueue,
+  queueProcessor,
+}: AppendApprovedInitialMessageInput): Promise<AppendApprovedInitialMessageResult> {
+  if (!router || !invocationQueue || !queueProcessor) {
+    const stored = await messageStore.append({
+      userId,
+      catId: null,
+      content,
+      mentions: [],
+      timestamp: Date.now(),
+      threadId,
+    });
+    return {
+      messageId: stored.id,
+      warning: 'initialMessage dispatch skipped: routing dependencies unavailable',
+    };
+  }
+
+  const resolved = await router.resolveTargetsAndIntent(content, threadId, { persist: true });
+  let targetCats: readonly CatId[] = resolved.targetCats;
+  let intentName: string = resolved.intent.intent;
+
+  // F128 — preferredCats fallback: if the user-typed initialMessage has no
+  // @-mention, the router returns 0 targets and we'd silently skip dispatch.
+  // But the proposal card already let the user pick proposed members; honoring
+  // that choice is the whole product point. Treat preferredCats as the
+  // fallback target list.
+  //
+  // Intent: parseIntent's default rule (≥2 cats → ideate → parallel) is wrong
+  // for proposal-card cases. Picking members on the card implies user wants
+  // them in that ORDER (chain / 轮转 / 接龙). parallel ideate scrambles the
+  // order. So we honor explicit #ideate / #execute tags from the user, but
+  // default to 'execute' (serial) when neither is present — this preserves
+  // the preferredCats ordering as a serial chain.
+  if (targetCats.length === 0 && preferredCats && preferredCats.length > 0) {
+    targetCats = preferredCats;
+    const parsed = parseIntent(content, preferredCats.length);
+    intentName = parsed.explicit ? parsed.intent : 'execute';
+  }
+
+  if (targetCats.length === 0) {
+    const stored = await messageStore.append({
+      userId,
+      catId: null,
+      content,
+      mentions: [],
+      timestamp: Date.now(),
+      threadId,
+    });
+    return {
+      messageId: stored.id,
+      warning: 'initialMessage dispatch skipped: no target cats resolved',
+    };
+  }
+
+  const enqueueResult = invocationQueue.enqueue({
+    threadId,
+    userId,
+    idempotencyKey: `proposal-initial:${proposalId}`,
+    content,
+    source: 'user',
+    targetCats: targetCats as CatId[],
+    intent: intentName,
+  });
+
+  if (enqueueResult.outcome === 'full' || !enqueueResult.entry) {
+    const stored = await messageStore.append({
+      userId,
+      catId: null,
+      content,
+      mentions: [...targetCats],
+      timestamp: Date.now(),
+      threadId,
+    });
+    return {
+      messageId: stored.id,
+      warning: 'initialMessage dispatch skipped: queue is full',
+    };
+  }
+
+  let storedMessageId = enqueueResult.entry.messageId ?? null;
+  if (!enqueueResult.deduped || !storedMessageId) {
+    try {
+      const stored = await messageStore.append({
+        userId,
+        catId: null,
+        content,
+        mentions: [...targetCats],
+        timestamp: Date.now(),
+        threadId,
+        idempotencyKey: `proposal-initial:${proposalId}`,
+        deliveryStatus: 'queued',
+      });
+      storedMessageId = stored.id;
+      invocationQueue.backfillMessageId(threadId, userId, enqueueResult.entry.id, stored.id);
+    } catch (err) {
+      invocationQueue.rollbackEnqueue(threadId, userId, enqueueResult.entry.id);
+      throw err;
+    }
+  }
+
+  try {
+    const started = await queueProcessor.processNext(threadId, userId);
+    if (!started.started) {
+      return {
+        messageId: storedMessageId,
+        warning: 'initialMessage queued but did not start automatically',
+      };
+    }
+  } catch (err) {
+    return {
+      messageId: storedMessageId,
+      warning: `initialMessage queued but auto-start failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  return { messageId: storedMessageId };
+}

--- a/packages/api/src/routes/proposal-routes.ts
+++ b/packages/api/src/routes/proposal-routes.ts
@@ -1,0 +1,340 @@
+/**
+ * F128 User-side proposal endpoints.
+ *
+ * POST /api/proposals/:proposalId/approve  — create thread + mark proposal approved
+ * POST /api/proposals/:proposalId/reject   — mark proposal rejected
+ * GET  /api/proposals/pending              — list user's pending proposals
+ *
+ * All routes require user auth via X-Cat-Cafe-User. The cat-side propose
+ * route lives in callback-propose-thread-routes.ts.
+ */
+
+import type { CatId } from '@cat-cafe/shared';
+import { catIdSchema } from '@cat-cafe/shared';
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import type { InvocationQueue } from '../domains/cats/services/agents/invocation/InvocationQueue.js';
+import type { QueueProcessor } from '../domains/cats/services/agents/invocation/QueueProcessor.js';
+import type { AgentRouter } from '../domains/cats/services/index.js';
+import type { IMessageStore } from '../domains/cats/services/stores/ports/MessageStore.js';
+import type { IProposalStore } from '../domains/cats/services/stores/ports/ProposalStore.js';
+import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
+import type { SocketManager } from '../infrastructure/websocket/index.js';
+import { resolveUserId } from '../utils/request-identity.js';
+import { appendApprovedInitialMessage, enrichWithParentThreadHeader } from './proposal-approve-dispatch.js';
+import { handleApproveStaleClaim, handleRejectStaleClaim } from './proposal-stale-recovery.js';
+
+export interface ProposalRoutesOptions {
+  proposalStore: IProposalStore;
+  threadStore: IThreadStore;
+  messageStore: IMessageStore;
+  socketManager: SocketManager;
+  router?: Pick<AgentRouter, 'resolveTargetsAndIntent'>;
+  invocationQueue?: Pick<InvocationQueue, 'enqueue' | 'backfillMessageId' | 'rollbackEnqueue'>;
+  queueProcessor?: Pick<QueueProcessor, 'processNext'>;
+}
+
+const approveBodySchema = z
+  .object({
+    title: z.string().trim().min(1).max(200).optional(),
+    parentThreadId: z.string().min(1).optional(),
+    preferredCats: z.array(catIdSchema()).max(10).optional(),
+    initialMessage: z.string().max(4000).nullable().optional(),
+  })
+  .strict();
+
+const rejectBodySchema = z
+  .object({
+    rejectionReason: z.string().trim().min(1).max(500).optional(),
+  })
+  .strict();
+
+const proposalParamsSchema = z.object({
+  proposalId: z.string().min(1).max(200),
+});
+
+export const proposalRoutes: FastifyPluginAsync<ProposalRoutesOptions> = async (app, opts) => {
+  const { proposalStore, threadStore, messageStore, socketManager } = opts;
+
+  app.post('/api/proposals/:proposalId/approve', async (request, reply) => {
+    const paramsParse = proposalParamsSchema.safeParse(request.params);
+    if (!paramsParse.success) {
+      reply.status(400);
+      return { error: 'Invalid proposalId' };
+    }
+    const bodyParse = approveBodySchema.safeParse(request.body ?? {});
+    if (!bodyParse.success) {
+      reply.status(400);
+      return { error: 'Invalid request body', details: bodyParse.error.issues };
+    }
+    const userId = resolveUserId(request);
+    if (!userId) {
+      reply.status(401);
+      return { error: 'Identity required (X-Cat-Cafe-User header or userId query)' };
+    }
+
+    const proposal = await proposalStore.get(paramsParse.data.proposalId);
+    if (!proposal) {
+      reply.status(404);
+      return { error: 'Proposal not found' };
+    }
+    if (proposal.createdBy !== userId) {
+      reply.status(403);
+      return { error: 'Proposal does not belong to the current user' };
+    }
+    if (proposal.status === 'rejected') {
+      reply.status(409);
+      return { error: 'Proposal already rejected', status: proposal.status };
+    }
+    if (proposal.status === 'approved' && proposal.createdThreadId) {
+      return {
+        proposalId: proposal.proposalId,
+        threadId: proposal.createdThreadId,
+        status: proposal.status,
+        deduped: true,
+      };
+    }
+    if (proposal.status === 'approving') {
+      const outcome = await handleApproveStaleClaim({
+        proposal,
+        userId,
+        proposalStore,
+        threadStore,
+        socketManager,
+        reply,
+      });
+      if (outcome.kind === 'in_flight') {
+        return { error: 'Proposal is being approved by another request; retry shortly', status: proposal.status };
+      }
+      if (outcome.kind === 'recoveredBody') return outcome.body;
+      if (outcome.kind === 'race_retry') {
+        return { error: 'Proposal status changed concurrently — retry approve' };
+      }
+      // kind === 'cleared' → fall through; claimForApproval below will re-claim.
+    }
+
+    const overrides = bodyParse.data;
+    const finalTitle = overrides.title ?? proposal.title;
+    let finalParentThreadId = overrides.parentThreadId ?? proposal.parentThreadId;
+    if (overrides.parentThreadId && overrides.parentThreadId !== proposal.parentThreadId) {
+      const parent = await threadStore.get(overrides.parentThreadId);
+      if (!parent || parent.createdBy !== userId) {
+        reply.status(403);
+        return { error: 'parentThreadId does not belong to the current user' };
+      }
+      finalParentThreadId = overrides.parentThreadId;
+    }
+    const finalPreferredCats = (overrides.preferredCats ?? proposal.preferredCats) as CatId[];
+    const finalInitialMessage = resolveInitialMessage(proposal.initialMessage, overrides.initialMessage);
+
+    // Atomic claim — guards against concurrent approve/reject leaving an orphan thread.
+    const claimed = await proposalStore.claimForApproval({ proposalId: proposal.proposalId, approvedBy: userId });
+    if (!claimed) {
+      reply.status(409);
+      return { error: 'Proposal status changed concurrently — retry approve' };
+    }
+
+    // Stage 1: create the thread. Only this step is allowed to rollback the claim,
+    // because nothing user-visible has been committed yet.
+    let thread;
+    try {
+      thread = await threadStore.create(userId, finalTitle, proposal.projectPath, finalParentThreadId, {
+        createdFromProposalId: proposal.proposalId,
+        sourceThreadId: proposal.sourceThreadId,
+        approvedBy: userId,
+        approvedAt: Date.now(),
+      });
+    } catch (err) {
+      await proposalStore.rollbackClaim(proposal.proposalId);
+      throw err;
+    }
+
+    // Stage 1.5: persist createdThreadId on the proposal BEFORE finalize. If the process dies
+    // between create and finalize, the next stale-claim recovery sees this field and re-finalizes
+    // against the existing thread — preventing duplicate threads on retry.
+    try {
+      await proposalStore.recordCreatedThread(proposal.proposalId, thread.id);
+    } catch {
+      // best-effort persist; failure here only weakens crash recovery, doesn't break the
+      // happy path. Finalize below still writes createdThreadId atomically.
+    }
+
+    // Stage 2: finalize the proposal NOW that a real threadId exists. After this point,
+    // any side-effect failure is reported as a warning — the proposal must NOT roll back
+    // (that would leave an orphan thread).
+    const finalized = await proposalStore.finalizeApproval({
+      proposalId: proposal.proposalId,
+      createdThreadId: thread.id,
+      overrides: {
+        title: finalTitle,
+        parentThreadId: finalParentThreadId,
+        preferredCats: finalPreferredCats,
+        initialMessage: finalInitialMessage === undefined ? null : finalInitialMessage,
+      },
+    });
+    if (!finalized) {
+      // Should not happen — we hold the approving claim. Surface as 500; thread is intentionally
+      // kept (writing finalize is the only contract violation here, not the thread itself).
+      reply.status(500);
+      return { error: 'Proposal finalize failed unexpectedly after claim', threadId: thread.id };
+    }
+
+    // Stage 3: best-effort side effects. Failures become warnings, not 500s.
+    const warnings: string[] = [];
+    if (finalPreferredCats.length > 0) {
+      try {
+        await threadStore.updatePreferredCats(thread.id, finalPreferredCats);
+      } catch (err) {
+        warnings.push(`updatePreferredCats failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (finalInitialMessage) {
+      try {
+        // F128 (thread-orchestration skill Step 5 enforcement): inject the
+        // "## 主 Thread" header into the first sub-thread message so cats
+        // inside the new thread can locate the parent and report back when
+        // work completes. Cat-typed initialMessage often omits this header,
+        // breaking the fork-and-return loop the user (CVO) expects.
+        // The proposal store keeps the raw user-typed initialMessage; only
+        // the appended thread message gets enriched.
+        const sourceThread = await threadStore.get(proposal.sourceThreadId);
+        const enrichedContent = enrichWithParentThreadHeader(
+          finalInitialMessage,
+          proposal.sourceThreadId,
+          sourceThread?.title,
+        );
+
+        const result = await appendApprovedInitialMessage({
+          proposalId: proposal.proposalId,
+          userId,
+          threadId: thread.id,
+          content: enrichedContent,
+          // F128: pass the proposal's preferredCats so dispatch can wake up all
+          // proposed members even when the user-typed initialMessage has no
+          // @-mention. Without this, only the thread owner gets woken up.
+          preferredCats: finalPreferredCats,
+          messageStore,
+          router: opts.router,
+          invocationQueue: opts.invocationQueue,
+          queueProcessor: opts.queueProcessor,
+        });
+        if (result.warning) warnings.push(result.warning);
+      } catch (err) {
+        warnings.push(`initialMessage append failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    const updatedThread = (await threadStore.get(thread.id)) ?? thread;
+    socketManager.emitToUser(userId, 'thread_created', updatedThread);
+    socketManager.emitToUser(userId, 'proposal_updated', finalized);
+
+    return {
+      proposalId: finalized.proposalId,
+      threadId: thread.id,
+      status: finalized.status,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
+  });
+
+  app.post('/api/proposals/:proposalId/reject', async (request, reply) => {
+    const paramsParse = proposalParamsSchema.safeParse(request.params);
+    if (!paramsParse.success) {
+      reply.status(400);
+      return { error: 'Invalid proposalId' };
+    }
+    const bodyParse = rejectBodySchema.safeParse(request.body ?? {});
+    if (!bodyParse.success) {
+      reply.status(400);
+      return { error: 'Invalid request body', details: bodyParse.error.issues };
+    }
+    const userId = resolveUserId(request);
+    if (!userId) {
+      reply.status(401);
+      return { error: 'Identity required (X-Cat-Cafe-User header or userId query)' };
+    }
+
+    const proposal = await proposalStore.get(paramsParse.data.proposalId);
+    if (!proposal) {
+      reply.status(404);
+      return { error: 'Proposal not found' };
+    }
+    if (proposal.createdBy !== userId) {
+      reply.status(403);
+      return { error: 'Proposal does not belong to the current user' };
+    }
+    if (proposal.status === 'approved') {
+      reply.status(409);
+      return { error: 'Proposal already approved', status: proposal.status };
+    }
+    if (proposal.status === 'approving') {
+      const outcome = await handleRejectStaleClaim({ proposal, proposalStore, reply });
+      if (outcome.kind === 'in_flight') {
+        return {
+          error: 'Proposal is being approved — wait for the in-flight approve to settle',
+          status: proposal.status,
+        };
+      }
+      if (outcome.kind === 'cannot_reject') return outcome.body;
+      // kind === 'cleared' → fall through to markRejected.
+    }
+    if (proposal.status === 'rejected') {
+      return { proposalId: proposal.proposalId, status: proposal.status, deduped: true };
+    }
+
+    const marked = await proposalStore.markRejected({
+      proposalId: proposal.proposalId,
+      rejectedBy: userId,
+      ...(bodyParse.data.rejectionReason ? { rejectionReason: bodyParse.data.rejectionReason } : {}),
+    });
+    if (!marked) {
+      reply.status(409);
+      return { error: 'Proposal status changed concurrently — retry reject' };
+    }
+
+    socketManager.emitToUser(userId, 'proposal_updated', marked);
+
+    return { proposalId: marked.proposalId, status: marked.status };
+  });
+
+  app.get('/api/proposals/:proposalId', async (request, reply) => {
+    const paramsParse = proposalParamsSchema.safeParse(request.params);
+    if (!paramsParse.success) {
+      reply.status(400);
+      return { error: 'Invalid proposalId' };
+    }
+    const userId = resolveUserId(request);
+    if (!userId) {
+      reply.status(401);
+      return { error: 'Identity required (X-Cat-Cafe-User header or userId query)' };
+    }
+    const proposal = await proposalStore.get(paramsParse.data.proposalId);
+    if (!proposal) {
+      reply.status(404);
+      return { error: 'Proposal not found' };
+    }
+    if (proposal.createdBy !== userId) {
+      reply.status(403);
+      return { error: 'Proposal does not belong to the current user' };
+    }
+    return { proposal };
+  });
+
+  app.get('/api/proposals/pending', async (request, reply) => {
+    const userId = resolveUserId(request);
+    if (!userId) {
+      reply.status(401);
+      return { error: 'Identity required (X-Cat-Cafe-User header or userId query)' };
+    }
+    const proposals = await proposalStore.listPending(userId);
+    return { proposals };
+  });
+};
+
+function resolveInitialMessage(
+  fromProposal: string | undefined,
+  override: string | null | undefined,
+): string | undefined {
+  if (override === undefined) return fromProposal;
+  if (override === null) return undefined;
+  return override;
+}

--- a/packages/api/src/routes/proposal-stale-recovery.ts
+++ b/packages/api/src/routes/proposal-stale-recovery.ts
@@ -1,0 +1,128 @@
+/**
+ * F128 stale-claim recovery helpers, extracted from proposal-routes.ts to satisfy
+ * the 350-line per-file hard limit (AC-X1).
+ *
+ * When a proposal status is `approving` past the stale window, the previous claimer
+ * almost certainly crashed between `claimForApproval` and `finalize` / `rollback`.
+ * Two recovery paths depending on whether `createdThreadId` was persisted via
+ * recordCreatedThread (Stage 1.5):
+ *  - createdThreadId set → finalize against the existing thread (no duplicate thread)
+ *  - createdThreadId absent → rollbackClaim and let caller re-claim
+ */
+
+import type { ThreadProposal } from '@cat-cafe/shared';
+import type { FastifyReply } from 'fastify';
+import type { IProposalStore } from '../domains/cats/services/stores/ports/ProposalStore.js';
+import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
+import type { SocketManager } from '../infrastructure/websocket/index.js';
+
+/**
+ * Age threshold past which an `approving` claim is considered abandoned
+ * (process crash / aborted request between claimForApproval and finalize/rollback).
+ * Normal flow completes in well under a second; 30s leaves generous headroom.
+ */
+export const STALE_APPROVING_MS = 30_000;
+
+export type ApproveStaleRecoveryOutcome =
+  | { kind: 'in_flight'; status: 409 }
+  | { kind: 'recovered'; threadId: string; status: 'approved' }
+  | { kind: 'race_retry' }
+  | { kind: 'cleared' };
+
+/**
+ * Approve-handler stale path. Mutates `reply` for non-`cleared` outcomes and returns
+ * the caller's next-action signal:
+ *  - `in_flight`: still within stale window — caller should `return` a 409.
+ *  - `recovered`: existing thread was finalized — caller should `return` the recovered body.
+ *  - `race_retry`: another writer raced and won — caller should `return` a 409.
+ *  - `cleared`: status was not 'approving' OR rollback succeeded — caller falls through.
+ */
+export async function handleApproveStaleClaim(args: {
+  proposal: ThreadProposal;
+  userId: string;
+  proposalStore: IProposalStore;
+  threadStore: IThreadStore;
+  socketManager: SocketManager;
+  reply: FastifyReply;
+}): Promise<ApproveStaleRecoveryOutcome | { kind: 'recoveredBody'; body: Record<string, unknown> }> {
+  const { proposal, userId, proposalStore, threadStore, socketManager, reply } = args;
+  if (proposal.status !== 'approving') return { kind: 'cleared' };
+
+  const ageMs = proposal.claimedAt ? Date.now() - proposal.claimedAt : Number.POSITIVE_INFINITY;
+  if (ageMs <= STALE_APPROVING_MS) {
+    reply.status(409);
+    return { kind: 'in_flight', status: 409 };
+  }
+
+  if (proposal.createdThreadId) {
+    const recovered = await proposalStore.finalizeApproval({
+      proposalId: proposal.proposalId,
+      createdThreadId: proposal.createdThreadId,
+    });
+    if (recovered) {
+      const recoveredThread = await threadStore.get(proposal.createdThreadId);
+      if (recoveredThread) socketManager.emitToUser(userId, 'thread_created', recoveredThread);
+      socketManager.emitToUser(userId, 'proposal_updated', recovered);
+      return {
+        kind: 'recoveredBody',
+        body: {
+          proposalId: recovered.proposalId,
+          threadId: proposal.createdThreadId,
+          status: recovered.status,
+          recovered: true,
+        },
+      };
+    }
+    reply.status(409);
+    return { kind: 'race_retry' };
+  }
+
+  // No thread created — safe to roll back so caller can re-claim.
+  await proposalStore.rollbackClaim(proposal.proposalId);
+  return { kind: 'cleared' };
+}
+
+/**
+ * Reject-handler stale path. Same age check + createdThreadId split as approve, but
+ * rejection is invalid if a thread already exists — finalize the orphan claim and
+ * return 409 telling the caller that the proposal is approved (not rejected).
+ */
+export async function handleRejectStaleClaim(args: {
+  proposal: ThreadProposal;
+  proposalStore: IProposalStore;
+  reply: FastifyReply;
+}): Promise<
+  | { kind: 'cleared' }
+  | { kind: 'in_flight'; status: 409 }
+  | { kind: 'cannot_reject'; status: 409; body: Record<string, unknown> }
+> {
+  const { proposal, proposalStore, reply } = args;
+  if (proposal.status !== 'approving') return { kind: 'cleared' };
+
+  const ageMs = proposal.claimedAt ? Date.now() - proposal.claimedAt : Number.POSITIVE_INFINITY;
+  if (ageMs <= STALE_APPROVING_MS) {
+    reply.status(409);
+    return { kind: 'in_flight', status: 409 };
+  }
+
+  if (proposal.createdThreadId) {
+    const recovered = await proposalStore.finalizeApproval({
+      proposalId: proposal.proposalId,
+      createdThreadId: proposal.createdThreadId,
+    });
+    reply.status(409);
+    return {
+      kind: 'cannot_reject',
+      status: 409,
+      body: {
+        error: 'Proposal cannot be rejected — a thread was already created by a prior approve attempt',
+        status: recovered?.status ?? 'approved',
+        threadId: proposal.createdThreadId,
+      },
+    };
+  }
+
+  // No thread created — safe to roll back so caller can proceed with markRejected.
+  await proposalStore.rollbackClaim(proposal.proposalId);
+  return { kind: 'cleared' };
+}

--- a/packages/api/src/utils/cat-mention-handle.ts
+++ b/packages/api/src/utils/cat-mention-handle.ts
@@ -1,0 +1,56 @@
+/**
+ * Resolve a registered catId to its primary stable mention handle, and
+ * normalise `@catId` tokens inside free-form text to `@<handle>`.
+ *
+ * Why this exists (F128):
+ *   AgentRouter.parseAllMentions only recognises mentions that match
+ *   catRegistry's configured `mentionPatterns` (e.g. "@砚砚", "@opus46").
+ *   Raw catId tokens like `@cat-rcs85pvn` are NOT in those patterns, so
+ *   downstream dispatch can't route on them. When a cat proposes a new
+ *   thread it sometimes writes `@cat-rcs85pvn` into `initialMessage`
+ *   (carried over from `cat_cafe_get_thread_cats` output). Normalising at
+ *   the propose boundary lets the persisted message route correctly.
+ *
+ *   Keeps `preferredCats` field on the proposal record AS-IS (catIds are
+ *   the right shape for dispatch lookup). Only the human-readable
+ *   `initialMessage` text is rewritten so router can identify the mention.
+ */
+
+import { catRegistry } from '@cat-cafe/shared';
+
+/**
+ * Resolve a registered catId to its primary stable mention handle (with
+ * leading "@"). Returns null if the catId is not registered or the entry has
+ * no mention patterns configured.
+ *
+ * Example: `cat-rcs85pvn` → `"@砚砚"`
+ */
+export function primaryMentionHandleForCatId(catId: string): string | null {
+  const entry = catRegistry.tryGet(catId);
+  if (!entry) return null;
+  const pattern = entry.config.mentionPatterns?.[0];
+  if (!pattern) return null;
+  return pattern.startsWith('@') ? pattern : `@${pattern}`;
+}
+
+/**
+ * Replace `@<token>` matches in text with the cat's primary mention handle
+ * when the token resolves to a registered catId. Tokens that don't resolve
+ * (e.g. user wrote `@铲屎官` or already-stable handles like `@砚砚`) are left
+ * untouched.
+ *
+ * Test seam: callers may pass a custom `resolveHandle` to test without
+ * touching the global catRegistry state.
+ */
+export function normalizeCatIdMentionsInText(
+  text: string,
+  resolveHandle: (token: string) => string | null = primaryMentionHandleForCatId,
+): string {
+  // Match @<token> where token starts with a letter and may contain letters,
+  // digits, underscore, or hyphen. Hyphen support is what makes `@cat-rcs85pvn`
+  // captured as a single token instead of stopping at `@cat`.
+  return text.replace(/@([A-Za-z][A-Za-z0-9_-]*)/g, (full, captured: string) => {
+    const handle = resolveHandle(captured);
+    return handle ?? full;
+  });
+}

--- a/packages/api/test/cat-mention-handle.test.js
+++ b/packages/api/test/cat-mention-handle.test.js
@@ -1,0 +1,83 @@
+// @ts-check
+/**
+ * F128 — normalize @<catId> tokens in user-typed text to @<stable-handle>
+ * so AgentRouter.parseAllMentions can recognise them downstream.
+ *
+ * Why: cats sometimes write `@cat-rcs85pvn` in `initialMessage` (carried
+ * over from cat_cafe_get_thread_cats output). Router only knows configured
+ * mentionPatterns; raw catId tokens aren't matched. Normalising at the
+ * propose boundary aligns thread text with how the cat would have written
+ * mentions in the same thread (e.g. `@砚砚`).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const { normalizeCatIdMentionsInText } = await import('../dist/utils/cat-mention-handle.js');
+
+// Test-only resolver simulating a populated catRegistry. Real production uses
+// `primaryMentionHandleForCatId` which reads the live catRegistry.
+function makeResolver(map) {
+  return (token) => map[token] ?? null;
+}
+
+describe('normalizeCatIdMentionsInText (F128 propose-text normalization)', () => {
+  it('replaces @cat-XXX with the cat primary stable handle', () => {
+    const resolve = makeResolver({
+      'cat-rcs85pvn': '@砚砚',
+      'cat-g820pwcz': '@opus46',
+    });
+    const input = '下一棒 @cat-rcs85pvn 然后第三棒 @cat-g820pwcz';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, '下一棒 @砚砚 然后第三棒 @opus46');
+  });
+
+  it('leaves @<token> unchanged when the token does not resolve', () => {
+    const resolve = makeResolver({}); // empty registry → no resolution
+    const input = '请 @铲屎官 决定，并 @cat-unknown 跟踪';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, input, 'unresolvable tokens must be passed through verbatim');
+  });
+
+  it('leaves already-stable handles (no catId substring) unchanged', () => {
+    const resolve = makeResolver({
+      'cat-rcs85pvn': '@砚砚',
+    });
+    const input = '@砚砚 接龙下一棒';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, '@砚砚 接龙下一棒', 'pre-stabilized mentions stay verbatim');
+  });
+
+  it('does not mangle email addresses or non-@ uses', () => {
+    const resolve = makeResolver({ 'cat-rcs85pvn': '@砚砚' });
+    const input = 'send to alice@example.com about cat-rcs85pvn (no @ prefix)';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    // Plain `cat-rcs85pvn` without @ stays. email's `@example.com` is parsed
+    // as a token but not in resolver → left as-is.
+    assert.equal(out, input);
+  });
+
+  it('handles multi-line messages with multiple @-mentions', () => {
+    const resolve = makeResolver({
+      'cat-rcs85pvn': '@砚砚',
+      'cat-g820pwcz': '@opus46',
+    });
+    const input = ['顺序:', '1. @cat-rcs85pvn', '2. @cat-g820pwcz', '3. 回到铲屎官'].join('\n');
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, ['顺序:', '1. @砚砚', '2. @opus46', '3. 回到铲屎官'].join('\n'));
+  });
+
+  it('handles repeated mention of the same catId', () => {
+    const resolve = makeResolver({ 'cat-rcs85pvn': '@砚砚' });
+    const input = '@cat-rcs85pvn 接 → @cat-rcs85pvn 再接';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, '@砚砚 接 → @砚砚 再接');
+  });
+
+  it('returns input unchanged when no @-mentions are present', () => {
+    const resolve = makeResolver({ 'cat-rcs85pvn': '@砚砚' });
+    const input = '开玩！我先起头：一帆风顺';
+    const out = normalizeCatIdMentionsInText(input, resolve);
+    assert.equal(out, input);
+  });
+});

--- a/packages/api/test/helpers/proposal-test-harness.js
+++ b/packages/api/test/helpers/proposal-test-harness.js
@@ -1,0 +1,108 @@
+/**
+ * F128 proposal test harness — shared setup so each proposal test file stays under the
+ * 350-line hard limit (AC-X1). Returns a fresh context object per test setup; tests then
+ * pull `app`, `threadStore`, `proposalStore`, `registry`, `messageStore`, `socketEvents`,
+ * and the http helpers (`propose`, `approve`, `reject`) from there.
+ */
+
+import Fastify from 'fastify';
+
+export async function createProposalTestContext({
+  proposalStoreOverride,
+  messageStoreOverride,
+  routerOverride,
+  invocationQueueOverride,
+  queueProcessorOverride,
+} = {}) {
+  const { InvocationRegistry } = await import(
+    '../../dist/domains/cats/services/agents/invocation/InvocationRegistry.js'
+  );
+  const { ThreadStore } = await import('../../dist/domains/cats/services/stores/ports/ThreadStore.js');
+  const { MessageStore } = await import('../../dist/domains/cats/services/stores/ports/MessageStore.js');
+  const { InMemoryProposalStore } = await import('../../dist/domains/cats/services/stores/ports/ProposalStore.js');
+  const { callbacksRoutes, proposalRoutes } = await import('../../dist/routes/index.js');
+
+  const registry = new InvocationRegistry();
+  const threadStore = new ThreadStore();
+  const messageStore = messageStoreOverride ?? new MessageStore();
+  const proposalStore = proposalStoreOverride ?? new InMemoryProposalStore();
+  const socketEvents = [];
+  const socketManager = {
+    emitToUser(userId, event, data) {
+      socketEvents.push({ kind: 'user', userId, event, data });
+    },
+    broadcastToRoom(room, event, data) {
+      socketEvents.push({ kind: 'room', room, event, data });
+    },
+  };
+
+  const app = Fastify();
+  await app.register(callbacksRoutes, {
+    registry,
+    messageStore,
+    socketManager,
+    threadStore,
+    proposalStore,
+    evidenceStore: {
+      ingestRaw() {},
+      search() {
+        return [];
+      },
+    },
+    markerQueue: { enqueue() {} },
+    reflectionService: { reflect() {} },
+  });
+  await app.register(proposalRoutes, {
+    proposalStore,
+    threadStore,
+    messageStore,
+    socketManager,
+    ...(routerOverride ? { router: routerOverride } : {}),
+    ...(invocationQueueOverride ? { invocationQueue: invocationQueueOverride } : {}),
+    ...(queueProcessorOverride ? { queueProcessor: queueProcessorOverride } : {}),
+  });
+
+  async function propose({ userId, catId = 'opus', threadId, body = {} }) {
+    const { invocationId, callbackToken } = await registry.create(userId, catId, threadId);
+    return app.inject({
+      method: 'POST',
+      url: '/api/callbacks/propose-thread',
+      headers: { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken },
+      payload: { title: 'New thread', reason: 'Because', ...body },
+    });
+  }
+
+  async function approve(userId, proposalId, body = {}) {
+    return app.inject({
+      method: 'POST',
+      url: `/api/proposals/${proposalId}/approve`,
+      headers: { 'x-cat-cafe-user': userId, 'content-type': 'application/json' },
+      payload: body,
+    });
+  }
+
+  async function reject(userId, proposalId, body = {}) {
+    return app.inject({
+      method: 'POST',
+      url: `/api/proposals/${proposalId}/reject`,
+      headers: { 'x-cat-cafe-user': userId, 'content-type': 'application/json' },
+      payload: body,
+    });
+  }
+
+  return {
+    app,
+    registry,
+    threadStore,
+    messageStore,
+    proposalStore,
+    socketManager,
+    socketEvents,
+    router: routerOverride,
+    invocationQueue: invocationQueueOverride,
+    queueProcessor: queueProcessorOverride,
+    propose,
+    approve,
+    reject,
+  };
+}

--- a/packages/api/test/proposal-approve-dispatch.test.js
+++ b/packages/api/test/proposal-approve-dispatch.test.js
@@ -1,0 +1,296 @@
+// @ts-check
+/**
+ * F128 approve dispatch — initialMessage routing through the queue processor.
+ *
+ * Core lifecycle (propose / approve / reject mechanics) stays in
+ * `proposal-flow.test.js`. This file holds the higher-level "what happens to
+ * the initial message when the user approves a proposal" behaviours:
+ *
+ *  - approve dispatches initialMessage via router + InvocationQueue + processNext
+ *  - preferredCats fallback when router resolves 0 targets from message text
+ *  - explicit #ideate / #execute tags vs default serial intent
+ *  - server-injected "## 主 Thread" header (fork-and-return / skill Step 5c)
+ *  - explicit @-mention in content beats preferredCats fallback
+ *
+ * Split out from proposal-flow.test.js to honor AC-X1 ≤350-line file cap
+ * (砚砚 re-review on fd8f07ae..76e8d164 flagged the regression).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import './helpers/setup-cat-registry.js';
+import { createProposalTestContext } from './helpers/proposal-test-harness.js';
+
+describe('F128 approve dispatch — initialMessage routing', () => {
+  test('approve dispatches initialMessage through the queue processor', async () => {
+    const { InvocationQueue } = await import('../dist/domains/cats/services/agents/invocation/InvocationQueue.js');
+    const invocationQueue = new InvocationQueue();
+    const resolveCalls = [];
+    const processCalls = [];
+    const router = {
+      async resolveTargetsAndIntent(content, threadId, options) {
+        resolveCalls.push({ content, threadId, options });
+        return { targetCats: ['opus'], intent: { intent: 'execute' }, hasMentions: false };
+      },
+    };
+    const queueProcessor = {
+      async processNext(threadId, userId) {
+        processCalls.push({ threadId, userId });
+        return { started: true };
+      },
+    };
+    const ctx = await createProposalTestContext({
+      routerOverride: router,
+      invocationQueueOverride: invocationQueue,
+      queueProcessorOverride: queueProcessor,
+    });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: { initialMessage: 'Kick this off', preferredCats: ['opus'] },
+        })
+      ).body,
+    );
+
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.warnings, undefined);
+    assert.equal(resolveCalls.length, 1);
+    // Server now injects "## 主 Thread" header (skill Step 5c fork-and-return),
+    // so router sees enriched content. The header is additive — user-typed
+    // content still appears at the start.
+    assert.ok(
+      resolveCalls[0].content.startsWith('Kick this off'),
+      'router input should start with user-typed initialMessage',
+    );
+    assert.equal(resolveCalls[0].threadId, body.threadId);
+    assert.equal(resolveCalls[0].options.persist, true);
+    assert.deepEqual(processCalls, [{ threadId: body.threadId, userId: 'alice' }]);
+
+    const entries = invocationQueue.list(body.threadId, 'alice');
+    assert.equal(entries.length, 1);
+    assert.ok(entries[0].content.startsWith('Kick this off'), 'enqueued content should start with user-typed content');
+    assert.deepEqual(entries[0].targetCats, ['opus']);
+    assert.equal(entries[0].intent, 'execute');
+    assert.ok(entries[0].messageId);
+    const stored = await ctx.messageStore.getById(entries[0].messageId);
+    assert.equal(stored.deliveryStatus, 'queued');
+    assert.deepEqual(stored.mentions, ['opus']);
+  });
+
+  test('approve falls back to preferredCats when initialMessage has no @-mention', async () => {
+    // The product bug this pins: cat proposes a thread with preferredCats=[kimi,gemini25,codex]
+    // and an initialMessage like "开玩！" (no @-mention). Without fallback, the router resolves
+    // 0 targets, dispatch silently skips, and only the thread owner ever gets woken up via the
+    // user's next manual message. With fallback, the proposal's chosen members get woken up
+    // immediately as the user intended when picking them on the card.
+    const { InvocationQueue } = await import('../dist/domains/cats/services/agents/invocation/InvocationQueue.js');
+    const invocationQueue = new InvocationQueue();
+    const router = {
+      async resolveTargetsAndIntent() {
+        // Simulate the real router behaviour for a no-@-mention message: 0 targets.
+        return { targetCats: [], intent: { intent: 'execute' }, hasMentions: false };
+      },
+    };
+    const processCalls = [];
+    const queueProcessor = {
+      async processNext(threadId, userId) {
+        processCalls.push({ threadId, userId });
+        return { started: true };
+      },
+    };
+    const ctx = await createProposalTestContext({
+      routerOverride: router,
+      invocationQueueOverride: invocationQueue,
+      queueProcessorOverride: queueProcessor,
+    });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: { initialMessage: '开玩！', preferredCats: ['kimi', 'gemini', 'codex'] },
+        })
+      ).body,
+    );
+
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.warnings, undefined, 'fallback should succeed without warnings');
+    assert.deepEqual(processCalls, [{ threadId: body.threadId, userId: 'alice' }]);
+
+    const entries = invocationQueue.list(body.threadId, 'alice');
+    assert.equal(entries.length, 1);
+    assert.deepEqual(
+      entries[0].targetCats,
+      ['kimi', 'gemini', 'codex'],
+      'targetCats must come from preferredCats when content has no @-mention',
+    );
+    assert.equal(
+      entries[0].intent,
+      'execute',
+      'fallback intent must default to serial (execute) so preferredCats order is honored as a chain — picking members on the card implies an ordered walk, not parallel ideate',
+    );
+    const stored = await ctx.messageStore.getById(entries[0].messageId);
+    assert.deepEqual(
+      stored.mentions,
+      ['kimi', 'gemini', 'codex'],
+      'message mentions must reflect the fallback targets so cats see why they were woken',
+    );
+  });
+
+  test('approve fallback honors explicit #ideate tag (parallel still opt-in)', async () => {
+    // Defensive: if the user genuinely wants parallel ideation, they tag #ideate
+    // explicitly in initialMessage. Fallback must NOT clobber that intent down
+    // to execute — explicit user tags always win.
+    const { InvocationQueue } = await import('../dist/domains/cats/services/agents/invocation/InvocationQueue.js');
+    const invocationQueue = new InvocationQueue();
+    const router = {
+      async resolveTargetsAndIntent() {
+        return { targetCats: [], intent: { intent: 'ideate' }, hasMentions: false };
+      },
+    };
+    const queueProcessor = {
+      async processNext() {
+        return { started: true };
+      },
+    };
+    const ctx = await createProposalTestContext({
+      routerOverride: router,
+      invocationQueueOverride: invocationQueue,
+      queueProcessorOverride: queueProcessor,
+    });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: {
+            initialMessage: '#ideate 大家分别说说自己的看法',
+            preferredCats: ['kimi', 'gemini'],
+          },
+        })
+      ).body,
+    );
+
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    const entries = invocationQueue.list(body.threadId, 'alice');
+    assert.equal(entries[0].intent, 'ideate', 'explicit #ideate must override the proposal-card serial default');
+  });
+
+  test('approve injects "## 主 Thread" header into sub-thread first message (fork-and-return loop)', async () => {
+    // thread-orchestration skill Step 5c: cats in the sub-thread must be able
+    // to find the parent thread so they can report back when work is done.
+    // Server defensively injects the header so cats who forget to write it in
+    // initialMessage still preserve the fork-and-return loop.
+    const { InvocationQueue } = await import('../dist/domains/cats/services/agents/invocation/InvocationQueue.js');
+    const invocationQueue = new InvocationQueue();
+    const router = {
+      async resolveTargetsAndIntent() {
+        return { targetCats: ['opus'], intent: { intent: 'execute' }, hasMentions: false };
+      },
+    };
+    const queueProcessor = {
+      async processNext() {
+        return { started: true };
+      },
+    };
+    const ctx = await createProposalTestContext({
+      routerOverride: router,
+      invocationQueueOverride: invocationQueue,
+      queueProcessorOverride: queueProcessor,
+    });
+    const source = await ctx.threadStore.create('alice', 'Strategy Discussion');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: { initialMessage: '开玩！我先起头：一帆风顺', preferredCats: ['opus'] },
+        })
+      ).body,
+    );
+
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    const entries = invocationQueue.list(body.threadId, 'alice');
+    assert.equal(entries.length, 1);
+    const enqueued = entries[0].content;
+    assert.ok(
+      enqueued.includes('## 主 Thread'),
+      `enqueued content must include "## 主 Thread" header; got:\n${enqueued}`,
+    );
+    assert.ok(enqueued.includes(source.id), 'header must contain sourceThreadId so cats can locate parent');
+    assert.ok(enqueued.includes('Strategy Discussion'), 'header must contain sourceThread title when available');
+    assert.ok(
+      enqueued.includes('cat_cafe_cross_post_message'),
+      'header must remind cats to cross_post the report back via cat_cafe_cross_post_message',
+    );
+    // Original user content must still be present — header is additive, not destructive.
+    assert.ok(enqueued.includes('开玩！我先起头：一帆风顺'), 'original user-typed content must be preserved verbatim');
+
+    // The proposal store must keep the user-typed content RAW (no header) — the
+    // header is a thread-message artifact, not part of the proposal record.
+    const stored = await ctx.proposalStore.get(proposalId);
+    assert.equal(
+      stored.initialMessage,
+      '开玩！我先起头：一帆风顺',
+      'proposal record stores user-typed initialMessage verbatim; header lives only in the thread message',
+    );
+  });
+
+  test('approve preserves router-resolved targets when initialMessage has @-mention (no fallback)', async () => {
+    // Defensive: if the user explicitly @-mentions someone in initialMessage, the router's
+    // resolution wins — preferredCats does NOT override the explicit user intent.
+    const { InvocationQueue } = await import('../dist/domains/cats/services/agents/invocation/InvocationQueue.js');
+    const invocationQueue = new InvocationQueue();
+    const router = {
+      async resolveTargetsAndIntent() {
+        return { targetCats: ['codex'], intent: { intent: 'execute' }, hasMentions: true };
+      },
+    };
+    const queueProcessor = {
+      async processNext() {
+        return { started: true };
+      },
+    };
+    const ctx = await createProposalTestContext({
+      routerOverride: router,
+      invocationQueueOverride: invocationQueue,
+      queueProcessorOverride: queueProcessor,
+    });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: {
+            initialMessage: '@codex 帮我看一下',
+            preferredCats: ['kimi', 'gemini'],
+          },
+        })
+      ).body,
+    );
+
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    const entries = invocationQueue.list(body.threadId, 'alice');
+    assert.deepEqual(
+      entries[0].targetCats,
+      ['codex'],
+      'explicit @-mention in content must beat the preferredCats fallback',
+    );
+  });
+});

--- a/packages/api/test/proposal-concurrency.test.js
+++ b/packages/api/test/proposal-concurrency.test.js
@@ -1,0 +1,111 @@
+/**
+ * F128 Proposal Flow — concurrency + stale-claim recovery tests.
+ * Split from proposal-flow.test.js to keep each file under the 350-line hard limit (AC-X1).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import './helpers/setup-cat-registry.js';
+import { createProposalTestContext } from './helpers/proposal-test-harness.js';
+
+describe('F128 concurrency + stale-claim recovery', () => {
+  test('concurrent approve + reject leaves no orphan thread', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class SlowApprovalStore extends InMemoryProposalStore {
+      async claimForApproval(input) {
+        const claimed = super.claimForApproval(input);
+        await new Promise((r) => setTimeout(r, 30));
+        return claimed;
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new SlowApprovalStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const threadsBefore = ctx.threadStore.size;
+    const [approveRes, rejectRes] = await Promise.all([
+      ctx.approve('alice', proposalId),
+      new Promise((r) => setTimeout(r, 5)).then(() => ctx.reject('alice', proposalId)),
+    ]);
+    assert.equal(approveRes.statusCode, 200);
+    assert.equal(rejectRes.statusCode, 409);
+    const proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'approved');
+    assert.equal(ctx.threadStore.size, threadsBefore + 1);
+  });
+
+  test('reject wins over approve when reject claims first (no orphan thread)', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class SlowApprovalStore extends InMemoryProposalStore {
+      async claimForApproval(input) {
+        await new Promise((r) => setTimeout(r, 30));
+        return super.claimForApproval(input);
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new SlowApprovalStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const threadsBefore = ctx.threadStore.size;
+    const [approveRes, rejectRes] = await Promise.all([
+      ctx.approve('alice', proposalId),
+      ctx.reject('alice', proposalId),
+    ]);
+    assert.equal(rejectRes.statusCode, 200);
+    assert.equal(approveRes.statusCode, 409);
+    assert.equal(ctx.threadStore.size, threadsBefore, 'reject must not create any thread');
+    const proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'rejected');
+  });
+
+  test('approving status with stale claim is auto-recovered on next approve', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    ctx.proposalStore.claimForApproval({ proposalId, approvedBy: 'alice' });
+    let proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'approving');
+    assert.ok(proposal.claimedAt);
+    ctx.proposalStore.proposals.get(proposalId).claimedAt = Date.now() - 60_000;
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'approved');
+    proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'approved');
+    assert.ok(proposal.createdThreadId);
+  });
+
+  test('stale claim with createdThreadId recovers via finalize (no duplicate thread)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    ctx.proposalStore.claimForApproval({ proposalId, approvedBy: 'alice' });
+    const orphanedThread = await ctx.threadStore.create('alice', 'Recovered', 'default');
+    ctx.proposalStore.recordCreatedThread(proposalId, orphanedThread.id);
+    ctx.proposalStore.proposals.get(proposalId).claimedAt = Date.now() - 60_000;
+    const threadCountBefore = ctx.threadStore.size;
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'approved');
+    assert.equal(body.threadId, orphanedThread.id);
+    assert.equal(body.recovered, true);
+    assert.equal(ctx.threadStore.size, threadCountBefore, 'must not create a second thread');
+  });
+
+  test('reject on stale-claim with createdThreadId refuses (thread already exists)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    ctx.proposalStore.claimForApproval({ proposalId, approvedBy: 'alice' });
+    const orphanedThread = await ctx.threadStore.create('alice', 'Recovered', 'default');
+    ctx.proposalStore.recordCreatedThread(proposalId, orphanedThread.id);
+    ctx.proposalStore.proposals.get(proposalId).claimedAt = Date.now() - 60_000;
+    const res = await ctx.reject('alice', proposalId);
+    assert.equal(res.statusCode, 409);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'approved');
+    assert.equal(body.threadId, orphanedThread.id);
+    const finalProposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(finalProposal.status, 'approved');
+  });
+});

--- a/packages/api/test/proposal-flow.test.js
+++ b/packages/api/test/proposal-flow.test.js
@@ -1,0 +1,194 @@
+/**
+ * F128 Proposal Flow — core lifecycle tests (propose / approve / reject).
+ * Concurrency + stale recovery: proposal-concurrency.test.js
+ * Partial-commit + dedup + self-heal: proposal-resilience.test.js
+ *
+ * Covers AC-B7:
+ *  - cat-auth propose happy path
+ *  - stale invocation guard
+ *  - cross-user parent ownership rejection
+ *  - clientRequestId idempotency
+ *  - user-auth approve happy path + double-approve idempotency
+ *  - cross-user approve 403
+ *  - approve-after-reject 409
+ *  - reject happy path + reject-after-approve 409
+ *  - audit metadata + socket payload shape
+ *  - edit-on-approve applied to created thread
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import './helpers/setup-cat-registry.js';
+import { createProposalTestContext } from './helpers/proposal-test-harness.js';
+
+describe('F128 propose / approve / reject lifecycle', () => {
+  test('propose creates a pending proposal without creating a thread', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const before = ctx.threadStore.size;
+    const res = await ctx.propose({ userId: 'alice', threadId: source.id });
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'pending');
+    assert.match(body.proposalId, /^proposal_/);
+    assert.equal(ctx.threadStore.size, before, 'no new thread should be created on propose');
+    const stored = await ctx.proposalStore.get(body.proposalId);
+    assert.equal(stored.sourceThreadId, source.id);
+    assert.equal(stored.parentThreadId, source.id);
+  });
+
+  test('propose returns stale_ignored when a newer invocation supersedes', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const first = await ctx.registry.create('alice', 'opus', source.id);
+    await ctx.registry.create('alice', 'opus', source.id);
+    const res = await ctx.app.inject({
+      method: 'POST',
+      url: '/api/callbacks/propose-thread',
+      headers: { 'x-invocation-id': first.invocationId, 'x-callback-token': first.callbackToken },
+      payload: { title: 't', reason: 'r' },
+    });
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).status, 'stale_ignored');
+  });
+
+  test('propose rejects parentThreadId owned by another user (403)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const foreign = await ctx.threadStore.create('bob', 'Foreign');
+    const res = await ctx.propose({ userId: 'alice', threadId: source.id, body: { parentThreadId: foreign.id } });
+    assert.equal(res.statusCode, 403);
+  });
+
+  test('propose is idempotent on clientRequestId', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const first = await ctx.propose({ userId: 'alice', threadId: source.id, body: { clientRequestId: 'req-1' } });
+    const second = await ctx.propose({ userId: 'alice', threadId: source.id, body: { clientRequestId: 'req-1' } });
+    const firstId = JSON.parse(first.body).proposalId;
+    const secondBody = JSON.parse(second.body);
+    assert.equal(secondBody.proposalId, firstId);
+    assert.equal(secondBody.deduped, true);
+  });
+
+  test('approve creates a new thread and marks proposal approved', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'approved');
+    const newThread = await ctx.threadStore.get(body.threadId);
+    assert.ok(newThread);
+    assert.equal(newThread.title, 'New thread');
+    assert.equal(newThread.parentThreadId, source.id);
+    const proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'approved');
+    assert.equal(proposal.createdThreadId, body.threadId);
+    assert.equal(proposal.approvedBy, 'alice');
+  });
+
+  // Approve-side dispatch behaviours (queue processor wiring, preferredCats
+  // fallback, intent default, fork-and-return header, explicit-mention
+  // precedence) moved to proposal-approve-dispatch.test.js to keep this file
+  // under the AC-X1 350-line cap.
+  test('double approve returns the same thread (idempotent)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const first = JSON.parse((await ctx.approve('alice', proposalId)).body);
+    const second = JSON.parse((await ctx.approve('alice', proposalId)).body);
+    assert.equal(second.threadId, first.threadId);
+    assert.equal(second.deduped, true);
+  });
+
+  test('approve by a different user returns 403', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const res = await ctx.approve('bob', proposalId);
+    assert.equal(res.statusCode, 403);
+  });
+
+  test('approve after reject returns 409', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    await ctx.reject('alice', proposalId);
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 409);
+  });
+
+  test('reject marks proposal rejected without creating a thread', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const sizeBefore = ctx.threadStore.size;
+    const res = await ctx.reject('alice', proposalId, { rejectionReason: 'not now' });
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).status, 'rejected');
+    assert.equal(ctx.threadStore.size, sizeBefore);
+    const proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'rejected');
+    assert.equal(proposal.rejectionReason, 'not now');
+  });
+
+  test('reject after approve returns 409', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    await ctx.approve('alice', proposalId);
+    const res = await ctx.reject('alice', proposalId);
+    assert.equal(res.statusCode, 409);
+  });
+
+  test('approve writes audit metadata onto the created thread', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    const { threadId } = JSON.parse((await ctx.approve('alice', proposalId)).body);
+    const thread = await ctx.threadStore.get(threadId);
+    assert.equal(thread.createdFromProposalId, proposalId);
+    assert.equal(thread.sourceThreadId, source.id);
+    assert.equal(thread.approvedBy, 'alice');
+    assert.ok(typeof thread.approvedAt === 'number' && thread.approvedAt > 0);
+  });
+
+  test('thread_created socket event emits the Thread itself (no envelope wrapper)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse((await ctx.propose({ userId: 'alice', threadId: source.id })).body);
+    ctx.socketEvents.length = 0;
+    await ctx.approve('alice', proposalId);
+    const evt = ctx.socketEvents.find((e) => e.event === 'thread_created');
+    assert.ok(evt);
+    assert.ok(evt.data && typeof evt.data.id === 'string', 'payload must have id at top level');
+    assert.equal(typeof evt.data.thread, 'undefined', 'payload must NOT be wrapped in {thread}');
+  });
+
+  test('approve applies user overrides (title + initialMessage)', async () => {
+    const ctx = await createProposalTestContext();
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (
+        await ctx.propose({
+          userId: 'alice',
+          threadId: source.id,
+          body: { title: 'orig title', initialMessage: 'orig msg' },
+        })
+      ).body,
+    );
+    const res = await ctx.approve('alice', proposalId, { title: 'edited title', initialMessage: 'edited msg' });
+    assert.equal(res.statusCode, 200);
+    const { threadId } = JSON.parse(res.body);
+    const newThread = await ctx.threadStore.get(threadId);
+    assert.equal(newThread.title, 'edited title');
+    const msgs = await ctx.messageStore.getByThread(threadId);
+    const userMsg = msgs.find((m) => m.userId === 'alice' && m.catId === null);
+    assert.ok(userMsg);
+    // Server injects "## 主 Thread" header; edited message is at the start.
+    assert.ok(userMsg.content.startsWith('edited msg'), 'thread first message should start with user-edited content');
+    assert.ok(userMsg.content.includes('## 主 Thread'), 'thread first message should include parent header');
+  });
+});

--- a/packages/api/test/proposal-resilience.test.js
+++ b/packages/api/test/proposal-resilience.test.js
@@ -1,0 +1,272 @@
+/**
+ * F128 Proposal Flow — partial-commit, dedup race, and self-heal tests.
+ * Split from proposal-flow.test.js to keep each file under the 350-line hard limit (AC-X1).
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import './helpers/setup-cat-registry.js';
+import { createProposalTestContext } from './helpers/proposal-test-harness.js';
+
+describe('F128 partial-commit + dedup + self-heal', () => {
+  test('initialMessage append failure does NOT roll back the thread or proposal (best-effort warning)', async () => {
+    const { MessageStore } = await import('../dist/domains/cats/services/stores/ports/MessageStore.js');
+    class FailingMessageStore extends MessageStore {
+      append(msg) {
+        if (msg.catId === null && msg.userId === 'alice') {
+          throw new Error('synthetic append failure');
+        }
+        return super.append(msg);
+      }
+    }
+    const ctx = await createProposalTestContext({ messageStoreOverride: new FailingMessageStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { proposalId } = JSON.parse(
+      (await ctx.propose({ userId: 'alice', threadId: source.id, body: { initialMessage: 'will fail to post' } })).body,
+    );
+    const threadsBefore = ctx.threadStore.size;
+    const res = await ctx.approve('alice', proposalId);
+    assert.equal(res.statusCode, 200);
+    const body = JSON.parse(res.body);
+    assert.equal(body.status, 'approved');
+    assert.ok(Array.isArray(body.warnings));
+    assert.ok(body.warnings.some((w) => w.includes('initialMessage')));
+    const proposal = await ctx.proposalStore.get(proposalId);
+    assert.equal(proposal.status, 'approved', 'proposal must NOT roll back to pending after thread creation');
+    assert.equal(ctx.threadStore.size, threadsBefore + 1, 'thread must remain');
+  });
+
+  test('self-heal works even when 60+ messages have accumulated after the marker failure', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class FlakyMarkerStore extends InMemoryProposalStore {
+      constructor() {
+        super();
+        this.failNext = true;
+      }
+      setCardMessageId(proposalId, cardMessageId) {
+        if (this.failNext) {
+          this.failNext = false;
+          throw new Error('synthetic marker failure');
+        }
+        return super.setCardMessageId(proposalId, cardMessageId);
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new FlakyMarkerStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const payload = {
+      title: 'Old card retry',
+      reason: 'Marker fails then thread fills up',
+      clientRequestId: 'old-card-key',
+    };
+    const send = () => ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    const first = await send();
+    assert.equal(first.statusCode, 200);
+    for (let i = 0; i < 60; i++) {
+      await ctx.messageStore.append({
+        userId: 'alice',
+        catId: null,
+        content: `filler ${i}`,
+        mentions: [],
+        timestamp: Date.now() + i,
+        threadId: source.id,
+      });
+    }
+    const second = await send();
+    assert.equal(second.statusCode, 200, `retry must self-heal old card, got ${second.statusCode}`);
+    const secondBody = JSON.parse(second.body);
+    assert.equal(secondBody.deduped, true);
+    const healed = await ctx.proposalStore.get(secondBody.proposalId);
+    assert.ok(healed.cardMessageId);
+  });
+
+  test('setCardMessageId failure: 200 with warning + retry self-heals via source thread scan', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class FlakyMarkerStore extends InMemoryProposalStore {
+      constructor() {
+        super();
+        this.failNext = true;
+      }
+      setCardMessageId(proposalId, cardMessageId) {
+        if (this.failNext) {
+          this.failNext = false;
+          throw new Error('synthetic marker write failure');
+        }
+        return super.setCardMessageId(proposalId, cardMessageId);
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new FlakyMarkerStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const payload = {
+      title: 'Marker fail test',
+      reason: 'Marker write throws',
+      clientRequestId: 'marker-fail-key',
+    };
+    const send = () => ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    const first = await send();
+    assert.equal(first.statusCode, 200);
+    const firstBody = JSON.parse(first.body);
+    assert.ok(Array.isArray(firstBody.warnings));
+    assert.ok(firstBody.warnings.some((w) => w.includes('setCardMessageId')));
+    const stored = await ctx.proposalStore.get(firstBody.proposalId);
+    assert.equal(stored.cardMessageId, undefined);
+    const second = await send();
+    assert.equal(second.statusCode, 200);
+    const secondBody = JSON.parse(second.body);
+    assert.equal(secondBody.proposalId, firstBody.proposalId);
+    assert.equal(secondBody.deduped, true);
+    const healed = await ctx.proposalStore.get(firstBody.proposalId);
+    assert.ok(healed.cardMessageId);
+  });
+
+  test('concurrent retry during in-flight card append returns 503 (not phantom 200 deduped)', async () => {
+    const { MessageStore } = await import('../dist/domains/cats/services/stores/ports/MessageStore.js');
+    let releaseFirstAppend;
+    const firstAppendBlocked = new Promise((resolve) => {
+      releaseFirstAppend = resolve;
+    });
+    let firstAppendSeen = false;
+    class BlockingMessageStore extends MessageStore {
+      async append(msg) {
+        if (!firstAppendSeen && String(msg.content ?? '').startsWith('提议新建 thread')) {
+          firstAppendSeen = true;
+          await firstAppendBlocked;
+        }
+        return super.append(msg);
+      }
+    }
+    const ctx = await createProposalTestContext({ messageStoreOverride: new BlockingMessageStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const payload = {
+      title: 'In-flight test',
+      reason: 'Card append blocks',
+      clientRequestId: 'inflight-key',
+    };
+    const send = () => ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    const firstPromise = send();
+    await new Promise((r) => setTimeout(r, 10));
+    const second = await send();
+    assert.equal(second.statusCode, 503, `expected 503 in-flight, got ${second.statusCode}: ${second.body}`);
+    const body = JSON.parse(second.body);
+    assert.equal(body.status, 'retryable');
+    assert.notEqual(body.deduped, true);
+    releaseFirstAppend();
+    const first = await firstPromise;
+    assert.equal(first.statusCode, 200);
+    const winningId = JSON.parse(first.body).proposalId;
+    const third = await send();
+    assert.equal(third.statusCode, 200);
+    const thirdBody = JSON.parse(third.body);
+    assert.equal(thirdBody.proposalId, winningId);
+    assert.equal(thirdBody.deduped, true);
+  });
+
+  test('card append failure cleans up proposal + releases dedup so retry creates a visible card', async () => {
+    const { MessageStore } = await import('../dist/domains/cats/services/stores/ports/MessageStore.js');
+    class FailFirstAppendStore extends MessageStore {
+      constructor() {
+        super();
+        this.failNext = true;
+      }
+      append(msg) {
+        if (this.failNext && msg.content && String(msg.content).startsWith('提议新建 thread')) {
+          this.failNext = false;
+          throw new Error('synthetic card append failure');
+        }
+        return super.append(msg);
+      }
+    }
+    const ctx = await createProposalTestContext({ messageStoreOverride: new FailFirstAppendStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const payload = {
+      title: 'Card retry test',
+      reason: 'Verify card append cleanup',
+      clientRequestId: 'card-retry-key',
+    };
+    const first = await ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    assert.notEqual(first.statusCode, 200);
+    const pendingAfterFirst = await ctx.proposalStore.listPending('alice');
+    assert.equal(pendingAfterFirst.length, 0);
+    const second = await ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    assert.equal(second.statusCode, 200);
+    const body = JSON.parse(second.body);
+    assert.notEqual(body.deduped, true);
+    assert.ok(body.proposalId);
+    const sourceMessages = await ctx.messageStore.getByThread(source.id);
+    const cardMessage = sourceMessages.find((m) => String(m.content ?? '').startsWith('提议新建 thread'));
+    assert.ok(cardMessage);
+  });
+
+  test('reserve success + create failure releases dedup so retry can reclaim', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class FailFirstCreateStore extends InMemoryProposalStore {
+      constructor() {
+        super();
+        this.createCalls = 0;
+      }
+      create(input) {
+        this.createCalls += 1;
+        if (this.createCalls === 1) throw new Error('synthetic create failure');
+        return super.create(input);
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new FailFirstCreateStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const payload = {
+      title: 'Retry test',
+      reason: 'Need to verify dedup release',
+      clientRequestId: 'retry-key',
+    };
+    const first = await ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    assert.notEqual(first.statusCode, 200);
+    const second = await ctx.app.inject({ method: 'POST', url: '/api/callbacks/propose-thread', headers, payload });
+    assert.equal(second.statusCode, 200);
+    const body = JSON.parse(second.body);
+    assert.notEqual(body.deduped, true);
+    assert.ok(body.proposalId);
+    const stored = await ctx.proposalStore.get(body.proposalId);
+    assert.ok(stored);
+    assert.equal(stored.status, 'pending');
+  });
+
+  test('dedup race: loser leaves no orphan proposal in the pending list', async () => {
+    const { InMemoryProposalStore } = await import('../dist/domains/cats/services/stores/ports/ProposalStore.js');
+    class SlowReserveStore extends InMemoryProposalStore {
+      async reserveDedup(userId, clientRequestId, proposalId) {
+        await new Promise((r) => setTimeout(r, 30));
+        return super.reserveDedup(userId, clientRequestId, proposalId);
+      }
+    }
+    const ctx = await createProposalTestContext({ proposalStoreOverride: new SlowReserveStore() });
+    const source = await ctx.threadStore.create('alice', 'Source');
+    const { invocationId, callbackToken } = await ctx.registry.create('alice', 'opus', source.id);
+    const headers = { 'x-invocation-id': invocationId, 'x-callback-token': callbackToken };
+    const send = () =>
+      ctx.app.inject({
+        method: 'POST',
+        url: '/api/callbacks/propose-thread',
+        headers,
+        payload: {
+          title: 'New thread',
+          reason: 'Because',
+          clientRequestId: 'race-key',
+        },
+      });
+    const [first, second] = await Promise.all([send(), send()]);
+    const firstBody = JSON.parse(first.body);
+    const secondBody = JSON.parse(second.body);
+    assert.equal(secondBody.proposalId, firstBody.proposalId);
+    const pending = await ctx.proposalStore.listPending('alice');
+    assert.equal(pending.length, 1);
+    assert.equal(pending[0].proposalId, firstBody.proposalId);
+  });
+});

--- a/packages/api/test/proposal-store-ttl.test.js
+++ b/packages/api/test/proposal-store-ttl.test.js
@@ -1,0 +1,120 @@
+// @ts-check
+/**
+ * F128 P0 contract — RedisProposalStore must NOT auto-expire proposal hashes.
+ *
+ * Iron law #5 (LL-048): user-visible/recoverable state defaults to persistent
+ * (TTL=0); TTL is only opt-in. Proposal hashes carry approval-card UI state +
+ * approval audit lineage, and the zset indices (proposals:user/pending/thread)
+ * would otherwise dangle when the hash expires. This unit test pins the
+ * contract by intercepting `multi()` and asserting whether `expire()` was
+ * issued — no live Redis required, so it runs in the public CI test job.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const { RedisProposalStore } = await import('../dist/domains/cats/services/stores/redis/RedisProposalStore.js');
+
+/**
+ * Capture all pipeline ops for a given multi() call.
+ * RedisProposalStore.create() only uses: hset, expire, zadd, exec.
+ */
+function createMockRedis() {
+  /** @type {Array<{ ops: Array<[string, ...unknown[]]> }>} */
+  const pipelines = [];
+
+  function makePipeline() {
+    /** @type {Array<[string, ...unknown[]]>} */
+    const ops = [];
+    const pipeline = {
+      hset(...args) {
+        ops.push(['hset', ...args]);
+        return pipeline;
+      },
+      expire(...args) {
+        ops.push(['expire', ...args]);
+        return pipeline;
+      },
+      zadd(...args) {
+        ops.push(['zadd', ...args]);
+        return pipeline;
+      },
+      async exec() {
+        return [];
+      },
+    };
+    pipelines.push({ ops });
+    return pipeline;
+  }
+
+  return {
+    pipelines,
+    multi: makePipeline,
+    pipeline: makePipeline,
+  };
+}
+
+function baseInput(overrides = {}) {
+  return {
+    sourceThreadId: 'thread_src',
+    sourceInvocationId: 'inv_1',
+    sourceCatId: 'opus',
+    title: 'TTL contract',
+    reason: 'pin LL-048 / iron law #5',
+    parentThreadId: 'thread_src',
+    preferredCats: ['codex'],
+    projectPath: '/tmp/ttl-test',
+    createdBy: 'alice',
+    ...overrides,
+  };
+}
+
+describe('RedisProposalStore — TTL contract (iron law #5 / LL-048)', () => {
+  it('default constructor: create() does NOT issue EXPIRE on the proposal hash', async () => {
+    const redis = createMockRedis();
+    const store = new RedisProposalStore(/** @type {any} */ (redis));
+    await store.create(baseInput());
+    assert.equal(redis.pipelines.length, 1, 'create should use exactly one multi() pipeline');
+    const expireOps = redis.pipelines[0].ops.filter((op) => op[0] === 'expire');
+    assert.equal(
+      expireOps.length,
+      0,
+      'default create must NOT call expire — user-visible state is persistent by default',
+    );
+  });
+
+  it('explicit ttlSeconds > 0 opts in: EXPIRE is issued on the proposal hash', async () => {
+    const redis = createMockRedis();
+    const store = new RedisProposalStore(/** @type {any} */ (redis), { ttlSeconds: 60 });
+    const created = await store.create(baseInput({ createdBy: 'bob' }));
+    const expireOps = redis.pipelines[0].ops.filter((op) => op[0] === 'expire');
+    assert.equal(expireOps.length, 1, 'explicit positive ttlSeconds must call expire exactly once');
+    // op shape: ['expire', key, seconds]
+    assert.equal(expireOps[0][1], `proposal:${created.proposalId}`);
+    assert.equal(expireOps[0][2], 60);
+  });
+
+  it('ttlSeconds = 0 is treated as no-ttl (defensive against accidental zeroing)', async () => {
+    const redis = createMockRedis();
+    const store = new RedisProposalStore(/** @type {any} */ (redis), { ttlSeconds: 0 });
+    await store.create(baseInput({ createdBy: 'carol' }));
+    const expireOps = redis.pipelines[0].ops.filter((op) => op[0] === 'expire');
+    assert.equal(expireOps.length, 0, 'ttlSeconds=0 must be treated as no-ttl');
+  });
+
+  it('negative ttlSeconds is treated as no-ttl', async () => {
+    const redis = createMockRedis();
+    const store = new RedisProposalStore(/** @type {any} */ (redis), { ttlSeconds: -1 });
+    await store.create(baseInput({ createdBy: 'dave' }));
+    const expireOps = redis.pipelines[0].ops.filter((op) => op[0] === 'expire');
+    assert.equal(expireOps.length, 0, 'negative ttlSeconds must be treated as no-ttl');
+  });
+
+  it('NaN ttlSeconds is treated as no-ttl', async () => {
+    const redis = createMockRedis();
+    const store = new RedisProposalStore(/** @type {any} */ (redis), { ttlSeconds: Number.NaN });
+    await store.create(baseInput({ createdBy: 'erin' }));
+    const expireOps = redis.pipelines[0].ops.filter((op) => op[0] === 'expire');
+    assert.equal(expireOps.length, 0, 'NaN ttlSeconds must be treated as no-ttl');
+  });
+});

--- a/packages/mcp-server/src/tools/callback-tools.ts
+++ b/packages/mcp-server/src/tools/callback-tools.ts
@@ -1152,6 +1152,65 @@ export async function handleBootcampEnvCheck(input: { threadId: string }): Promi
   return callbackPost('/api/callbacks/bootcamp-env-check', { threadId: input.threadId });
 }
 
+// ============ Propose Thread (F128) ============
+
+export const proposeThreadInputSchema = {
+  title: z.string().min(1).max(200).describe('Title for the proposed thread (user can edit before approving)'),
+  reason: z.string().min(1).max(1000).describe('Why a new thread is needed (shown to the user on the proposal card)'),
+  preferredCats: z
+    .array(z.string().min(1))
+    .max(10)
+    .optional()
+    .describe('Optional cat IDs to preselect for the new thread (e.g. ["codex","gemini"])'),
+  initialMessage: z
+    .string()
+    .max(4000)
+    .optional()
+    .describe('Optional first message body that will be posted by the user into the new thread on approve'),
+  parentThreadId: z.string().min(1).optional().describe('Optional parent thread ID. Defaults to the current thread.'),
+  clientRequestId: z
+    .string()
+    .min(1)
+    .max(200)
+    .optional()
+    .describe('Optional idempotency key. Resending with the same value returns the same proposalId.'),
+};
+
+export async function handleProposeThread(input: {
+  title: string;
+  reason: string;
+  preferredCats?: string[] | undefined;
+  initialMessage?: string | undefined;
+  parentThreadId?: string | undefined;
+  clientRequestId?: string | undefined;
+}): Promise<ToolResult> {
+  // P2-1: always send an idempotency key — auto-generate when the caller didn't supply one,
+  // so transient network retries from callbackPost never produce duplicate proposals.
+  const body: Record<string, unknown> = {
+    title: input.title,
+    reason: input.reason,
+    clientRequestId: input.clientRequestId ?? randomUUID(),
+  };
+  if (input.preferredCats?.length) body.preferredCats = input.preferredCats;
+  if (input.initialMessage) body.initialMessage = input.initialMessage;
+  if (input.parentThreadId) body.parentThreadId = input.parentThreadId;
+
+  const result = await callbackPost('/api/callbacks/propose-thread', body);
+  if (!result.isError) {
+    try {
+      const data = JSON.parse((result.content[0] as { text: string }).text);
+      if (data?.status === 'stale_ignored') {
+        return errorResult(
+          'Proposal was NOT created: this invocation has been superseded by a newer one (stale_ignored).',
+        );
+      }
+    } catch {
+      // parse failure is fine
+    }
+  }
+  return result;
+}
+
 // ============ Thread Cats Discovery ============
 
 export const getThreadCatsInputSchema = {};
@@ -1437,6 +1496,22 @@ export const callbackTools = [
       'Returns the full check results for display to the user. Only use during bootcamp phase-2-env-check.',
     inputSchema: bootcampEnvCheckInputSchema,
     handler: handleBootcampEnvCheck,
+  },
+  // F128: Cat-initiated thread proposal (user approves before thread is created)
+  {
+    name: 'cat_cafe_propose_thread',
+    description:
+      'Propose a new thread to the user. Returns proposalId, NOT a threadId — the thread is only created after the user approves the proposal card. Use sparingly: ' +
+      'only when a clearly separable, long-running discussion genuinely deserves its own thread, or when the owner asks for "新开一个 thread". ' +
+      'Do NOT use to escape the current conversation, to split routine tasks, or proactively without an obvious need. ' +
+      'parentThreadId defaults to the current thread. After proposing, continue your current work — do not assume the thread exists until the user approves. ' +
+      'WRITING @-mentions in `initialMessage`: use the SAME stable handle you use in the current thread (e.g. `@砚砚`, `@opus46`, `@gemini`) — NOT the raw catId form like `@cat-rcs85pvn`. ' +
+      'Server normalizes known catIds to stable handles defensively, but always prefer the handle form so the proposal card reads naturally to the user. ' +
+      'preferredCats accepts catIds (returned by cat_cafe_get_thread_cats), and dispatch will wake them in the listed order when the user approves. ' +
+      'FORK-AND-RETURN pattern (thread-orchestration skill Step 5c): if you proposed this thread to delegate a discussion or workflow, write into `initialMessage` who is responsible for reporting back to the source thread when work is done (e.g. "最后一棒猫负责 cat_cafe_cross_post_message 把结果回报到主 thread"). Server auto-injects a "## 主 Thread" header so cats can locate the parent, but you should still state the completion / report-back protocol explicitly so the cats inside the sub-thread know when to close the loop. ' +
+      'INTENT (serial vs ideate): by default the sub-thread first message is dispatched serially in the preferredCats order — write members in the exact order you want them woken (e.g. 接龙 / 轮转). If you genuinely want parallel ideation, tag the message with `#ideate`.',
+    inputSchema: proposeThreadInputSchema,
+    handler: handleProposeThread,
   },
   // ============ F155: Guide Engine ============
   {

--- a/packages/mcp-server/test/tool-registration.test.js
+++ b/packages/mcp-server/test/tool-registration.test.js
@@ -49,6 +49,8 @@ const EXPECTED_TOOLS = [
   // Bootcamp tools (F087)
   'cat_cafe_update_bootcamp_state',
   'cat_cafe_bootcamp_env_check',
+  // F128: Cat-initiated thread proposal
+  'cat_cafe_propose_thread',
   // Callback-scoped memory tools
   'cat_cafe_retain_memory_callback',
   // Direct evidence tools (cat_cafe_reflect removed in F193 Phase D AC-D1)
@@ -148,6 +150,8 @@ const EXPECTED_COLLAB_TOOLS = [
   'cat_cafe_start_vote',
   'cat_cafe_update_bootcamp_state',
   'cat_cafe_bootcamp_env_check',
+  // F128: Cat-initiated thread proposal
+  'cat_cafe_propose_thread',
   'cat_cafe_submit_game_action',
   // F139 Phase 3A: Schedule tools
   'cat_cafe_list_schedule_templates',

--- a/packages/shared/src/types/ids.ts
+++ b/packages/shared/src/types/ids.ts
@@ -14,6 +14,7 @@ export type CatId = Brand<string, 'CatId'>;
 export type ThreadId = Brand<string, 'ThreadId'>;
 export type SessionId = Brand<string, 'SessionId'>;
 export type UserId = Brand<string, 'UserId'>;
+export type ProposalId = Brand<string, 'ProposalId'>;
 
 /**
  * Generate a random ID with optional prefix
@@ -83,4 +84,18 @@ export function generateSessionId(): SessionId {
  */
 export function createUserId(id: string): UserId {
   return id as UserId;
+}
+
+/**
+ * Create a ProposalId from a string
+ */
+export function createProposalId(id: string): ProposalId {
+  return id as ProposalId;
+}
+
+/**
+ * Generate a new ProposalId
+ */
+export function generateProposalId(): ProposalId {
+  return createProposalId(generateId('proposal'));
 }

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -289,6 +289,7 @@ export {
 export type {
   CatId,
   MessageId,
+  ProposalId,
   SessionId,
   ThreadId,
   UserId,
@@ -296,11 +297,13 @@ export type {
 export {
   createCatId,
   createMessageId,
+  createProposalId,
   createSessionId,
   createThreadId,
   createUserId,
   generateId,
   generateMessageId,
+  generateProposalId,
   generateSessionId,
   generateThreadId,
 } from './ids.js';
@@ -443,6 +446,12 @@ export type {
   ResolverType,
   WorkflowAction,
 } from './pack.js';
+// Proposal types (F128 Cat Thread Proposal)
+export type {
+  ProposalApproveOverrides,
+  ProposalStatus,
+  ThreadProposal,
+} from './proposal.js';
 // Reflux types (F076 Phase 2 — 回流)
 export type {
   CreateRefluxPatternInput,

--- a/packages/shared/src/types/proposal.ts
+++ b/packages/shared/src/types/proposal.ts
@@ -1,0 +1,79 @@
+/**
+ * F128: Thread proposal types.
+ *
+ * Cats propose a new thread via `cat_cafe_propose_thread`; the user
+ * sees a card, edits if needed, and approves or rejects. Only on
+ * approve does the backend actually create a thread.
+ */
+
+import type { CatId } from './ids.js';
+
+/**
+ * Status lifecycle:
+ *   pending → approving → approved   (claim then finalize, atomic against reject)
+ *   pending → rejected               (one-shot)
+ *   approving → pending              (rollback on thread-creation failure)
+ */
+export type ProposalStatus = 'pending' | 'approving' | 'approved' | 'rejected';
+
+/**
+ * A thread proposal created by a cat, awaiting user decision.
+ */
+export interface ThreadProposal {
+  proposalId: string;
+  status: ProposalStatus;
+
+  // Source / lineage
+  sourceThreadId: string;
+  sourceInvocationId: string;
+  sourceCatId: CatId;
+
+  // Prefilled fields (user may override at approve time)
+  title: string;
+  reason: string;
+  parentThreadId: string; // defaults to sourceThreadId at create time
+  preferredCats: CatId[]; // empty array if none
+  initialMessage?: string;
+  projectPath: string;
+
+  // Audit — creation
+  createdBy: string;
+  createdAt: number;
+
+  /**
+   * Message id of the rich proposal card that was successfully appended to the source thread.
+   * Acts as the visibility commit marker: until this is set, the proposal is in-flight and
+   * MUST NOT be returned via the dedup fast path. Concurrent retries between create() and
+   * card append would otherwise hand callers a phantom proposalId that gets cleaned up.
+   */
+  cardMessageId?: string;
+
+  // Audit — approval outcome
+  approvedBy?: string;
+  approvedAt?: number;
+  createdThreadId?: string;
+  /**
+   * Unix ms when claimForApproval transitioned status pending → approving.
+   * If the process crashes between claim and finalize, this lets approve/reject
+   * detect a stale claim (now - claimedAt > STALE_APPROVING_MS) and forcibly
+   * release it so the proposal isn't stuck forever.
+   */
+  claimedAt?: number;
+
+  // Audit — rejection outcome
+  rejectedBy?: string;
+  rejectedAt?: number;
+  rejectionReason?: string;
+}
+
+/**
+ * Fields the user may override at approve time.
+ * `null` means "clear the field" for preferredCats/initialMessage;
+ * `undefined` means "keep the proposal's prefilled value".
+ */
+export interface ProposalApproveOverrides {
+  title?: string;
+  parentThreadId?: string;
+  preferredCats?: CatId[];
+  initialMessage?: string | null;
+}

--- a/packages/web/src/components/__tests__/proposal-card.test.tsx
+++ b/packages/web/src/components/__tests__/proposal-card.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * F128 ProposalCard frontend tests (AC-F6).
+ *
+ * Covers: render, edit-on-approve payload, reject, approved/rejected state flip,
+ * and the `cat-cafe:proposal-updated` CustomEvent → status sync.
+ */
+
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Stub MarkdownContent so we don't pull the markdown stack into the unit test.
+vi.mock('@/components/MarkdownContent', () => ({
+  MarkdownContent: ({ content }: { content: string }) => React.createElement('p', null, content),
+}));
+
+const apiFetchMock = vi.fn();
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+}));
+
+import { ProposalCard } from '@/components/rich/ProposalCard';
+import type { RichCardBlock } from '@/stores/chat-types';
+
+const PROPOSAL_ID = 'proposal_test123';
+
+function makeBlock(overrides: Partial<RichCardBlock> = {}): RichCardBlock {
+  return {
+    id: `proposal-${PROPOSAL_ID}`,
+    kind: 'card',
+    v: 1,
+    title: `📥 提议新建 thread：F128 verification`,
+    bodyMarkdown: 'Need a dedicated thread for review.',
+    tone: 'info',
+    fields: [
+      { label: '父 Thread', value: 'thread_parent' },
+      { label: '建议成员', value: 'codex, gemini' },
+      { label: '首条消息', value: 'Kick off here.' },
+    ],
+    actions: [
+      { label: '批准并创建', action: 'propose:approve', payload: { proposalId: PROPOSAL_ID } },
+      { label: '驳回', action: 'propose:reject', payload: { proposalId: PROPOSAL_ID } },
+    ],
+    ...overrides,
+  };
+}
+
+function jsonResponse(status: number, body: Record<string, unknown>): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('ProposalCard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    apiFetchMock.mockReset();
+    // First mount-time GET /api/proposals/:id → 404 by default so each test starts in pending state.
+    apiFetchMock.mockImplementation(() => Promise.resolve(jsonResponse(404, { error: 'not found' })));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  async function render(block: RichCardBlock = makeBlock()) {
+    await act(async () => {
+      root.render(React.createElement(ProposalCard, { block }));
+    });
+  }
+
+  function findButton(label: string): HTMLButtonElement {
+    const button = [...container.querySelectorAll('button')].find((node) => node.textContent?.includes(label));
+    if (!button) throw new Error(`Missing button: ${label}`);
+    return button as HTMLButtonElement;
+  }
+
+  it('renders title, body, prefilled fields, and pending action buttons', async () => {
+    await render();
+    expect(container.textContent).toContain('📥 提议新建 thread：F128 verification');
+    expect(container.textContent).toContain('Need a dedicated thread for review.');
+    expect(container.textContent).toContain('thread_parent');
+    expect(container.textContent).toContain('codex, gemini');
+    expect(container.textContent).toContain('Kick off here.');
+    // Pending state shows 3 action buttons
+    const buttonLabels = [...container.querySelectorAll('button')].map((b) => b.textContent?.trim());
+    expect(buttonLabels).toContain('批准并创建');
+    expect(buttonLabels).toContain('编辑');
+    expect(buttonLabels).toContain('驳回');
+  });
+
+  it('approve POSTs to /api/proposals/:id/approve and flips card to approved state', async () => {
+    await render();
+    apiFetchMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse(200, { proposalId: PROPOSAL_ID, threadId: 'thread_new', status: 'approved' })),
+    );
+    await act(async () => {
+      findButton('批准并创建').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // Wait microtasks for fetch promise resolution
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      `/api/proposals/${PROPOSAL_ID}/approve`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(container.textContent).toContain('✓ 已批准');
+    expect(container.textContent).toContain('thread_new');
+  });
+
+  it('reject POSTs to /api/proposals/:id/reject and flips card to rejected state', async () => {
+    await render();
+    apiFetchMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse(200, { proposalId: PROPOSAL_ID, status: 'rejected' })),
+    );
+    await act(async () => {
+      findButton('驳回').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      `/api/proposals/${PROPOSAL_ID}/reject`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(container.textContent).toContain('✗ 已驳回');
+  });
+
+  it('edit mode sends user overrides in approve payload', async () => {
+    await render();
+    await act(async () => {
+      findButton('编辑').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // Mutate the title input. React listens to onChange synthetic events that fire on the
+    // native `input` event, but it tracks the previous value via a hidden property — assigning
+    // `.value = ...` directly bypasses that tracking and React skips the update. We use the
+    // native setter so React's change-tracker sees the new value.
+    const titleInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(titleInput).toBeTruthy();
+    const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    await act(async () => {
+      nativeSetter?.call(titleInput, 'edited title');
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    apiFetchMock.mockImplementation(() =>
+      Promise.resolve(jsonResponse(200, { proposalId: PROPOSAL_ID, threadId: 'thread_edited', status: 'approved' })),
+    );
+    await act(async () => {
+      findButton('批准（含编辑）').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The last call must include the edited title in its JSON body
+    const approveCall = apiFetchMock.mock.calls.find(([url]) => String(url).endsWith('/approve'));
+    expect(approveCall).toBeTruthy();
+    const sentBody = JSON.parse((approveCall![1] as { body: string }).body);
+    expect(sentBody.title).toBe('edited title');
+  });
+
+  it('cat-cafe:proposal-updated CustomEvent flips status without refetching', async () => {
+    await render();
+    expect(container.textContent).not.toContain('✓ 已批准');
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('cat-cafe:proposal-updated', {
+          detail: { proposalId: PROPOSAL_ID, status: 'approved', createdThreadId: 'thread_socket' },
+        }),
+      );
+    });
+    expect(container.textContent).toContain('✓ 已批准');
+    expect(container.textContent).toContain('thread_socket');
+  });
+});

--- a/packages/web/src/components/rich/ProposalCard.tsx
+++ b/packages/web/src/components/rich/ProposalCard.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { MarkdownContent } from '@/components/MarkdownContent';
+import type { RichCardBlock } from '@/stores/chat-types';
+import { apiFetch } from '@/utils/api-client';
+
+type Status = 'pending' | 'approving' | 'approved' | 'rejected';
+
+interface ProposalSnapshot {
+  proposalId: string;
+  status: Status;
+  createdThreadId?: string;
+}
+
+interface ProposalCardProps {
+  block: RichCardBlock;
+  messageId?: string;
+}
+
+interface ProposalFieldEdits {
+  title: string;
+  parentThreadId: string;
+  preferredCats: string;
+  initialMessage: string;
+}
+
+function extractProposalId(block: RichCardBlock): string | null {
+  const approveAction = block.actions?.find((a) => a.action === 'propose:approve');
+  const id = approveAction?.payload?.proposalId;
+  return typeof id === 'string' ? id : null;
+}
+
+function readField(block: RichCardBlock, label: string): string {
+  return block.fields?.find((f) => f.label === label)?.value ?? '';
+}
+
+function parsePreferredCats(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && s !== '（未指定）');
+}
+
+export function ProposalCard({ block }: ProposalCardProps) {
+  const proposalId = useMemo(() => extractProposalId(block), [block]);
+  const [status, setStatus] = useState<Status>('pending');
+  const [resultThreadId, setResultThreadId] = useState<string | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [edits, setEdits] = useState<ProposalFieldEdits>(() => ({
+    title: block.title.replace(/^📥 提议新建 thread：/, ''),
+    parentThreadId: readField(block, '父 Thread'),
+    preferredCats: readField(block, '建议成员'),
+    initialMessage: readField(block, '首条消息'),
+  }));
+
+  // Mount: fetch real status so reload / multi-tab views don't drift to stale "pending".
+  useEffect(() => {
+    if (!proposalId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await apiFetch(`/api/proposals/${proposalId}`);
+        if (!res.ok || cancelled) return;
+        const data = (await res.json()) as { proposal: ProposalSnapshot };
+        if (data.proposal && !cancelled) {
+          setStatus(data.proposal.status);
+          if (data.proposal.createdThreadId) setResultThreadId(data.proposal.createdThreadId);
+        }
+      } catch {
+        // best-effort sync; keep the optimistic 'pending' if fetch fails
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [proposalId]);
+
+  // Subscribe to socket-driven updates so other tabs / async approves reflect immediately.
+  useEffect(() => {
+    if (!proposalId || typeof window === 'undefined') return;
+    const handler = (ev: Event) => {
+      const detail = (ev as CustomEvent<ProposalSnapshot>).detail;
+      if (!detail || detail.proposalId !== proposalId) return;
+      setStatus(detail.status);
+      if (detail.createdThreadId) setResultThreadId(detail.createdThreadId);
+    };
+    window.addEventListener('cat-cafe:proposal-updated', handler);
+    return () => {
+      window.removeEventListener('cat-cafe:proposal-updated', handler);
+    };
+  }, [proposalId]);
+
+  const approve = useCallback(async () => {
+    if (!proposalId) return;
+    setLoading(true);
+    setError(null);
+    const body = editing
+      ? {
+          title: edits.title.trim() || undefined,
+          parentThreadId: edits.parentThreadId.trim() || undefined,
+          preferredCats: parsePreferredCats(edits.preferredCats),
+          initialMessage: edits.initialMessage.trim() ? edits.initialMessage.trim() : null,
+        }
+      : {};
+    try {
+      const res = await apiFetch(`/api/proposals/${proposalId}/approve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = (await res.json()) as { threadId?: string; error?: string };
+      if (!res.ok) throw new Error(data.error ?? `HTTP ${res.status}`);
+      setResultThreadId(data.threadId ?? null);
+      setStatus('approved');
+      setEditing(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '批准失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [proposalId, editing, edits]);
+
+  const reject = useCallback(async () => {
+    if (!proposalId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiFetch(`/api/proposals/${proposalId}/reject`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(data.error ?? `HTTP ${res.status}`);
+      }
+      setStatus('rejected');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '驳回失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [proposalId]);
+
+  if (!proposalId) {
+    return (
+      <div className="border-l-4 border-l-red-400 bg-red-50 dark:bg-red-950/30 rounded-r-lg p-3 text-xs text-red-600">
+        Proposal card missing proposalId
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-l-4 border-l-blue-400 bg-blue-50 dark:bg-blue-950/30 rounded-r-lg p-3">
+      <div className="font-medium text-sm">{block.title}</div>
+      {block.bodyMarkdown && (
+        <div className="mt-1 text-xs text-gray-600 dark:text-gray-300 [&_p]:mb-1 [&_p:last-child]:mb-0">
+          <MarkdownContent content={block.bodyMarkdown} className="!text-xs" disableCommandPrefix />
+        </div>
+      )}
+      {!editing && (
+        <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-1 text-xs">
+          <div>
+            <span className="text-gray-500">父 Thread:</span>{' '}
+            <span className="font-mono break-all">{edits.parentThreadId}</span>
+          </div>
+          <div>
+            <span className="text-gray-500">建议成员:</span>{' '}
+            <span className="font-mono break-all">{edits.preferredCats || '（未指定）'}</span>
+          </div>
+          {edits.initialMessage && (
+            <div className="sm:col-span-2">
+              <span className="text-gray-500">首条消息:</span> <span>{edits.initialMessage}</span>
+            </div>
+          )}
+        </div>
+      )}
+      {editing && (
+        <div className="mt-2 space-y-1 text-xs">
+          <EditField label="标题" value={edits.title} onChange={(v) => setEdits((p) => ({ ...p, title: v }))} />
+          <EditField
+            label="父 Thread"
+            value={edits.parentThreadId}
+            onChange={(v) => setEdits((p) => ({ ...p, parentThreadId: v }))}
+          />
+          <EditField
+            label="建议成员 (逗号分隔)"
+            value={edits.preferredCats}
+            onChange={(v) => setEdits((p) => ({ ...p, preferredCats: v }))}
+          />
+          <EditField
+            label="首条消息"
+            value={edits.initialMessage}
+            onChange={(v) => setEdits((p) => ({ ...p, initialMessage: v }))}
+            multiline
+          />
+        </div>
+      )}
+      {status === 'pending' && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          <button type="button" disabled={loading} onClick={approve} className={btnPrimary}>
+            {loading ? '处理中...' : editing ? '批准（含编辑）' : '批准并创建'}
+          </button>
+          <button type="button" disabled={loading} onClick={() => setEditing((v) => !v)} className={btnSecondary}>
+            {editing ? '取消编辑' : '编辑'}
+          </button>
+          <button type="button" disabled={loading} onClick={reject} className={btnDanger}>
+            驳回
+          </button>
+        </div>
+      )}
+      {status === 'approving' && <div className="mt-2 text-xs text-blue-600 dark:text-blue-300">批准中…</div>}
+      {status === 'approved' && (
+        <div className="mt-2 text-xs text-green-700 dark:text-green-300">
+          ✓ 已批准，thread 已创建 {resultThreadId ? <span className="font-mono">({resultThreadId})</span> : null}
+        </div>
+      )}
+      {status === 'rejected' && <div className="mt-2 text-xs text-red-600 dark:text-red-300">✗ 已驳回</div>}
+      {error && <div className="mt-1 text-xs text-red-500">{error}</div>}
+    </div>
+  );
+}
+
+const btnPrimary =
+  'text-xs px-3 py-1 rounded bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 transition-colors';
+const btnSecondary =
+  'text-xs px-3 py-1 rounded bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-700 disabled:opacity-50 transition-colors';
+const btnDanger =
+  'text-xs px-3 py-1 rounded bg-red-100 dark:bg-red-900/40 hover:bg-red-200 dark:hover:bg-red-800/50 text-red-700 dark:text-red-200 border border-red-300 dark:border-red-700 disabled:opacity-50 transition-colors';
+
+function EditField({
+  label,
+  value,
+  onChange,
+  multiline,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  multiline?: boolean;
+}) {
+  return (
+    <label className="block">
+      <span className="text-gray-500">{label}:</span>{' '}
+      {multiline ? (
+        <textarea
+          className="mt-0.5 w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-1 font-mono text-xs"
+          rows={2}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      ) : (
+        <input
+          type="text"
+          className="mt-0.5 w-full rounded border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 p-1 font-mono text-xs"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      )}
+    </label>
+  );
+}
+
+export function isProposalCardBlock(block: RichCardBlock): boolean {
+  return block.actions?.some((a) => a.action === 'propose:approve') ?? false;
+}

--- a/packages/web/src/components/rich/RichBlocks.tsx
+++ b/packages/web/src/components/rich/RichBlocks.tsx
@@ -12,6 +12,7 @@ import { HtmlWidgetBlock } from './HtmlWidgetBlock';
 import { InteractiveBlock } from './InteractiveBlock';
 import { InteractiveBlockGroup } from './InteractiveBlockGroup';
 import { MediaGalleryBlock } from './MediaGalleryBlock';
+import { isProposalCardBlock, ProposalCard } from './ProposalCard';
 
 function RichBlockRenderer({
   block,
@@ -26,6 +27,8 @@ function RichBlockRenderer({
 }) {
   switch (block.kind) {
     case 'card': {
+      // F128: proposal cards have dedicated approval-card renderer
+      if (isProposalCardBlock(block)) return <ProposalCard block={block} messageId={messageId} />;
       // F174 D2b-1: cards tagged with meta.kind = 'callback_auth_failure' get the
       // dedicated in-context observability renderer ("明厨亮灶" — entity carries its
       // own state). Plain cards continue to use the default CardBlock.

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -577,6 +577,29 @@ export function useSocket(callbacks: SocketCallbacks, threadId?: string) {
       },
     );
 
+    // F128: New thread created via MCP callback — prepend to sidebar thread list
+    socket.on('thread_created', (thread: import('../stores/chat-types').Thread) => {
+      const store = useChatStore.getState();
+      const existing = store.threads;
+      if (!existing.some((t) => t.id === thread.id)) {
+        store.setThreads([thread, ...existing]);
+      }
+    });
+
+    // F128: proposal status changed (approved/rejected/etc) — broadcast to interested cards.
+    // ProposalCard listens via CustomEvent('cat-cafe:proposal-updated'); we don't push into a
+    // global store because proposal state is card-local and only mounted cards need to react.
+    socket.on('proposal_updated', (proposal: { proposalId: string; status: string; createdThreadId?: string }) => {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('cat-cafe:proposal-updated', { detail: proposal }));
+      }
+    });
+    socket.on('proposal_created', (proposal: { proposalId: string; status: string }) => {
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('cat-cafe:proposal-created', { detail: proposal }));
+      }
+    });
+
     socket.on(
       'intent_mode',
       (data: { threadId: string; mode: string; targetCats: string[]; invocationId?: string }) => {

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -354,6 +354,8 @@ export interface Thread {
   backlogItemId?: string;
   /** F042: Thread-scoped routing policy (intent/scope). */
   routingPolicy?: ThreadRoutingPolicyV1;
+  /** Thread hierarchy: parent thread ID for orchestrated sub-threads. */
+  parentThreadId?: string;
   /** F095 Phase D: Soft-delete timestamp. Null/undefined = not deleted. */
   deletedAt?: number | null;
   /** F087: CVO Bootcamp onboarding state. */


### PR DESCRIPTION
## Summary

F128 v2 — **proposal-first** thread creation, replacing the v1 direct-create implementation (which was rejected by maintainer on 2026-05-22). Cats propose threads via a rich card; the user reviews / edits / approves; only then does the backend create the thread.

> ⚠️ This PR has been **force-pushed from v1 → v2**. All v1 direct-create code was deleted; v2 is the only implementation in the diff now. Branch history through 2026-05-22 retained the v1 review trail in the PR comments above for context.

Closes #82

## Flow

```
cat → cat_cafe_propose_thread(title, reason, ...)
    → backend creates Proposal (status=pending), posts a rich card in source thread
    → user reviews card, optionally edits fields, then clicks Approve / Reject
    → backend creates the thread on approve (idempotent), or marks proposal rejected
    → audit fields written: createdBy / approvedBy / createdThreadId / approvedAt / etc.
```

## Changes

### Shared types
- `ThreadProposal` interface + `ProposalStatus` + `ProposalApproveOverrides`
- `ProposalId` branded type + `createProposalId` / `generateProposalId`

### Backend
- `IProposalStore` port + `InMemoryProposalStore` (sync, for tests/dev) + `RedisProposalStore` (Lua CAS for pending → approved/rejected) + `ProposalStoreFactory`
- Redis keys: `proposal:{id}` hash + `proposals:user:{userId}` + `proposals:pending:{userId}` + `proposals:thread:{threadId}` + `dedup:propose:{userId}:{rid}`
- Routes:
  - `POST /api/callbacks/propose-thread` (cat auth via `invocationId + callbackToken`) — creates proposal, posts rich card, returns `{ proposalId, status: 'pending' }`. Idempotent via `clientRequestId`. Stale invocation guard. Parent thread ownership check.
  - `POST /api/proposals/:id/approve` (user auth via `X-Cat-Cafe-User`) — accepts optional `{ title, parentThreadId, preferredCats, initialMessage }` overrides, creates thread via `threadStore.create`, posts initial message if present, marks proposal approved via CAS, emits `thread_created` + `proposal_updated`.
  - `POST /api/proposals/:id/reject` (user auth) — marks rejected via CAS, emits `proposal_updated`.
  - `GET  /api/proposals/pending` (user auth) — list user's pending proposals.
- Idempotency: double-approve returns the same `threadId`. Approve-after-reject → 409. Reject-after-approve → 409.

### MCP layer
- New tool `cat_cafe_propose_thread` registered in `callbackTools` + collab surface. Description explicitly states "returns proposalId NOT threadId" and "wait for user approval".
- `SystemPromptBuilder` MCP_TOOLS_SECTION entry updated.
- Old `cat_cafe_create_thread` tool fully removed (handler, schema, test expectations, system prompt entry).

### Frontend
- `ProposalCard.tsx` — dedicated card renderer for proposal blocks (detected via `actions[0].action === 'propose:approve'`). Pending state shows Approve / Edit / Reject buttons. Edit mode exposes editable fields. On success, card flips to approved/rejected with feedback.
- `RichBlocks.tsx` dispatcher: card with proposal action → `ProposalCard`; otherwise legacy `CardBlock`.

### Skill + Spec
- `thread-orchestration` skill rewritten for propose-first flow. Common mistakes section gains two entries about "proposalId ≠ threadId" and "wait for user approval".
- `docs/features/F128-cat-create-thread.md` rewritten as v2, with full schema, endpoint contracts, lifecycle, audit fields, and v1 → v2 migration notes.
- `docs/ROADMAP.md` + `docs/features/index.json` regenerated.

### v1 code deleted
- `packages/api/src/routes/callback-create-thread-routes.ts`
- `packages/api/test/callback-create-thread.test.js`
- `packages/web/src/components/ThreadSidebar/ThreadHierarchyToggle.tsx`
- `packages/web/src/components/ThreadSidebar/thread-hierarchy.ts` (+ tests)
- ThreadItem.tsx / ThreadSidebar.tsx reverted to `zts/main` (drop hierarchy props)
- `cat_cafe_create_thread` MCP tool definition

**Hierarchy sidebar UI is explicitly deferred** to a follow-up that reconciles with F190 console restructure — kept `parentThreadId` data model + `getChildThreads()` for that future work.

## Test plan

- [x] `pnpm check` (biome + features + env-ports): **PASS**
- [x] `pnpm lint`: PASS for F128 code; pre-existing tsc errors for missing `@types/*` (`web-push`, `better-sqlite3`, `http-proxy`, `nodemailer`, `yaml`) — also present on `main`.
- [x] `packages/api/test/proposal-flow.test.js`: **11/11 PASS** covering all AC-B7 cases:
  - propose happy path (no thread created)
  - stale invocation → `stale_ignored`
  - cross-user parentThreadId → 403
  - `clientRequestId` idempotency
  - approve happy path with audit fields
  - double-approve idempotency (same threadId)
  - cross-user approve → 403
  - approve-after-reject → 409
  - reject happy path
  - reject-after-approve → 409
  - approve overrides applied (title + initialMessage written to created thread)
- [ ] `tool-registration.test.js`: 4 pre-existing failures unrelated to F128 (PR branch expects `cat_cafe_search_messages` which was D15-removed; this stale expectation existed before v2). Out of scope.

## Known limitation

`packages/mcp-server/src/tools/callback-tools.ts` is a pre-existing ~900-line file. v2 extends it by ~60 lines (propose tool schema + handler + registration). Splitting it into per-tool files is out of scope here; tracked as separate technical debt.

## References

- Issue: #82
- Maintainer correction comment (issue): https://github.com/zts212653/clowder-ai/issues/82#issuecomment-4516585087
- Maintainer correction comment (PR): https://github.com/zts212653/clowder-ai/pull/85#issuecomment-4516589522

🐾 Generated with [Claude Code](https://claude.com/claude-code)