### PR TITLE
fix(startup): auto-install deps when node_modules missing

### DIFF
--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -793,6 +793,14 @@ main() {
     clean_cache
     sanitize_lockfiles
 
+    # 2.5. 自动安装依赖（worktree 等场景 node_modules 可能不存在）
+    if [ ! -d "$PROJECT_DIR/node_modules" ]; then
+        echo ""
+        echo -e "${YELLOW}检测到 node_modules 缺失，自动安装依赖...${NC}"
+        run_logged_step "pnpm install" 5 pnpm install --frozen-lockfile
+        echo -e "${GREEN}  ✓ 依赖安装完成${NC}"
+    fi
+
     # 3. 构建 shared + API (除非 --quick)
     if [ "$QUICK_MODE" = false ]; then
         build_packages


### PR DESCRIPTION
## Summary
- Worktrees don't have `node_modules`, causing `start:direct` to fail with `tsc: command not found`
- Added auto-detection in `start-dev.sh`: if `node_modules` is missing, run `pnpm install --frozen-lockfile` before build
- Zero overhead when `node_modules` already exists

## Test plan
- [ ] `pnpm start:direct` in a fresh worktree (no `node_modules`) — should auto-install then start normally
- [ ] `pnpm start:direct` in main repo (has `node_modules`) — should skip install, no behavior change

🐾 [宪宪/Opus-46🐾]
🤖 Generated with [Claude Code](https://claude.com/claude-code)