### PR TITLE
F113 post-merge cleanup: fix Windows installer secret prompt sync regression

### DIFF
--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -465,26 +465,19 @@ function Remove-ClaudeInstallerProfile {
 function Read-InstallerSecret {
     param([string]$Prompt)
 
-    Write-Host -NoNewline "$Prompt"
-    $input = ""
-    while ($true) {
-        $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
-        if ($key.VirtualKeyCode -eq 13) {
-            # Enter pressed
-            Write-Host ""
-            break
-        } elseif ($key.VirtualKeyCode -eq 8) {
-            # Backspace
-            if ($input.Length -gt 0) {
-                $input = $input.Substring(0, $input.Length - 1)
-                Write-Host -NoNewline "`b `b"
-            }
-        } elseif ($key.Character -ne [char]0) {
-            $input += $key.Character
-            Write-Host -NoNewline "*"
+    $secureValue = Read-Host $Prompt -AsSecureString
+    if ($null -eq $secureValue) {
+        return ""
+    }
+
+    $bstr = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($secureValue)
+    try {
+        return [Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr)
+    } finally {
+        if ($bstr -ne [IntPtr]::Zero) {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr)
         }
     }
-    return $input
 }
 
 function Configure-InstallerAuth {


### PR DESCRIPTION
## Summary
- audit the stale F113 follow-up branches against current `main`
- conclude that `fix/F113-install-tty-input` has no surviving tree-state diff worth reviving
- keep only the real residual fix from the Windows follow-up line: update `Read-InstallerSecret` to match the split test expectations already on `main`

## What this PR actually fixes
`origin/main` already contains the split Windows Redis test files from sync commit `808bb79`, including assertions that the installer secret prompt uses `Read-Host -AsSecureString` and frees the converted BSTR with `ZeroFreeBSTR`.

Before this PR, `scripts/install-windows-helpers.ps1` still used the older hand-rolled masked input loop, so the synced split test expectation and the implementation were out of sync. This PR fixes that regression.

## Source branch audit
- `fix/F113-install-tty-input`
  - three-point diff history looked noisy (`958` lines), but tree-state comparison against current `main` showed no meaningful residual patch to keep
  - remaining differences were already superseded by current mainline behavior or were non-value comment/test-shape churn
- `fix/f113-final-review`
  - audited commit-by-commit against current `main`
  - most review-era changes were already absorbed or obsolete
  - the only surviving code-level value was the installer secret prompt hardening now carried by this PR

## Net diff
- `scripts/install-windows-helpers.ps1`
  - replace the manual character-by-character masked prompt loop
  - use `Read-Host -AsSecureString`
  - convert via `SecureStringToBSTR` and zero the unmanaged buffer with `ZeroFreeBSTR`

## Intentionally not included
- no monolithic `windows-portable-redis-script.test.js`
  - `main` already has the split coverage in:
    - `windows-portable-redis-lifecycle.test.js`
    - `windows-portable-redis-tools.test.js`
    - `windows-portable-redis-url.test.js`
    - `windows-portable-redis-test-helpers.js`
- no unrelated formatting churn

## Test evidence
- `node --test packages/api/test/windows-portable-redis-tools.test.js packages/api/test/windows-portable-redis-lifecycle.test.js packages/api/test/windows-portable-redis-url.test.js packages/api/test/install-auth-config-script.test.js`
- result: 64 passed, 0 failed

## Context
- Tracking issue: #164
- Previously merged PRs: #113, #128

[砚砚/GPT-5.4🐾]