### PR TITLE
feat: add generic process cleanup scripts with auto-detect project path

### DIFF
--- a/scripts/kill-all.sh
+++ b/scripts/kill-all.sh
@@ -19,7 +19,8 @@ echo "   Project path: $PROJECT"
 echo ""
 
 # Find PIDs by cmdline (most reliable)
-PIDS=$(ps aux | grep -E "(node|tsx|next|esbuild)" | grep "$PROJECT" | grep -v grep | awk '{print $2}' || true)
+# Use -F for fixed string matching to handle special characters in paths
+PIDS=$(ps aux | grep -E "(node|tsx|next|esbuild)" | grep -F "$PROJECT" | grep -v grep | awk '{print $2}' || true)
 
 # Also check by cwd (catches subprocesses)
 for pid in $(ps aux | awk '{print $2}'); do

--- a/scripts/kill-project-processes.sh
+++ b/scripts/kill-project-processes.sh
@@ -32,7 +32,8 @@ echo ""
 
 # Find all processes related to the project directory
 # This matches: node, tsx, next, esbuild, pnpm processes that contain the project path
-PIDS=$(ps aux | grep -E "(node|tsx|next|esbuild|pnpm)" | grep -E "$PROJECT_PATH" | grep -v grep | awk '{print $2}' || true)
+# Use -F for fixed string matching to handle special characters in paths
+PIDS=$(ps aux | grep -E "(node|tsx|next|esbuild|pnpm)" | grep -F "$PROJECT_PATH" | grep -v grep | awk '{print $2}' || true)
 
 # Also find related child processes that might be in node_modules but not show full path
 # Check for processes with CWD in the project


### PR DESCRIPTION
## Summary
Add two utility scripts for cleaning up development processes, with auto-detect project path support.

## Scripts

### `scripts/kill-all.sh` - Quick process killer
- Auto-detects project root from script location
- Optional project path argument for flexibility
- Simple, fast cleanup for common development workflow

Usage:
\`\`\`bash
# Auto-detect (run from project root)
./scripts/kill-all.sh

# Specify project path
./scripts/kill-all.sh /path/to/project
\`\`\`

### `scripts/kill-project-processes.sh` - Comprehensive process manager
- Graceful shutdown with SIGTERM, then SIGKILL if needed
- Shows process details before killing
- Waits up to 5 seconds for clean exit
- Optional project path argument

Usage:
\`\`\`bash
# Auto-detect (run from project root)
./scripts/kill-project-processes.sh

# Specify project path
./scripts/kill-project-processes.sh /path/to/project
\`\`\`

## Use Cases
- **Development**: Quickly clean up stuck processes after crashes
- **Testing**: Ensure clean state between test runs
- **Multi-instance**: Kill processes for specific project directories

## Improvements over original
- Auto-detect project path instead of hardcoded paths
- Works in any project location
- Accepts optional project path argument for flexibility
- Better error handling with `set -euo pipefail`

## Test plan
- [ ] Run `./scripts/kill-all.sh` and verify it kills project processes
- [ ] Run `./scripts/kill-project-processes.sh` and verify graceful shutdown
- [ ] Test with custom project path argument
- [ ] Test on different project locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)