### PR TITLE
fix(a2a): prevent cross-path double-trigger

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -386,12 +386,31 @@ export class InvocationQueue {
     return count;
   }
 
-  /** F122B: Check if a specific cat already has a queued agent entry for this thread. */
+  /** F122B: Check if a specific cat already has a queued agent entry for this thread.
+   *  Used by callback-a2a-trigger for dedup — only checks 'queued' so that new handoffs
+   *  can still be enqueued while an earlier entry is processing. */
   hasQueuedAgentForCat(threadId: string, catId: string): boolean {
     for (const [key, q] of this.queues) {
       if (!key.startsWith(`${threadId}:`)) continue;
       for (const e of q) {
         if (e.source === 'agent' && e.status === 'queued' && e.targetCats.includes(catId)) return true;
+      }
+    }
+    return false;
+  }
+
+  /** Cross-path dedup: checks both queued AND processing agent entries.
+   *  Used by route-serial to prevent text-scan @mention when callback already dispatched. */
+  hasActiveOrQueuedAgentForCat(threadId: string, catId: string): boolean {
+    for (const [key, q] of this.queues) {
+      if (!key.startsWith(`${threadId}:`)) continue;
+      for (const e of q) {
+        if (
+          e.source === 'agent' &&
+          (e.status === 'queued' || e.status === 'processing') &&
+          e.targetCats.includes(catId)
+        )
+          return true;
       }
     }
     return false;

--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -166,6 +166,15 @@ export class QueueProcessor {
     return this.deps.queue.hasQueuedForThread(threadId);
   }
 
+  /** A2A dedup: check if a specific cat already has a queued or processing entry for this thread. */
+  hasQueuedAgentForCat(threadId: string, catId: string): boolean {
+    return this.deps.queue.hasQueuedAgentForCat(threadId, catId);
+  }
+
+  hasActiveOrQueuedAgentForCat(threadId: string, catId: string): boolean {
+    return this.deps.queue.hasActiveOrQueuedAgentForCat(threadId, catId);
+  }
+
   /** Returns pause reason when paused; otherwise undefined. */
   getPauseReason(threadId: string, catId?: string): 'canceled' | 'failed' | undefined {
     if (!this.isPaused(threadId, catId)) return undefined;
@@ -537,6 +546,7 @@ export class QueueProcessor {
           ...(contentBlocks.length > 0 ? { contentBlocks } : {}),
           ...(controller.signal ? { signal: controller.signal } : {}),
           queueHasQueuedMessages: (tid: string) => queue.hasQueuedForThread(tid),
+          hasQueuedOrActiveAgentForCat: (tid: string, catId: string) => queue.hasActiveOrQueuedAgentForCat(tid, catId),
           cursorBoundaries,
           persistenceContext,
           ...(invocationId ? { parentInvocationId: invocationId } : {}),

--- a/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
@@ -734,6 +734,7 @@ export class AgentRouter {
       uploadDir?: string;
       signal?: AbortSignal;
       queueHasQueuedMessages?: (threadId: string) => boolean;
+      hasQueuedOrActiveAgentForCat?: (threadId: string, catId: string) => boolean;
       /** ADR-008 S3: pass a Map to collect cursor boundaries; caller acks after succeeded */
       cursorBoundaries?: Map<string, string>;
       /** P1-2: pass to track persistence failures across generator boundary */
@@ -761,6 +762,7 @@ export class AgentRouter {
       uploadDir: options?.uploadDir,
       signal: options?.signal,
       queueHasQueuedMessages: options?.queueHasQueuedMessages,
+      hasQueuedOrActiveAgentForCat: options?.hasQueuedOrActiveAgentForCat,
       promptTags: intent.promptTags,
       currentUserMessageId: userMessageId,
       thinkingMode,

--- a/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
@@ -59,6 +59,8 @@ export interface RouteOptions {
   maxA2ADepth?: number | undefined;
   /** Queue fairness hook: when true for current thread, routeSerial must stop extending A2A chain. */
   queueHasQueuedMessages?: ((threadId: string) => boolean) | undefined;
+  /** A2A dedup hook: skip text-scan @mention if cat already dispatched via callback path. */
+  hasQueuedOrActiveAgentForCat?: ((threadId: string, catId: string) => boolean) | undefined;
   /** ADR-008 S3: When provided, cursor boundaries are collected here instead of acking immediately.
    *  Caller acks after invocation succeeds. If absent, legacy immediate ack behavior. */
   cursorBoundaries?: Map<string, string>;

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -72,6 +72,7 @@ export async function* routeSerial(
     modeSystemPrompt,
     modeSystemPromptByCat,
     queueHasQueuedMessages,
+    hasQueuedOrActiveAgentForCat,
   } = options;
   const previousResponses: { catId: CatId; content: string }[] = [];
   const thinkingMode = options.thinkingMode ?? 'play';
@@ -718,6 +719,14 @@ export async function* routeSerial(
           const pendingOriginalTargets = targetCats.slice(index + 1);
           for (const nextCat of a2aMentions) {
             if (worklistEntry.a2aCount >= maxDepth) break;
+            // A2A cross-path dedup: skip if this cat was already dispatched via callback (InvocationQueue)
+            if (hasQueuedOrActiveAgentForCat && hasQueuedOrActiveAgentForCat(threadId, nextCat)) {
+              log.info(
+                { threadId, catId: nextCat, fromCat: catId },
+                'A2A text-scan dedup: cat already in InvocationQueue, skipping',
+              );
+              continue;
+            }
             if (pendingTail.includes(nextCat)) {
               // Keep original user-selected targets replying to user, not to another cat.
               if (!pendingOriginalTargets.includes(nextCat)) {

--- a/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
+++ b/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
@@ -326,6 +326,8 @@ export class ConnectorInvokeTrigger {
         ...(contentBlocks ? { contentBlocks } : {}),
         ...(controller?.signal ? { signal: controller.signal } : {}),
         queueHasQueuedMessages: (tid: string) => invocationQueue.hasQueuedForThread(tid),
+        hasQueuedOrActiveAgentForCat: (tid: string, catId: string) =>
+          invocationQueue.hasActiveOrQueuedAgentForCat(tid, catId),
         cursorBoundaries,
         persistenceContext,
         parentInvocationId: createResult.invocationId,

--- a/packages/api/src/routes/invocations.ts
+++ b/packages/api/src/routes/invocations.ts
@@ -194,6 +194,8 @@ export const invocationsRoutes: FastifyPluginAsync<InvocationsRoutesOptions> = a
             ...(opts.queueProcessor
               ? {
                   queueHasQueuedMessages: (tid: string) => opts.queueProcessor?.hasQueuedForThread(tid) ?? false,
+                  hasQueuedOrActiveAgentForCat: (tid: string, catId: string) =>
+                    opts.queueProcessor?.hasActiveOrQueuedAgentForCat(tid, catId) ?? false,
                 }
               : {}),
             cursorBoundaries,

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -679,6 +679,8 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
               ...(opts.invocationQueue
                 ? {
                     queueHasQueuedMessages: (tid: string) => opts.invocationQueue?.hasQueuedForThread(tid) ?? false,
+                    hasQueuedOrActiveAgentForCat: (tid: string, catId: string) =>
+                      opts.invocationQueue?.hasActiveOrQueuedAgentForCat(tid, catId) ?? false,
                   }
                 : {}),
               cursorBoundaries,

--- a/packages/api/test/invocation-queue.test.js
+++ b/packages/api/test/invocation-queue.test.js
@@ -420,4 +420,112 @@ describe('InvocationQueue', () => {
     // Different userId (system vs u1) → different scope key → never merge
     assert.equal(r2.outcome, 'enqueued');
   });
+
+  // ── hasQueuedAgentForCat: only checks 'queued' (callback-path dedup) ──
+
+  it('hasQueuedAgentForCat returns true for queued agent entry', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'callback handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    assert.equal(queue.hasQueuedAgentForCat('t1', 'codex'), true);
+    assert.equal(queue.hasQueuedAgentForCat('t1', 'opus'), false);
+  });
+
+  it('hasQueuedAgentForCat returns false for processing entries (allows new handoffs to enqueue)', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'callback handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    queue.markProcessing('t1', 'system');
+    assert.equal(
+      queue.hasQueuedAgentForCat('t1', 'codex'),
+      false,
+      'processing entries must not block new callback handoffs (P1-1 fix)',
+    );
+  });
+
+  it('hasQueuedAgentForCat returns false for user-sourced entries', () => {
+    queue.enqueue(entry({ targetCats: ['opus'] }));
+    assert.equal(queue.hasQueuedAgentForCat('t1', 'opus'), false, 'user entries should not block A2A dedup');
+  });
+
+  it('hasQueuedAgentForCat returns false after entry completes', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    const e = queue.markProcessing('t1', 'system');
+    queue.removeProcessed('t1', 'system', e.id);
+    assert.equal(queue.hasQueuedAgentForCat('t1', 'codex'), false);
+  });
+
+  // ── hasActiveOrQueuedAgentForCat: checks both queued AND processing (route-serial dedup) ──
+
+  it('hasActiveOrQueuedAgentForCat returns true for queued entry', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    assert.equal(queue.hasActiveOrQueuedAgentForCat('t1', 'codex'), true);
+  });
+
+  it('hasActiveOrQueuedAgentForCat returns true for processing entry (prevents text-scan double-trigger)', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    queue.markProcessing('t1', 'system');
+    assert.equal(
+      queue.hasActiveOrQueuedAgentForCat('t1', 'codex'),
+      true,
+      'must detect processing entries to prevent text-scan double-trigger',
+    );
+  });
+
+  it('hasActiveOrQueuedAgentForCat returns false after entry completes', () => {
+    queue.enqueue({
+      threadId: 't1',
+      userId: 'system',
+      content: 'handoff',
+      source: 'agent',
+      targetCats: ['codex'],
+      intent: 'execute',
+      autoExecute: true,
+      callerCatId: 'opus',
+    });
+    const e = queue.markProcessing('t1', 'system');
+    queue.removeProcessed('t1', 'system', e.id);
+    assert.equal(queue.hasActiveOrQueuedAgentForCat('t1', 'codex'), false);
+  });
 });

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -298,6 +298,27 @@ describe('routeSerial A2A worklist', () => {
     assert.equal(handoffs.length, 0, 'should not emit handoff when fairness guard blocks extension');
   });
 
+  it('skips A2A text-scan @mention when cat already dispatched via callback (cross-path dedup)', async () => {
+    const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+    const deps = createMockDeps({
+      opus: createMockService('opus', '代码完成\n@缅因猫 请 review'),
+      codex: createMockService('codex', 'should not be invoked via text-scan'),
+    });
+
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'test', 'user1', 'thread1', {
+      hasQueuedOrActiveAgentForCat: (_tid, catId) => catId === 'codex',
+    })) {
+      messages.push(msg);
+    }
+
+    const codexText = messages.filter((m) => m.type === 'text' && m.catId === 'codex');
+    assert.equal(codexText.length, 0, 'codex must NOT be invoked when already in InvocationQueue');
+
+    const handoffs = messages.filter((m) => m.type === 'a2a_handoff');
+    assert.equal(handoffs.length, 0, 'should not emit handoff for deduped cat');
+  });
+
   it('self-mention does not trigger A2A', async () => {
     const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
     const deps = createMockDeps({


### PR DESCRIPTION
Fixes #160

## Summary
This backports the A2A cross-path dedup fix so the same cat is not triggered twice when callback dispatch and text `@mention` target the same cat in the same turn.

## What changed
- split queue predicates into queued-only vs queued-or-processing
- keep callback-path dedup queued-only so legitimate follow-up handoffs can still enqueue
- make route-serial skip text-scan `@mention` when callback path already queued or is actively processing the same cat
- wire the new hook through the route entrypoints
- add queue + route regression coverage

## Scope choice
This is a minimal community hotfix. I intentionally did **not** carry the unrelated frontend `#586` follow-up from home because it is not required for this bug and would widen the patch surface.

## Validation
- `pnpm --dir packages/api build`
- `node --test packages/api/test/invocation-queue.test.js packages/api/test/route-strategies.test.js`
- Result: `99 pass / 0 fail`

## Source
Manual public hotfix port of home commit `5a3aab8c39f2bd89f1dfafc45dade2f5bb6065c0`.
