### PR TITLE
fix(#30): CLI timeout 5→10min + frontend alignment

### DIFF
--- a/docs/architecture/cli-integration.md
+++ b/docs/architecture/cli-integration.md
@@ -107,7 +107,7 @@ export async function* spawnCli(options: CliSpawnOptions): AsyncGenerator<unknow
 
 | 问题 | 解决方案 |
 |------|----------|
-| 进程超时 | 可配置超时 (`CLI_TIMEOUT_MS`)，默认 30 分钟，`0` 禁用 |
+| 进程超时 | 可配置超时 (`CLI_TIMEOUT_MS`)，默认 10 分钟，`0` 禁用 |
 | 优雅终止 | 先 SIGTERM，3 秒后 SIGKILL |
 | 僵尸进程 | `process.on('exit')` 钩子强制清理 |
 | 用户取消 | 支持 `AbortSignal` |

--- a/packages/api/src/utils/cli-timeout.ts
+++ b/packages/api/src/utils/cli-timeout.ts
@@ -1,5 +1,5 @@
-export const DEFAULT_CLI_TIMEOUT_MS = 5 * 60 * 1000;
-export const DEFAULT_CLI_TIMEOUT_LABEL = `${DEFAULT_CLI_TIMEOUT_MS} (5分钟)`;
+export const DEFAULT_CLI_TIMEOUT_MS = 10 * 60 * 1000;
+export const DEFAULT_CLI_TIMEOUT_LABEL = `${DEFAULT_CLI_TIMEOUT_MS} (10分钟)`;
 
 export function parseCliTimeoutMs(raw: string | undefined): number | undefined {
   if (raw === undefined) return undefined;

--- a/packages/api/test/cli-spawn.test.js
+++ b/packages/api/test/cli-spawn.test.js
@@ -200,7 +200,7 @@ test('CLI_TIMEOUT_MS=0 disables timeout (no auto-kill on silence)', async () => 
   }
 });
 
-test('spawnCli uses 5 minute fallback timeout when CLI_TIMEOUT_MS is unset', async () => {
+test('spawnCli uses 10 minute fallback timeout when CLI_TIMEOUT_MS is unset', async () => {
   const savedEnv = process.env.CLI_TIMEOUT_MS;
   delete process.env.CLI_TIMEOUT_MS;
 
@@ -222,7 +222,7 @@ test('spawnCli uses 5 minute fallback timeout when CLI_TIMEOUT_MS is unset', asy
     await promise;
 
     assert.ok(delays.length > 0);
-    assert.equal(delays[0], 300000);
+    assert.equal(delays[0], 600000);
   } finally {
     global.setTimeout = originalSetTimeout;
     if (savedEnv === undefined) {

--- a/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
@@ -236,7 +236,7 @@ describe('useAgentMessages loading lifecycle', () => {
       storeState.currentThreadId = 'thread-2';
 
       act(() => {
-        vi.advanceTimersByTime(5 * 60 * 1000);
+        vi.advanceTimersByTime(10 * 60 * 1000);
       });
 
       expect(mockAddMessage).not.toHaveBeenCalledWith(
@@ -332,7 +332,7 @@ describe('useAgentMessages loading lifecycle', () => {
       });
 
       act(() => {
-        vi.advanceTimersByTime(5 * 60 * 1000);
+        vi.advanceTimersByTime(10 * 60 * 1000);
       });
 
       expect(mockAddMessageToThread).not.toHaveBeenCalledWith(
@@ -380,7 +380,7 @@ describe('useAgentMessages loading lifecycle', () => {
       });
 
       act(() => {
-        vi.advanceTimersByTime(5 * 60 * 1000);
+        vi.advanceTimersByTime(10 * 60 * 1000);
       });
 
       expect(mockAddMessage).toHaveBeenCalledWith(
@@ -422,7 +422,7 @@ describe('useAgentMessages loading lifecycle', () => {
       mockClearCatStatuses.mockClear();
 
       act(() => {
-        vi.advanceTimersByTime(5 * 60 * 1000);
+        vi.advanceTimersByTime(10 * 60 * 1000);
       });
 
       expect(mockAddMessage).not.toHaveBeenCalled();

--- a/packages/web/src/hooks/useAgentMessages.ts
+++ b/packages/web/src/hooks/useAgentMessages.ts
@@ -5,8 +5,8 @@ import { recordDebugEvent } from '@/debug/invocationEventDebug';
 import { useChatStore } from '@/stores/chatStore';
 import { compactToolResultDetail } from '@/utils/toolPreview';
 
-/** Timeout for done(isFinal) - 5 minutes */
-const DONE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Timeout for done(isFinal) - 10 minutes (matches CLI timeout) */
+const DONE_TIMEOUT_MS = 10 * 60 * 1000;
 /** Monotonic counter for collision-safe callback bubble IDs */
 let cbSeq = 0;
 const DEBUG_SKIP_FILE_CHANGE_UI = process.env.NEXT_PUBLIC_DEBUG_SKIP_FILE_CHANGE_UI === '1';
@@ -100,6 +100,8 @@ export function useAgentMessages() {
 
   /** Map<catId, { id: messageId, catId }> — one entry per active stream */
   const activeRefs = useRef<Map<string, { id: string; catId: string }>>(new Map());
+  /** #30 fix: Track whether tool events were seen in this invocation (for timeout message) */
+  const sawToolEventsRef = useRef(false);
   /** Track callback-replaced invocations so delayed stream chunks do not recreate ghost bubbles. */
   const replacedInvocationsRef = useRef<Map<string, string>>(new Map());
 
@@ -130,6 +132,12 @@ export function useAgentMessages() {
       const store = useChatStore.getState();
       const isActiveThreadTimeout = store.currentThreadId === timeoutThreadId;
 
+      // #30 fix: Context-aware timeout message (read before clearing)
+      const timeoutContent = sawToolEventsRef.current
+        ? '⏱ 工具已执行但最终响应未返回。CLI 可能仍在后台运行，或已超时终止。'
+        : '⏱ Response timed out. The operation may still be running in the background.';
+      sawToolEventsRef.current = false;
+
       if (!isActiveThreadTimeout) {
         const threadState = store.getThreadState(timeoutThreadId);
         for (const message of threadState.messages) {
@@ -142,7 +150,7 @@ export function useAgentMessages() {
           id: `sysinfo-timeout-${Date.now()}`,
           type: 'system',
           variant: 'info',
-          content: '⏱ Response timed out. The operation may still be running in the background.',
+          content: timeoutContent,
           timestamp: Date.now(),
         });
         return;
@@ -161,7 +169,7 @@ export function useAgentMessages() {
         id: `sysinfo-timeout-${Date.now()}`,
         type: 'system',
         variant: 'info',
-        content: '⏱ Response timed out. The operation may still be running in the background.',
+        content: timeoutContent,
         timestamp: Date.now(),
       });
     }, DONE_TIMEOUT_MS);
@@ -454,6 +462,7 @@ export function useAgentMessages() {
           }
         }
       } else if (msg.type === 'tool_use') {
+        sawToolEventsRef.current = true;
         setCatStatus(msg.catId, 'streaming');
         sawStreamDataRef.current.add(msg.catId);
         const toolName = msg.toolName ?? 'unknown';
@@ -545,6 +554,7 @@ export function useAgentMessages() {
           setIntentMode(null);
           clearCatStatuses();
           a2aGroupRef.current = null;
+          sawToolEventsRef.current = false;
           // Bug C safety net: if done(isFinal) arrived but no streaming bubble
           // was ever created for this cat, text events were lost (socket transport
           // drop, dual-pointer guard mismatch, etc.). Request a history catch-up
@@ -870,7 +880,8 @@ export function useAgentMessages() {
         });
         // Only stop loading on isFinal; size===0 would false-positive in serial gaps
         if (msg.isFinal) {
-          clearDoneTimeout(); // prevent 5-min timer from firing timeout text after error
+          sawToolEventsRef.current = false;
+          clearDoneTimeout(); // prevent done-timeout from firing after error
           setLoading(false);
           // F108: clear this cat's invocation slot on terminal error
           if (msg.invocationId) {
@@ -928,6 +939,7 @@ export function useAgentMessages() {
   const handleStop = useCallback(
     (cancelFn: (threadId: string) => void, threadId: string) => {
       cancelFn(threadId);
+      sawToolEventsRef.current = false;
       const store = useChatStore.getState();
       const isActiveThreadStop = threadId === store.currentThreadId;
 


### PR DESCRIPTION
## Summary
- Backend `DEFAULT_CLI_TIMEOUT_MS` 和 Frontend `DONE_TIMEOUT_MS` 从 5 分钟调整为 10 分钟，避免长时间 API thinking 触发误超时
- 新增 `sawToolEventsRef` 追踪是否收到过 tool 事件，提供上下文感知的超时消息（区分"工具执行中超时"与"未收到响应超时"）
- 同步更新所有相关测试和文档

## Context
Issue #30 的第二部分修复（第一部分 done(isFinal) guarantee 见 PR #121）

铲屎官要求将原 PR #106 拆分为两个独立 PR：
1. PR #121 — done(isFinal) 终端事件保证 ✅ 已创建
2. **本 PR** — CLI 超时调整 + 前端对齐

## Changes
| File | Change |
|------|--------|
| `packages/api/src/utils/cli-timeout.ts` | `DEFAULT_CLI_TIMEOUT_MS`: 5min → 10min |
| `packages/web/src/hooks/useAgentMessages.ts` | `DONE_TIMEOUT_MS`: 5min → 10min, 新增 `sawToolEventsRef` |
| `packages/api/test/cli-spawn.test.js` | 更新超时断言 300000 → 600000 |
| `packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts` | 更新 timer 值 5min → 10min |
| `docs/architecture/cli-integration.md` | 文档对齐 |

## Test plan
- [x] `cli-spawn.test.js` — 27 pass, 0 fail
- [x] `useAgentMessages-loading.test.ts` — 13 pass, 0 fail
- [x] `pnpm lint` (types) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)