### PR TITLE
fix: add browser favicon to Next.js metadata

### DIFF
--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -15,6 +15,10 @@ export const metadata: Metadata = {
   description: 'Your AI team collaboration space',
   manifest: '/manifest.json',
   icons: {
+    icon: [
+      { url: '/icons/icon-192x192.png', sizes: '192x192', type: 'image/png' },
+      { url: '/icons/icon-512x512.png', sizes: '512x512', type: 'image/png' },
+    ],
     apple: '/icons/apple-touch-icon.png',
   },
   appleWebApp: {


### PR DESCRIPTION
## Summary
- Browser tabs were showing the default icon instead of Clowder AI logo
- Root cause: `metadata.icons` in `layout.tsx` only had `apple` (iOS touch icon), missing `icon` (standard browser favicon)
- Added `icon` entries pointing to existing `icon-192x192.png` and `icon-512x512.png`

## Test plan
- [ ] Hard-refresh the app (Cmd+Shift+R) and verify the Clowder AI logo appears in the browser tab
- [ ] Verify the Apple touch icon still works on iOS

🐾 [宪宪/Opus-46]
🤖 Generated with [Claude Code](https://claude.com/claude-code)