### PR TITLE
fix(F113): post-merge Windows skill mount + IPv6 loopback follow-up

### DIFF
--- a/packages/api/test/windows-portable-redis-script.test.js
+++ b/packages/api/test/windows-portable-redis-script.test.js
@@ -480,9 +480,15 @@ test('Windows startup preserves runtime Redis overrides, validates artifacts, an
   assert.match(startWindowsScript, /Service job '\$\(\$job.Name\)' stopped \(\$\(\$job.State\)\)/);
 });
 
-test('Windows Redis URL handling preserves external backends and treats localhost URLs with suffixes as local', () => {
+test('Windows Redis URL handling preserves external backends and treats loopback URLs with suffixes as local', () => {
   assert.match(startWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
-  assert.match(helpersScript, /\$uri\.Host -notin @\("localhost", "127\.0\.0\.1"\)/);
+  assert.match(helpersScript, /\$isLoopbackHost = \$uri\.Host -eq "localhost"/);
+  assert.match(
+    helpersScript,
+    /if \(-not \$isLoopbackHost -and \[System\.Net\.IPAddress\]::TryParse\(\$uri\.Host, \[ref\]\$ipAddress\)\) \{/,
+  );
+  assert.match(helpersScript, /\$isLoopbackHost = \[System\.Net\.IPAddress\]::IsLoopback\(\$ipAddress\)/);
+  assert.match(helpersScript, /if \(-not \$isLoopbackHost\) \{/);
   assert.match(helpersScript, /if \(\$uri\.Port -gt 0 -and "\$\(\$uri\.Port\)" -ne "\$RedisPort"\) \{/);
   assert.match(
     stopWindowsScript,
@@ -495,6 +501,24 @@ test('Windows Redis URL handling preserves external backends and treats localhos
   assert.match(
     stopWindowsScript,
     /Write-Warn "Skipping local Redis shutdown because REDIS_URL points to an external host"/,
+  );
+});
+
+test('Windows installer refreshes stale skill junctions instead of skipping any existing target', () => {
+  assert.match(helpersScript, /function Get-InstallerNormalizedPath/);
+  assert.match(helpersScript, /function Get-InstallerSkillLinkTarget/);
+  assert.match(helpersScript, /\$expectedTarget = Get-InstallerNormalizedPath -Path \$skill\.FullName/);
+  assert.match(helpersScript, /\$existingItem = Get-Item -LiteralPath \$skillTarget -Force -ErrorAction SilentlyContinue/);
+  assert.match(helpersScript, /\$existingTarget = Get-InstallerSkillLinkTarget -Path \$skillTarget/);
+  assert.match(
+    helpersScript,
+    /if \(\$existingTarget -eq \$expectedTarget\) \{\s+Write-Ok "Skill already mounted: \$skillTarget"\s+continue\s+\}/s,
+  );
+  assert.match(helpersScript, /Write-Warn "Refreshing stale skill mount: \$skillTarget"/);
+  assert.match(helpersScript, /cmd \/c rmdir "\$skillTarget" 2>\$null \| Out-Null/);
+  assert.doesNotMatch(
+    helpersScript,
+    /if \(Test-Path \$skillTarget\) \{\s+Write-Ok "Skill already mounted: \$skillTarget"\s+continue\s+\}/s,
   );
 });
 

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -19,9 +19,24 @@ function Mount-InstallerSkills {
         }
         foreach ($skill in $skillItems) {
             $skillTarget = Join-Path $skillsRoot $skill.Name
-            if (Test-Path $skillTarget) {
-                Write-Ok "Skill already mounted: $skillTarget"
-                continue
+            $expectedTarget = Get-InstallerNormalizedPath -Path $skill.FullName
+            $existingItem = Get-Item -LiteralPath $skillTarget -Force -ErrorAction SilentlyContinue
+            if ($existingItem) {
+                $existingTarget = Get-InstallerSkillLinkTarget -Path $skillTarget
+                if ($existingTarget -eq $expectedTarget) {
+                    Write-Ok "Skill already mounted: $skillTarget"
+                    continue
+                }
+                $linkType = "$($existingItem.LinkType)"
+                if ($linkType -notin @("Junction", "SymbolicLink")) {
+                    Write-Warn "Skill target exists and is not a junction: $skillTarget"
+                    continue
+                }
+                Write-Warn "Refreshing stale skill mount: $skillTarget"
+                cmd /c rmdir "$skillTarget" 2>$null | Out-Null
+                if (Get-Item -LiteralPath $skillTarget -Force -ErrorAction SilentlyContinue) {
+                    throw "stale junction cleanup failed"
+                }
             }
             try {
                 cmd /c mklink /J "$skillTarget" "$($skill.FullName)" 2>$null | Out-Null
@@ -36,6 +51,41 @@ function Mount-InstallerSkills {
             }
         }
     }
+}
+
+function Get-InstallerNormalizedPath {
+    param([string]$Path)
+
+    if (-not $Path) {
+        return ""
+    }
+
+    try {
+        return [System.IO.Path]::GetFullPath($Path).TrimEnd('\', '/').ToLowerInvariant()
+    } catch {
+        return $Path.TrimEnd('\', '/').ToLowerInvariant()
+    }
+}
+
+function Get-InstallerSkillLinkTarget {
+    param([string]$Path)
+
+    $item = Get-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
+    if (-not $item) {
+        return ""
+    }
+
+    $linkType = "$($item.LinkType)"
+    if ($linkType -notin @("Junction", "SymbolicLink")) {
+        return ""
+    }
+
+    $target = @($item.Target) | Where-Object { $_ } | Select-Object -First 1
+    if (-not $target) {
+        return ""
+    }
+
+    return Get-InstallerNormalizedPath -Path "$target"
 }
 
 function Add-ProcessPathPrefix {
@@ -103,7 +153,13 @@ function Test-LocalRedisUrl {
         return $false
     }
 
-    if ($uri.Host -notin @("localhost", "127.0.0.1")) {
+    $isLoopbackHost = $uri.Host -eq "localhost"
+    $ipAddress = $null
+    if (-not $isLoopbackHost -and [System.Net.IPAddress]::TryParse($uri.Host, [ref]$ipAddress)) {
+        $isLoopbackHost = [System.Net.IPAddress]::IsLoopback($ipAddress)
+    }
+
+    if (-not $isLoopbackHost) {
         return $false
     }
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #113 for two late Windows review findings that landed after the original merge:

- refresh stale `~/.claude/skills`, `~/.codex/skills`, and `~/.gemini/skills` junctions on reinstall instead of treating any existing path as already mounted
- treat IPv6 loopback Redis URLs such as `redis://[::1]:6379/0` as local across installer / startup / shutdown flows

## Why

PR #113 was already merged before these two P2 review comments were processed, so the fixes need to land as a separate post-merge patch to reach `main`.

## Verification

- `node --test scripts/check-env-port-drift.test.mjs packages/api/test/windows-portable-redis-script.test.js packages/api/test/install-auth-config-script.test.js` -> `79/79 pass`

## References

- Follow-up to #113
- Addresses review threads `discussion_r2958574500` and `discussion_r2958574506`