### PR TITLE
Fix/52 proxy upstream resilience

### DIFF
--- a/packages/api/test/anthropic-proxy.test.js
+++ b/packages/api/test/anthropic-proxy.test.js
@@ -105,6 +105,34 @@ async function startProxy(upstreams, envOverrides = {}) {
   };
 }
 
+function requestViaHttp({ port, path, method = 'GET', headers = {}, body = '' }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers,
+      },
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.once('error', reject);
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
 test('anthropic proxy retries transient upstream socket failures and succeeds on retry', async () => {
   let attempts = 0;
   const upstream = http.createServer((req, res) => {
@@ -214,5 +242,69 @@ test('anthropic proxy includes cause codes for terminal network failures', async
     assert.match(body.error.message, /connection refused/i);
   } finally {
     await proxy.close();
+  }
+});
+
+test('anthropic proxy preserves request forwarding when sanitization changes body length', async () => {
+  const requests = [];
+  const upstream = http.createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      requests.push({
+        headers: req.headers,
+        body: Buffer.concat(chunks).toString('utf8'),
+      });
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+
+  const upstreamPort = await listen(upstream);
+  const proxy = await startProxy(
+    { sponsor: `http://127.0.0.1:${upstreamPort}` },
+    {
+      ANTHROPIC_PROXY_MAX_RETRIES: '0',
+      ANTHROPIC_PROXY_UPSTREAM_TIMEOUT_MS: '3000',
+    },
+  );
+
+  const requestPayload = {
+    model: 'claude-opus-4-6',
+    max_tokens: 1,
+    messages: [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'private reasoning', signature: 'sig' },
+          { type: 'text', text: 'visible context' },
+        ],
+      },
+      { role: 'user', content: 'ping' },
+    ],
+  };
+  const requestBody = JSON.stringify(requestPayload);
+
+  try {
+    const response = await requestViaHttp({
+      port: proxy.port,
+      path: '/sponsor/v1/messages',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': String(Buffer.byteLength(requestBody)),
+      },
+      body: requestBody,
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(requests.length, 1);
+
+    const forwardedPayload = JSON.parse(requests[0].body);
+    assert.deepEqual(forwardedPayload.messages[0].content, [{ type: 'text', text: 'visible context' }]);
+    assert.equal(requests[0].headers['content-length'], String(Buffer.byteLength(requests[0].body)));
+  } finally {
+    await proxy.close();
+    await new Promise((resolve) => upstream.close(() => resolve()));
   }
 });

--- a/scripts/anthropic-proxy.mjs
+++ b/scripts/anthropic-proxy.mjs
@@ -436,6 +436,7 @@ const server = createServer(async (req, res) => {
   for (const [key, value] of Object.entries(req.headers)) {
     if (key === 'host' || key === 'connection') continue;
     if (key === 'accept-encoding') continue; // override below
+    if (key === 'content-length' || key === 'transfer-encoding') continue;
     forwardHeaders[key] = value;
   }
   forwardHeaders['accept-encoding'] = 'identity';


### PR DESCRIPTION
## Summary
- Add configurable upstream timeout (`ANTHROPIC_PROXY_UPSTREAM_TIMEOUT_MS`, default 120s) and network-level retry (`ANTHROPIC_PROXY_MAX_RETRIES`, default 2) to the local anthropic proxy
- Classify network errors with actionable `causeCode` labels (`UPSTREAM_TIMEOUT`, `ECONNREFUSED`, `ECONNRESET`, etc.) instead of generic `fetch failed`
- Strip `content-length` and `transfer-encoding` headers before forwarding, so that when the proxy rewrites the request body (e.g. removing `thinking` blocks), fetch auto-calculates the correct length — fixes `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH`

Closes #52

## Test plan
- [x] `node --test packages/api/test/anthropic-proxy.test.js` — 4/4 pass
  - Transient socket failure → retry succeeds
  - Upstream hang → timeout with 504 + causeCode=UPSTREAM_TIMEOUT
  - Terminal network error → 502 + specific causeCode
  - Body rewrite (thinking strip) → correct content-length forwarded
- [ ] Smoke test: send a message to opus via Cat Cafe after deploying to runtime
