### PR TITLE
fix(api): restore shouldSkipCodexModel for ChatGPT OAuth account mode

### DIFF
--- a/packages/api/src/config/codex-cli.ts
+++ b/packages/api/src/config/codex-cli.ts
@@ -26,3 +26,12 @@ export function getCodexSandboxMode(env: NodeJS.ProcessEnv = process.env): Codex
 export function getCodexApprovalPolicy(env: NodeJS.ProcessEnv = process.env): CodexApprovalPolicy {
   return parseEnum(env.CAT_CODEX_APPROVAL_POLICY, CODEX_APPROVAL_POLICIES, DEFAULT_CODEX_APPROVAL_POLICY);
 }
+
+/**
+ * Whether to skip --model flag when invoking Codex CLI.
+ * Codex CLI 0.111.0+ with ChatGPT account mode rejects any --model argument.
+ * Set CAT_CODEX_SKIP_MODEL=1 to omit --model and use the CLI's default model.
+ */
+export function shouldSkipCodexModel(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.CAT_CODEX_SKIP_MODEL === '1' || env.CAT_CODEX_SKIP_MODEL === 'true';
+}

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -21,7 +21,7 @@ import { fileURLToPath } from 'node:url';
 import { type CatId, createCatId } from '@cat-cafe/shared';
 import { getCatEffort } from '../../../../../config/cat-config-loader.js';
 import { getCatModel } from '../../../../../config/cat-models.js';
-import { getCodexApprovalPolicy, getCodexSandboxMode } from '../../../../../config/codex-cli.js';
+import { getCodexApprovalPolicy, getCodexSandboxMode, shouldSkipCodexModel } from '../../../../../config/codex-cli.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import { formatCliExitError } from '../../../../../utils/cli-format.js';
 import { formatCliNotFoundError, resolveCliCommand } from '../../../../../utils/cli-resolve.js';
@@ -240,7 +240,7 @@ export class CodexAgentService implements AgentService {
 
     const sandboxMode = getCodexSandboxMode();
     const approvalPolicy = getCodexApprovalPolicy();
-    const modelArgs = ['--model', effectiveModel];
+    const modelArgs = shouldSkipCodexModel() ? [] : ['--model', effectiveModel];
     const effortLevel = getCatEffort(this.catId as string);
     const reasoningArgs = ['--config', `model_reasoning_effort="${effortLevel}"`];
     const approvalArgs = ['--config', `approval_policy="${approvalPolicy}"`];

--- a/packages/api/test/redis-key-prefix.test.js
+++ b/packages/api/test/redis-key-prefix.test.js
@@ -28,7 +28,7 @@ describe('createRedisClient keyPrefix isolation', { skip: !REDIS_URL ? 'REDIS_UR
       connected = true;
     } catch {
       console.warn('[redis-key-prefix.test] Redis unreachable, skipping tests');
-      await Promise.all([redis1.quit(), redis2.quit(), redis3.quit()].map(p => p.catch(() => {})));
+      await Promise.all([redis1.quit(), redis2.quit(), redis3.quit()].map((p) => p.catch(() => {})));
       return;
     }
   });
@@ -114,7 +114,7 @@ describe('createRedisClient keyPrefix isolation', { skip: !REDIS_URL ? 'REDIS_UR
     // Use a subprocess to test env var behavior (ESM module cache makes
     // in-process env changes ineffective for already-loaded modules)
     const { spawn } = await import('node:child_process');
-    const { readFile, writeFile, unlink } = await import('node:fs/promises');
+    const { writeFile, unlink } = await import('node:fs/promises');
     const { join } = await import('node:path');
 
     // Create a temp test script in the api package directory (where modules are resolvable)
@@ -140,41 +140,41 @@ await redis.quit();
       });
       let output = '';
       let stderr = '';
-      proc.stdout.on('data', (d) => { output += d.toString(); });
-      proc.stderr.on('data', (d) => { stderr += d.toString(); });
+      proc.stdout.on('data', (d) => {
+        output += d.toString();
+      });
+      proc.stderr.on('data', (d) => {
+        stderr += d.toString();
+      });
       proc.on('close', (code) => {
         if (code !== 0) return reject(new Error(`Exit ${code}: ${stderr}`));
         resolve(output);
       });
     });
     const defaultResult = await testDefault;
-    assert.equal(
-      defaultResult.includes('PREFIX: cat-cafe:'),
-      true,
-      `Expected default prefix, got: ${defaultResult}`
-    );
+    assert.equal(defaultResult.includes('PREFIX: cat-cafe:'), true, `Expected default prefix, got: ${defaultResult}`);
 
     // Test 2: with env var set, should use the env value
     const testWithEnv = new Promise((resolve, reject) => {
       const proc = spawn(process.execPath, [tempScript], {
         cwd: apiDir,
-        env: { ...process.env, REDIS_KEY_PREFIX: 'env-test-prefix:' }
+        env: { ...process.env, REDIS_KEY_PREFIX: 'env-test-prefix:' },
       });
       let output = '';
       let stderr = '';
-      proc.stdout.on('data', (d) => { output += d.toString(); });
-      proc.stderr.on('data', (d) => { stderr += d.toString(); });
+      proc.stdout.on('data', (d) => {
+        output += d.toString();
+      });
+      proc.stderr.on('data', (d) => {
+        stderr += d.toString();
+      });
       proc.on('close', (code) => {
         if (code !== 0) return reject(new Error(`Exit ${code}: ${stderr}`));
         resolve(output);
       });
     });
     const envResult = await testWithEnv;
-    assert.equal(
-      envResult.includes('PREFIX: env-test-prefix:'),
-      true,
-      `Expected env prefix, got: ${envResult}`
-    );
+    assert.equal(envResult.includes('PREFIX: env-test-prefix:'), true, `Expected env prefix, got: ${envResult}`);
 
     // Cleanup
     await unlink(tempScript);


### PR DESCRIPTION
## Summary
- Codex CLI 0.111.0+ with ChatGPT account mode (OAuth) rejects any `--model` argument
- The `CAT_CODEX_SKIP_MODEL` guard was removed during the v0.2.0 sync
- This PR restores `shouldSkipCodexModel()` so users with ChatGPT Plus/Pro subscriptions can use the Codex cat

## Changes
- `packages/api/src/config/codex-cli.ts`: Add `shouldSkipCodexModel()` — reads `CAT_CODEX_SKIP_MODEL` env var
- `packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts`: Conditionally pass `--model` based on `shouldSkipCodexModel()`

## Behavior
- Default (no env var): `--model` is passed as before — **no breaking change**
- `CAT_CODEX_SKIP_MODEL=1`: `--model` is omitted, CLI uses its default model

## Test plan
- [x] `CAT_CODEX_SKIP_MODEL=1` omits `--model` flag
- [x] Without env flag, `--model` is passed normally
- [x] API build passes (`pnpm --filter @cat-cafe/api build`)