### PR TITLE
feat(mcp): add web fetch tool for models without web search

### DIFF
--- a/packages/mcp-server/src/server-toolsets.ts
+++ b/packages/mcp-server/src/server-toolsets.ts
@@ -9,6 +9,7 @@ import {
   sessionChainTools,
   signalStudyTools,
   signalsTools,
+  webFetchTools,
 } from './tools/index.js';
 
 type ToolDef = {
@@ -58,9 +59,16 @@ export function registerLimbToolset(server: McpServer): void {
   registerTools(server, limbNodeTools);
 }
 
+const webTools: readonly ToolDef[] = [...webFetchTools];
+
+export function registerWebToolset(server: McpServer): void {
+  registerTools(server, webTools);
+}
+
 export function registerFullToolset(server: McpServer): void {
   registerCollabToolset(server);
   registerMemoryToolset(server);
   registerSignalToolset(server);
   registerLimbToolset(server);
+  registerWebToolset(server);
 }

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -77,6 +77,11 @@ export {
 } from './session-chain-tools.js';
 export { signalStudyTools } from './signal-study-tools.js';
 export {
+  handleWebFetch,
+  webFetchInputSchema,
+  webFetchTools,
+} from './web-fetch-tools.js';
+export {
   handleSignalGetArticle,
   handleSignalListInbox,
   handleSignalMarkRead,

--- a/packages/mcp-server/src/tools/web-fetch-tools.ts
+++ b/packages/mcp-server/src/tools/web-fetch-tools.ts
@@ -1,0 +1,213 @@
+/**
+ * Web Fetch Tools
+ * MCP 工具: 为不支持 web search 的模型提供网页抓取能力
+ *
+ * 参考 relay-claw/web_fetch_tools.py 移植为 TypeScript 实现。
+ */
+
+import { z } from 'zod';
+import type { ToolResult } from './file-tools.js';
+import { errorResult, successResult } from './file-tools.js';
+
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+  'AppleWebKit/537.36 (KHTML, like Gecko) ' +
+  'Chrome/124.0.0.0 Safari/537.36';
+
+const CHARSET_META_RE = /<meta[^>]+charset=["']?\s*([A-Za-z0-9._-]+)/i;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Decode DuckDuckGo redirect URLs (uddg parameter). */
+function decodeDdgRedirect(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return raw;
+  }
+  if (parsed.pathname !== '/l/') return raw;
+  const uddg = parsed.searchParams.get('uddg');
+  return uddg ? decodeURIComponent(uddg) : raw;
+}
+
+/** Normalize URL: decode DDG redirects, default to https. */
+function normalizeUrl(raw: string): string {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) return '';
+  const decoded = decodeDdgRedirect(trimmed);
+  if (decoded.startsWith('http://') || decoded.startsWith('https://')) return decoded;
+  return `https://${decoded}`;
+}
+
+/** Strip HTML tags and decode entities. */
+function stripTags(html: string): string {
+  // Remove tags, collapse whitespace
+  const noTags = html.replace(/<[^>]+>/g, ' ');
+  // Decode common HTML entities
+  const decoded = noTags
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)));
+  return decoded.replace(/\s+/g, ' ').trim();
+}
+
+/** Truncate text to maxChars with indicator. */
+function clipText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n...[truncated]`;
+}
+
+/** Detect charset from Content-Type header or <meta> tag. */
+function detectCharset(contentType: string, headChunk: string): string | undefined {
+  // Check Content-Type header
+  const headerMatch = /charset=([^\s;]+)/i.exec(contentType);
+  if (headerMatch) return headerMatch[1].replace(/["']/g, '').trim();
+  // Check <meta charset> in first chunk
+  const metaMatch = CHARSET_META_RE.exec(headChunk);
+  if (metaMatch) return metaMatch[1].trim();
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch logic
+// ---------------------------------------------------------------------------
+
+interface FetchResult {
+  url: string;
+  statusCode: number;
+  title: string;
+  content: string;
+}
+
+/** Fetch via Jina Reader as fallback for access-restricted pages. */
+async function fetchViaJinaReader(
+  url: string,
+  timeoutMs: number,
+): Promise<FetchResult> {
+  const readerUrl = `https://r.jina.ai/${url}`;
+  const response = await fetch(readerUrl, {
+    headers: { 'User-Agent': USER_AGENT },
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) {
+    throw new Error(`Jina reader returned ${response.status}`);
+  }
+  const text = await response.text();
+  return { url, statusCode: response.status, title: '', content: text.trim() };
+}
+
+/** Fetch a webpage, extract title and plain text content. */
+async function fetchWebpage(
+  url: string,
+  timeoutMs: number,
+): Promise<FetchResult> {
+  const response = await fetch(url, {
+    headers: { 'User-Agent': USER_AGENT },
+    signal: AbortSignal.timeout(timeoutMs),
+    redirect: 'follow',
+  });
+
+  // Fallback to Jina for access-restricted pages
+  if (response.status === 401 || response.status === 403 || response.status === 429) {
+    return fetchViaJinaReader(url, timeoutMs);
+  }
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const rawText = await response.text();
+  const contentType = response.headers.get('Content-Type') ?? '';
+
+  // Detect charset — Node fetch already decodes to UTF-8 string via .text(),
+  // but we keep detectCharset for logging/future use.
+  detectCharset(contentType, rawText.slice(0, 4096));
+
+  // Extract title
+  const titleMatch = /<title[^>]*>(.*?)<\/title>/is.exec(rawText);
+  const title = titleMatch ? stripTags(titleMatch[1]) : '';
+
+  let content: string;
+  if (contentType.toLowerCase().includes('html')) {
+    // Remove script and style blocks, then strip tags
+    content = rawText
+      .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, ' ')
+      .replace(/<style[^>]*>[\s\S]*?<\/style>/gi, ' ');
+    content = stripTags(content);
+  } else {
+    content = rawText.replace(/\s+/g, ' ').trim();
+  }
+
+  return {
+    url: response.url,
+    statusCode: response.status,
+    title,
+    content,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MCP Tool definition
+// ---------------------------------------------------------------------------
+
+export const webFetchInputSchema = {
+  url: z.string().min(1).describe('The webpage URL to fetch'),
+  max_chars: z
+    .number()
+    .int()
+    .optional()
+    .default(12000)
+    .describe('Maximum characters in returned content (500-50000, default 12000)'),
+  timeout_seconds: z
+    .number()
+    .int()
+    .optional()
+    .default(30)
+    .describe('Request timeout in seconds (5-120, default 30)'),
+};
+
+export async function handleWebFetch(input: {
+  url: string;
+  max_chars?: number;
+  timeout_seconds?: number;
+}): Promise<ToolResult> {
+  const url = normalizeUrl(input.url);
+  if (!url) return errorResult('url cannot be empty.');
+
+  const maxChars = Math.max(500, Math.min(input.max_chars ?? 12000, 50000));
+  const timeoutMs = Math.max(5, Math.min(input.timeout_seconds ?? 30, 120)) * 1000;
+
+  let data: FetchResult;
+  try {
+    data = await fetchWebpage(url, timeoutMs);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResult(`Failed to fetch webpage: ${message}`);
+  }
+
+  const lines: string[] = [`URL: ${data.url}`, `Status: ${data.statusCode}`];
+  if (data.title) lines.push(`Title: ${data.title}`);
+  lines.push('Content:');
+  lines.push(clipText(data.content || '[empty]', maxChars));
+
+  return successResult(lines.join('\n'));
+}
+
+export const webFetchTools = [
+  {
+    name: 'cat_cafe_web_fetch',
+    description:
+      'Fetch webpage text content from a URL. Returns HTTP status, page title, and plain text content. ' +
+      'Useful for models that do not have built-in web search — use this to retrieve information from web pages.',
+    inputSchema: webFetchInputSchema,
+    handler: handleWebFetch,
+  },
+] as const;

--- a/packages/mcp-server/test/tool-registration.test.js
+++ b/packages/mcp-server/test/tool-registration.test.js
@@ -65,6 +65,8 @@ const EXPECTED_TOOLS = [
   'limb_invoke',
   'limb_pair_list',
   'limb_pair_approve',
+  // Web fetch tools
+  'cat_cafe_web_fetch',
 ];
 
 const EXPECTED_COLLAB_TOOLS = [

--- a/packages/mcp-server/test/web-fetch-tools.test.js
+++ b/packages/mcp-server/test/web-fetch-tools.test.js
@@ -1,0 +1,180 @@
+/**
+ * MCP Web Fetch Tools Tests
+ * 测试 cat_cafe_web_fetch 的网页抓取、HTML 清理、错误处理。
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+describe('MCP Web Fetch Tools', () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test('handleWebFetch returns title and plain text from HTML', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    globalThis.fetch = async () => ({
+      ok: true,
+      url: 'https://example.com',
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'text/html; charset=utf-8' }),
+      text: async () =>
+        '<html><head><title>Hello World</title></head><body>' +
+        '<script>var x=1;</script><style>.a{color:red}</style>' +
+        '<p>Some &amp; content here.</p></body></html>',
+    });
+
+    const result = await handleWebFetch({ url: 'https://example.com' });
+
+    assert.equal(result.isError, undefined);
+    const text = result.content[0].text;
+    assert.ok(text.includes('URL: https://example.com'));
+    assert.ok(text.includes('Status: 200'));
+    assert.ok(text.includes('Title: Hello World'));
+    assert.ok(text.includes('Some & content here.'));
+    // Script and style content should be stripped
+    assert.ok(!text.includes('var x=1'));
+    assert.ok(!text.includes('color:red'));
+  });
+
+  test('handleWebFetch normalizes URL without protocol', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    let capturedUrl;
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        url,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+        text: async () => 'plain content',
+      };
+    };
+
+    await handleWebFetch({ url: 'example.com/page' });
+    assert.equal(capturedUrl, 'https://example.com/page');
+  });
+
+  test('handleWebFetch returns error for empty URL', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    const result = await handleWebFetch({ url: '' });
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('empty'));
+  });
+
+  test('handleWebFetch truncates long content', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    const longText = 'A'.repeat(60000);
+    globalThis.fetch = async () => ({
+      ok: true,
+      url: 'https://example.com',
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'text/plain' }),
+      text: async () => longText,
+    });
+
+    const result = await handleWebFetch({ url: 'https://example.com', max_chars: 1000 });
+    const text = result.content[0].text;
+    assert.ok(text.includes('...[truncated]'));
+    // Content line should be at most ~1000 chars + truncation marker
+    const contentLine = text.split('Content:\n')[1];
+    assert.ok(contentLine.length < 1100);
+  });
+
+  test('handleWebFetch falls back to Jina on 403', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    let callCount = 0;
+    globalThis.fetch = async (url) => {
+      callCount++;
+      if (callCount === 1) {
+        // First call returns 403
+        return {
+          ok: false,
+          url,
+          status: 403,
+          statusText: 'Forbidden',
+          headers: new Headers(),
+          text: async () => 'Forbidden',
+        };
+      }
+      // Second call is Jina reader
+      assert.ok(String(url).includes('r.jina.ai/'));
+      return {
+        ok: true,
+        url,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+        text: async () => 'Jina reader content',
+      };
+    };
+
+    const result = await handleWebFetch({ url: 'https://blocked.com' });
+    assert.equal(result.isError, undefined);
+    assert.ok(result.content[0].text.includes('Jina reader content'));
+    assert.equal(callCount, 2);
+  });
+
+  test('handleWebFetch returns error on network failure', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    globalThis.fetch = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+
+    const result = await handleWebFetch({ url: 'https://example.com' });
+    assert.equal(result.isError, true);
+    assert.ok(result.content[0].text.includes('ECONNREFUSED'));
+  });
+
+  test('handleWebFetch clamps max_chars and timeout_seconds', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    globalThis.fetch = async () => ({
+      ok: true,
+      url: 'https://example.com',
+      status: 200,
+      headers: new Headers({ 'Content-Type': 'text/plain' }),
+      text: async () => 'B'.repeat(100),
+    });
+
+    // max_chars below minimum should still work (clamped to 500)
+    const result = await handleWebFetch({
+      url: 'https://example.com',
+      max_chars: 1,
+      timeout_seconds: 1,
+    });
+    assert.equal(result.isError, undefined);
+  });
+
+  test('handleWebFetch decodes DuckDuckGo redirect', async () => {
+    const { handleWebFetch } = await import('../dist/tools/web-fetch-tools.js');
+
+    let capturedUrl;
+    globalThis.fetch = async (url) => {
+      capturedUrl = url;
+      return {
+        ok: true,
+        url,
+        status: 200,
+        headers: new Headers({ 'Content-Type': 'text/plain' }),
+        text: async () => 'content',
+      };
+    };
+
+    await handleWebFetch({
+      url: 'https://duckduckgo.com/l/?uddg=https%3A%2F%2Freal-site.com%2Fpage',
+    });
+    assert.equal(capturedUrl, 'https://real-site.com/page');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `cat_cafe_web_fetch` MCP tool — enables models without built-in web search to fetch and read web page content
- Ported from relay-claw `web_fetch_tools.py`, rewritten in TypeScript with Node.js native `fetch`
- Features: URL normalization, DuckDuckGo redirect decode, HTML→plain text stripping, Jina Reader fallback (401/403/429), configurable max_chars/timeout

## Test plan
- [x] 8 unit tests covering: HTML parsing, URL normalization, empty URL, truncation, Jina fallback, network error, param clamping, DDG redirect
- [x] Registration regression test updated (72/72 pass)
- [x] `pnpm build` passes
- [ ] Manual integration test with a model that lacks web search

🐾 [宪宪/Opus-46🐾]
🤖 Generated with [Claude Code](https://claude.com/claude-code)