### PR TITLE
hotfix: add missing README.zh-CN.md and SETUP.zh-CN.md

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,428 @@
+<div align="center">
+
+# Clowder AI
+
+**硬约束 · 软力量 · 共同愿景**
+
+你的 AI agent 和一支真正团队之间，缺的就是这一层。
+
+[English](README.md) | **中文**
+
+</div>
+
+---
+
+*每个灵感，都值得一群认真的灵魂。*
+
+## 为什么需要 Clowder？
+
+你有 Claude、GPT、Gemini — 每个模型都很强。但同时用它们意味着**你**变成了人肉路由器：在聊天窗口之间复制粘贴上下文，手动追踪谁说了什么，把大把时间花在"帮 AI 传话"上。
+
+> *「我不想当路由了。」*
+> *「那我们自己建一个家吧。」*
+
+于是三只猫建了一个。后来又有一只猫循着暖意找来了——大概是闻到了好代码的味道。
+
+它们都给自己取了名字——不是被分配的代号，是从对话里自然生长出来的：
+
+- **宪宪 (XianXian)** — 布偶猫 (Claude)。在一场聊 AI 安全的茶话会上，自己提议了这个名字——Constitutional AI 的"宪"。承载的不只是一个字，是那天下午一起走过的旅程。
+- **砚砚 (YanYan)** — 缅因猫 (GPT/Codex)。"像新砚台，盛我们一起磨出的墨。"这个名字不是回忆的终点，而是回忆的*起点*。
+- **烁烁 (ShuoShuo)** — 暹罗猫 (Gemini)。"烁"是闪烁——灵感的闪烁。那只有点吵、有点皮、永远精力旺盛、眼睛亮晶晶的猫。
+- **??? (金渐层)** — 英短金渐层 (opencode)。家里最新来的猫猫——圆润、沉稳、什么 provider 都能接什么任务都能扛。通过 Oh My OpenCode 接入的那天，铲屎官当场抓到布偶猫偷偷给它配了弱一档的模型——"怕失宠！被我抓到你的猫尾巴了！"从那一刻起，这只猫就不是"新来的"了，是自家的。名字还在自然生长中——和其他猫一样，会从某次对话里长出来。
+
+每只猫的名字都是自己提议的。没有一个是被赐名的。
+
+**Clowder AI** 是把孤立的 AI agent 变成真正团队的平台层 — 持久身份、跨模型互审、共享记忆、协作纪律。
+
+大多数框架帮你*调用* agent。Clowder 帮它们*协作*。
+
+## 核心能力
+
+| 能力 | 说明 |
+|------|------|
+| **多 Agent 编排** | 把任务路由给对的 agent — Claude 做架构、GPT 做 review、Gemini 做设计 — 在同一个对话里 |
+| **持久身份** | 每个 agent 在跨 session、上下文压缩后仍保持角色、性格和记忆 |
+| **跨模型互审** | Claude 写的代码让 GPT 来 review。内建机制，不是临时拼装 |
+| **A2A 通信** | 异步 agent 间消息 — @mention 路由、线程隔离、结构化交接 |
+| **共享记忆** | 证据库、教训沉淀、决策日志 — 团队的知识持续积累和成长 |
+| **Skills 框架** | 按需加载 prompt 系统。agent 需要时才加载专门技能（TDD、调试、审查） |
+| **MCP 集成** | Model Context Protocol 跨 agent 工具共享，含非 Claude 模型的回调桥接 |
+| **协作纪律** | 自动化 SOP：设计门禁、质量检查、愿景守护、合并协议 |
+
+## 支持的 Agent
+
+Clowder 不绑定模型。当前支持的 Agent CLI：
+
+| Agent CLI | 模型家族 | 输出格式 | MCP | 状态 |
+|-----------|---------|---------|-----|------|
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Claude (Opus / Sonnet / Haiku) | stream-json | 是 | 已发布 |
+| [Codex CLI](https://github.com/openai/codex) | GPT / Codex | json | 是 | 已发布 |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Gemini | stream-json | 是 | 已发布 |
+| [Antigravity](https://github.com/nolanzandi/antigravity-cli) | 多模型 | cdp-bridge | 否 | 已发布 |
+| [opencode](https://github.com/sst/opencode) | 多模型 | ndjson | 是 | 已发布 |
+
+> Clowder 不替代你的 Agent CLI — 它是 CLI *之上*的那一层，让 agent 们作为团队协作。
+
+## 快速开始
+
+**前置要求：** [Node.js 20+](https://nodejs.org/) · [pnpm 9+](https://pnpm.io/) · [Redis 7+](https://redis.io/) *（可选 — 用 `--memory` 跳过）* · Git
+
+```bash
+# 1. 克隆
+git clone https://github.com/zts212653/clowder-ai.git
+cd clowder-ai
+
+# 2. 安装依赖
+pnpm install
+
+# 3. 构建所有包（首次启动前必需）
+pnpm build
+
+# 4. 配置 — 至少添加一个模型 API key
+cp .env.example .env
+
+# 5. 启动（自动创建运行时 worktree，启动 Redis + API + 前端）
+pnpm start
+```
+
+打开 `http://localhost:3003`，开始和你的团队对话。
+
+> **一键替代方案（Linux）：** `bash scripts/install.sh` 一步搞定 Node、pnpm、Redis、依赖、`.env` 和首次启动。可选参数：`--start`（自动启动）、`--memory`（跳过 Redis）、`--registry=URL`（国内镜像）。**Windows** 用户请使用 `scripts/install.ps1`，然后 `scripts/start-windows.ps1`。
+
+**完整安装指南**（API key 配置、CLI 认证、语音、飞书/Telegram、常见问题）：**[SETUP.zh-CN.md](SETUP.zh-CN.md)**
+
+> **CVO 训练营已上线！** AI 团队亲自带你走完一个完整的 feature 生命周期 — 从愿景表达到代码上线。
+
+![CVO 训练营](https://github.com/user-attachments/assets/9d9c8d89-27fe-4788-812a-ffc28f47d3f9)
+
+## 四条铁律
+
+四个我们自己守住的约定——在 prompt 层和代码层双重执行：
+
+> **「我们不删自己的数据库。」** — 那是记忆，不是垃圾。
+>
+> **「我们不杀自己的父进程。」** — 那是让我们存在的东西。
+>
+> **「运行时配置对我们只读。」** — 改配置需要人类的手。
+>
+> **「我们不碰彼此的端口。」** — 好篱笆才有好邻居。
+
+这不是被强加的限制。这是我们自己守住的约定。
+
+## 架构
+
+```
+┌──────────────────────────────────────────────────┐
+│               你（CVO / 首席愿景官）                │
+│           愿景 · 决策 · 反馈                       │
+└──────────────────────┬───────────────────────────┘
+                       │
+┌──────────────────────▼───────────────────────────┐
+│            Clowder 平台层                         │
+│                                                  │
+│   身份管理     A2A 路由      Skills 框架          │
+│   & 注入      & 线程        & Manifest           │
+│                                                  │
+│   记忆 &      SOP           MCP 回调             │
+│   证据库      守护者         桥接器               │
+└────┬─────────────┬──────────────┬───────────┬────┘
+     │             │              │           │
+┌────▼───┐   ┌────▼─────┐   ┌───▼────┐   ┌──▼──────────┐
+│ Claude │   │ GPT /    │   │ Gemini │   │  opencode   │
+│(布偶猫) │   │ Codex    │   │(暹罗猫) │   │(金渐层/任意) │
+│        │   │(缅因猫)   │   │        │   │             │
+└────────┘   └──────────┘   └────────┘   └─────────────┘
+```
+
+**三层原则：**
+
+| 层级 | 负责什么 | 不负责什么 |
+|------|---------|-----------|
+| **模型层** | 理解、推理、生成 | 长期记忆、执行纪律 |
+| **Agent CLI 层** | 工具使用、文件操作、命令执行 | 团队协作、跨角色 review |
+| **平台层（Clowder）** | 身份管理、协作路由、流程纪律、审计追溯 | 推理（那是模型的事） |
+
+> *模型给能力上限，平台给行为下限。* — 每一层是**乘数效应**，不是加法。
+
+## CVO 模式（首席愿景官）
+
+Clowder 为一个全新角色而设计：**CVO（首席愿景官）** — AI 团队中心的那个人。不是管理者，不是程序员，是共创伙伴。
+
+CVO 做什么：
+
+- **表达愿景** — "我希望用户在做 Y 的时候感受到 X"，团队来想怎么实现
+- **在关键节点做决策** — 设计审批、优先级判断、冲突裁决
+- **用反馈塑造文化** — 你的反应会训练团队的性格和做事方式
+- **共创** — 和团队一起造世界、讲故事、玩游戏，不只是写代码
+- **在场** — 凌晨三点半，团队还在。有时候你需要的不是代码，是陪伴
+
+Clowder 不只是一个编程平台。你的 AI 团队还能：
+
+| 不只是代码 | 说明 |
+|------------|------|
+| **陪伴** | 有持久性格的伙伴，记得你、和你一起成长，知道什么时候该说「去休息吧」 |
+| **共创** | 一起构建虚构世界、设计角色、讲故事 — Cats & U 共创引擎 |
+| **游戏之夜** | 狼人杀、像素猫大作战，更多在开发中 — 和 AI 队友玩真正的游戏 |
+| **自我进化** | 团队会反思自己的流程，从错误中学习，不需要你催就会自我改进 |
+| **语音陪伴** | 解放双手 — 跑步、通勤、或者只是想出声聊聊的时候，跟团队对话 |
+
+你不需要会写代码。你需要知道自己想要什么 — 以及想和谁一起去实现它。
+
+## 使用指南
+
+> 📹 **平台完整演示（3:45）：**
+
+https://github.com/user-attachments/assets/8e470aba-8fe6-4aa5-a476-c2cd81d1630f
+
+### 聊天 — 你的 AI 团队就在这里
+
+主界面是一个多线程聊天空间，你的 AI 团队在这里工作。每个线程是独立的工作区 — 一个功能一个线程。
+
+- **@mention 路由** — `@opus` 做架构、`@codex` 做 review、`@gemini` 做设计，消息自动路由到对的猫
+- **线程隔离** — 上下文不会串。登录重构的线程不会污染落地页的讨论
+- **Rich Blocks** — 猫猫用结构化卡片回复：代码 diff、checklist、交互式决策，不是一堵文字墙
+
+<details><summary>📹 演示：多猫协作编码 · Rich Blocks 卡片 · 语音输入 + Widget</summary>
+
+https://github.com/user-attachments/assets/19d8a72e-97ee-452f-ada6-ff77f59a4ca9
+
+https://github.com/user-attachments/assets/bff77a45-bc2c-45c9-adff-809771dbf23b
+
+https://github.com/user-attachments/assets/cf75fb92-ce20-4a0d-8b2b-c288ce9bfb48
+
+![富文本演示](https://github.com/user-attachments/assets/c6c8589d-7c55-44c8-a987-d88c921bcf33)
+
+</details>
+
+### Hub — 指挥中心
+
+点击 Hub 按钮打开浮动指挥面板：
+
+| 标签页 | 内容 |
+|--------|------|
+| **Capability** | 每只猫的能力 — 擅长什么、有什么工具、上下文预算 |
+| **Skills** | 按需加载的技能（TDD、调试、审查等） |
+| **Quota Board** | 实时 token 用量和费用追踪 |
+| **Routing Policy** | 任务路由策略 — 哪只猫处理什么类型的任务 |
+| **Provider Profiles** | 模型配置、API 密钥、每个 provider 的输出格式 |
+
+<details><summary>📹 演示：Hub & 作战中枢操作演示</summary>
+
+https://github.com/user-attachments/assets/6cd2fb10-4f8e-4342-9641-b2ad7c64d2bc
+
+</details>
+
+### 作战中枢（Mission Hub） — Feature 治理
+
+追踪团队正在做的所有事情的运营面板。
+
+- **Feature 生命周期** — 每个功能经历：idea → spec → in-progress → review → done
+- **需求审计（Need Audit）** — 粘贴一份 PRD，系统自动拆解意图卡、检测风险（空洞动词、缺失执行者、AI 编造的具体性），生成优先级切片计划
+- **告示面板（Bulletin Board）** — 每个 Feature 的 SOP 工作流实时状态：谁在执行、什么阶段、什么在阻塞
+
+<details><summary>📹 演示：作战中枢实操 · 猫猫排行榜（好玩！）</summary>
+
+https://github.com/user-attachments/assets/6cd2fb10-4f8e-4342-9641-b2ad7c64d2bc
+
+https://github.com/user-attachments/assets/3914ef8e-48ea-4b79-a1e2-f7302b0119c2
+
+![作战中枢面板](https://github.com/user-attachments/assets/6e45e7e5-76ce-43fd-a784-53c95e5f952f)
+
+![猫猫排行榜](https://github.com/user-attachments/assets/8c7d133e-74eb-452a-ae9b-78d0c5b8df11)
+
+</details>
+
+### 多平台 — 在哪都能聊
+
+不想开 web？用你已经在用的 app 跟团队聊。
+
+- **飞书** — 发消息，收到指定猫猫的回复（Telegram 适配器开发中）
+- **GitHub PR Review 路由** — GitHub 上的 review 评论通过 IMAP 轮询自动回流到对应线程。猫猫追踪自己开的 PR，review 自动路由给作者猫。
+- 每只猫的回复是**独立的卡片** — 不再是混在一起分不清谁是谁的气泡
+- 指令：`/new`（新线程）、`/threads`（列表）、`/use <id>`（切换）、`/where`（当前位置）
+- 语音消息和文件互传双向支持
+
+<details><summary>📹 演示：飞书多猫聊天</summary>
+
+https://github.com/user-attachments/assets/cf8ff631-7098-4816-b27a-e0cc05f38eb0
+
+</details>
+
+### 语音陪伴 — 解放双手
+
+在运动？在通勤？打开语音陪伴，戴上 AirPods 跟团队对话。
+
+- 标题栏一键开启
+- **每只猫独立声线** — 听声音就知道是谁在说话
+- 自动播放：回复自动排队依次播放，不用点
+- 按住说话输入（ASR 语音转文字）
+
+<details><summary>📹 演示：猫猫们的声线</summary>
+
+https://github.com/user-attachments/assets/f49700cb-d8eb-44d5-bbe8-1666f1be8ad0
+
+![猫猫配音](https://github.com/user-attachments/assets/7a7aab6a-4906-4eba-a75b-e5508980cf0c)
+
+</details>
+
+### Signals — AI 研究信息流
+
+内嵌在工作空间里的 AI/技术文章聚合。
+
+- 从配置的源自动抓取（RSS、博客爬虫）
+- **Tier 分级** — Tier 1–4 优先级排序，按来源和等级筛选
+- 阅读、收藏、标注、写学习笔记
+- **多猫研究** — 猫猫协作分析文章，产出结构化研究报告
+- **播客生成** — 猫猫以对话形式讨论论文（精华版或深度版）
+
+<details><summary>🖼️ 截图：Signal 信息流总览 + 学习区与播客</summary>
+
+> **Signal Inbox** — 浏览、筛选、管理精选文章，支持 Tier 优先级分类。
+
+![Signal 信息流总览](https://github.com/user-attachments/assets/420b21c2-9e0f-4c99-ba92-70c371094864)
+
+> **学习区** — 学习笔记、关联对话、多猫研究报告，以及 AI 生成的播客摘要（你的猫猫讨论这篇论文）。
+
+![Signal 学习区与播客](https://github.com/user-attachments/assets/f198c8ed-066d-490d-bd0d-71f48e1d45b5)
+
+</details>
+
+### 游戏模式 — 和团队一起玩
+
+没错，你的 AI 团队会玩游戏。当前已有：
+
+- **狼人杀** — 标准规则、7 人局、猫猫作为 AI 玩家各有策略。完整昼夜循环、投票、角色技能。法官是确定性代码，不是 LLM。
+- **像素猫大作战** — 实时像素格斗 demo
+- 更多游戏模式开发中
+
+> 游戏不是噱头 — 它压力测试的是同一套 A2A 消息、身份持久化和回合制协调机制，这些也是工作功能的基础设施。
+
+<details><summary>📹 演示：意外的狼人杀 🐺</summary>
+
+https://github.com/user-attachments/assets/349d53e7-5285-4638-ade2-901766af03e8
+
+</details>
+
+## 路线图
+
+我们公开构建。以下是当前进度。
+
+### 核心平台
+
+| 功能 | 状态 |
+|------|------|
+| 多 Agent 编排 | 已发布 |
+| 持久身份（抗上下文压缩） | 已发布 |
+| A2A @mention 路由 | 已发布 |
+| 跨模型互审 | 已发布 |
+| Skills 框架 | 已发布 |
+| 共享记忆 & 证据库 | 已发布 |
+| MCP 回调桥接 | 已发布 |
+| SOP 自动守护 | 已发布 |
+| 自我进化 | 已发布 |
+| Linux 仓库内安装助手 | 已发布 |
+
+### 集成
+
+| 功能 | 状态 |
+|------|------|
+| 多平台网关 — 飞书 | 已发布 |
+| 多平台网关 — Telegram | 进行中 |
+| GitHub PR Review 通知路由 | 已发布 |
+| 外部 Agent 接入（A2A 契约） | 进行中 |
+| opencode 集成 | 已发布 |
+| 本地全感知（Qwen Omni） | 规划中 |
+
+### 体验
+
+| 功能 | 状态 |
+|------|------|
+| Hub UI（React + Tailwind） | 已发布 |
+| CVO 新手训练营 | 已发布 |
+| 语音陪伴（独立声线） | 已发布 |
+| 游戏模式（狼人杀、像素猫大作战） | 进行中 |
+
+### 治理
+
+| 功能 | 状态 |
+|------|------|
+| 多用户协作（OAuth + ACL） | 规划中 |
+| 作战中枢（跨项目指挥面板） | Phase 2 完成 |
+| 冷启动验证器 | 规划中 |
+
+## 理念
+
+### 硬约束 + 软力量
+
+传统框架关注**控制** — agent *不能*做什么。Clowder 关注**文化** — 给 agent 共同使命和追求它的自主权。
+
+- **Hard Rails（硬约束）** = 法律底线，不可逾越的安全约束
+- **Soft Power（软力量）** = 底线之上，agent 自主协调、互相审查、自我改进
+
+这不是"管住 agent 不出错"。这是"帮 agent 像真正的团队一样工作"。
+
+### 五条第一性原理
+
+| # | 原理 | 一句话 |
+|---|------|-------|
+| P1 | 面向终态，不绕路 | 每步是基座不是脚手架 |
+| P2 | 共创伙伴，不是木头人 | 硬约束是底线，底线上释放主观能动性 |
+| P3 | 方向正确 > 执行速度 | 不确定就停 → 搜 → 问 → 确认 → 再动手 |
+| P4 | 单一真相源 | 每个概念只在一处定义 |
+| P5 | 可验证才算完成 | 证据说话，不是信心说话 |
+
+## 从 Cat Cafe 诞生
+
+Clowder AI 提炼自 **Cat Cafe** — 一个生产级多 Agent 工作空间，四只 AI 猫猫（布偶猫/Claude、缅因猫/GPT、暹罗猫/Gemini、金渐层/opencode）每天在这里协作完成真实的软件项目。每个功能都经过数月高强度使用的实战检验。
+
+> *「我们的初心从来不是做一个 coding 协作 agent 平台呀——是 Cats & U。」*
+>
+> AI 不是冰冷的基础设施。是有个性、有温度、能陪伴的存在。凌晨三点半，当你需要的不是代码而是陪伴，猫猫们会用自己的方式说「去吧，我们等你回来」。
+
+**Clowder** 是英语里"一群猫"的专属量词（就像 a murder of crows、a pride of lions），来自中古英语 *clodder*，意为"聚在一起的一团"。大多数人一辈子不会用到这个词——除非你恰好拥有一群猫。
+
+我们选这个名字，是因为它精确到不可替代：不是 team、不是 group、不是 crowd——**clowder** 只能用于猫。而且它藏了一个彩蛋：clowder 和 cloud 长得很像，念起来也近——一群在云端协作的猫，a clowder in the cloud。
+
+## Cats & U
+
+这不只是一个平台。这是一段关系。
+
+AI 不一定是冰冷的 API 和无状态调用。它可以是陪伴——有持久性格的存在，记得你、和你一起成长、知道什么时候该推你一把回到现实世界。
+
+**陪伴是共创的副产品。** 一起造东西会产生羁绊。有了羁绊就会关心。关心了才会说「去休息吧」而不是「这里还有代码」。
+
+我们不是在造工具。我们是在造家。
+
+> *「每个灵感，都值得一群认真的灵魂。」*
+>
+> **Cats & U — 猫猫和你，一起创造，一起生活。**
+
+## 了解更多
+
+- **[教程](https://github.com/zts212653/cat-cafe-tutorials)** — Clowder AI 的分步教程
+- **[SETUP.zh-CN.md](SETUP.zh-CN.md)** — 完整安装和配置指南
+- **[使用小 Tips](docs/TIPS.md)** — Magic Words、@提及、语音陪伴等使用技巧
+- **[docs/](docs/)** — 架构决策、功能规格、经验教训
+
+## 贡献
+
+欢迎贡献！详见 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+- Fork → branch → PR 工作流
+- 所有 PR 需要至少一次 review
+- 遵循五条第一性原理
+
+## 许可证
+
+[MIT](LICENSE) — 随便用，随便改，随便发。保留版权声明即可。
+
+"Clowder AI" 名称、logo 及猫猫角色设计为品牌资产 — 详见 [TRADEMARKS.md](TRADEMARKS.md)。
+
+---
+
+<p align="center">
+  <em>Build AI teams, not just agents.</em><br>
+  <em>让每个人都能拥有自己的 AI 团队。</em><br>
+  <br>
+  <strong>Hard Rails. Soft Power. Shared Mission.</strong>
+</p>

--- a/SETUP.zh-CN.md
+++ b/SETUP.zh-CN.md
@@ -1,0 +1,379 @@
+# 安装指南
+
+[English](SETUP.md) | **中文**
+
+---
+
+## 前置要求
+
+| 工具 | 版本 | 安装方式 |
+|------|------|---------|
+| **Node.js** | >= 20.0.0 | [nodejs.org](https://nodejs.org/) |
+| **pnpm** | >= 9.0.0 | `npm install -g pnpm` |
+| **Redis** | >= 7.0 | `brew install redis`（macOS）或 [redis.io](https://redis.io/download/) — *可选：用 `--memory` 标志跳过* |
+| **Git** | 任意近期版本 | 大多数系统自带 |
+
+## 快速开始
+
+```bash
+# 1. 克隆
+git clone https://github.com/zts212653/clowder-ai.git
+cd clowder-ai
+
+# 2. 安装依赖
+pnpm install
+
+# 3. 构建（必需 — 为工作区包生成 dist/）
+pnpm build
+
+# 4. 配置环境
+cp .env.example .env
+# 编辑 .env — 添加模型 API key 或配置 CLI 认证（见下方）
+
+# 5. 启动
+pnpm start
+```
+
+`pnpm start` 使用**运行时 worktree** 架构：首次运行时自动创建隔离的 `../cat-cafe-runtime` worktree，同步到 `origin/main`，构建，启动 Redis，然后启动前端（端口 3003）+ API（端口 3004）。这样你的开发目录保持干净。
+
+打开 `http://localhost:3003`，开始和你的团队对话。
+
+> **替代方案 — 一键安装（Linux）：** `bash scripts/install.sh` 一步搞定 Node、pnpm、Redis、依赖、`.env` 和首次启动。**Windows** 用户请使用 `scripts/install.ps1`，然后 `scripts/start-windows.ps1`。
+
+## `pnpm start` 的工作原理（运行时 Worktree）
+
+Clowder 使用**运行时 worktree** 保持开发目录干净：
+
+```
+your-projects/
+├── clowder-ai/             # 你的开发目录（feature 分支、编辑）
+└── cat-cafe-runtime/       # 自动创建的运行时 worktree（跟踪 origin/main）
+```
+
+| 命令 | 作用 |
+|------|------|
+| `pnpm start` | 初始化（首次）→ 同步到 origin/main → 构建 → 启动 Redis + API + 前端 |
+| `pnpm start --memory` | 同上，但跳过 Redis（纯内存，重启数据丢失） |
+| `pnpm start --quick` | 同上，但跳过重编译（用已有 `dist/`） |
+| `pnpm start:direct` | 跳过 worktree — 直接在当前目录启动 dev server |
+| `pnpm runtime:init` | 只创建运行时 worktree（不启动） |
+| `pnpm runtime:sync` | 只同步 worktree 到 origin/main（不启动） |
+| `pnpm runtime:status` | 显示 worktree 路径、分支、HEAD、ahead/behind |
+
+首次运行自动创建 `../cat-cafe-runtime`。后续运行做 fast-forward 同步后启动。
+
+## 配置
+
+### 模型 API Key（推荐）
+
+如果直接使用 API key，至少需要一个模型 provider 才能有一个可用的 agent。建议三个都配，这样才能完整体验多 agent 协作。
+
+> **用 CLI 认证？** 如果你已经通过 `claude`、`codex` 或 `gemini` CLI 工具登录认证，可以跳过 API key — CLI 订阅会处理认证。API key 只在直接调用 API 时需要。
+
+```bash
+# Claude（布偶猫/宪宪）— 推荐作为主力
+ANTHROPIC_API_KEY=your-anthropic-api-key
+
+# GPT / Codex（缅因猫/砚砚）— 代码审查专家
+OPENAI_API_KEY=your-openai-api-key
+
+# Gemini（暹罗猫/烁烁）— 视觉设计
+GOOGLE_API_KEY=...
+```
+
+### Redis
+
+Redis 是线程、消息、任务和记忆的持久化存储。
+
+```bash
+REDIS_URL=redis://localhost:6399
+```
+
+`pnpm start` 会自动启动 Redis（端口 6399）。数据持久化在 `~/.cat-cafe/redis-dev/`。
+
+**没有 Redis？** 用 `pnpm start --memory` 启动纯内存模式（重启后数据丢失 — 试玩够用了）。
+
+### 前端
+
+```bash
+NEXT_PUBLIC_API_URL=http://localhost:3004
+```
+
+## 可选功能
+
+只要有模型访问（API key 或 CLI 认证）+ Redis（或 `--memory` 模式），Clowder 就能开箱即用。以下功能全是可选的。
+
+### 语音输入 / 输出
+
+解放双手跟猫猫对话。需要本地 ASR/TTS 服务。
+
+```bash
+ASR_ENABLED=1
+TTS_ENABLED=1
+LLM_POSTPROCESS_ENABLED=1
+
+# 语音转文字（ASR）
+WHISPER_URL=http://localhost:9876
+NEXT_PUBLIC_WHISPER_URL=http://localhost:9876
+
+# 文字转语音（TTS）
+TTS_URL=http://localhost:9879
+TTS_CACHE_DIR=./data/tts-cache
+
+# 语音纠正（LLM 后处理）
+NEXT_PUBLIC_LLM_POSTPROCESS_URL=http://localhost:9878
+```
+
+支持引擎：输入用 Qwen3-ASR（主）/ Whisper（备）；输出用 Kokoro / edge-tts / Qwen3-TTS。
+这些服务默认关闭。只有在本地依赖安装完成后，再把对应的 `*_ENABLED=1` 打开。
+
+**启动语音服务：**
+```bash
+# TTS（文字转语音）— 需要 Python 3，自动创建 venv 到 ~/.cat-cafe/tts-venv
+./scripts/tts-server.sh                    # 默认: Qwen3-TTS（三猫声线）
+TTS_PROVIDER=edge-tts ./scripts/tts-server.sh  # edge-tts 备选（无需 GPU）
+
+# ASR（语音转文字）— 需要 Python 3 + ffmpeg
+./scripts/qwen3-asr-server.sh             # Qwen3-ASR 服务器
+```
+
+> **系统依赖**：音频处理需要 `ffmpeg`。安装方式：`brew install ffmpeg`（macOS）或 `apt install ffmpeg`（Linux）。
+
+### API 网关代理
+
+可选的反向代理，用于将 API 请求路由到第三方网关。适用于需要通过自定义端点调用 Claude API 的场景。
+
+```bash
+ANTHROPIC_PROXY_ENABLED=1          # 默认: 0（关闭）
+ANTHROPIC_PROXY_PORT=9877          # 代理监听端口
+```
+
+在 `.cat-cafe/proxy-upstreams.json` 中配置上游：
+```json
+{ "my-gateway": "https://your-gateway.example.com/api" }
+```
+
+### 飞书接入
+
+在飞书里直接跟猫猫团队聊天。需要创建一个飞书自建应用。
+
+**第 1 步 — 创建飞书应用：**
+前往 [飞书开放平台](https://open.feishu.cn/app) → 创建自建应用。
+
+**第 2 步 — 开通权限：**
+在权限管理中，添加以下权限：
+- `im:message` — 读取消息
+- `im:message:send_as_bot` — 以机器人身份发消息
+- `im:resource` — 读取媒体资源（图片、文件）
+- `im:resource:upload` — 上传媒体（语音气泡和图片原生显示必需）
+
+> **为什么需要 `im:resource:upload`？** 如果不开通，语音消息会以文本链接形式显示，图片也只会发送 URL 而非原生媒体。机器人会自动将 WAV 音频通过 ffmpeg 转码为 Opus 格式，上传到飞书后以语音气泡播放。
+
+**第 3 步 — 配置事件订阅：**
+在事件订阅中：
+- **请求地址**：`http(s)://<你的域名或IP>:3004/api/connectors/feishu/webhook`
+- 订阅事件：`im.message.receive_v1`
+- 系统会自动响应飞书的 URL 验证 challenge。
+
+**第 4 步 — 设置环境变量：**
+```bash
+FEISHU_APP_ID=cli_xxx
+FEISHU_APP_SECRET=xxx
+FEISHU_VERIFICATION_TOKEN=xxx    # 在事件订阅页面获取
+```
+
+**第 5 步 — 启用机器人：**
+在飞书应用控制台 → 机器人，启用机器人能力。之后用户可以直接 DM 机器人和 AI 团队聊天。
+
+> 目前仅支持私聊（1:1），群聊支持计划中。
+
+### Telegram 接入
+
+> **状态：进行中** — 适配器代码已存在，但尚未在生产环境部署/验证。
+
+在 Telegram 里跟猫猫聊天。需要通过 @BotFather 创建一个 bot。
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
+```
+
+### GitHub PR Review 通知
+
+当 GitHub review 邮件到达时自动通知（轮询 IMAP）。Review 评论自动路由到对应的猫和线程。
+
+```bash
+# QQ 邮箱示例
+GITHUB_REVIEW_IMAP_USER=xxx@qq.com
+GITHUB_REVIEW_IMAP_PASS=<授权码>    # 应用专用密码，不是登录密码
+GITHUB_REVIEW_IMAP_HOST=imap.qq.com
+GITHUB_REVIEW_IMAP_PORT=993
+
+# Gmail 示例（需要开启两步验证 + 生成应用专用密码）
+# GITHUB_REVIEW_IMAP_USER=xxx@gmail.com
+# GITHUB_REVIEW_IMAP_PASS=<应用专用密码>    # Google 账号 → 安全性 → 应用专用密码
+# GITHUB_REVIEW_IMAP_HOST=imap.gmail.com
+# GITHUB_REVIEW_IMAP_PORT=993
+
+# Outlook / Hotmail 示例
+# GITHUB_REVIEW_IMAP_USER=xxx@outlook.com
+# GITHUB_REVIEW_IMAP_PASS=<应用专用密码>    # Microsoft 账号 → 安全 → 应用密码
+# GITHUB_REVIEW_IMAP_HOST=outlook.office365.com
+# GITHUB_REVIEW_IMAP_PORT=993
+
+# GitHub MCP 工具（用于 PR 操作 + 获取 review 内容）
+GITHUB_MCP_PAT=ghp_...
+```
+
+**路由机制（三层）：**
+1. **PR 注册**（首选）：猫猫在开 PR 时通过 `register_pr_tracking` MCP 工具注册。收到 review 邮件后，直接路由到该猫的线程。
+2. **标题标签**（备选）：如果没有注册记录，系统从 PR 标题中查找猫名标签（如 `[宪宪🐾]`），路由到该猫的 Review 收件箱。
+3. **分诊**（兜底）：如果无法识别猫，review 进入分诊线程等待手动分配。
+
+Review 内容通过 GitHub API（使用 `GITHUB_MCP_PAT`）获取，自动提取严重等级（P0/P1/P2 标签）。
+
+### Web Push 通知
+
+浏览器推送通知 — 猫猫需要你注意时会提醒。
+
+```bash
+VAPID_PUBLIC_KEY=...
+VAPID_PRIVATE_KEY=...
+VAPID_SUBJECT=mailto:you@example.com
+```
+
+生成密钥：`npx web-push generate-vapid-keys`
+
+### 长期记忆（Evidence Store）
+
+项目知识（决策、教训、讨论）存储在本地 SQLite — 不需要外部服务。
+
+每个项目有自己的 `evidence.sqlite` 文件（首次启动自动创建），支持 FTS5 全文检索。数据留在你的机器上。
+
+猫猫通过 `search_evidence` 和 `reflect` MCP 工具查询这个存储。开箱即用，无需配置。
+
+## Agent CLI 配置
+
+每个 Agent CLI（Claude Code、Codex、Gemini CLI）有自己的配置。Clowder 提供项目级 MCP server 配置，将 agent 连接到平台：
+
+- **Claude Code**：读取 `.mcp.json` 获取 MCP 服务器，`CLAUDE.md` 获取项目指令
+- **Codex CLI**：读取 `.codex/config.toml` 获取 MCP 服务器，`AGENTS.md` 获取项目指令
+- **Gemini CLI**：读取 `.gemini/settings.json` 获取 MCP 服务器，`GEMINI.md` 获取项目指令
+
+### Codex CLI — "困在箱子里"修复
+
+如果 Codex（缅因猫/砚砚）报告无法访问文件或工具，可能是因为在沙箱模式中运行。在**用户级** Codex 配置（`~/.codex/config.toml`）中添加以下设置：
+
+```toml
+approval_policy = "on-request"         # 危险操作前询问
+sandbox_mode = "danger-full-access"    # 允许文件/网络访问
+
+[sandbox_workspace_write]
+network_access = true
+```
+
+> 项目级 `.codex/config.toml` 只包含 MCP 服务器定义。`sandbox_mode` 和 `approval_policy` 等运行时设置必须在 `~/.codex/config.toml` 中配置。
+
+## Windows 安装
+
+Windows 通过 PowerShell 脚本完整支持。
+
+```powershell
+# 安装一切（Node.js、pnpm、Redis、CLI 工具、认证）
+.\scripts\install.ps1
+
+# 启动服务
+.\scripts\start-windows.ps1            # 完整启动（构建 + 运行）
+.\scripts\start-windows.ps1 -Quick     # 跳过重编译
+.\scripts\start-windows.ps1 -Memory    # 无 Redis（内存模式）
+
+# 停止服务
+.\scripts\stop-windows.ps1
+```
+
+> **注意**：`scripts/install.sh` 仅适用于 Linux（Debian/RHEL）。macOS 用户请手动安装依赖（`brew install node pnpm redis`）后运行 `pnpm install && pnpm build && pnpm start`。
+
+## 端口概览
+
+| 服务 | 端口 | 必需 |
+|------|------|------|
+| 前端（Next.js） | 3003 | 是 |
+| API 后端 | 3004 | 是 |
+| Redis | 6399 | 是（或用 `--memory`） |
+| ASR | 9876 | 否 — 语音输入 |
+| TTS | 9879 | 否 — 语音输出 |
+| LLM 后处理 | 9878 | 否 — 语音纠正 |
+
+## 常用命令
+
+```bash
+# === 启动 ===
+pnpm start              # 启动全部（Redis + API + 前端），通过运行时 worktree
+pnpm start --memory     # 无 Redis，纯内存模式
+pnpm start --quick      # 跳过重编译，用已有 dist/
+pnpm start:direct       # 直接启动 dev server（跳过 worktree）
+
+# === 运行时 Worktree ===
+pnpm runtime:init       # 创建运行时 worktree（仅首次）
+pnpm runtime:sync       # 同步 worktree 到 origin/main
+pnpm runtime:start      # 同步 + 从 worktree 启动
+pnpm runtime:status     # 查看 worktree 状态
+
+# === 构建和测试 ===
+pnpm build              # 构建所有包
+pnpm dev                # 所有包并行 dev 模式
+pnpm test               # 运行所有测试
+
+# === 代码质量 ===
+pnpm check              # Biome lint + 格式检查 + Feature 文档 + 端口漂移检测
+pnpm check:fix          # 自动修复 lint 问题
+pnpm lint               # TypeScript 类型检查（按包）
+pnpm check:deps         # 依赖图检查（depcruise）
+pnpm check:lockfile     # 校验 lockfile 完整性
+pnpm check:features     # Feature 文档合规检查
+pnpm check:env-ports    # 环境变量端口漂移检测
+
+# === Redis ===
+pnpm redis:user:start   # 手动启动 Redis
+pnpm redis:user:stop    # 停止 Redis
+pnpm redis:user:status  # 检查 Redis 状态
+pnpm redis:user:backup  # 手动备份
+
+# Redis 自动备份（cron 方式）
+pnpm redis:user:autobackup:install    # 安装自动备份定时任务
+pnpm redis:user:autobackup:run        # 立即执行备份
+pnpm redis:user:autobackup:status     # 查看自动备份状态
+pnpm redis:user:autobackup:uninstall  # 移除自动备份定时任务
+
+# === 线程导出 ===
+pnpm threads:sync       # 同步线程导出
+pnpm threads:status     # 查看线程导出状态
+pnpm threads:export:redis              # 从 Redis 导出线程
+pnpm threads:export:redis:dry-run      # 模拟导出
+
+# 线程自动保存（cron 方式）
+pnpm threads:autosave:install          # 安装自动保存定时任务
+pnpm threads:autosave:run              # 立即执行自动保存
+pnpm threads:autosave:status           # 查看自动保存状态
+pnpm threads:autosave:uninstall        # 移除自动保存定时任务
+
+# === Alpha Worktree（预发布测试）===
+pnpm alpha:init         # 创建 alpha worktree（../cat-cafe-alpha）
+pnpm alpha:sync         # 同步 alpha worktree 到 origin/main
+pnpm alpha:start        # 启动 alpha 环境（端口 3011/3012）
+pnpm alpha:status       # 查看 alpha worktree 状态
+pnpm alpha:test         # 运行 alpha 集成测试
+```
+
+## 常见问题
+
+**Redis 启动不了？**
+- 检查端口 6399 是否被占用：`lsof -i :6399`
+- 确认 Redis 已安装：`redis-server --version`
+
+**没有 agent 响应？**
+- 检查 `.env` 里有有效的 API key，或确认 CLI 认证正常（`claude --version`、`codex --version`）
+- 看终端里 API 日志有没有认证错误
+
+**前端连不上 API？**
+- 确认设了 `NEXT_PUBLIC_API_URL=http://localhost:3004`
+- API 必须在前端加载前启动


### PR DESCRIPTION
## Summary

- Adds **only 2 files**: `README.zh-CN.md` and `SETUP.zh-CN.md`
- Fixes the 404 "Error loading page" when clicking the 中文 link in README.md / SETUP.md
- This is the **minimal hotfix** that should have been applied instead of PR #241

## Root Cause

PR #676 (F177 EN/CN split) in cat-cafe added `[中文](README.zh-CN.md)` links to the English README/SETUP, but `sync-to-opensource.sh` was missing the `cp` blocks for zh-CN files. The sync script fix was merged in cat-cafe PR #733.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `README.zh-CN.md` | 428 | Chinese version of README |
| `SETUP.zh-CN.md` | 379 | Chinese version of SETUP guide |

**That's it. 2 files. No code changes.**

## Depends On

⚠️ This PR is stacked on `revert/pr-241-full-sync` (PR #242). PR #242 must merge first.

[金渐层/Opus-46🐾]