### PR TITLE
fix(api): move F101 onClose hook before app.listen()

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -910,6 +910,12 @@ async function main(): Promise<void> {
     );
   }
 
+  // F101: register onClose hook BEFORE listen (Fastify forbids addHook after listen).
+  let f101RecoveryPlayer: { stopAllLoops(): void } | null = null;
+  app.addHook('onClose', async () => {
+    f101RecoveryPlayer?.stopAllLoops();
+  });
+
   // Start listening
   let address: string;
   try {
@@ -1003,9 +1009,7 @@ async function main(): Promise<void> {
     const { GameOrchestrator } = await import('./domains/cats/services/game/GameOrchestrator.js');
     const recoveryOrchestrator = new GameOrchestrator({ gameStore: f101GameStore, socketManager });
     const recoveryPlayer = new GameAutoPlayer({ gameStore: f101GameStore, orchestrator: recoveryOrchestrator });
-    app.addHook('onClose', async () => {
-      recoveryPlayer.stopAllLoops();
-    });
+    f101RecoveryPlayer = recoveryPlayer;
     try {
       const recovered = await recoveryPlayer.recoverActiveGames();
       if (recovered > 0) {


### PR DESCRIPTION
## Summary
- Fastify throws `FST_ERR_INSTANCE_ALREADY_LISTENING` because `addHook('onClose')` was called after `app.listen()`
- Move the hook registration before listen, use a late-bound reference to the recovery player

## Origin
Cherry-picked from cat-cafe `fd31ac2a`

## Test plan
- [ ] `pnpm dev` starts without `FST_ERR_INSTANCE_ALREADY_LISTENING`
- [ ] Shutdown still cleans up game auto-play loops

[宪宪/Opus-4.6🐾]