### PR TITLE
fix: guarantee done(isFinal=true) delivery in route-serial (#30)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -82,6 +82,8 @@ export async function* routeSerial(
   const worklistEntry = registerWorklist(threadId, worklist, maxDepth, options.parentInvocationId);
 
   let index = 0;
+  // #30 fix: Track whether done(isFinal=true) has been yielded to prevent double-emit
+  let yieldedFinalDone = false;
   // F27: Track how many worklist entries have had a2a_handoff emitted
   let handoffEmitted = targetCats.length; // Original targets don't get handoff events
   // F042 Wave 3: Fetch thread participant activity once before loop (threadId doesn't change).
@@ -873,9 +875,18 @@ export async function* routeSerial(
 
       // Yield buffered done with correct isFinal (evaluated AFTER worklist may have grown)
       // MUST always reach here regardless of append success (缅因猫 review P1-2)
-      if (doneMsg) {
-        yield { ...doneMsg, ...(mentionsUser ? { mentionsUser } : {}), isFinal: index === worklist.length - 1 };
+      // #30 fix: Synthesize done if missing (signal abort or invokeSingleCat didn't yield one)
+      if (!doneMsg) {
+        doneMsg = {
+          type: 'done' as AgentMessageType,
+          catId,
+          timestamp: Date.now(),
+          ...(firstMetadata ? { metadata: firstMetadata } : {}),
+        } as AgentMessage;
       }
+      const isFinal = index === worklist.length - 1;
+      if (isFinal) yieldedFinalDone = true;
+      yield { ...doneMsg, ...(mentionsUser ? { mentionsUser } : {}), isFinal };
 
       // F27: Advance executedIndex so pushToWorklist knows which cats are done
       worklistEntry.executedIndex = index + 1;
@@ -885,5 +896,18 @@ export async function* routeSerial(
     // F27: Always unregister worklist, even on error/abort.
     // Pass owner ref so preempting new invocation's worklist is not deleted (缅因猫 R1 P1-1)
     unregisterWorklist(threadId, worklistEntry, options.parentInvocationId);
+
+    // #30 fix: If we exited the while loop without yielding done(isFinal=true)
+    // (e.g. unhandled exception, signal abort at loop top), yield a synthetic terminal
+    // event so the frontend ALWAYS receives isFinal and can clear its loading state.
+    if (!yieldedFinalDone && worklist.length > 0) {
+      const lastCatId = worklist[Math.min(index, worklist.length - 1)]!;
+      yield {
+        type: 'done' as AgentMessageType,
+        catId: lastCatId,
+        isFinal: true,
+        timestamp: Date.now(),
+      } as AgentMessage;
+    }
   }
 }

--- a/packages/api/test/route-serial-done-guarantee.test.js
+++ b/packages/api/test/route-serial-done-guarantee.test.js
@@ -1,0 +1,140 @@
+/**
+ * #30 fix: Tests for done(isFinal=true) terminal event guarantee
+ *
+ * Verifies that routeSerial ALWAYS yields done(isFinal=true) even when:
+ * 1. The agent service does not yield a done event
+ * 2. The invocation is aborted via AbortSignal
+ * 3. Normal flow with multiple cats completes correctly
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+
+function createMockDeps(services) {
+  let counter = 0;
+  return {
+    services,
+    invocationDeps: {
+      registry: {
+        create: () => ({ invocationId: `inv-${++counter}`, callbackToken: `tok-${counter}` }),
+        verify: () => null,
+      },
+      sessionManager: {
+        getOrCreate: async () => ({}),
+        resolveWorkingDirectory: () => '/tmp/test',
+      },
+      threadStore: null,
+      apiUrl: 'http://localhost:3102',
+    },
+    messageStore: {
+      append: async () => ({
+        id: `msg-${counter}`,
+        userId: '',
+        catId: null,
+        content: '',
+        mentions: [],
+        timestamp: 0,
+      }),
+      getRecent: () => [],
+      getMentionsFor: () => [],
+      getBefore: () => [],
+      getByThread: () => [],
+      getByThreadAfter: () => [],
+      getByThreadBefore: () => [],
+    },
+  };
+}
+
+describe('#30 done(isFinal) guarantee', () => {
+  it('synthesizes done(isFinal=true) when agent service yields no done', async () => {
+    const service = {
+      async *invoke() {
+        yield { type: 'text', catId: 'opus', content: 'hello', timestamp: Date.now() };
+        // Deliberately NOT yielding done
+      },
+    };
+
+    const deps = createMockDeps({ opus: service });
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'test', 'user-1', 'thread-1')) {
+      messages.push(msg);
+    }
+
+    const doneMessages = messages.filter((m) => m.type === 'done');
+    assert.ok(doneMessages.length >= 1, 'should have at least one done message');
+
+    const finalDone = doneMessages.find((m) => m.isFinal === true);
+    assert.ok(finalDone, 'should have a done with isFinal=true');
+    assert.equal(finalDone.catId, 'opus');
+  });
+
+  it('yields done(isFinal=true) on signal abort', async () => {
+    const ac = new AbortController();
+    const service = {
+      async *invoke() {
+        yield { type: 'text', catId: 'opus', content: 'starting...', timestamp: Date.now() };
+        // Simulate long-running work — abort fires during iteration
+        ac.abort();
+        yield { type: 'text', catId: 'opus', content: 'more text', timestamp: Date.now() };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = createMockDeps({ opus: service });
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'test', 'user-1', 'thread-1', {
+      signal: ac.signal,
+    })) {
+      messages.push(msg);
+    }
+
+    const finalDone = messages.find((m) => m.type === 'done' && m.isFinal === true);
+    assert.ok(finalDone, 'should have a done with isFinal=true even after abort');
+  });
+
+  it('normal multi-cat flow yields exactly one done(isFinal=true) for last cat', async () => {
+    const opusService = {
+      async *invoke() {
+        yield { type: 'text', catId: 'opus', content: 'opus reply', timestamp: Date.now() };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+    const codexService = {
+      async *invoke() {
+        yield { type: 'text', catId: 'codex', content: 'codex reply', timestamp: Date.now() };
+        yield { type: 'done', catId: 'codex', timestamp: Date.now() };
+      },
+    };
+
+    const deps = createMockDeps({ opus: opusService, codex: codexService });
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus', 'codex'], 'test', 'user-1', 'thread-1')) {
+      messages.push(msg);
+    }
+
+    const doneMessages = messages.filter((m) => m.type === 'done');
+    assert.equal(doneMessages.length, 2, 'should have two done messages (one per cat)');
+    assert.equal(doneMessages[0].isFinal, false, 'first cat done should not be isFinal');
+    assert.equal(doneMessages[1].isFinal, true, 'last cat done should be isFinal');
+    assert.equal(doneMessages[1].catId, 'codex');
+  });
+
+  it('does not double-emit done(isFinal=true) in normal flow', async () => {
+    const service = {
+      async *invoke() {
+        yield { type: 'text', catId: 'opus', content: 'reply', timestamp: Date.now() };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = createMockDeps({ opus: service });
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'test', 'user-1', 'thread-1')) {
+      messages.push(msg);
+    }
+
+    const finalDones = messages.filter((m) => m.type === 'done' && m.isFinal === true);
+    assert.equal(finalDones.length, 1, 'should have exactly one done(isFinal=true)');
+  });
+});


### PR DESCRIPTION
## Summary
- Synthesize `done(isFinal=true)` when agent service exits without yielding one
- `yieldedFinalDone` flag prevents double-emit in normal flow
- `finally` block safety net for unhandled exceptions / signal abort at loop top
- 4 new test cases covering: missing done, signal abort, multi-cat, no double-emit

## Root cause
Three paths could cause `done(isFinal=true)` to never reach the frontend:
1. `signal?.aborted` break exits the `for await` loop before `done` is received
2. Agent service exits without yielding `done` (exception, early return)
3. Unhandled exception in persistence phase prevents reaching the yield

## Changed files
- `packages/api/src/domains/cats/services/agents/routing/route-serial.ts`
- `packages/api/test/route-serial-done-guarantee.test.js` (new)

## Test plan
- [x] 4 new tests pass (synthesized done, signal abort, multi-cat, no double-emit)
- [x] Biome lint clean
- [x] TypeScript type check passes

Part 1 of 2 for issue #30. Part 2 (CLI timeout adjustment) in a separate PR.

Closes #30