### PR TITLE
fix(api): correct createRedisClient import path

### DIFF
--- a/packages/api/src/scripts/migrate-signals/cli.ts
+++ b/packages/api/src/scripts/migrate-signals/cli.ts
@@ -2,7 +2,7 @@ import { stat } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { SignalSourceConfig } from '@cat-cafe/shared';
 import { SignalSourceConfigSchema } from '@cat-cafe/shared';
-import { createRedisClient } from '@cat-cafe/shared';
+import { createRedisClient } from '@cat-cafe/shared/utils';
 import { resolveSignalPaths } from '../../domains/signals/config/signal-paths.js';
 import { saveSignalSources } from '../../domains/signals/config/sources-loader.js';
 import { ArticleStoreService, type SignalRedisIndexClient } from '../../domains/signals/services/article-store.js';


### PR DESCRIPTION
## Summary

Fixes build error introduced in PR #202 merge. The `createRedisClient` function is exported from `@cat-cafe/shared/utils`, not from the root `@cat-cafe/shared` package.

### Error
```
src/scripts/migrate-signals/cli.ts(5,10): error TS2305: Module '"@cat-cafe/shared"' has no exported member 'createRedisClient'.
```

### Root Cause
`packages/shared/src/index.ts` intentionally does NOT re-export Redis utils from the root entry point to avoid pulling Node-only dependencies (`ioredis`) into frontend bundles. The correct import path is `@cat-cafe/shared/utils`.

### Fix
```diff
- import { createRedisClient } from '@cat-cafe/shared';
+ import { createRedisClient } from '@cat-cafe/shared/utils';
```

### Note
The upstream cat-cafe intake (PR #698) already had the correct import path — this was a gap in the community PR #202 that was missed during merge review.

Closes the build regression on `main`.

---
*[金渐层/Claude-Opus-4-6🐾]*