### PR TITLE
docs: add prerequisites and troubleshooting for Quick Start (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ You don't need to be a developer. You need to know what you want — and who you
 
 > CVO Bootcamp coming soon — a guided onboarding where your AI team walks you through a complete feature lifecycle.
 
+**Prerequisites:** Node.js >= 20, pnpm >= 9 (`npm install -g pnpm`). Full details in [SETUP.md](SETUP.md).
+
 ```bash
 git clone https://github.com/zts212653/clowder-ai.git
 cd clowder-ai
@@ -495,6 +497,8 @@ Clowder 不只是一个编程平台。你的 AI 团队还能：
 ## 快速开始
 
 > CVO 训练营即将推出 — AI 团队亲自带你走完一个完整的 feature 生命周期。
+
+**前置要求：** Node.js >= 20、pnpm >= 9（`npm install -g pnpm`）。完整说明见 [SETUP.md](SETUP.md)。
 
 ```bash
 git clone https://github.com/zts212653/clowder-ai.git

--- a/SETUP.md
+++ b/SETUP.md
@@ -217,6 +217,19 @@ pnpm redis:user:backup  # Manual backup
 - Make sure `NEXT_PUBLIC_API_URL=http://localhost:3004` is set
 - API must be running before frontend loads
 
+**`pnpm` not found?**
+- Install pnpm: `npm install -g pnpm` (requires Node.js >= 20)
+- Verify: `pnpm --version` should show >= 9.0.0
+- If `npm` is also missing, install Node.js first from [nodejs.org](https://nodejs.org/)
+
+**`tsc` not found or TypeScript compile errors?**
+- Run `pnpm install` first — TypeScript is a project dependency, no global install needed
+- If errors persist: `rm -rf node_modules && pnpm install`
+
+**`Cannot find module 'zod'` or type resolution errors?**
+- Same fix: `rm -rf node_modules && pnpm install`
+- Check Node.js version: `node -v` (must be >= 20)
+
 ---
 
 <a id="中文"></a>
@@ -431,3 +444,16 @@ pnpm redis:user:backup  # 手动备份
 **前端连不上 API？**
 - 确认设了 `NEXT_PUBLIC_API_URL=http://localhost:3004`
 - API 必须在前端加载前启动
+
+**找不到 `pnpm`？**
+- 安装：`npm install -g pnpm`（需要 Node.js >= 20）
+- 验证：`pnpm --version` 应显示 >= 9.0.0
+- 如果 `npm` 也没有，先从 [nodejs.org](https://nodejs.org/) 安装 Node.js
+
+**`tsc` 找不到或 TypeScript 编译报错？**
+- 先运行 `pnpm install` — TypeScript 是项目依赖，不需要全局安装
+- 仍然报错：`rm -rf node_modules && pnpm install`
+
+**`Cannot find module 'zod'` 或类型解析报错？**
+- 同样的修复：`rm -rf node_modules && pnpm install`
+- 检查 Node.js 版本：`node -v`（必须 >= 20）


### PR DESCRIPTION
## Summary
- Add **Node.js >= 20 / pnpm >= 9** prerequisite notice to README Quick Start (EN + CN sections)
- Add three troubleshooting entries to SETUP.md (EN + CN): `pnpm` not found, `tsc` errors, `zod` module resolution

Closes #23

## Test plan
- [ ] Verify README Quick Start sections (EN L145, CN L498) show prerequisites line
- [ ] Verify SETUP.md Troubleshooting sections (EN L222+, CN L434+) have the three new entries
- [ ] Links to SETUP.md from README resolve correctly

🐱 Generated with [Claude Code](https://claude.com/claude-code)