### PR TITLE
chore(ci): clear biome baseline drift

### DIFF
--- a/docs/features/index.json
+++ b/docs/features/index.json
@@ -777,7 +777,7 @@
     {
       "id": "F127",
       "name": "猫猫管理重构 — 账户配置与猫猫实例分离，支持动态创建猫 + 自定义别名 @ 路由",
-      "status": "design-approved | **Owner**: Golden Chinchilla + Maine Coon(gpt52) | **Priority**: P1",
+      "status": "design-approved | **Owner**: 金渐层 + 缅因猫 GPT-5.4",
       "file": "F127-cat-instance-management.md"
     },
     {
@@ -805,5 +805,5 @@
       "file": "F131-workspace-navigator.md"
     }
   ],
-  "generated_at": "2026-03-21T08:34:18.916Z"
+  "generated_at": "2026-03-21T12:49:11.410Z"
 }

--- a/packages/api/src/config/ConfigRegistry.ts
+++ b/packages/api/src/config/ConfigRegistry.ts
@@ -7,9 +7,9 @@
  */
 
 import { CAT_CONFIGS, catRegistry } from '@cat-cafe/shared';
-import { getOwnerConfig } from './cat-config-loader.js';
 import { DEFAULT_CLI_TIMEOUT_MS, readCliTimeoutMsFromEnv } from '../utils/cli-timeout.js';
 import { getAllCatBudgets } from './cat-budgets.js';
+import { getOwnerConfig } from './cat-config-loader.js';
 import { getCatModel } from './cat-models.js';
 import { getCodexApprovalPolicy, getCodexSandboxMode } from './codex-cli.js';
 import type { CodexAuthMode, ConfigSnapshot } from './config-snapshot.js';

--- a/packages/api/src/config/cat-account-binding.ts
+++ b/packages/api/src/config/cat-account-binding.ts
@@ -17,7 +17,7 @@ function trimBinding(value: unknown): string | undefined {
 export function isSeedCat(projectRoot: string, catId: string): boolean {
   try {
     const seedCats = toAllCatConfigs(loadCatConfig(resolveProjectTemplatePath(projectRoot)));
-    return Object.prototype.hasOwnProperty.call(seedCats, catId);
+    return Object.hasOwn(seedCats, catId);
   } catch {
     return false;
   }
@@ -39,9 +39,7 @@ export function resolveBoundAccountRefForCat(
   const builtinClient = resolveBuiltinClientForProvider(catConfig.provider);
   const runtimeCatalogExists = existsSync(resolve(projectRoot, '.cat-cafe', 'cat-catalog.json'));
   const inheritedTemplateDefaultBinding =
-    !runtimeCatalogExists &&
-    !!builtinClient &&
-    explicitAccountRef === builtinAccountIdForClient(builtinClient);
+    !runtimeCatalogExists && !!builtinClient && explicitAccountRef === builtinAccountIdForClient(builtinClient);
   const inheritedSeedBootstrapBinding = runtimeCatalogExists && isSeedCat(projectRoot, catId);
 
   if (inheritedTemplateDefaultBinding || inheritedSeedBootstrapBinding) {

--- a/packages/api/src/config/cat-catalog-store.ts
+++ b/packages/api/src/config/cat-catalog-store.ts
@@ -1,9 +1,9 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import { dirname, relative, resolve, sep } from 'node:path';
 import type { CatCafeConfig, Roster } from '@cat-cafe/shared';
+import { resolveProjectTemplatePath } from './project-template-path.js';
 import { builtinAccountIdForClient, readBootstrapBindingsSync } from './provider-profiles.js';
 import type { BootstrapBinding, BuiltinAccountClient } from './provider-profiles.types.js';
-import { resolveProjectTemplatePath } from './project-template-path.js';
 import { resolveProviderProfilesRootSync } from './provider-profiles-root.js';
 
 const CAT_CAFE_DIR = '.cat-cafe';
@@ -163,7 +163,8 @@ function readSeedMetadata(projectRoot: string): {
       for (const variant of variants) {
         const client = providerToBootstrapClient(variant.provider);
         if (!client) continue;
-        const catId = typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
+        const catId =
+          typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
         if (!catId) continue;
         const clientSeedCatIds = seedCatIdsByClient.get(client) ?? new Set<string>();
         clientSeedCatIds.add(catId);
@@ -195,7 +196,8 @@ function resolveLegacySeedBindingBackfill(
       const client = providerToBootstrapClient(variant.provider);
       if (!client) continue;
 
-      const catId = typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
+      const catId =
+        typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
       if (!catId) continue;
 
       const providerProfileId = trimBinding(variant.providerProfileId);
@@ -246,7 +248,8 @@ function migrateExistingCatalogBindings(
     for (const variant of variants) {
       const client = providerToBootstrapClient(variant.provider);
       if (!client) continue;
-      const catId = typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
+      const catId =
+        typeof variant.catId === 'string' ? variant.catId : typeof breed.catId === 'string' ? breed.catId : null;
       const explicitProviderProfileId = trimBinding(variant.providerProfileId);
       const existingAccountRef = typeof variant.accountRef === 'string' ? variant.accountRef.trim() : '';
       const legacyExplicitAccountRef = catId ? legacySeedBindingBackfill.get(catId) : undefined;

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -348,7 +348,9 @@ export function toAllCatConfigs(config: CatCafeConfig): Record<string, CatConfig
         defaultModel: variant.defaultModel,
         mcpSupport: variant.mcpSupport,
         ...(projectedCommandArgs != null ? { commandArgs: projectedCommandArgs } : {}),
-        ...(variant.cliConfigArgs != null && variant.cliConfigArgs.length > 0 ? { cliConfigArgs: [...variant.cliConfigArgs] } : {}),
+        ...(variant.cliConfigArgs != null && variant.cliConfigArgs.length > 0
+          ? { cliConfigArgs: [...variant.cliConfigArgs] }
+          : {}),
         ...(variant.contextBudget != null ? { contextBudget: variant.contextBudget } : {}),
         roleDescription: variant.roleDescription ?? breed.roleDescription,
         personality: variant.personality ?? defaultVariant?.personality ?? '',

--- a/packages/api/src/config/provider-binding-compat.ts
+++ b/packages/api/src/config/provider-binding-compat.ts
@@ -1,5 +1,9 @@
 import type { CatProvider } from '@cat-cafe/shared';
-import type { BuiltinAccountClient, ProviderProfileProtocol, RuntimeProviderProfile } from './provider-profiles.types.js';
+import type {
+  BuiltinAccountClient,
+  ProviderProfileProtocol,
+  RuntimeProviderProfile,
+} from './provider-profiles.types.js';
 
 export function resolveBuiltinClientForProvider(provider: CatProvider): BuiltinAccountClient | null {
   switch (provider) {

--- a/packages/api/src/config/runtime-cat-catalog.ts
+++ b/packages/api/src/config/runtime-cat-catalog.ts
@@ -12,9 +12,9 @@ import type {
 } from '@cat-cafe/shared';
 import { CAT_CONFIGS, createCatId } from '@cat-cafe/shared';
 import { clearBudgetCache } from './cat-budgets.js';
+import { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } from './cat-catalog-store.js';
 import { _resetCachedConfig, loadCatConfig, toAllCatConfigs } from './cat-config-loader.js';
 import { clearVoiceCache } from './cat-voices.js';
-import { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } from './cat-catalog-store.js';
 import { resolveProjectTemplatePath } from './project-template-path.js';
 
 export interface RuntimeCatInput {
@@ -113,9 +113,9 @@ function isSeedCat(projectRoot: string, catId: string): boolean {
   try {
     const templatePath = resolveProjectTemplatePath(projectRoot);
     const seedCats = toAllCatConfigs(loadCatConfig(templatePath));
-    return Object.prototype.hasOwnProperty.call(seedCats, catId);
+    return Object.hasOwn(seedCats, catId);
   } catch {
-    return Object.prototype.hasOwnProperty.call(CAT_CONFIGS, catId);
+    return Object.hasOwn(CAT_CONFIGS, catId);
   }
 }
 
@@ -145,7 +145,7 @@ function assertUniqueMentionAliases(catalog: CatCafeConfig): void {
     }
   }
 
-  const ownerMentionPatterns = catalog.version === 2 ? catalog.owner?.mentionPatterns ?? [] : [];
+  const ownerMentionPatterns = catalog.version === 2 ? (catalog.owner?.mentionPatterns ?? []) : [];
   for (const mentionPattern of ownerMentionPatterns) {
     const trimmed = mentionPattern.trim();
     if (!trimmed) continue;
@@ -443,11 +443,7 @@ export function updateRuntimeOwner(projectRoot: string, patch: RuntimeOwnerUpdat
     ...(patch.name !== undefined ? { name: patch.name } : {}),
     ...(patch.aliases !== undefined
       ? {
-          aliases: Array.from(
-            new Set(
-              patch.aliases.map((alias) => alias.trim()).filter((alias) => alias.length > 0),
-            ),
-          ),
+          aliases: Array.from(new Set(patch.aliases.map((alias) => alias.trim()).filter((alias) => alias.length > 0))),
         }
       : {}),
     ...(patch.mentionPatterns !== undefined

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -635,9 +635,11 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       dare: 'openai',
     };
     const effectiveProtocol =
-      (resolvedAccount?.authType === 'api_key' && resolvedAccount.protocol)
+      resolvedAccount?.authType === 'api_key' && resolvedAccount.protocol
         ? resolvedAccount.protocol
-        : (provider ? defaultProtocolForProvider[provider] ?? null : null);
+        : provider
+          ? (defaultProtocolForProvider[provider] ?? null)
+          : null;
 
     // Pass protocol hint to CLI via callbackEnv (used by OpenCode/Claude for model prefix)
     if (effectiveProtocol) {

--- a/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
@@ -54,7 +54,6 @@ function formatThinkingSignatureRescueError(sessionId: string | undefined): stri
 
 const IS_WINDOWS = process.platform === 'win32';
 
-
 export { pickGitBashPathFromWhere } from './claude-agent-win.js';
 
 function buildClaudeEnvOverrides(callbackEnv?: Record<string, string>): Record<string, string | null> {
@@ -216,7 +215,13 @@ export class ClaudeAgentService implements AgentService {
     try {
       const claudeCommand = resolveCliCommand('claude');
       if (!claudeCommand) {
-        yield { type: 'error' as const, catId: this.catId, error: formatCliNotFoundError('claude'), metadata, timestamp: Date.now() };
+        yield {
+          type: 'error' as const,
+          catId: this.catId,
+          error: formatCliNotFoundError('claude'),
+          metadata,
+          timestamp: Date.now(),
+        };
         yield { type: 'done' as const, catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -259,11 +259,16 @@ export class CodexAgentService implements AgentService {
     const customBaseUrl = options?.callbackEnv?.OPENAI_BASE_URL ?? options?.callbackEnv?.OPENAI_API_BASE;
     const customProviderArgs: string[] = customBaseUrl
       ? [
-          '--config', 'model_provider="custom"',
-          '--config', `model_providers.custom.base_url=${toTomlString(customBaseUrl)}`,
-          '--config', 'model_providers.custom.name="Custom API Key"',
-          '--config', 'model_providers.custom.wire_api="responses"',
-          '--config', 'model_providers.custom.env_key="OPENAI_API_KEY"',
+          '--config',
+          'model_provider="custom"',
+          '--config',
+          `model_providers.custom.base_url=${toTomlString(customBaseUrl)}`,
+          '--config',
+          'model_providers.custom.name="Custom API Key"',
+          '--config',
+          'model_providers.custom.wire_api="responses"',
+          '--config',
+          'model_providers.custom.env_key="OPENAI_API_KEY"',
         ]
       : [];
 
@@ -336,7 +341,13 @@ export class CodexAgentService implements AgentService {
 
       const codexCommand = resolveCliCommand('codex');
       if (!codexCommand) {
-        yield { type: 'error' as const, catId: this.catId, error: formatCliNotFoundError('codex'), metadata, timestamp: Date.now() };
+        yield {
+          type: 'error' as const,
+          catId: this.catId,
+          error: formatCliNotFoundError('codex'),
+          metadata,
+          timestamp: Date.now(),
+        };
         yield { type: 'done' as const, catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -104,7 +104,13 @@ export class GeminiAgentService implements AgentService {
     try {
       const geminiCommand = resolveCliCommand('gemini');
       if (!geminiCommand) {
-        yield { type: 'error' as const, catId: this.catId, error: formatCliNotFoundError('gemini'), metadata, timestamp: Date.now() };
+        yield {
+          type: 'error' as const,
+          catId: this.catId,
+          error: formatCliNotFoundError('gemini'),
+          metadata,
+          timestamp: Date.now(),
+        };
         yield { type: 'done' as const, catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }

--- a/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
@@ -66,7 +66,13 @@ export class OpenCodeAgentService implements AgentService {
     try {
       const opencodeCommand = resolveCliCommand('opencode');
       if (!opencodeCommand) {
-        yield { type: 'error' as const, catId: this.catId, error: formatCliNotFoundError('opencode'), metadata, timestamp: Date.now() };
+        yield {
+          type: 'error' as const,
+          catId: this.catId,
+          error: formatCliNotFoundError('opencode'),
+          metadata,
+          timestamp: Date.now(),
+        };
         yield { type: 'done' as const, catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -15,10 +15,7 @@ import { resolveBoundAccountRefForCat } from './config/cat-account-binding.js';
 import { getCatContextBudget } from './config/cat-budgets.js';
 import { bootstrapDefaultCatCatalog, getConfigSessionStrategy, toAllCatConfigs } from './config/cat-config-loader.js';
 import { resolveFrontendBaseUrl, resolveFrontendCorsOrigins } from './config/frontend-origin.js';
-import {
-  resolveAnthropicRuntimeProfile,
-  resolveRuntimeProviderProfileForClient,
-} from './config/provider-profiles.js';
+import { resolveAnthropicRuntimeProfile, resolveRuntimeProviderProfileForClient } from './config/provider-profiles.js';
 import { initRuntimeOverrides } from './config/session-strategy-overrides.js';
 import { assertStorageReady } from './config/storage-guard.js';
 import { createTaskProgressStore } from './domains/cats/services/agents/invocation/createTaskProgressStore.js';
@@ -312,7 +309,11 @@ async function main(): Promise<void> {
             catId,
             catConfig as CatConfig & { providerProfileId?: string },
           );
-          const runtime = await resolveRuntimeProviderProfileForClient(projectRoot, catConfig.provider, boundAccountRef);
+          const runtime = await resolveRuntimeProviderProfileForClient(
+            projectRoot,
+            catConfig.provider,
+            boundAccountRef,
+          );
           if (!runtime?.apiKey) return null;
           return { apiKey: runtime.apiKey, baseUrl: runtime.baseUrl || 'https://api.anthropic.com' };
         }

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -17,7 +17,10 @@ import {
   validateModelFormatForProvider,
   validateRuntimeProviderBinding,
 } from '../config/provider-binding-compat.js';
-import { resolveRuntimeProviderProfileById, resolveRuntimeProviderProfileForClient } from '../config/provider-profiles.js';
+import {
+  resolveRuntimeProviderProfileById,
+  resolveRuntimeProviderProfileForClient,
+} from '../config/provider-profiles.js';
 import { createRuntimeCat, deleteRuntimeCat, updateRuntimeCat } from '../config/runtime-cat-catalog.js';
 import { deleteRuntimeOverride, getRuntimeOverride, setRuntimeOverride } from '../config/session-strategy-overrides.js';
 import { resolveActiveProjectRoot } from '../utils/active-project-root.js';
@@ -52,7 +55,10 @@ const baseCatSchema = z.object({
   name: z.string().min(1),
   displayName: z.string().min(1),
   nickname: z.string().optional(),
-  avatar: z.preprocess((val) => (typeof val === 'string' && val.trim() === '' ? undefined : val), z.string().min(1).optional()),
+  avatar: z.preprocess(
+    (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+    z.string().min(1).optional(),
+  ),
   color: colorSchema,
   mentionPatterns: z.array(z.string().min(1)).min(1),
   accountRef: z.string().min(1).optional(),
@@ -481,7 +487,8 @@ export const catsRoutes: FastifyPluginAsync<CatsRoutesOptions> = async (app, opt
     const effectiveClient = body.client ?? currentCat.provider;
     const nextAccountRef = resolveAccountRef(body);
     const currentEffectiveAccountRef = await resolveEffectiveAccountRef(currentCat);
-    const effectiveAccountRef = nextAccountRef !== undefined ? (nextAccountRef ?? undefined) : currentEffectiveAccountRef;
+    const effectiveAccountRef =
+      nextAccountRef !== undefined ? (nextAccountRef ?? undefined) : currentEffectiveAccountRef;
     const effectiveDefaultModel = body.defaultModel !== undefined ? body.defaultModel : currentCat.defaultModel;
     const providerConfigTouched =
       body.client !== undefined || body.defaultModel !== undefined || nextAccountRef !== undefined;

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -13,8 +13,8 @@ import { z } from 'zod';
 import { collectConfigSnapshot } from '../config/ConfigRegistry.js';
 import { configStore } from '../config/ConfigStore.js';
 import type { ConfigSnapshot } from '../config/config-snapshot.js';
-import { updateRuntimeOwner } from '../config/runtime-cat-catalog.js';
 import { buildEnvSummary, ENV_CATEGORIES, isEditableEnvVarName } from '../config/env-registry.js';
+import { updateRuntimeOwner } from '../config/runtime-cat-catalog.js';
 import { AuditEventTypes, getEventAuditLog } from '../domains/cats/services/orchestration/EventAuditLog.js';
 import { resolveActiveProjectRoot } from '../utils/active-project-root.js';
 

--- a/packages/api/src/routes/provider-profiles.ts
+++ b/packages/api/src/routes/provider-profiles.ts
@@ -142,8 +142,15 @@ function inferProbeProtocol(
     return 'openai';
   }
 
-  const normalizedHints = nameHints.map((hint) => hint?.trim().toLowerCase() ?? '').filter(Boolean).join(' ');
-  if (normalizedHints.includes('claude') || normalizedHints.includes('anthropic') || normalizedHints.includes('opencode')) {
+  const normalizedHints = nameHints
+    .map((hint) => hint?.trim().toLowerCase() ?? '')
+    .filter(Boolean)
+    .join(' ');
+  if (
+    normalizedHints.includes('claude') ||
+    normalizedHints.includes('anthropic') ||
+    normalizedHints.includes('opencode')
+  ) {
     return 'anthropic';
   }
   if (normalizedHints.includes('gemini') || normalizedHints.includes('google')) {

--- a/packages/api/test/agent-router.test.js
+++ b/packages/api/test/agent-router.test.js
@@ -227,7 +227,10 @@ function createAvailabilityConfigProject(availabilityOverrides = {}) {
         provider,
         defaultModel,
         mcpSupport: true,
-        cli: { command: provider === 'anthropic' ? 'claude' : provider === 'google' ? 'gemini' : 'codex', outputFormat: 'json' },
+        cli: {
+          command: provider === 'anthropic' ? 'claude' : provider === 'google' ? 'gemini' : 'codex',
+          outputFormat: 'json',
+        },
       },
     ],
   });
@@ -2094,7 +2097,11 @@ describe('F078: Default to last replier', () => {
       );
 
       const { targetCats } = await router.resolveTargetsAndIntent('hello', 't1');
-      assert.deepStrictEqual(targetCats, ['codex'], 'should skip unavailable default cat and pick an available fallback');
+      assert.deepStrictEqual(
+        targetCats,
+        ['codex'],
+        'should skip unavailable default cat and pick an available fallback',
+      );
     });
   });
 

--- a/packages/api/test/cat-account-binding.test.js
+++ b/packages/api/test/cat-account-binding.test.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -52,7 +51,9 @@ describe('cat account binding', () => {
   });
 
   it('backfills legacy accountRef-only seed bindings before suppressing inherited bootstrap refs', async () => {
-    const { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } = await import('../dist/config/cat-catalog-store.js');
+    const { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } = await import(
+      '../dist/config/cat-catalog-store.js'
+    );
     const { toAllCatConfigs } = await import('../dist/config/cat-config-loader.js');
     const { resolveBoundAccountRefForCat } = await import('../dist/config/cat-account-binding.js');
     const projectRoot = await mkdtemp(join(tmpdir(), 'cat-account-binding-legacy-seed-'));
@@ -96,7 +97,9 @@ describe('cat account binding', () => {
   });
 
   it('keeps untouched seed siblings inherited after bootstrap switches to a new account', async () => {
-    const { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } = await import('../dist/config/cat-catalog-store.js');
+    const { bootstrapCatCatalog, readCatCatalog, resolveCatCatalogPath } = await import(
+      '../dist/config/cat-catalog-store.js'
+    );
     const { toAllCatConfigs } = await import('../dist/config/cat-config-loader.js');
     const { resolveBoundAccountRefForCat } = await import('../dist/config/cat-account-binding.js');
     const { activateProviderProfile, createProviderProfile } = await import('../dist/config/provider-profiles.js');

--- a/packages/api/test/cats-routes-runtime-catalog.test.js
+++ b/packages/api/test/cats-routes-runtime-catalog.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, afterEach, beforeEach, describe, it } from 'node:test';
@@ -179,7 +179,12 @@ describe('cats routes read runtime catalog', { concurrency: false }, () => {
     const opencodeTemplate = makeCatalog('opencode', 'OpenCode', 'opencode', 'claude-opus-4-6');
     const template = {
       version: 1,
-      breeds: [...codexTemplate.breeds, ...dareTemplate.breeds, ...antigravityTemplate.breeds, ...opencodeTemplate.breeds],
+      breeds: [
+        ...codexTemplate.breeds,
+        ...dareTemplate.breeds,
+        ...antigravityTemplate.breeds,
+        ...opencodeTemplate.breeds,
+      ],
     };
     const projectRoot = createTemplateOnlyProject(template);
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
@@ -228,9 +233,15 @@ describe('cats routes read runtime catalog', { concurrency: false }, () => {
       assert.equal(res.statusCode, 200);
       const body = JSON.parse(res.body);
       const localTemplateCat = body.cats.find((cat) => cat.id === 'local-template');
-      assert.ok(localTemplateCat, 'GET /api/cats should read the local project template when CAT_TEMPLATE_PATH is stale');
+      assert.ok(
+        localTemplateCat,
+        'GET /api/cats should read the local project template when CAT_TEMPLATE_PATH is stale',
+      );
       assert.equal(localTemplateCat.source, 'seed');
-      assert.equal(readFileSync(join(projectRoot, '.cat-cafe', 'cat-catalog.json'), 'utf-8').includes('local-template'), true);
+      assert.equal(
+        readFileSync(join(projectRoot, '.cat-cafe', 'cat-catalog.json'), 'utf-8').includes('local-template'),
+        true,
+      );
     } finally {
       process.chdir(previousCwd);
       await app.close();
@@ -272,7 +283,9 @@ describe('cats routes read runtime catalog', { concurrency: false }, () => {
   });
 
   it('GET /api/cats/:id/status resolves runtime-only Antigravity cats', async () => {
-    const projectRoot = createRuntimeCatalogProject(makeCatalog('runtime-antigravity', '运行时桥接猫', 'antigravity', 'gemini-bridge'));
+    const projectRoot = createRuntimeCatalogProject(
+      makeCatalog('runtime-antigravity', '运行时桥接猫', 'antigravity', 'gemini-bridge'),
+    );
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
 
     const Fastify = (await import('fastify')).default;

--- a/packages/api/test/domains/preview/preview-routes.test.js
+++ b/packages/api/test/domains/preview/preview-routes.test.js
@@ -1,8 +1,8 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
 import { mkdtemp, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { after, before, describe, it } from 'node:test';
 import Fastify from 'fastify';
 import { PortDiscoveryService } from '../../../dist/domains/preview/port-discovery.js';
 import { previewRoutes } from '../../../dist/routes/preview.js';

--- a/packages/api/test/install-auth-config-script.test.js
+++ b/packages/api/test/install-auth-config-script.test.js
@@ -85,7 +85,10 @@ test('client-auth remove drops the installer api key account and restores oauth 
     runHelper(['client-auth', 'remove', '--project-dir', projectRoot, '--client', 'openai']);
 
     const { profiles, secrets } = readInstallerState(projectRoot);
-    assert.equal(profiles.providers.some((profile) => profile.id === 'installer-openai'), false);
+    assert.equal(
+      profiles.providers.some((profile) => profile.id === 'installer-openai'),
+      false,
+    );
     assert.deepEqual(profiles.bootstrapBindings.openai, {
       enabled: true,
       mode: 'oauth',
@@ -174,7 +177,10 @@ test('claude-profile create and remove keeps installer-managed account in sync',
     runHelper(['claude-profile', 'remove', '--project-dir', projectRoot]);
 
     const afterRemove = readInstallerState(projectRoot);
-    assert.equal(afterRemove.profiles.providers.some((profile) => profile.id === 'installer-managed'), false);
+    assert.equal(
+      afterRemove.profiles.providers.some((profile) => profile.id === 'installer-managed'),
+      false,
+    );
     assert.deepEqual(afterRemove.profiles.bootstrapBindings.anthropic, {
       enabled: true,
       mode: 'oauth',
@@ -249,7 +255,10 @@ test('client-auth remove fails when the installer-managed account is still refer
     assert.match(String(result.stderr), /still referenced by runtime cats: runtime-codex/i);
 
     const { profiles, secrets } = readInstallerState(projectRoot);
-    assert.equal(profiles.providers.some((profile) => profile.id === 'installer-openai'), true);
+    assert.equal(
+      profiles.providers.some((profile) => profile.id === 'installer-openai'),
+      true,
+    );
     assert.deepEqual(profiles.bootstrapBindings.openai, {
       enabled: true,
       mode: 'api_key',
@@ -463,13 +472,19 @@ test('claude-profile v2 migration preserves non-installer accounts and secrets o
     runHelper(['claude-profile', 'remove', '--project-dir', projectRoot]);
 
     const afterRemove = readInstallerState(projectRoot);
-    assert.equal(afterRemove.profiles.providers.some((profile) => profile.id === 'installer-managed'), false);
+    assert.equal(
+      afterRemove.profiles.providers.some((profile) => profile.id === 'installer-managed'),
+      false,
+    );
     assert.deepEqual(afterRemove.profiles.bootstrapBindings.anthropic, {
       enabled: true,
       mode: 'oauth',
       accountRef: 'claude',
     });
-    assert.equal(afterRemove.profiles.providers.some((profile) => profile.id === 'personal'), true);
+    assert.equal(
+      afterRemove.profiles.providers.some((profile) => profile.id === 'personal'),
+      true,
+    );
     assert.equal(afterRemove.secrets.profiles.personal.apiKey, 'personal-key');
     assert.equal('installer-managed' in (afterRemove.secrets.profiles ?? {}), false);
   } finally {

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -2971,7 +2971,10 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       );
       assert.equal(invokeCount, 1, 'service.invoke should run when api_key profile is member-bound');
       assert.ok(messages.some((m) => m.type === 'done'));
-      assert.equal(messages.some((m) => m.type === 'error' && /bound provider profile/i.test(String(m.error))), false);
+      assert.equal(
+        messages.some((m) => m.type === 'error' && /bound provider profile/i.test(String(m.error))),
+        false,
+      );
     } finally {
       process.chdir(previousCwd);
       catRegistry.reset();

--- a/packages/api/test/opencode-agent-service.test.js
+++ b/packages/api/test/opencode-agent-service.test.js
@@ -138,7 +138,10 @@ describe('OpenCodeAgentService', () => {
 
     const textMsgs = messages.filter((m) => m.type === 'text');
     assert.equal(textMsgs.length, 0, 'empty text chunk should be ignored');
-    assert.ok(messages.some((m) => m.type === 'done'), 'done should still be emitted');
+    assert.ok(
+      messages.some((m) => m.type === 'done'),
+      'done should still be emitted',
+    );
   });
 
   test('passes --format json and -m model in CLI args', async () => {
@@ -378,7 +381,11 @@ describe('OpenCodeAgentService', () => {
     await promise;
 
     const opts = spawnFn.mock.calls[0].arguments[2];
-    assert.strictEqual(opts.env.ANTHROPIC_BASE_URL, 'http://127.0.0.1:9877/slug/v1', 'explicit /v1 should be preserved');
+    assert.strictEqual(
+      opts.env.ANTHROPIC_BASE_URL,
+      'http://127.0.0.1:9877/slug/v1',
+      'explicit /v1 should be preserved',
+    );
   });
 
   // ── P2-1: multiple step_start should NOT produce multiple session_init ──

--- a/packages/api/test/provider-profiles-store.test.js
+++ b/packages/api/test/provider-profiles-store.test.js
@@ -72,7 +72,10 @@ describe('provider profile store', () => {
     const claude = data.providers.find((profile) => profile.id === 'claude');
     assert.ok(claude, 'builtin Claude account should exist');
     assert.ok(claude.models.includes('claude-opus-4-6'));
-    assert.equal(claude.models.some((model) => model.includes('[1m]')), false);
+    assert.equal(
+      claude.models.some((model) => model.includes('[1m]')),
+      false,
+    );
   });
 
   it('creates a client-agnostic api_key account and keeps secrets out of meta', async () => {

--- a/packages/shared/src/types/cat.ts
+++ b/packages/shared/src/types/cat.ts
@@ -3,8 +3,8 @@
  * 三只 AI 猫猫的类型定义和配置
  */
 
-import type { CatId, SessionId } from './ids.js';
 import type { ContextBudget } from './cat-breed.js';
+import type { CatId, SessionId } from './ids.js';
 import { createCatId } from './ids.js';
 
 /**

--- a/packages/web/src/components/CatCafeHub.tsx
+++ b/packages/web/src/components/CatCafeHub.tsx
@@ -5,29 +5,30 @@ import { useCatData } from '@/hooks/useCatData';
 import { useChatStore } from '@/stores/chatStore';
 import { apiFetch } from '@/utils/api-client';
 import { BrakeSettingsPanel } from './BrakeSettingsPanel';
-import { HubClaudeRescueSection } from './HubClaudeRescueSection';
+import {
+  AccordionSection,
+  ALL_TABS,
+  findGroupForTab,
+  HUB_GROUPS,
+  type HubTabId,
+  resolveRequestedHubTab,
+} from './cat-cafe-hub.navigation';
 import { CatOverviewTab, type ConfigData, SystemTab } from './config-viewer-tabs';
 import { HubCapabilityTab } from './HubCapabilityTab';
-import { HubCommandsTab } from './HubCommandsTab';
 import { HubCatEditor } from './HubCatEditor';
+import { HubClaudeRescueSection } from './HubClaudeRescueSection';
+import { HubCommandsTab } from './HubCommandsTab';
 import { HubEnvFilesTab } from './HubEnvFilesTab';
 import { HubGovernanceTab } from './HubGovernanceTab';
 import { HubLeaderboardTab } from './HubLeaderboardTab';
 import { HubOwnerEditor } from './HubOwnerEditor';
 import { HubProviderProfilesTab } from './HubProviderProfilesTab';
 import { HubRoutingPolicyTab } from './HubRoutingPolicyTab';
-import {
-  AccordionSection,
-  ALL_TABS,
-  findGroupForTab,
-  HUB_GROUPS,
-  resolveRequestedHubTab,
-  type HubTabId,
-} from './cat-cafe-hub.navigation';
 import { PushSettingsPanel } from './PushSettingsPanel';
 import { VoiceSettingsPanel } from './VoiceSettingsPanel';
-export { findGroupForTab, resolveRequestedHubTab } from './cat-cafe-hub.navigation';
+
 export type { HubTabId } from './cat-cafe-hub.navigation';
+export { findGroupForTab, resolveRequestedHubTab } from './cat-cafe-hub.navigation';
 
 /* ─── Main Hub modal ─── */
 export function CatCafeHub() {
@@ -248,7 +249,13 @@ export function CatCafeHub() {
             {tab === 'leaderboard' && <HubLeaderboardTab />}
           </div>
         </div>
-        <HubCatEditor open={editorOpen} cat={editingCat} draft={createDraft} onClose={closeEditor} onSaved={handleEditorSaved} />
+        <HubCatEditor
+          open={editorOpen}
+          cat={editingCat}
+          draft={createDraft}
+          onClose={closeEditor}
+          onSaved={handleEditorSaved}
+        />
         <HubOwnerEditor
           open={ownerEditorOpen}
           owner={config?.owner}

--- a/packages/web/src/components/HubAddMemberWizard.tsx
+++ b/packages/web/src/components/HubAddMemberWizard.tsx
@@ -7,16 +7,15 @@ import {
   CLIENT_ROW_1,
   CLIENT_ROW_2,
   clientLabel,
-  FALLBACK_ANTIGRAVITY_MODELS,
   FALLBACK_ANTIGRAVITY_ARGS,
+  FALLBACK_ANTIGRAVITY_MODELS,
   PillChoiceButton,
 } from './hub-add-member-wizard.parts';
 import {
   builtinAccountIdForClient,
-  filterAccounts,
   type ClientValue,
+  filterAccounts,
   type HubCatEditorDraft,
-
 } from './hub-cat-editor.model';
 import type { ProfileItem, ProviderProfilesResponse } from './hub-provider-profiles.types';
 
@@ -28,9 +27,9 @@ interface HubAddMemberWizardProps {
 
 export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWizardProps) {
   const [profiles, setProfiles] = useState<ProfileItem[]>([]);
-  const [seedCats, setSeedCats] = useState<Array<{ provider: string; source?: string; defaultModel?: string; commandArgs?: string[] }>>(
-    [],
-  );
+  const [seedCats, setSeedCats] = useState<
+    Array<{ provider: string; source?: string; defaultModel?: string; commandArgs?: string[] }>
+  >([]);
   const [loadingProfiles, setLoadingProfiles] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [client, setClient] = useState<ClientValue | null>(null);
@@ -43,9 +42,7 @@ export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWi
       (cat) => cat.provider === 'antigravity' && (cat.source === 'seed' || cat.source === undefined),
     );
     const command = templateAntigravity.find((cat) => (cat.commandArgs?.length ?? 0) > 0)?.commandArgs?.join(' ');
-    const models = templateAntigravity
-      .map((cat) => cat.defaultModel?.trim() ?? '')
-      .filter((value) => value.length > 0);
+    const models = templateAntigravity.map((cat) => cat.defaultModel?.trim() ?? '').filter((value) => value.length > 0);
     return {
       command: command?.trim() || FALLBACK_ANTIGRAVITY_ARGS,
       models: models.length > 0 ? Array.from(new Set(models)) : [...FALLBACK_ANTIGRAVITY_MODELS],
@@ -66,9 +63,7 @@ export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWi
     if (client === 'antigravity') return antigravityDefaults.models;
     const currentModel = defaultModel.trim();
     const profileModels =
-      selectedProfile?.models
-        ?.map((value) => value.trim())
-        .filter((value) => value.length > 0) ?? [];
+      selectedProfile?.models?.map((value) => value.trim()).filter((value) => value.length > 0) ?? [];
     if (currentModel && !profileModels.includes(currentModel)) {
       return [currentModel, ...profileModels];
     }
@@ -118,7 +113,9 @@ export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWi
     apiFetch('/api/cats')
       .then(async (res) => {
         if (!res.ok) throw new Error(`成员模板加载失败 (${res.status})`);
-        return (await res.json()) as { cats?: Array<{ provider: string; source?: string; defaultModel?: string; commandArgs?: string[] }> };
+        return (await res.json()) as {
+          cats?: Array<{ provider: string; source?: string; defaultModel?: string; commandArgs?: string[] }>;
+        };
       })
       .then((body) => {
         if (cancelled) return;
@@ -179,7 +176,8 @@ export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWi
       });
       return;
     }
-    const resolvedProfileId = availableProfiles.find((profile) => profile.id === selectedProfileId)?.id ?? selectedProfileId.trim();
+    const resolvedProfileId =
+      availableProfiles.find((profile) => profile.id === selectedProfileId)?.id ?? selectedProfileId.trim();
     if (!resolvedProfileId) return;
     onComplete({
       client,
@@ -205,10 +203,12 @@ export function HubAddMemberWizard({ open, onClose, onComplete }: HubAddMemberWi
           <section className="space-y-4 rounded-[20px] border border-[#F1E7DF] bg-[#FFFDFC] p-[18px]">
             <div>
               <h4 className="text-[17px] font-bold text-[#2D2118]">Step 1: 选择 Client</h4>
-              <p className="mt-1 text-sm leading-6 text-[#7F7168]">选择要接入的 CLI 工具、Agent 平台或 Antigravity bridge</p>
+              <p className="mt-1 text-sm leading-6 text-[#7F7168]">
+                选择要接入的 CLI 工具、Agent 平台或 Antigravity bridge
+              </p>
             </div>
             {[CLIENT_ROW_1, CLIENT_ROW_2].map((row, index) => (
-              <div key={index} aria-label={`Client Row ${index + 1}`} className="flex flex-wrap gap-3">
+              <div key={index} role="group" aria-label={`Client Row ${index + 1}`} className="flex flex-wrap gap-3">
                 {row.map((value) => (
                   <PillChoiceButton
                     key={value}

--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -10,8 +10,8 @@ import {
   buildCodexConfigPatches,
   buildStrategyPayload,
   builtinAccountIdForClient,
-  DEFAULT_ANTIGRAVITY_COMMAND_ARGS,
   type CodexRuntimeSettings,
+  DEFAULT_ANTIGRAVITY_COMMAND_ARGS,
   filterAccounts,
   type HubCatEditorDraft,
   type HubCatEditorFormState,
@@ -19,7 +19,6 @@ import {
   type StrategyFormState,
   toCodexRuntimeSettings,
   toStrategyForm,
-
 } from './hub-cat-editor.model';
 import { AccountSection, IdentitySection, RoutingSection } from './hub-cat-editor.sections';
 import { AdvancedRuntimeSection } from './hub-cat-editor-advanced';
@@ -424,7 +423,12 @@ export function HubCatEditor({ cat, draft, open, onClose, onSaved }: HubCatEdito
                 </svg>
               </button>
             ) : null}
-            <button type="button" onClick={requestClose} className="text-2xl leading-none text-[#B59A88]" aria-label="关闭">
+            <button
+              type="button"
+              onClick={requestClose}
+              className="text-2xl leading-none text-[#B59A88]"
+              aria-label="关闭"
+            >
               ×
             </button>
           </div>

--- a/packages/web/src/components/HubEnvFilesTab.tsx
+++ b/packages/web/src/components/HubEnvFilesTab.tsx
@@ -173,8 +173,18 @@ function PathAction({
 
 function buildConfigFiles(projectRoot: string) {
   return [
-    { name: 'cat-template.json', path: `${projectRoot}/cat-template.json`, desc: '猫猫模板（只读 seed）', isDir: false },
-    { name: '.cat-cafe/cat-catalog.json', path: `${projectRoot}/.cat-cafe/cat-catalog.json`, desc: '运行时成员真相源', isDir: false },
+    {
+      name: 'cat-template.json',
+      path: `${projectRoot}/cat-template.json`,
+      desc: '猫猫模板（只读 seed）',
+      isDir: false,
+    },
+    {
+      name: '.cat-cafe/cat-catalog.json',
+      path: `${projectRoot}/.cat-cafe/cat-catalog.json`,
+      desc: '运行时成员真相源',
+      isDir: false,
+    },
     { name: '.env', path: `${projectRoot}/.env`, desc: '可编辑环境变量真相源（不含认证凭证）', isDir: false },
     { name: '.env.local', path: `${projectRoot}/.env.local`, desc: '本地环境变量覆盖', isDir: false },
     { name: 'start-dev.sh', path: `${projectRoot}/scripts/start-dev.sh`, desc: '开发启动脚本', isDir: false },
@@ -202,7 +212,9 @@ function isEditableVariable(variable: EnvVar): boolean {
 }
 
 function isMaskedUrlVariable(variable: EnvVar): boolean {
-  return variable.maskMode === 'url' && typeof variable.currentValue === 'string' && variable.currentValue.includes('***');
+  return (
+    variable.maskMode === 'url' && typeof variable.currentValue === 'string' && variable.currentValue.includes('***')
+  );
 }
 
 function initialDraftValue(variable: EnvVar): string {
@@ -228,8 +240,13 @@ function ConfigFilesSection({ projectRoot }: { projectRoot: string }) {
         {files.map((f) => {
           const cls = classifyPath(f.path, projectRoot, f.isDir);
           return (
-            <div key={f.name} className="flex items-baseline gap-2 rounded-[12px] border border-[#F3E8DE] bg-white px-3 py-2">
-              <code className="shrink-0 rounded bg-[#F7F3F0] px-1.5 py-0.5 font-mono text-xs text-[#6A5A50]">{f.name}</code>
+            <div
+              key={f.name}
+              className="flex items-baseline gap-2 rounded-[12px] border border-[#F3E8DE] bg-white px-3 py-2"
+            >
+              <code className="shrink-0 rounded bg-[#F7F3F0] px-1.5 py-0.5 font-mono text-xs text-[#6A5A50]">
+                {f.name}
+              </code>
               <span className="text-xs text-[#8A776B]">{f.desc}</span>
               <PathAction classification={cls} absPath={f.path} />
             </div>
@@ -268,7 +285,8 @@ function EnvVarsSection({
   return (
     <Section title="环境变量">
       <div className="mb-3 rounded-[12px] border border-[#D7E9D7] bg-[#F6FBF6] px-3 py-2 text-xs leading-5 text-[#5B7A5C]">
-        变量值可直接编辑，保存后自动回填 `.env`。写回 .env 后需重启相关服务生效；URL 型连接串当前值已脱敏，修改时请填写完整值。
+        变量值可直接编辑，保存后自动回填 `.env`。写回 .env 后需重启相关服务生效；URL
+        型连接串当前值已脱敏，修改时请填写完整值。
       </div>
       <div className="space-y-3">
         {grouped.map((group) => (
@@ -340,7 +358,10 @@ function DataDirsSection({ dataDirs, projectRoot }: { dataDirs: DataDirs; projec
         {dirs.map((d) => {
           const cls = classifyPath(d.path, projectRoot, d.isDir);
           return (
-            <div key={d.name} className="flex items-baseline gap-2 rounded-[12px] border border-[#F3E8DE] bg-white px-3 py-2">
+            <div
+              key={d.name}
+              className="flex items-baseline gap-2 rounded-[12px] border border-[#F3E8DE] bg-white px-3 py-2"
+            >
               <span className="shrink-0 text-xs font-medium text-[#6A5A50]">{d.name}</span>
               <span className="text-xs text-[#8A776B]">{d.desc}</span>
               <PathAction classification={cls} absPath={d.path} />

--- a/packages/web/src/components/HubMemberOverviewCard.tsx
+++ b/packages/web/src/components/HubMemberOverviewCard.tsx
@@ -33,7 +33,13 @@ function clientRuntimeLabel(cat: CatData, configCat?: CatConfig) {
 function accountSummary(cat: CatData) {
   const accountRef = cat.accountRef?.trim() ?? cat.providerProfileId?.trim() ?? '';
   if (!accountRef) return humanizeProvider(cat.provider);
-  if (accountRef === 'claude' || accountRef === 'codex' || accountRef === 'gemini' || accountRef === 'dare' || accountRef === 'opencode') {
+  if (
+    accountRef === 'claude' ||
+    accountRef === 'codex' ||
+    accountRef === 'gemini' ||
+    accountRef === 'dare' ||
+    accountRef === 'opencode'
+  ) {
     return '内置 OAuth 账号';
   }
   return `API Key · ${accountRef}`;
@@ -105,7 +111,9 @@ export function HubOwnerOverviewCard({ owner, onEdit }: { owner: OwnerConfig; on
         </div>
         <span className="rounded-full bg-[#FFF3E0] px-2.5 py-1 text-[11px] font-semibold text-[#E65100]">🔒 Owner</span>
       </div>
-      <p className="mt-2.5 text-[13px] text-[#8A776B]">别名: {owner.aliases.join(' · ') || '无'} · 只能编辑，不能新增或删除</p>
+      <p className="mt-2.5 text-[13px] text-[#8A776B]">
+        别名: {owner.aliases.join(' · ') || '无'} · 只能编辑，不能新增或删除
+      </p>
       <p className="mt-2 text-[13px]" style={{ color: primary }}>
         {formatMentionPreview(owner.mentionPatterns, 2)}
       </p>

--- a/packages/web/src/components/HubOwnerEditor.tsx
+++ b/packages/web/src/components/HubOwnerEditor.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { apiFetch } from '@/utils/api-client';
 import { primeOwnerConfigCache } from '@/hooks/useOwnerConfig';
+import { apiFetch } from '@/utils/api-client';
 import type { OwnerConfig } from './config-viewer-types';
-import { PersistenceBanner, SectionCard, TextField } from './hub-cat-editor-fields';
 import { uploadAvatarAsset } from './hub-cat-editor.client';
+import { PersistenceBanner, SectionCard, TextField } from './hub-cat-editor-fields';
 import { TagEditor } from './hub-tag-editor';
 
 const DEFAULT_OWNER: OwnerConfig = {
@@ -149,7 +149,14 @@ export function HubOwnerEditor({ open, owner, onClose, onSaved }: HubOwnerEditor
           <PersistenceBanner />
 
           <SectionCard title="身份信息">
-            <TextField label="名称" ariaLabel="Owner Name" value={name} onChange={setName} required placeholder="Owner 显示名称" />
+            <TextField
+              label="名称"
+              ariaLabel="Owner Name"
+              value={name}
+              onChange={setName}
+              required
+              placeholder="Owner 显示名称"
+            />
 
             <div className="flex items-center gap-3">
               <span className="w-[140px] shrink-0 text-[13px] font-medium text-[#5C4B42]">Avatar</span>

--- a/packages/web/src/components/HubProviderProfileItem.tsx
+++ b/packages/web/src/components/HubProviderProfileItem.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useCallback, useState } from 'react';
-import { TagEditor } from './hub-tag-editor';
 import type { ApiProtocol } from './hub-provider-profiles.sections';
 import type { ProfileItem } from './hub-provider-profiles.types';
+import { TagEditor } from './hub-tag-editor';
 
 const PROTOCOL_OPTIONS: Array<{ value: ApiProtocol; label: string }> = [
   { value: 'anthropic', label: 'Anthropic' },
@@ -78,7 +78,9 @@ export function HubProviderProfileItem({ profile, busy, onSave, onDelete }: HubP
                 className="w-full rounded border border-[#E8DCCF] bg-white px-3 py-2 text-sm"
               >
                 {PROTOCOL_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
                 ))}
               </select>
               <input
@@ -142,7 +144,9 @@ export function HubProviderProfileItem({ profile, busy, onSave, onDelete }: HubP
             <span className="text-base font-bold text-[#2D2118]">{profile.displayName}</span>
             {profile.builtin ? <span className="text-[11px] font-semibold text-[#8A776B]">🔒 内置</span> : null}
             {!profile.builtin ? (
-              <span className="rounded-full bg-[#F3E8FF] px-2.5 py-1 text-[11px] font-semibold text-[#9D7BC7]">api_key</span>
+              <span className="rounded-full bg-[#F3E8FF] px-2.5 py-1 text-[11px] font-semibold text-[#9D7BC7]">
+                api_key
+              </span>
             ) : null}
           </div>
           {summaryText(profile) ? <p className="text-sm text-[#8A776B]">{summaryText(profile)}</p> : null}

--- a/packages/web/src/components/HubProviderProfilesTab.tsx
+++ b/packages/web/src/components/HubProviderProfilesTab.tsx
@@ -4,15 +4,9 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 import { apiFetch } from '@/utils/api-client';
 import { HubProviderProfileItem, type ProfileEditPayload } from './HubProviderProfileItem';
-import {
-  CreateApiKeyProfileSection,
-  ProviderProfilesSummaryCard,
-} from './hub-provider-profiles.sections';
-import {
-  ensureBuiltinProviderProfiles,
-  resolveAccountActionId,
-} from './hub-provider-profiles.view';
+import { CreateApiKeyProfileSection, ProviderProfilesSummaryCard } from './hub-provider-profiles.sections';
 import type { ProviderProfilesResponse } from './hub-provider-profiles.types';
+import { ensureBuiltinProviderProfiles, resolveAccountActionId } from './hub-provider-profiles.view';
 import { getProjectPaths, projectDisplayName } from './ThreadSidebar/thread-utils';
 
 export function HubProviderProfilesTab() {
@@ -63,7 +57,7 @@ export function HubProviderProfilesTab() {
     (nextPath: string | null) => {
       setProjectPath(nextPath);
       setLoading(true);
-      fetchProfiles((nextPath ?? threadProjectPath) ?? undefined);
+      fetchProfiles(nextPath ?? threadProjectPath ?? undefined);
     },
     [fetchProfiles, threadProjectPath],
   );
@@ -203,7 +197,7 @@ export function HubProviderProfilesTab() {
         onSwitchProject={switchProject}
       />
 
-      <div aria-label="Provider Profile List" className="space-y-4">
+      <div role="group" aria-label="Provider Profile List" className="space-y-4">
         {displayCards.map((profile) => (
           <HubProviderProfileItem
             key={profile.id}

--- a/packages/web/src/components/__tests__/cat-cafe-hub-provider-profiles-tab.test.ts
+++ b/packages/web/src/components/__tests__/cat-cafe-hub-provider-profiles-tab.test.ts
@@ -458,10 +458,12 @@ describe('CatCafeHub provider profiles tab', () => {
     expect(container.textContent).not.toContain('默认/覆盖模型');
 
     // Form is collapsed by default — expand it
-    const expandButton = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('新建 API Key 账号'),
+    const expandButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('新建 API Key 账号'),
     )!;
-    await act(async () => { expandButton.click(); });
+    await act(async () => {
+      expandButton.click();
+    });
     await flushEffects();
 
     expect(container.querySelector('input[placeholder*="API 服务地址"]')).toBeTruthy();
@@ -522,15 +524,15 @@ describe('CatCafeHub provider profiles tab', () => {
     await flushEffects();
 
     // Expand the collapsed create form
-    const expandButton = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('新建 API Key 账号'),
+    const expandButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('新建 API Key 账号'),
     )!;
-    await act(async () => { expandButton.click(); });
+    await act(async () => {
+      expandButton.click();
+    });
     await flushEffects();
 
-    const displayNameInput = container.querySelector(
-      'input[placeholder*="账号显示名"]',
-    ) as HTMLInputElement;
+    const displayNameInput = container.querySelector('input[placeholder*="账号显示名"]') as HTMLInputElement;
     const baseUrlInput = container.querySelector('input[placeholder*="API 服务地址"]') as HTMLInputElement;
     const apiKeyInput = container.querySelector('input[placeholder*="sk-"]') as HTMLInputElement;
     expect(apiKeyInput.type).toBe('password');
@@ -600,15 +602,15 @@ describe('CatCafeHub provider profiles tab', () => {
     await flushEffects();
 
     // Expand the collapsed create form
-    const expandButton = Array.from(container.querySelectorAll('button')).find(
-      (b) => b.textContent?.includes('新建 API Key 账号'),
+    const expandButton = Array.from(container.querySelectorAll('button')).find((b) =>
+      b.textContent?.includes('新建 API Key 账号'),
     )!;
-    await act(async () => { expandButton.click(); });
+    await act(async () => {
+      expandButton.click();
+    });
     await flushEffects();
 
-    const displayNameInput = container.querySelector(
-      'input[placeholder*="账号显示名"]',
-    ) as HTMLInputElement;
+    const displayNameInput = container.querySelector('input[placeholder*="账号显示名"]') as HTMLInputElement;
     const baseUrlInput = container.querySelector('input[placeholder*="API 服务地址"]') as HTMLInputElement;
     const apiKeyInput = container.querySelector('input[placeholder*="sk-"]') as HTMLInputElement;
 
@@ -787,7 +789,9 @@ describe('CatCafeHub provider profiles tab', () => {
     });
     await flushEffects();
 
-    expect(Array.from(container.querySelectorAll('button')).filter((button) => button.textContent?.trim() === '测试')).toHaveLength(0);
+    expect(
+      Array.from(container.querySelectorAll('button')).filter((button) => button.textContent?.trim() === '测试'),
+    ).toHaveLength(0);
     expect(container.textContent).toContain('Codex Sponsor');
   });
 

--- a/packages/web/src/components/__tests__/hub-add-member-wizard.test.tsx
+++ b/packages/web/src/components/__tests__/hub-add-member-wizard.test.tsx
@@ -276,7 +276,9 @@ describe('HubAddMemberWizard', () => {
     expect(queryField<HTMLInputElement>(container, 'input[aria-label="CLI Command"]').value).toBe(
       '. --remote-debugging-port=9010',
     );
-    expect(queryField<HTMLInputElement>(container, 'input[aria-label="Model"]').value).toBe('template-antigravity-model');
+    expect(queryField<HTMLInputElement>(container, 'input[aria-label="Model"]').value).toBe(
+      'template-antigravity-model',
+    );
   });
 
   it('uses seed antigravity defaults from /api/cats instead of runtime cat values', async () => {

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -1313,7 +1313,9 @@ describe('HubCatEditor', () => {
 
     await changeField(queryField(container, 'input[aria-label="Name"]'), '临时名字');
 
-    const cancelButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === '取消');
+    const cancelButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '取消',
+    );
     await act(async () => {
       cancelButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });

--- a/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
+++ b/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
@@ -155,13 +155,17 @@ describe('HubEnvFilesTab', () => {
     const frontendUrlInput = container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement;
     await changeField(frontendUrlInput, 'http://localhost:3200');
 
-    const saveButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === '保存到 .env');
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '保存到 .env',
+    );
     await act(async () => {
       saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     await flushEffects();
 
-    const patchCall = mockApiFetch.mock.calls.find(([path, init]) => path === '/api/config/env' && init?.method === 'PATCH');
+    const patchCall = mockApiFetch.mock.calls.find(
+      ([path, init]) => path === '/api/config/env' && init?.method === 'PATCH',
+    );
     expect(patchCall).toBeTruthy();
     expect(String(patchCall?.[1]?.body)).not.toContain('API_SERVER_PORT');
     expect(String(patchCall?.[1]?.body)).not.toContain('PREVIEW_GATEWAY_PORT');
@@ -185,9 +189,14 @@ describe('HubEnvFilesTab', () => {
     });
     await flushEffects();
 
-    await changeField(container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement, 'http://localhost:3200');
+    await changeField(
+      container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement,
+      'http://localhost:3200',
+    );
 
-    const saveButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === '保存到 .env');
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '保存到 .env',
+    );
     await act(async () => {
       saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
@@ -214,8 +223,13 @@ describe('HubEnvFilesTab', () => {
     });
     await flushEffects();
 
-    await changeField(container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement, 'http://localhost:3200');
-    const saveButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent === '保存到 .env');
+    await changeField(
+      container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement,
+      'http://localhost:3200',
+    );
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '保存到 .env',
+    );
 
     await act(async () => {
       saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));

--- a/packages/web/src/components/__tests__/hub-owner-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-owner-editor.test.tsx
@@ -25,7 +25,9 @@ async function flushEffects() {
 }
 
 function queryButton(container: HTMLElement, text: string): HTMLButtonElement {
-  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(text));
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
   if (!button) throw new Error(`Missing button: ${text}`);
   return button as HTMLButtonElement;
 }

--- a/packages/web/src/components/__tests__/hub-provider-profile-item.test.tsx
+++ b/packages/web/src/components/__tests__/hub-provider-profile-item.test.tsx
@@ -5,7 +5,9 @@ import { HubProviderProfileItem, type ProfileEditPayload } from '@/components/Hu
 import type { ProfileItem } from '@/components/hub-provider-profiles.types';
 
 function queryButton(container: HTMLElement, text: string): HTMLButtonElement {
-  const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes(text));
+  const button = Array.from(container.querySelectorAll('button')).find((candidate) =>
+    candidate.textContent?.includes(text),
+  );
   if (!button) {
     throw new Error(`Missing button: ${text}`);
   }
@@ -58,14 +60,7 @@ describe('HubProviderProfileItem', () => {
     const onSave = vi.fn(async () => {});
 
     await act(async () => {
-      root.render(
-        <HubProviderProfileItem
-          profile={profile}
-          busy={false}
-          onSave={onSave}
-          onDelete={() => {}}
-        />,
-      );
+      root.render(<HubProviderProfileItem profile={profile} busy={false} onSave={onSave} onDelete={() => {}} />);
     });
 
     await act(async () => {
@@ -82,7 +77,7 @@ describe('HubProviderProfileItem', () => {
       baseUrl: 'https://api.anthropic.com',
       models: ['claude-opus-4-1'],
     });
-    expect(Object.prototype.hasOwnProperty.call(payload, 'modelOverride')).toBe(false);
+    expect(Object.hasOwn(payload, 'modelOverride')).toBe(false);
   });
 
   it('sends empty baseUrl when clearing an API-key account base URL', async () => {
@@ -104,14 +99,7 @@ describe('HubProviderProfileItem', () => {
     const onSave = vi.fn(async () => {});
 
     await act(async () => {
-      root.render(
-        <HubProviderProfileItem
-          profile={profile}
-          busy={false}
-          onSave={onSave}
-          onDelete={() => {}}
-        />,
-      );
+      root.render(<HubProviderProfileItem profile={profile} busy={false} onSave={onSave} onDelete={() => {}} />);
     });
 
     await act(async () => {
@@ -152,12 +140,7 @@ describe('HubProviderProfileItem', () => {
 
     await act(async () => {
       root.render(
-        <HubProviderProfileItem
-          profile={profile}
-          busy={false}
-          onSave={vi.fn(async () => {})}
-          onDelete={() => {}}
-        />,
+        <HubProviderProfileItem profile={profile} busy={false} onSave={vi.fn(async () => {})} onDelete={() => {}} />,
       );
     });
 
@@ -186,12 +169,7 @@ describe('HubProviderProfileItem', () => {
 
     await act(async () => {
       root.render(
-        <HubProviderProfileItem
-          profile={profile}
-          busy={false}
-          onSave={vi.fn(async () => {})}
-          onDelete={() => {}}
-        />,
+        <HubProviderProfileItem profile={profile} busy={false} onSave={vi.fn(async () => {})} onDelete={() => {}} />,
       );
     });
 
@@ -221,12 +199,7 @@ describe('HubProviderProfileItem', () => {
 
     await act(async () => {
       root.render(
-        <HubProviderProfileItem
-          profile={profile}
-          busy={false}
-          onSave={vi.fn(async () => {})}
-          onDelete={onDelete}
-        />,
+        <HubProviderProfileItem profile={profile} busy={false} onSave={vi.fn(async () => {})} onDelete={onDelete} />,
       );
     });
 

--- a/packages/web/src/components/config-viewer-tabs.tsx
+++ b/packages/web/src/components/config-viewer-tabs.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 import type { CatData } from '@/hooks/useCatData';
-import { HubMemberOverviewCard, HubOverviewToolbar, HubOwnerOverviewCard } from './HubMemberOverviewCard';
 import type { ConfigData } from './config-viewer-types';
+import { HubMemberOverviewCard, HubOverviewToolbar, HubOwnerOverviewCard } from './HubMemberOverviewCard';
 
 export type { Capabilities, CatConfig, ConfigData, ContextBudget } from './config-viewer-types';
 

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -109,19 +109,21 @@ export function AdvancedRuntimeSection({
               onChange={(nextTags) => onChange({ cliConfigArgs: nextTags })}
               addLabel="+ 添加参数"
               placeholder={
-                form.client === 'opencode'
-                  ? '例如 --variant low'
-                  : '例如 --config model_reasoning_effort="low"'
+                form.client === 'opencode' ? '例如 --variant low' : '例如 --config model_reasoning_effort="low"'
               }
               emptyLabel="无额外参数"
               tone="green"
             />
             <p className="text-[11px] leading-4 text-[#8A776B]">
-              每条直接追加到 CLI 命令，不做隐式转换。
-              参考：{form.client === 'opencode' ? (
-                <a href="https://opencode.ai/docs/cli" target="_blank" rel="noreferrer" className="underline">OpenCode CLI</a>
+              每条直接追加到 CLI 命令，不做隐式转换。 参考：
+              {form.client === 'opencode' ? (
+                <a href="https://opencode.ai/docs/cli" target="_blank" rel="noreferrer" className="underline">
+                  OpenCode CLI
+                </a>
               ) : (
-                <a href="https://github.com/openai/codex" target="_blank" rel="noreferrer" className="underline">Codex CLI</a>
+                <a href="https://github.com/openai/codex" target="_blank" rel="noreferrer" className="underline">
+                  Codex CLI
+                </a>
               )}
             </p>
           </div>

--- a/packages/web/src/components/hub-cat-editor-fields.tsx
+++ b/packages/web/src/components/hub-cat-editor-fields.tsx
@@ -16,7 +16,10 @@ function FieldShell({
   const labelColor = tone === 'success' ? 'text-[#5B7A5C]' : 'text-[#8A776B]';
   return (
     <label className="flex flex-col gap-1.5 text-[#5C4B42] sm:flex-row sm:items-center sm:gap-3">
-      <span className={`text-[13px] font-semibold ${labelColor} sm:w-[140px] sm:shrink-0`}>{label}{required && <span className="ml-0.5 text-[#E29578]">*</span>}</span>
+      <span className={`text-[13px] font-semibold ${labelColor} sm:w-[140px] sm:shrink-0`}>
+        {label}
+        {required && <span className="ml-0.5 text-[#E29578]">*</span>}
+      </span>
       <div className="min-w-0 flex-1">{children}</div>
     </label>
   );

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -1,7 +1,7 @@
 import type { CatData } from '@/hooks/useCatData';
+import { defaultMcpSupportForClient } from './hub-cat-editor.protocols';
 import type { BuiltinAccountClient, ProfileItem } from './hub-provider-profiles.types';
 import type { CatStrategyEntry, StrategyType } from './hub-strategy-types';
-import { defaultMcpSupportForClient } from './hub-cat-editor.protocols';
 
 export type ClientValue = 'anthropic' | 'openai' | 'google' | 'dare' | 'opencode' | 'antigravity';
 export type SessionChainValue = 'true' | 'false';
@@ -175,7 +175,9 @@ export function splitStrengthTags(raw: string): string[] {
 }
 
 function isBuiltinClient(client: ClientValue): client is BuiltinAccountClient {
-  return client === 'anthropic' || client === 'openai' || client === 'google' || client === 'dare' || client === 'opencode';
+  return (
+    client === 'anthropic' || client === 'openai' || client === 'google' || client === 'dare' || client === 'opencode'
+  );
 }
 
 function legacyProfileClient(profile: ProfileItem): BuiltinAccountClient | undefined {
@@ -248,11 +250,7 @@ export function initialState(cat?: CatData | null, draft?: HubCatEditorDraft | n
     strengths: cat?.strengths?.join(', ') ?? '',
     client: (cat?.provider as ClientValue | undefined) ?? createDraft?.client ?? 'anthropic',
     accountRef:
-      cat?.accountRef ??
-      cat?.providerProfileId ??
-      createDraft?.accountRef ??
-      createDraft?.providerProfileId ??
-      '',
+      cat?.accountRef ?? cat?.providerProfileId ?? createDraft?.accountRef ?? createDraft?.providerProfileId ?? '',
     defaultModel: cat?.defaultModel ?? createDraft?.defaultModel ?? '',
     commandArgs: cat?.commandArgs?.join(' ') ?? createDraft?.commandArgs ?? '',
     cliConfigArgs: [...(cat?.cliConfigArgs ?? [])],
@@ -265,12 +263,9 @@ export function initialState(cat?: CatData | null, draft?: HubCatEditorDraft | n
 }
 
 export function buildContextBudget(form: HubCatEditorFormState) {
-  const values = [
-    form.maxPromptTokens,
-    form.maxContextTokens,
-    form.maxMessages,
-    form.maxContentLengthPerMsg,
-  ].map((value) => value.trim());
+  const values = [form.maxPromptTokens, form.maxContextTokens, form.maxMessages, form.maxContentLengthPerMsg].map(
+    (value) => value.trim(),
+  );
   const filledCount = values.filter((value) => value.length > 0).length;
   if (filledCount === 0) return undefined;
   if (filledCount !== values.length) {
@@ -371,18 +366,16 @@ export function validateModelFormatForClient(client: ClientValue, model: string)
 }
 
 function resolveFormAccountRef(form: HubCatEditorFormState): string {
-  return trimText(form.accountRef ?? (form as HubCatEditorFormState & { providerProfileId?: string }).providerProfileId);
+  return trimText(
+    form.accountRef ?? (form as HubCatEditorFormState & { providerProfileId?: string }).providerProfileId,
+  );
 }
 
 export function buildCatPayload(form: HubCatEditorFormState, cat?: CatData | null) {
   const contextBudget = buildContextBudget(form);
   const hasExistingBudget = Boolean(cat?.contextBudget);
   const contextBudgetPatch =
-    contextBudget !== undefined
-      ? { contextBudget }
-      : cat && hasExistingBudget
-        ? { contextBudget: null as null }
-        : {};
+    contextBudget !== undefined ? { contextBudget } : cat && hasExistingBudget ? { contextBudget: null as null } : {};
   const name = trimText(form.name);
   const displayName = trimText(form.displayName) || name;
   const createName = name || displayName;
@@ -405,11 +398,7 @@ export function buildCatPayload(form: HubCatEditorFormState, cat?: CatData | nul
       secondary: trimText(form.colorSecondary),
     },
     mentionPatterns: Array.from(
-      new Set(
-        splitMentionPatterns(form.mentionPatterns)
-          .map(normalizeMentionPattern)
-          .filter(Boolean),
-      ),
+      new Set(splitMentionPatterns(form.mentionPatterns).map(normalizeMentionPattern).filter(Boolean)),
     ),
     roleDescription: trimText(form.roleDescription),
     personality: trimText(form.personality),

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -70,10 +70,21 @@ export function IdentitySection({
           <input type="hidden" aria-label="Cat ID" value={form.catId} />
         </>
       ) : (
-        <TextField label="名称" ariaLabel="Name" value={form.name} onChange={(value) => onChange({ name: value, displayName: value })} />
+        <TextField
+          label="名称"
+          ariaLabel="Name"
+          value={form.name}
+          onChange={(value) => onChange({ name: value, displayName: value })}
+        />
       )}
 
-      <TextField label="昵称" ariaLabel="Nickname" value={form.nickname} onChange={(value) => onChange({ nickname: value })} placeholder="可选，铲屎官给的昵称" />
+      <TextField
+        label="昵称"
+        ariaLabel="Nickname"
+        value={form.nickname}
+        onChange={(value) => onChange({ nickname: value })}
+        placeholder="可选，铲屎官给的昵称"
+      />
       <TextField
         label="角色描述"
         ariaLabel="Description"
@@ -152,7 +163,13 @@ export function IdentitySection({
         onChange={(value) => onChange({ teamStrengths: value })}
         placeholder="如 架构设计、安全分析"
       />
-      <TextField label="性格特征" ariaLabel="Personality" value={form.personality} onChange={(value) => onChange({ personality: value })} placeholder="如 温柔但有主见" />
+      <TextField
+        label="性格特征"
+        ariaLabel="Personality"
+        value={form.personality}
+        onChange={(value) => onChange({ personality: value })}
+        placeholder="如 温柔但有主见"
+      />
       <TextField
         label="注意事项"
         ariaLabel="Caution"

--- a/packages/web/src/components/hub-provider-profiles.sections.tsx
+++ b/packages/web/src/components/hub-provider-profiles.sections.tsx
@@ -34,9 +34,7 @@ export function ProviderProfilesSummaryCard({
           </select>
         ) : null}
       </div>
-      <p className="mt-2 text-[13px] leading-6 text-[#8A776B]">
-        每个账号可添加或删除模型。
-      </p>
+      <p className="mt-2 text-[13px] leading-6 text-[#8A776B]">每个账号可添加或删除模型。</p>
     </div>
   );
 }
@@ -103,7 +101,9 @@ export function CreateApiKeyProfileSection({
             className="w-full rounded border border-[#E8DCCF] bg-white px-3 py-2 text-sm"
           >
             {PROTOCOL_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>{opt.label}</option>
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
             ))}
           </select>
           <input

--- a/packages/web/src/hooks/useOwnerConfig.ts
+++ b/packages/web/src/hooks/useOwnerConfig.ts
@@ -1,9 +1,9 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import type { OwnerConfig } from '@/components/config-viewer-types';
 import { refreshOwnerMentionData, resetMentionDataForTest } from '@/lib/mention-highlight';
 import { apiFetch } from '@/utils/api-client';
-import type { OwnerConfig } from '@/components/config-viewer-types';
 
 const DEFAULT_OWNER: OwnerConfig = {
   name: 'ME',

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -4,7 +4,12 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'n
 import path from 'node:path';
 
 const BUILTIN_ACCOUNT_SPECS = [
-  { id: 'claude', displayName: 'Claude', client: 'anthropic', models: ['claude-opus-4-6[1m]', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101'] },
+  {
+    id: 'claude',
+    displayName: 'Claude',
+    client: 'anthropic',
+    models: ['claude-opus-4-6[1m]', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101'],
+  },
   { id: 'codex', displayName: 'Codex', client: 'openai', models: ['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.3-codex-spark'] },
   { id: 'gemini', displayName: 'Gemini', client: 'google', models: ['gemini-3.1-pro-preview', 'gemini-2.5-pro'] },
   { id: 'dare', displayName: 'Dare', client: 'dare', models: ['z-ai/glm-4.7'] },

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -1,9 +1,8 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 const ROOT = resolve(process.cwd());


### PR DESCRIPTION
## Summary
- apply Biome organize-imports / format fixes across the current community main surface
- add `role="group"` to two labeled container divs so the existing labels stay valid under a11y lint
- refresh `docs/features/index.json` so the same `Lint` job's `check:features` step passes after Biome is clean

## Scope
This is a mechanical CI-baseline cleanup PR only:
- no runtime behavior changes intended
- no feature work mixed in
- no test logic changes beyond formatter output

## Verification
- `pnpm biome check . --diagnostic-level=error`
- `pnpm check`

Fixes #162
