### PR TITLE
fix(cli-spawn): decouple CLI done from process exit via semantic completion signal

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -260,6 +260,8 @@ export class CodexAgentService implements AgentService {
       // overwriting pre-copied auth.json/config.toml/sessions (see bug-report/tea-coffee/).
       const codexEnv = applyAuthMode(options?.callbackEnv ?? {});
 
+      const semanticCompletionController = new AbortController();
+
       const cliOpts = {
         command: 'codex' as const,
         args,
@@ -272,6 +274,7 @@ export class CodexAgentService implements AgentService {
           ? { rawArchivePath: this.rawArchive.getPath(options.invocationId) }
           : {}),
         ...(options?.livenessProbe ? { livenessProbe: options.livenessProbe } : {}),
+        semanticCompletionSignal: semanticCompletionController.signal,
       };
       const events = options?.spawnCliOverride
         ? options.spawnCliOverride(cliOpts)
@@ -396,6 +399,7 @@ export class CodexAgentService implements AgentService {
         if (typeof event === 'object' && event !== null) {
           const raw = event as Record<string, unknown>;
           if (raw.type === 'turn.completed') {
+            semanticCompletionController.abort();
             const u = raw.usage as Record<string, unknown> | undefined;
             if (u) {
               const usage: TokenUsage = {};

--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -21,6 +21,9 @@ function classifyKnownCliStderr(stderr: string): CliErrorReasonCode | undefined 
 /** Grace period between SIGTERM and SIGKILL */
 export const KILL_GRACE_MS = 3_000;
 
+/** Grace period after semantic completion before force-killing a lingering process */
+export const SEMANTIC_COMPLETION_GRACE_MS = 5_000;
+
 /**
  * Options for spawnCli (dependency injection for testing)
  */
@@ -236,12 +239,23 @@ export async function* spawnCli(
     // Check for spawn error that arrived during/after iteration
     if (spawnError) throw spawnError;
 
-    // Wait for child to fully exit after stdout closes
-    await exitPromise;
+    // Issue #116: If provider signaled semantic completion, give a short grace period
+    // instead of blocking on full exit. Process gets SEMANTIC_COMPLETION_GRACE_MS to
+    // exit naturally; if it doesn't, killChild() in finally will clean up.
+    const semanticDone = options.semanticCompletionSignal?.aborted === true;
 
-    // Yield error on abnormal exit (only if WE didn't kill it)
+    if (!semanticDone) {
+      // Wait for child to fully exit after stdout closes
+      await exitPromise;
+    } else if (!childExited) {
+      // Grace period: give the process time to exit naturally before force-killing.
+      // If it exits within grace, great; if not, killChild() in finally will clean up.
+      await Promise.race([exitPromise, new Promise<void>((r) => setTimeout(r, SEMANTIC_COMPLETION_GRACE_MS).unref())]);
+    }
+
+    // Yield error on abnormal exit (only if WE didn't kill it AND no semantic completion)
     // Covers both non-zero exitCode AND external signal kills
-    if (!killed && (exitCode !== 0 || exitSignal !== null)) {
+    if (!semanticDone && !killed && (exitCode !== 0 || exitSignal !== null)) {
       const reasonCode = classifyKnownCliStderr(stderrBuffer);
       // Log stderr for debugging (never expose to users — may contain thinking/traces)
       if (stderrBuffer.trim()) {

--- a/packages/api/src/utils/cli-types.ts
+++ b/packages/api/src/utils/cli-types.ts
@@ -36,6 +36,11 @@ export interface CliSpawnOptions {
   };
   /** F118 Phase B: Provider-scoped raw archive path for diagnostic enrichment */
   rawArchivePath?: string;
+  /**
+   * Issue #116: Provider signals CLI semantic completion (e.g. turn.completed).
+   * When aborted, spawnCli skips `await exitPromise` — decouples done from process exit.
+   */
+  semanticCompletionSignal?: AbortSignal;
 }
 
 /**

--- a/packages/api/test/cli-spawn.test.js
+++ b/packages/api/test/cli-spawn.test.js
@@ -8,9 +8,8 @@ import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 import { mock, test } from 'node:test';
 
-const { spawnCli, isCliError, isCliTimeout, isLivenessWarning, KILL_GRACE_MS } = await import(
-  '../dist/utils/cli-spawn.js'
-);
+const { spawnCli, isCliError, isCliTimeout, isLivenessWarning, KILL_GRACE_MS, SEMANTIC_COMPLETION_GRACE_MS } =
+  await import('../dist/utils/cli-spawn.js');
 
 /** Helper: collect all items from async iterable */
 async function collect(iterable) {
@@ -856,4 +855,180 @@ test('isLivenessWarning returns false for non-warning objects', () => {
   assert.ok(!isLivenessWarning(null));
   assert.ok(!isLivenessWarning(42));
   assert.ok(!isLivenessWarning({ __livenessWarning: false }));
+});
+
+// === Issue #116: Semantic completion decoupled from process exit ===
+
+test('Group A: semanticCompletionSignal aborted → generator finishes without waiting for exit', async () => {
+  const proc = createMockProcess({ exitOnKill: false });
+  const spawnFn = createMockSpawnFn(proc);
+
+  const semanticController = new AbortController();
+
+  const startMs = Date.now();
+  const promise = collect(
+    spawnCli(
+      {
+        command: 'codex',
+        args: ['exec', '--json'],
+        timeoutMs: 10_000,
+        semanticCompletionSignal: semanticController.signal,
+      },
+      { spawnFn },
+    ),
+  );
+
+  proc.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 't1' }) + '\n');
+  proc.stdout.write(JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 100 } }) + '\n');
+
+  semanticController.abort();
+  proc.stdout.end();
+
+  // Simulate process exiting naturally during grace period (e.g. git push finishes)
+  setTimeout(() => proc._emitter.emit('exit', 0, null), 200);
+
+  const results = await promise;
+  const elapsedMs = Date.now() - startMs;
+
+  // Should finish after process exits (~200ms), not wait for full timeout (10s)
+  assert.ok(elapsedMs < 2000, `Should finish once process exits during grace, took ${elapsedMs}ms`);
+  assert.equal(results.length, 2);
+  assert.deepEqual(results[0], { type: 'thread.started', thread_id: 't1' });
+  assert.deepEqual(results[1], { type: 'turn.completed', usage: { input_tokens: 100 } });
+});
+
+test('Group A: semanticCompletionSignal skips __cliError for post-completion exit', async () => {
+  const proc = createMockProcess({ exitOnKill: false });
+  const spawnFn = createMockSpawnFn(proc);
+
+  const semanticController = new AbortController();
+
+  const promise = collect(
+    spawnCli(
+      {
+        command: 'codex',
+        args: ['exec'],
+        semanticCompletionSignal: semanticController.signal,
+      },
+      { spawnFn },
+    ),
+  );
+
+  proc.stdout.write(JSON.stringify({ type: 'item.completed', text: 'hello' }) + '\n');
+  semanticController.abort();
+  proc.stdout.end();
+
+  // Process exits with non-zero during grace (Codex CLI quirk)
+  setTimeout(() => proc._emitter.emit('exit', 1, null), 100);
+
+  const results = await promise;
+
+  const hasCliError = results.some((r) => isCliError(r));
+  assert.equal(hasCliError, false, 'Post-semantic-completion exit error should be suppressed');
+
+  assert.equal(results.length, 1);
+  assert.deepEqual(results[0], { type: 'item.completed', text: 'hello' });
+});
+
+test('Group B: no semanticCompletionSignal → generator waits for exit (existing behavior)', async () => {
+  const proc = createMockProcess({ exitOnKill: true });
+  const spawnFn = createMockSpawnFn(proc);
+
+  const startMs = Date.now();
+  const promise = collect(
+    spawnCli(
+      {
+        command: 'codex',
+        args: ['exec'],
+        timeoutMs: 200,
+      },
+      { spawnFn },
+    ),
+  );
+
+  proc.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 't1' }) + '\n');
+  proc.stdout.end();
+
+  const results = await promise;
+  const elapsedMs = Date.now() - startMs;
+
+  assert.ok(elapsedMs >= 150, `Should wait for timeout (~200ms), only took ${elapsedMs}ms`);
+  const hasTimeout = results.some((r) => isCliTimeout(r));
+  assert.equal(hasTimeout, true, 'Without semanticCompletionSignal, should wait for exit and eventually timeout');
+});
+
+test('Group B: semanticCompletionSignal not aborted → still waits for exit', async () => {
+  const proc = createMockProcess({ exitOnKill: true });
+  const spawnFn = createMockSpawnFn(proc);
+
+  const semanticController = new AbortController();
+
+  const startMs = Date.now();
+  const promise = collect(
+    spawnCli(
+      {
+        command: 'codex',
+        args: ['exec'],
+        timeoutMs: 200,
+        semanticCompletionSignal: semanticController.signal,
+      },
+      { spawnFn },
+    ),
+  );
+
+  proc.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 't1' }) + '\n');
+  proc.stdout.end();
+
+  const results = await promise;
+  const elapsedMs = Date.now() - startMs;
+
+  assert.ok(elapsedMs >= 150, `Should wait for timeout (~200ms), only took ${elapsedMs}ms`);
+  const hasTimeout = results.some((r) => isCliTimeout(r));
+  assert.equal(hasTimeout, true, 'Un-aborted semanticCompletionSignal should behave like no signal');
+});
+
+test('Group A: lingering process is killed after grace period expires', async () => {
+  const proc = createMockProcess({ exitOnKill: false });
+  const spawnFn = createMockSpawnFn(proc);
+
+  const semanticController = new AbortController();
+
+  const promise = collect(
+    spawnCli(
+      {
+        command: 'codex',
+        args: ['exec'],
+        timeoutMs: 60_000,
+        semanticCompletionSignal: semanticController.signal,
+      },
+      { spawnFn },
+    ),
+  );
+
+  proc.stdout.write(JSON.stringify({ type: 'turn.completed' }) + '\n');
+  semanticController.abort();
+  proc.stdout.end();
+
+  // Process never exits — grace timer (SEMANTIC_COMPLETION_GRACE_MS) should expire,
+  // then killChild() in finally should fire SIGTERM.
+  // Emit exit after kill so generator can resolve.
+  const exitAfterKill = () => {
+    if (proc.kill.mock.callCount() > 0) {
+      proc._emitter.emit('exit', null, 'SIGTERM');
+    } else {
+      setTimeout(exitAfterKill, 50);
+    }
+  };
+  setTimeout(exitAfterKill, 100);
+
+  const startMs = Date.now();
+  await promise;
+  const elapsedMs = Date.now() - startMs;
+
+  assert.ok(proc.kill.mock.callCount() >= 1, 'Should kill lingering process after grace');
+  assert.equal(proc.kill.mock.calls[0].arguments[0], 'SIGTERM');
+  assert.ok(
+    elapsedMs >= SEMANTIC_COMPLETION_GRACE_MS - 500,
+    `Should wait for grace period (~${SEMANTIC_COMPLETION_GRACE_MS}ms), took ${elapsedMs}ms`,
+  );
 });

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -1025,3 +1025,58 @@ test('F24: enriches Codex context snapshot from resolver into done metadata', as
   assert.equal(done.metadata.usage.contextResetsAtMs, Date.UTC(2026, 1, 18, 0, 0, 0));
   assert.equal(done.metadata.usage.lastTurnInputTokens, 186_749);
 });
+
+test('Issue #116: turn.completed unblocks done even when process exit is delayed', async () => {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const emitter = new EventEmitter();
+  const proc = {
+    stdout,
+    stderr,
+    pid: 12345,
+    exitCode: null,
+    kill: mock.fn(() => true),
+    on: (event, listener) => {
+      emitter.on(event, listener);
+      return proc;
+    },
+    once: (event, listener) => {
+      emitter.once(event, listener);
+      return proc;
+    },
+    _emitter: emitter,
+  };
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new CodexAgentService({ spawnFn });
+
+  const startMs = Date.now();
+  const promise = collect(service.invoke('test'));
+
+  proc.stdout.write(JSON.stringify({ type: 'thread.started', thread_id: 'thread-116' }) + '\n');
+  proc.stdout.write(
+    JSON.stringify({
+      type: 'item.completed',
+      item: { id: 'msg-1', type: 'agent_message', text: 'Done!' },
+    }) + '\n',
+  );
+  proc.stdout.write(
+    JSON.stringify({
+      type: 'turn.completed',
+      usage: { input_tokens: 100, output_tokens: 50 },
+    }) + '\n',
+  );
+  proc.stdout.end();
+
+  // Process exits naturally during grace period (simulating delayed but normal exit)
+  setTimeout(() => emitter.emit('exit', 0, null), 300);
+
+  const msgs = await promise;
+  const elapsedMs = Date.now() - startMs;
+
+  assert.ok(elapsedMs < 2000, `Should complete quickly once process exits during grace, took ${elapsedMs}ms`);
+
+  const done = msgs.find((m) => m.type === 'done');
+  assert.ok(done, 'should have done message');
+  assert.equal(done.metadata?.usage?.inputTokens, 100);
+  assert.equal(done.metadata?.usage?.outputTokens, 50);
+});


### PR DESCRIPTION
## Summary

Provider completion was blocked on subprocess exit instead of CLI semantic completion. When stderr kept a process alive (e.g. `git push` progress output), the frontend stayed stuck in "executing" until timeout.

Fixes #116

## Root Cause

The original issue hypothesized that `readline done:true` loses buffered events. Investigation proved this wrong — Node.js readline async iterator guarantees buffer drain before signaling done.

**The real root cause**: `spawnCli()` unconditionally `await exitPromise` after stdout iteration ends. All providers emit `done` only after `for await spawnCli(...)` completes. If stderr keeps a subprocess alive, `done` is delayed indefinitely.

## Fix

- Add `semanticCompletionSignal` (AbortSignal) to `CliSpawnOptions`
- Codex provider wires `turn.completed` to abort the signal
- `spawnCli` honors semantic completion with a 5s grace period for natural exit
- Unconditional `killChild()` in `finally` prevents process leaks
- Scope: Codex path only (Claude/Gemini can adopt later)

## Test Evidence

- 130/130 tests pass (cli-spawn: 40, codex-agent: 32, claude-agent: 33, gemini-agent: 25)
- 6 new tests covering semantic completion, backward compatibility, and process leak prevention
