### PR TITLE
fix: remove duplicate setCurrentThread call in ChatContainer

### DIFF
--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -265,26 +265,37 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
 
   // Sync URL-driven threadId to store (store is follower, URL is source of truth)
   // setCurrentThread saves old thread state to map, restores new thread state.
+  //
+  // Bug fix (double-call issue):
+  // Previously, setCurrentThread was called twice on thread change:
+  // 1. Inside the if block (when prevThreadRef.current !== threadId)
+  // 2. Unconditionally after the if block ("First mount" case)
+  // This caused unnecessary save/restore cycles and potential state corruption.
+  //
+  // Solution: Only call setCurrentThread when actually needed:
+  // - On thread switch (prevThreadRef.current !== threadId)
+  // - When store is out of sync with URL (needsSync check)
   const setCurrentProject = useChatStore((s) => s.setCurrentProject);
   const storeThreads = useChatStore((s) => s.threads);
   const prevThreadRef = useRef(threadId);
   useEffect(() => {
-    if (prevThreadRef.current !== threadId) {
-      // Thread switch: store saves/restores per-thread state automatically
+    const storeThreadId = useChatStore.getState().currentThreadId;
+    const needsSync = storeThreadId !== threadId;
+
+    if (prevThreadRef.current !== threadId || needsSync) {
+      // Thread switch or store out of sync: save/restore per-thread state
       setCurrentThread(threadId);
       // Clean up non-thread-scoped refs
       resetRefs();
       clearTasks();
       prevThreadRef.current = threadId;
     }
-    // First mount — sync threadId to store without save/restore
-    setCurrentThread(threadId);
     // F101: Recover game state for the new thread (or clear stale game from previous thread)
     reconnectGame(threadId).catch(() => {});
   }, [
     threadId,
     clearTasks, // Clean up non-thread-scoped refs
-    resetRefs, // First mount — sync threadId to store without save/restore
+    resetRefs,
     setCurrentThread,
   ]); // eslint-disable-line react-hooks/exhaustive-deps
 


### PR DESCRIPTION
## Summary
Fix double-call bug where `setCurrentThread` was invoked twice on thread change, causing unnecessary save/restore cycles and potential state corruption.

## Root Cause
The original code had two calls to `setCurrentThread`:
1. Inside the if block when `prevThreadRef.current !== threadId`
2. Unconditionally after the if block (labeled "First mount")

This meant every thread switch triggered two save/restore cycles.

## Changes
- Added `needsSync` check to detect when store state is out of sync with URL
- Only call `setCurrentThread` when actually needed (thread switch OR store out of sync)
- Removed unconditional second call that caused double-save/restore

## Reproduction Steps (Before Fix)
1. Open ChatContainer with threadId "A"
2. Switch to threadId "B"
3. Observe: `setCurrentThread` called twice
   - First call: saves "A" state, restores "B" state
   - Second call: saves "B" state (unnecessary), restores "B" state (noop)

## Test plan
- [ ] Switch between threads and verify no duplicate save/restore cycles
- [ ] Verify thread state is correctly preserved on switch
- [ ] Check browser console for any errors during thread navigation
- [ ] Related to: `chatStore-multithread.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)