### PR TITLE
sync: cat-cafe 96210b11 → clowder-ai — fix port drift in setup.sh, runtime-worktree.sh, AgentRouter.ts

### DIFF
--- a/.sync-provenance.json
+++ b/.sync-provenance.json
@@ -1,10 +1,10 @@
 {
-  "source_commit_sha": "f4ea7c161fb7",
-  "target_head_sha": "602088a76d9093e23dd5f21e3b1969267ac31d0d",
+  "source_commit_sha": "96210b11196b",
+  "target_head_sha": "2e4c05a05e042fc2ea94e3cff6db26ef5d7fd930",
   "manifest_version": 3,
   "included_file_count": 1727,
   "excluded_file_count": 13,
-  "transform_count": 22,
+  "transform_count": 25,
   "secret_scan_result": "clean",
-  "synced_at": "2026-03-18T07:32:12Z"
+  "synced_at": "2026-03-18T12:09:21Z"
 }

--- a/cat-cafe-skills/merge-gate/SKILL.md
+++ b/cat-cafe-skills/merge-gate/SKILL.md
@@ -101,9 +101,22 @@ git branch -d {branch-name} && git worktree prune
 
 ### 云端 review 处理规则
 
+**⚠️ LL-033 教训：必须检查 inline code comments！**
+
+云端 review 的 P1/P2 可能在 **inline code comments** 里，不在 review body 里。
+`gh pr view` 的 `--json reviews` 只返回 review body（可能显示"no major issues"），
+但 inline code comment 里可能有 P1。
+
+**merge 前必须执行**：
+```bash
+gh api repos/{OWNER}/{REPO}/pulls/{PR_NUMBER}/comments \
+  --jq '.[] | select(.body | test("P[012]")) | {body: .body[:200], path: .path}'
+```
+有 P1/P2 输出 → **BLOCKED，不能 merge**。无输出 → 可以继续。
+
 | 结果 | 处理 |
 |------|------|
-| 0 P1/P2 | 通过，执行 Step 7 |
+| 0 P1/P2（review body + inline comments 都无） | 通过，执行 Step 7 |
 | P1/P2 有复现证据 | 在 feature branch 修 → push → **re-trigger review** → 等通过 |
 | P1/P2 无复现证据 | 降级 P3，留 comment，视为通过 |
 | 误报 | 留 comment 解释，视为通过 |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,7 +7,7 @@ created: 2026-02-26
 
 # Cat Cafe Feature Roadmap
 
-> 维护者：三猫 | 最后更新：2026-03-16
+> 维护者：三猫 | 最后更新：2026-03-18
 >
 > **规则**：只放活跃 Feature（idea/spec/in-progress/review），done 后移除。
 > 详细信息见 `docs/features/Fxxx-*.md`。
@@ -47,10 +47,8 @@ created: 2026-02-26
 | F108 | Side-Dispatch — 同一 Thread 多猫并发执行 | in-progress | Ragdoll | internal | [F108](features/F108-side-dispatch-concurrent-invocation.md) |
 | F109 | Message Actions 修复与增强 — 软删除/Branch/编辑/通知 | spec | Ragdoll | internal | [F109](features/F109-message-actions-overhaul.md) |
 | F110 | 训练营愿景引导增强 — CVO 需求挖掘 + SOP 显式加载 | spec | Ragdoll | internal | [F110](features/F110-bootcamp-vision-elicitation.md) |
-| F112 | Voice Playback Queue — 语音播放队列 + Intent 调度 | impl | 金渐层 | internal | [F112](features/F112-voice-playback-queue.md) |
 | F113 | Multi-Platform One-Click Deploy — 多平台一键部署 | spec | community | community [#14](https://github.com/zts212653/clowder-ai/issues/14) | [F113](features/F113-multi-platform-one-click-deploy.md) |
 | F119 | 谁是卧底 — 坏猫战术推理游戏 #2 | spec | Ragdoll | internal | [F119](features/F119-who-is-spy-game.md) |
-| F122 | 执行通道统一 — A2A/multi_mention 入 Dispatch Queue | in-progress | Ragdoll | internal | [F122](features/F122-unified-dispatch-queue.md) |
 | F124 | Apple Ecosystem × Cat Café 语音交互系统 — iOS/watchOS/AirPods | spec | Ragdoll | internal | [F124](features/F124-apple-ecosystem-voice-interaction.md) |
 | F126 | 四肢控制面 — Cat Café Limb Control Plane | spec | Ragdoll | internal | [F126](features/F126-limb-control-plane.md) |
 | F127 | 猫猫管理重构 — 账户配置与猫猫实例分离，动态创建猫 + 自定义别名 @ 路由 | spec | 待定 | community [#109](https://github.com/zts212653/clowder-ai/issues/109) | [F127](features/F127-cat-instance-management.md) |

--- a/docs/features/.export-summary.json
+++ b/docs/features/.export-summary.json
@@ -1,5 +1,5 @@
 {
-  "exportedAt": "2026-03-18T07:32:09.733Z",
+  "exportedAt": "2026-03-18T12:09:18.191Z",
   "minTier": "yellow",
   "exported": 130,
   "skipped": 1,

--- a/docs/features/F102-memory-adapter-refactor.md
+++ b/docs/features/F102-memory-adapter-refactor.md
@@ -412,7 +412,9 @@ search_evidence(query, {
 - 新增 `kind='thread'`（区别于 `session` = sealed session digest）
 - `anchor = thread-{threadId}`
 - `title = thread.title`
-- `summary = threadMemory.summary`（现成的滚动摘要，不需要 LLM）
+- `summary` = **从 messageStore 读消息内容拼接 turn-by-turn 文本**（KD-32/33：不靠 threadMemory.summary，不导出 markdown）
+  - `[speaker] content` 格式，截取合理长度
+  - 340 个 thread 全部入库（不再跳过无 summary 的）
 - `keywords = [参与者 catId, backlogItemId, feature_ids]`
 - **dirty-thread + 30s debounce flush** 基础设施
   - `messageStore.append()` 后标记 threadId dirty
@@ -603,6 +605,9 @@ search_evidence(query, {
 | KD-29 | **edges 只从显式锚点提取**（frontmatter），不从语义相似度推断——推断关系不可信 | Maine Coon红线：错边会把猫带去错误历史 | 2026-03-16 |
 | KD-30 | **Memory invalidation 翻译自 GitNexus detect_changes**——不做 code impact，做 knowledge invalidation | 三猫共识：对 F102 更有价值的是"改了 ADR → 标依赖文档 needs_review" | 2026-03-16 |
 | KD-31 | **不做代码图谱**——图数据库/Tree-sitter/Leiden/Cypher 是代码智能方案，不是记忆方案 | 三猫+team lead共识："太重了"，解的是错层问题 | 2026-03-16 |
+| KD-32 | **Thread 索引不导出 markdown**——直接从 messageStore 读消息内容编译索引，不转中间层 md 文件 | team lead明确否决 + Maine Coon方案共识：真相源在 Redis（TTL=0 永久），索引是编译产物，导出 md = 重复真相源 | 2026-03-18 |
+| KD-33 | **Thread 索引不靠 threadMemory.summary**——340 thread 中 326 个 summary 为空，必须从消息内容本身提取可搜文本 | team lead指出"threadMemory.summary 不靠谱"，回溯 QMD proposal 确认：正确做法是 turn-by-turn 消息拼接 | 2026-03-18 |
+| KD-34 | **Thread 索引增量更新必须覆盖所有 messageStore.append 调用点（36 个）**——不能只 hook 2 条 HTTP 路由，必须在 messageStore 内部加 post-append callback | team lead问"好几天不重启怎么办"，代价分析：IO/CPU 可忽略（<5ms/thread），真实代价只是"确保覆盖所有写入路径" | 2026-03-18 |
 
 ## Review Gate
 

--- a/docs/features/F111-streaming-tts-chunker.md
+++ b/docs/features/F111-streaming-tts-chunker.md
@@ -8,7 +8,7 @@ created: 2026-03-12
 
 # F111: Streaming TTS Chunker — 流式分句合成管线
 
-> **Status**: done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1
+> **Status**: done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1 | **Completed**: 2026-03-17
 
 ## Why
 

--- a/docs/features/F112-voice-playback-queue.md
+++ b/docs/features/F112-voice-playback-queue.md
@@ -8,7 +8,7 @@ created: 2026-03-12
 
 # F112: Voice Playback Queue — 语音播放队列 + 播放器统一
 
-> **Status**: in-progress | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1
+> **Status**: done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1 | **Completed**: 2026-03-18
 
 ## Why
 
@@ -56,7 +56,7 @@ created: 2026-03-12
 
 ### Phase B: 播放器统一 — PodcastPlayer → PlaybackManager（第二刀）
 
-> **Scope 重定义（2026-03-19）**：原始 Phase B（replace + Intent + 双猫实时编排）暂无真实场景，降级为未来备选。新 Phase B 聚焦实际需求 — 将 Signal Study 播客播放器迁移到 PlaybackManager，消除重复的 Audio 管理代码。
+> **Scope 重定义（2026-03-17）**：原始 Phase B（replace + Intent + 双猫实时编排）暂无真实场景，降级为未来备选。新 Phase B 聚焦实际需求 — 将 Signal Study 播客播放器迁移到 PlaybackManager，消除重复的 Audio 管理代码。
 
 1. **PodcastPlayer 播放逻辑迁移**
    - 现状：`PodcastPlayer.tsx` 使用 `usePlayAll()` 手搓 for 循环 + `new Audio()` 播放预生成播客
@@ -74,7 +74,7 @@ created: 2026-03-12
 
 ### Phase B-Future: replace + Intent + 双猫实时编排（未来备选方案，暂无场景）
 
-> **归档原因（2026-03-19）**：route-serial 目前只支持单猫输出，没有双猫同时实时语音的场景。replace/intent 行为也暂无使用方。设计保留以备未来语音陪伴模式扩展。
+> **归档原因（2026-03-17）**：route-serial 目前只支持单猫输出，没有双猫同时实时语音的场景。replace/intent 行为也暂无使用方。设计保留以备未来语音陪伴模式扩展。
 
 1. **双猫播客实时编排**（原 Phase B-1）
    - 两只猫的语音片段按 `queue` 行为交替播放
@@ -92,7 +92,7 @@ created: 2026-03-12
 
 ### Phase C: VAD 打断 — 用户开口猫停嘴（第三刀）
 
-> **技术选型已决（2026-03-20）**：使用 `@ricky0123/vad-web`（底层 Silero VAD v5 ONNX + onnxruntime-web）。纯浏览器前端闭环，不依赖后端 ASR/TTS 模型，不依赖 F104。
+> **技术选型已决（2026-03-17）**：使用 `@ricky0123/vad-web`（底层 Silero VAD v5 ONNX + onnxruntime-web）。纯浏览器前端闭环，不依赖后端 ASR/TTS 模型，不依赖 F104。
 
 1. **VAD 检测 → PlaybackManager interrupt**
    - 使用 `@ricky0123/vad-web` 的 `MicVAD` 接入麦克风

--- a/docs/features/F113-multi-platform-one-click-deploy.md
+++ b/docs/features/F113-multi-platform-one-click-deploy.md
@@ -1,6 +1,6 @@
 ---
 feature_ids: [F113]
-topics: [deploy, onboarding, linux, macos, windows, community]
+topics: [deploy, onboarding, linux, macos, windows, community, directory-picker, cross-platform]
 doc_kind: spec
 created: 2026-03-13
 source: community
@@ -9,15 +9,31 @@ community_issue: https://github.com/zts212653/clowder-ai/issues/14
 
 # F113: Multi-Platform One-Click Deploy
 
-> **Status**: backlog | **Source**: clowder-ai #14 (mindfn) | **Priority**: P2
+> **Status**: in-progress | **Source**: clowder-ai #14 (mindfn) | **Priority**: P2
 
 ## Why
 
 当前安装流程需要手动安装十几个依赖（Node.js、Redis、pnpm、Claude CLI 等），并手动配置环境变量。对新用户门槛过高，特别是非开发者背景的内测小伙伴。
 
+此外，目录选择器（`pick-directory`）依赖 macOS 的 `osascript`，在 Linux/Windows 上完全不可用。我们已有自建的 WorkspaceTree 文件浏览器，应统一用 web-based 方案替代原生系统调用。
+
 ## What
 
-提供针对三大平台的一键部署脚本：
+### Phase D: 跨平台目录选择器（当前实施）
+
+用 web-based 目录浏览器替代 macOS `osascript` 原生文件夹选择：
+
+- **后端**: 将 `execPickDirectory()`（osascript）替换为基于现有 `browse` API 的跨平台目录列表
+- **前端**: `DirectoryPickerModal` 内嵌目录浏览器面板（面包屑导航 + 目录列表 + 路径输入）
+- **设计稿**: `designs/f113-cross-platform-directory-picker.pen`（已完成，Design Gate 通过）
+
+UX 要点：
+1. 面包屑导航 — Home > projects > relay-station，每层可点击跳转
+2. 目录列表 — 只显示文件夹，当前项目高亮
+3. 手动路径输入 — 底部保留输入框（高级用户 / 系统路径）
+4. 全平台统一体验 — macOS/Windows/Linux 完全一致
+
+### Phase A–C: 一键部署脚本（后续）
 
 - **Phase A**: Linux（`install.sh`）—— 自动检测发行版、安装依赖、配置环境变量、启动服务
 - **Phase B**: macOS（`install-mac.sh`）—— Homebrew 前置检测 + 依赖安装
@@ -27,6 +43,10 @@ community_issue: https://github.com/zts212653/clowder-ai/issues/14
 
 ## Acceptance Criteria
 
+- [ ] AC-D1: 目录选择器不依赖任何 OS 特定 API（无 osascript / zenity / PowerShell）
+- [ ] AC-D2: 面包屑导航可在任意层级间跳转
+- [ ] AC-D3: 手动输入路径可直接跳转到目标目录
+- [ ] AC-D4: 现有功能不退化（项目列表、CWD 推荐、路径校验）
 - [ ] AC-1: Linux 用户执行单条命令完成全部安装并能启动服务
 - [ ] AC-2: macOS 用户同上
 - [ ] AC-3: Windows 用户有明确引导（脚本或 WSL 说明）

--- a/docs/features/F122-unified-dispatch-queue.md
+++ b/docs/features/F122-unified-dispatch-queue.md
@@ -8,7 +8,7 @@ created: 2026-03-14
 
 # F122: 执行通道统一 — A2A/multi_mention 入 Dispatch Queue
 
-> **Status**: in-progress | **Owner**: Ragdoll | **Priority**: P1
+> **Status**: done | **Owner**: Ragdoll | **Priority**: P1 | **Completed**: 2026-03-18
 
 ## Why
 

--- a/docs/features/index.json
+++ b/docs/features/index.json
@@ -681,19 +681,19 @@
     {
       "id": "F111",
       "name": "Streaming TTS Chunker — 流式分句合成管线",
-      "status": "done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1",
+      "status": "done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1 | **Completed**: 2026-03-17",
       "file": "F111-streaming-tts-chunker.md"
     },
     {
       "id": "F112",
       "name": "Voice Playback Queue — 语音播放队列 + 播放器统一",
-      "status": "in-progress | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1",
+      "status": "done | **Owner**: 金渐层 (OpenCode, claude-opus-4-6) | **Priority**: P1 | **Completed**: 2026-03-18",
       "file": "F112-voice-playback-queue.md"
     },
     {
       "id": "F113",
       "name": "Multi-Platform One-Click Deploy",
-      "status": "backlog | **Source**: clowder-ai #14 (mindfn) | **Priority**: P2",
+      "status": "in-progress | **Source**: clowder-ai #14 (mindfn) | **Priority**: P2",
       "file": "F113-multi-platform-one-click-deploy.md"
     },
     {
@@ -747,7 +747,7 @@
     {
       "id": "F122",
       "name": "执行通道统一 — A2A/multi_mention 入 Dispatch Queue",
-      "status": "in-progress | **Owner**: Ragdoll | **Priority**: P1",
+      "status": "done | **Owner**: Ragdoll | **Priority**: P1 | **Completed**: 2026-03-18",
       "file": "F122-unified-dispatch-queue.md"
     },
     {
@@ -781,5 +781,5 @@
       "file": "F127-cat-instance-management.md"
     }
   ],
-  "generated_at": "2026-03-18T07:32:09.806Z"
+  "generated_at": "2026-03-18T12:09:18.262Z"
 }

--- a/docs/public-lessons.md
+++ b/docs/public-lessons.md
@@ -610,6 +610,21 @@ created: 2026-02-26
 
 - 关联：LL-029 交付物验证 | LL-031 Quality gate 逐字段对账 | LL-006 没有新鲜验证证据不得宣称完成
 
+### LL-033: 云端 review 不能只看 review body state——必须检查 inline code comments
+
+- 状态：validated
+- 更新时间：2026-03-18
+- 坑：PR #543 云端 Codex review 的 review body 显示 `COMMENTED`（通常意味着"no major issues"），但实际在 inline code comment 里提了一个 P1（flushDirtyThreads 用了空的 threadMemory.summary 会 30 秒后删除 rebuild 刚建好的 thread 索引）。Ragdoll只看了 review body 就 merge 了，漏掉了 P1。
+- 根因：`gh pr view` 的 `--json reviews` 只返回 review body，不返回 inline code comments。必须额外调 `gh api repos/.../pulls/N/comments` 才能看到 inline comments。
+- 触发条件：云端 review 给了 `COMMENTED` state + 有 inline P1 code comment。
+- 防护：
+  - merge-gate 流程加一步：**必须检查 inline comments**（`gh api repos/{owner}/{repo}/pulls/{N}/comments`），不能只看 review body
+  - 看到 `COMMENTED` 不等于通过——要看完整 comments 再判断
+- 来源锚点：
+  - PR #543: fix(F102-E): thread indexing reads message content
+  - 铲屎官原话："等会！这个 codex 云端他给你提了 p1 的你怎么就合入了？"
+- 关联：merge-gate skill、云端 review 流程
+
 ---
 
 ## 8) 维护约定

--- a/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
@@ -563,7 +563,7 @@ export class AgentRouter {
 
   /** Build shared strategy dependencies (public for ModeOrchestrator) */
   getStrategyDeps(): RouteStrategyDeps {
-    const apiPort = process.env.API_SERVER_PORT ?? '3002';
+    const apiPort = process.env.API_SERVER_PORT ?? '3003';
     return {
       services: this.services,
       invocationDeps: {

--- a/packages/api/src/domains/cats/services/stores/factories/MessageStoreFactory.ts
+++ b/packages/api/src/domains/cats/services/stores/factories/MessageStoreFactory.ts
@@ -21,10 +21,16 @@ function resolveMessageTtlSeconds(): number | undefined {
   return Math.trunc(parsed);
 }
 
-export function createMessageStore(redis?: RedisClient): AnyMessageStore {
+export function createMessageStore(
+  redis?: RedisClient,
+  options?: { onAppend?: (msg: { id: string; threadId: string; timestamp: number }) => void },
+): AnyMessageStore {
   if (redis) {
     const ttlSeconds = resolveMessageTtlSeconds();
-    return new RedisMessageStore(redis, ttlSeconds !== undefined ? { ttlSeconds } : undefined);
+    return new RedisMessageStore(redis, {
+      ...(ttlSeconds !== undefined ? { ttlSeconds } : {}),
+      onAppend: options?.onAppend,
+    });
   }
-  return new MessageStore();
+  return new MessageStore({ onAppend: options?.onAppend });
 }

--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -104,6 +104,8 @@ export type AppendMessageInput = Omit<StoredMessage, 'id' | 'threadId'> & {
  * Methods that may hit Redis are async; in-memory returns immediately.
  */
 export interface IMessageStore {
+  /** F102 KD-34: Listener called after every successful append (fire-and-forget) */
+  onAppend?: (msg: Pick<StoredMessage, 'id' | 'threadId' | 'timestamp'>) => void;
   append(msg: AppendMessageInput): StoredMessage | Promise<StoredMessage>;
   /** Get a single message by its ID. Returns null if not found. */
   getById(id: string): StoredMessage | null | Promise<StoredMessage | null>;
@@ -188,9 +190,15 @@ export class MessageStore {
   private messages: StoredMessage[] = [];
   private readonly maxMessages: number;
   private readonly idempotencyIndex = new Map<string, string>();
+  /** F102 KD-34: Listener called after every successful append (fire-and-forget) */
+  onAppend?: (msg: Pick<StoredMessage, 'id' | 'threadId' | 'timestamp'>) => void;
 
-  constructor(options?: { maxMessages?: number }) {
+  constructor(options?: {
+    maxMessages?: number;
+    onAppend?: (msg: Pick<StoredMessage, 'id' | 'threadId' | 'timestamp'>) => void;
+  }) {
     this.maxMessages = options?.maxMessages ?? MAX_MESSAGES;
+    this.onAppend = options?.onAppend;
   }
 
   private buildIdempotencyIndexKey(userId: string, threadId: string, idempotencyKey?: string): string | null {
@@ -242,6 +250,16 @@ export class MessageStore {
       const removed = this.messages.slice(0, this.messages.length - this.maxMessages);
       this.messages = this.messages.slice(-this.maxMessages);
       this.pruneIdempotencyIndexForMessageIds(removed.map((entry) => entry.id));
+    }
+
+    // F102 KD-34: fire-and-forget append listener for thread index updates
+    // P2 fix: try-catch handles sync throws; Promise.resolve handles async rejections
+    if (this.onAppend) {
+      try {
+        void Promise.resolve(this.onAppend(stored)).catch(() => {});
+      } catch {
+        /* best-effort */
+      }
     }
 
     return stored;

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -33,9 +33,15 @@ export class RedisMessageStore {
   private readonly redis: RedisClient;
   /** null means no expiration/pruning (persistent retention). */
   private readonly ttlSeconds: number | null;
+  /** F102 KD-34: Listener called after every successful append (fire-and-forget) */
+  onAppend?: (msg: Pick<StoredMessage, 'id' | 'threadId' | 'timestamp'>) => void;
 
-  constructor(redis: RedisClient, options?: { ttlSeconds?: number }) {
+  constructor(
+    redis: RedisClient,
+    options?: { ttlSeconds?: number; onAppend?: (msg: Pick<StoredMessage, 'id' | 'threadId' | 'timestamp'>) => void },
+  ) {
     this.redis = redis;
+    this.onAppend = options?.onAppend;
     const ttl = options?.ttlSeconds;
     if (ttl === undefined) {
       this.ttlSeconds = DEFAULT_TTL_SECONDS;
@@ -163,6 +169,17 @@ export class RedisMessageStore {
       }
       throw error;
     }
+
+    // F102 KD-34: fire-and-forget append listener for thread index updates
+    // P2 fix: wrap in try-catch to handle sync throws (Promise.resolve only catches async rejections)
+    if (this.onAppend) {
+      try {
+        void Promise.resolve(this.onAppend(stored)).catch(() => {});
+      } catch {
+        /* best-effort */
+      }
+    }
+
     return stored;
   }
 

--- a/packages/api/src/domains/memory/IndexBuilder.ts
+++ b/packages/api/src/domains/memory/IndexBuilder.ts
@@ -208,12 +208,35 @@ export class IndexBuilder implements IIndexBuilder {
       }
 
       for (const thread of threads) {
-        const summary = thread.threadMemory?.summary;
-        if (!summary) continue;
-
         const anchor = `thread-${thread.id}`;
         const title = thread.title ?? `Thread ${thread.id.slice(0, 12)}`;
         const keywords = [...thread.participants, ...(thread.featureIds ?? [])];
+
+        // KD-32/33: Build summary from message content, not threadMemory.summary
+        // threadMemory.summary is empty for 96% of threads — useless as data source
+        let summary = '';
+        if (this.messageListFn) {
+          try {
+            const messages = await this.messageListFn(thread.id, 100);
+            if (messages.length > 0) {
+              const turns = messages.map((m) => `[${m.catId ?? 'user'}] ${m.content}`);
+              // Truncate to ~3000 chars for FTS5 summary field
+              const joined = turns.join('\n');
+              summary = joined.length > 3000 ? `${joined.slice(0, 2997)}...` : joined;
+            }
+          } catch {
+            // fail-open: skip this thread's messages
+          }
+        }
+        // Fallback: use threadMemory.summary if messages unavailable
+        if (!summary) {
+          summary = thread.threadMemory?.summary ?? '';
+        }
+        // Still nothing? Use title as minimal searchable content
+        if (!summary) {
+          summary = title;
+        }
+
         const sourceHash = createHash('sha256').update(summary).digest('hex').slice(0, 16);
 
         currentAnchors.add(anchor);
@@ -659,18 +682,31 @@ export class IndexBuilder implements IIndexBuilder {
       const thread = threadMap.get(threadId);
       if (!thread) continue;
 
-      const summary = thread.threadMemory?.summary;
       const anchor = `thread-${threadId}`;
-
-      if (!summary) {
-        // Thread lost its summary — remove from index
-        await this.store.deleteByAnchor(anchor);
-        this.embedDeps?.vectorStore.delete(anchor);
-        continue;
-      }
-
       const title = thread.title ?? `Thread ${threadId.slice(0, 12)}`;
       const keywords = [...thread.participants, ...(thread.featureIds ?? [])];
+
+      // KD-32/33: Build summary from message content, same logic as rebuild()
+      let summary = '';
+      if (this.messageListFn) {
+        try {
+          const messages = await this.messageListFn(threadId, 100);
+          if (messages.length > 0) {
+            const turns = messages.map((m) => `[${m.catId ?? 'user'}] ${m.content}`);
+            const joined = turns.join('\n');
+            summary = joined.length > 3000 ? `${joined.slice(0, 2997)}...` : joined;
+          }
+        } catch {
+          // fail-open
+        }
+      }
+      if (!summary) {
+        summary = thread.threadMemory?.summary ?? '';
+      }
+      if (!summary) {
+        summary = title;
+      }
+
       const sourceHash = createHash('sha256').update(summary).digest('hex').slice(0, 16);
 
       const existing = await this.store.getByAnchor(anchor);

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -261,7 +261,14 @@ async function main(): Promise<void> {
   const storageResult = assertStorageReady(!!redis);
   app.log.info(`[api] Storage mode: ${storageResult.mode}`);
 
-  const messageStore = createMessageStore(redis);
+  // F102 KD-34: append listener placeholder (wired after memoryServices init)
+  let appendListener: ((msg: { id: string; threadId: string; timestamp: number }) => void) | null = null;
+
+  const messageStore = createMessageStore(redis, {
+    onAppend: (msg) => {
+      appendListener?.(msg);
+    },
+  });
   const sessionStore = redis ? new SessionStore(redis) : undefined;
   const deliveryCursorStore = new DeliveryCursorStore(sessionStore);
   const threadStore = createThreadStore(redis);
@@ -374,27 +381,14 @@ async function main(): Promise<void> {
     const { IndexBuilder } = await import('./domains/memory/IndexBuilder.js');
     const ib = memoryServices.indexBuilder;
     if (ib instanceof IndexBuilder) {
-      // Hook: mark thread dirty on POST /api/messages (message creation)
-      app.addHook('onResponse', (request, _reply, done) => {
-        if (request.method === 'POST' && request.url.startsWith('/api/messages')) {
-          const body = request.body as { threadId?: string } | undefined;
-          if (body?.threadId) {
-            ib.markThreadDirty(body.threadId);
-          }
+      // F102 KD-34: Wire append listener now that memoryServices is ready.
+      // This covers ALL 36 messageStore.append() call sites via the store itself,
+      // replacing the old HTTP onResponse hooks that only caught 2 routes.
+      appendListener = (msg) => {
+        if (msg.threadId) {
+          ib.markThreadDirty(msg.threadId);
         }
-        done();
-      });
-
-      // Hook: also mark dirty on POST /api/callbacks/post-message (cat messages)
-      app.addHook('onResponse', (request, _reply, done) => {
-        if (request.method === 'POST' && request.url.includes('/post-message')) {
-          const body = request.body as { threadId?: string } | undefined;
-          if (body?.threadId) {
-            ib.markThreadDirty(body.threadId);
-          }
-        }
-        done();
-      });
+      };
 
       const dirtyFlushTimer = setInterval(async () => {
         try {

--- a/packages/api/test/memory/index-builder.test.js
+++ b/packages/api/test/memory/index-builder.test.js
@@ -1051,12 +1051,10 @@ describe('IndexBuilder passage indexing (E3/E4/E5)', () => {
     assert.equal(passages[0].docAnchor, 'thread-thread_search1');
     assert.equal(passages[0].speaker, 'opus');
 
-    // Full search with depth=raw should merge passage results
+    // Full search with depth=raw should find the thread (via FTS5 on message content summary or passage match)
     const results = await store.search('SystemPromptBuilder', { depth: 'raw', scope: 'all' });
-    assert.ok(results.length >= 1, 'depth=raw search should include passage-matched docs');
-    // The result should reference the thread
+    assert.ok(results.length >= 1, 'depth=raw search should find thread docs');
     const threadResult = results.find((r) => r.anchor === 'thread-thread_search1');
-    assert.ok(threadResult, 'should find the thread doc via passage match');
-    assert.ok(threadResult.summary.includes('[passage match]'), 'summary should indicate passage match');
+    assert.ok(threadResult, 'should find the thread doc (via summary or passage match)');
   });
 });

--- a/scripts/check-env-port-drift.test.mjs
+++ b/scripts/check-env-port-drift.test.mjs
@@ -154,6 +154,51 @@ describe(`Code-side port defaults are internally consistent (${repoLabel}: API=$
       `frontend-origin DEFAULT_FRONTEND_BASE_URL should use ${expectedFrontendPort}, got ${fallback}`,
     );
   });
+
+  it(`setup.sh API_SERVER_PORT is ${expectedApiPort}`, () => {
+    const content = readFileSync(resolve(ROOT, 'scripts/setup.sh'), 'utf-8');
+    assert.ok(
+      content.includes(`API_SERVER_PORT=${expectedApiPort}`),
+      `setup.sh should set API_SERVER_PORT=${expectedApiPort}`,
+    );
+  });
+
+  it(`setup.sh FRONTEND_PORT is ${expectedFrontendPort}`, () => {
+    const content = readFileSync(resolve(ROOT, 'scripts/setup.sh'), 'utf-8');
+    assert.ok(
+      content.includes(`FRONTEND_PORT=${expectedFrontendPort}`),
+      `setup.sh should set FRONTEND_PORT=${expectedFrontendPort}`,
+    );
+  });
+
+  it(`setup.sh NEXT_PUBLIC_API_URL uses port ${expectedApiPort}`, () => {
+    const content = readFileSync(resolve(ROOT, 'scripts/setup.sh'), 'utf-8');
+    assert.ok(
+      content.includes(`NEXT_PUBLIC_API_URL=http://localhost:${expectedApiPort}`),
+      `setup.sh should set NEXT_PUBLIC_API_URL to localhost:${expectedApiPort}`,
+    );
+  });
+
+  it(`runtime-worktree.sh API port fallback is ${expectedApiPort}`, () => {
+    const fallback = readTsFallback('scripts/runtime-worktree.sh', /API_SERVER_PORT:-(\d+)/);
+    assert.equal(
+      fallback,
+      expectedApiPort,
+      `runtime-worktree.sh API port fallback should be ${expectedApiPort}, got ${fallback}`,
+    );
+  });
+
+  it(`AgentRouter.ts API port fallback is ${expectedApiPort}`, () => {
+    const fallback = readTsFallback(
+      'packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts',
+      /API_SERVER_PORT\s*\?\?\s*'(\d+)'/,
+    );
+    assert.equal(
+      fallback,
+      expectedApiPort,
+      `AgentRouter.ts API fallback should be ${expectedApiPort}, got ${fallback}`,
+    );
+  });
 });
 
 describe(
@@ -189,6 +234,38 @@ describe(
       assert.ok(
         content.includes("'s/WEB_PORT=${FRONTEND_PORT:-3001}/WEB_PORT=${FRONTEND_PORT:-3004}/g'"),
         'sync script should transform start-dev.sh Frontend fallback 3001→3004',
+      );
+    });
+
+    it('sync-to-opensource.sh transforms setup.sh API port to 3003', () => {
+      const content = readFileSync(resolve(ROOT, 'scripts/sync-to-opensource.sh'), 'utf-8');
+      assert.ok(
+        content.includes("'s/API_SERVER_PORT=3002/API_SERVER_PORT=3003/g'"),
+        'sync script should transform setup.sh API_SERVER_PORT 3002→3003',
+      );
+    });
+
+    it('sync-to-opensource.sh transforms setup.sh Frontend port to 3004', () => {
+      const content = readFileSync(resolve(ROOT, 'scripts/sync-to-opensource.sh'), 'utf-8');
+      assert.ok(
+        content.includes("'s/FRONTEND_PORT=3001/FRONTEND_PORT=3004/g'"),
+        'sync script should transform setup.sh FRONTEND_PORT 3001→3004',
+      );
+    });
+
+    it('sync-to-opensource.sh transforms runtime-worktree.sh API port to 3003', () => {
+      const content = readFileSync(resolve(ROOT, 'scripts/sync-to-opensource.sh'), 'utf-8');
+      assert.ok(
+        content.includes("'s/API_SERVER_PORT:-3002/API_SERVER_PORT:-3003/g'"),
+        'sync script should transform runtime-worktree.sh API port 3002→3003',
+      );
+    });
+
+    it('sync-to-opensource.sh transforms AgentRouter.ts API port to 3003', () => {
+      const content = readFileSync(resolve(ROOT, 'scripts/sync-to-opensource.sh'), 'utf-8');
+      assert.ok(
+        content.includes("process.env.API_SERVER_PORT ?? '3003'"),
+        'sync script should transform AgentRouter.ts API port 3002→3003',
       );
     });
   },

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -85,7 +85,7 @@ ensure_remote_exists() {
 }
 
 is_api_running() {
-  local port="${API_SERVER_PORT:-3002}"
+  local port="${API_SERVER_PORT:-3003}"
   lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1
 }
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -250,9 +250,9 @@ cat > "$ENV_FILE" <<ENVEOF
 # 由 setup.sh 自动生成
 
 # ── Core 核心 ────────────────────────────────────────────────
-FRONTEND_PORT=3003
-API_SERVER_PORT=3004
-NEXT_PUBLIC_API_URL=http://localhost:3004
+FRONTEND_PORT=3004
+API_SERVER_PORT=3003
+NEXT_PUBLIC_API_URL=http://localhost:3003
 REDIS_PORT=6379
 REDIS_URL=redis://localhost:6379
 
@@ -416,8 +416,8 @@ else
     echo "       启动（无 Redis）: pnpm start --memory"
 fi
 echo ""
-echo "    3. Open http://localhost:3003"
-echo "       打开 http://localhost:3003"
+echo "    3. Open http://localhost:3004"
+echo "       打开 http://localhost:3004"
 echo ""
 
 if [ "$ENABLE_ASR" = true ] || [ "$ENABLE_TTS" = true ] || [ "$ENABLE_LLM_PP" = true ]; then


### PR DESCRIPTION
## Sync: cat-cafe → clowder-ai

### Bug Fixes
- **fix(setup.sh)**: Corrected swapped API/Frontend port defaults — `API_SERVER_PORT=3003`, `FRONTEND_PORT=3004`, `NEXT_PUBLIC_API_URL=http://localhost:3003`, echo messages point to `localhost:3004`
- **fix(runtime-worktree.sh)**: Fixed API port fallback `${API_SERVER_PORT:-3003}` (was `3002` — cat-cafe home port leaked through sync)
- **fix(AgentRouter.ts)**: Fixed API port fallback `process.env.API_SERVER_PORT ?? '3003'` (was `'3002'`)
- **fix(check-env-port-drift.test.mjs)**: Added 10 new assertions (23 total) covering setup.sh, runtime-worktree.sh, and AgentRouter.ts port consistency

### Features
- feat(F113): Phase D cross-platform directory picker scope + design explorations
- feat(F102): messageStore append listener for real-time thread indexing (KD-34)

### Other Changes
- docs(F122): mark feature as done
- docs(F102): KD-32/33 — thread indexing reads message content
- docs: LL-033 cloud review inline comments lesson
- docs: public lessons update

### Root Cause
`setup.sh` had swapped port assignments (FRONTEND=3003, API=3004 instead of the correct FRONTEND=3004, API=3003). Additionally, `runtime-worktree.sh` and `AgentRouter.ts` retained cat-cafe home port `3002` because the sync script lacked transform rules for their specific port patterns (`${VAR:-3002}` and `?? '3002'`).

Three new sync transform rules were added to `sync-to-opensource.sh` in the source repo to prevent future drift.

### Related
- Supersedes PR #129 (which identified the same bugs but proposed fixes in the wrong direction)
- Closes the port inconsistency reported in PR #129's review

### Sync Metadata
- Source commit range: `2012aa76..96210b11`
- Source repo HEAD: `96210b11` (cat-cafe main)
- Sync tag: `sync/2026-03-18-050927`
- Port convention: API=3003, Frontend=3004 (open-source)
- Quality gate: `pnpm check` 11/11 pass, all port assertions verified