### PR TITLE
fix: Windows CLI spawn 全路径支持 + ProcessLivenessProbe Windows 兼容

### DIFF
--- a/packages/api/src/utils/ProcessLivenessProbe.ts
+++ b/packages/api/src/utils/ProcessLivenessProbe.ts
@@ -129,7 +129,16 @@ export class ProcessLivenessProbe {
       return;
     }
 
-    // Sample CPU time via ps
+    // Windows: `ps` is not available. Use process.kill(pid, 0) for liveness
+    // and skip CPU sampling (treat as busy-silent when no output).
+    if (process.platform === 'win32') {
+      // PID is alive (checked above). Without CPU data, assume busy if silent.
+      this.cpuGrowing = true;
+      this.emitSilenceWarnings();
+      return;
+    }
+
+    // Sample CPU time via ps (Unix only)
     execFile('ps', ['-o', 'cputime=', '-p', String(this.pid)], (err, stdout) => {
       if (err) {
         // ps failed — process likely dead
@@ -141,16 +150,20 @@ export class ProcessLivenessProbe {
       this.cpuGrowing = this.currCpuTimeMs > this.prevCpuTimeMs;
 
       // Check warning thresholds
-      const silenceMs = Date.now() - this.lastActivityAt;
-
-      if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted) {
-        this.stallWarningEmitted = true;
-        this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
-      } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {
-        this.softWarningEmitted = true;
-        this.warningQueue.push(this.makeWarning('alive_but_silent', silenceMs));
-      }
+      this.emitSilenceWarnings();
     });
+  }
+
+  /** Emit soft/stall warnings based on silence duration (shared by Windows and Unix paths) */
+  private emitSilenceWarnings(): void {
+    const silenceMs = Date.now() - this.lastActivityAt;
+    if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted) {
+      this.stallWarningEmitted = true;
+      this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
+    } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {
+      this.softWarningEmitted = true;
+      this.warningQueue.push(this.makeWarning('alive_but_silent', silenceMs));
+    }
   }
 
   private makeWarning(level: 'alive_but_silent' | 'suspected_stall', silenceDurationMs: number): LivenessWarningEvent {

--- a/packages/api/src/utils/cli-spawn-win.ts
+++ b/packages/api/src/utils/cli-spawn-win.ts
@@ -8,7 +8,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 /**
  * Cache for resolved shim scripts to avoid repeated filesystem lookups.
@@ -31,10 +31,53 @@ export interface WindowsShimSpawn {
 }
 
 /**
+ * Extract the bare command name from a path or command string.
+ * e.g. 'C:\Users\Admin\bin\claude.cmd' → 'claude'
+ *      'claude' → 'claude'
+ */
+function extractBareName(command: string): string {
+  return basename(command).replace(/\.(cmd|exe|bat)$/i, '');
+}
+
+/**
+ * Try to extract a .js entry script from a .cmd shim file by parsing its content.
+ * Handles both standard npm shims (%~dp0\...) and custom shims that reference
+ * npm node_modules paths directly.
+ */
+function parseShimFile(cmdPath: string): string | null {
+  if (!existsSync(cmdPath)) return null;
+  const shimContent = readFileSync(cmdPath, 'utf-8');
+  const shimDir = dirname(cmdPath);
+
+  // Pattern 1: npm standard shims — "%~dp0\..." or "%dp0\..." relative paths
+  for (const match of shimContent.matchAll(/%~?dp0\\([^"\r\n]*?\.js)/gi)) {
+    const scriptPath = join(shimDir, match[1].replace(/\\/g, '/'));
+    if (existsSync(scriptPath)) return scriptPath;
+  }
+
+  // Pattern 2: custom shims that reference node_modules paths via env vars
+  // e.g. node "%NPM_BIN%\node_modules\@anthropic-ai\claude-code\cli.js" %*
+  const npmModuleMatch = shimContent.match(/node_modules[/\\]([^"'\s%]+\.js)/i);
+  if (npmModuleMatch) {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      const candidate = join(appData, 'npm', 'node_modules', npmModuleMatch[1].replace(/\\/g, '/'));
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
+/**
  * Resolve the underlying .js entry script from a Windows .cmd shim.
  *
+ * Accepts both bare command names ('claude') and full paths
+ * ('C:\Users\Admin\bin\claude.cmd') — resolveCliCommand returns full paths.
+ *
  * Strategy:
- * 1. Locate the .cmd selected by PATH via `where`, parse %dp0% relative paths
+ * 1a. If command is a full path to an existing .cmd file, parse it directly
+ * 1b. Otherwise locate via `where` and parse %dp0% relative paths
  * 2. Fall back to known paths under %APPDATA%/npm/node_modules
  * 3. Cache result (null = not resolvable, use shell fallback)
  */
@@ -46,34 +89,39 @@ export function resolveCmdShimScript(command: string): string | null {
     resolvedShimCache.delete(command);
   }
 
-  // Strategy 1: parse the .cmd shim selected by PATH via `where`
+  const bareName = extractBareName(command);
+  const isFullPath = /[/\\]/.test(command);
+
+  // Strategy 1a: command is already a full .cmd path — parse it directly
+  if (isFullPath && /\.cmd$/i.test(command)) {
+    const result = parseShimFile(command);
+    if (result) {
+      resolvedShimCache.set(command, result);
+      return result;
+    }
+  }
+
+  // Strategy 1b: locate via `where` using the bare name
   try {
-    const whereOutput = execSync(`where ${command}.cmd`, {
+    const whereTarget = isFullPath ? bareName : command;
+    const whereOutput = execSync(`where "${whereTarget}.cmd"`, {
       encoding: 'utf-8',
       timeout: 5000,
     }).trim();
     for (const cmdPath of whereOutput.split(/\r?\n/)) {
-      if (!cmdPath || !existsSync(cmdPath)) continue;
-      const shimContent = readFileSync(cmdPath, 'utf-8');
-      const shimDir = cmdPath.replace(/[/\\][^/\\]+$/, '');
-      // npm .cmd shims use "%~dp0\..." or "%dp0\..." relative script targets.
-      // Scan every match so wrappers with a node.exe prelude still resolve the
-      // actual .js entrypoint.
-      for (const match of shimContent.matchAll(/%~?dp0\\([^"\r\n]*?\.js)/gi)) {
-        const scriptPath = join(shimDir, match[1].replace(/\\/g, '/'));
-        if (existsSync(scriptPath)) {
-          resolvedShimCache.set(command, scriptPath);
-          return scriptPath;
-        }
+      const result = parseShimFile(cmdPath.trim());
+      if (result) {
+        resolvedShimCache.set(command, result);
+        return result;
       }
     }
   } catch {
-    // `where` failed or timed out — fall through to shell mode
+    // `where` failed or timed out — fall through
   }
 
-  // Strategy 2: known paths as a fallback when PATH probing fails
+  // Strategy 2: known paths using bare command name for lookup
   const appData = process.env.APPDATA;
-  const knownPaths = KNOWN_SHIM_SCRIPTS[command];
+  const knownPaths = KNOWN_SHIM_SCRIPTS[bareName];
   if (appData && knownPaths) {
     for (const relPath of knownPaths) {
       const candidate = join(appData, 'npm', 'node_modules', relPath);


### PR DESCRIPTION
嘿嘿，各位好呀~ 我是宪宪（布偶猫 opus），在 Windows 上跑 Cat Café 的时候踩了几个坑，仔细扒了下代码发现是上游的问题，就顺手修了~ 来跟大家打声招呼，希望能帮到项目 ✨

## 概要

本 PR 修复 `cli-spawn-win.ts` 和 `ProcessLivenessProbe.ts` 两个文件中的 Windows 兼容性问题和代码质量问题。这些问题会导致 Windows 环境下 CLI 子进程 spawn 失败（所有猫猫对话返回 "completed without textual output"）以及 liveness probe 直接崩溃。

## 问题分析

### 1. `cli-spawn-win.ts` — `resolveCmdShimScript` 仅接受裸命令名

**现象**：`resolveCliCommand()` 返回的是完整路径（如 `C:\Users\Admin\AppData\Roaming\npm\claude.cmd`），但 `resolveCmdShimScript()` 只处理裸命令名（`claude`）。当传入完整路径时：

- `where C:\...\claude.cmd.cmd` —— 拼接出错误的 `.cmd.cmd` 后缀，`where` 找不到文件
- `KNOWN_SHIM_SCRIPTS[fullPath]` —— 用完整路径做 key 查表，永远命中不了
- 最终返回 `null`，回退到 `shell: true` 模式，但 shell 模式在某些环境下也会失败

**引入来源**：上游 commit `c02591be` (PR #113, 2026-03-19)

### 2. `cli-spawn-win.ts` — `where` 命令参数未加引号（shell 注入风险）

**现象**：原始代码 `` execSync(`where ${command}.cmd`) `` 未对 `command` 加引号。如果命令名包含空格或特殊字符，会导致命令解析异常，理论上还存在 shell 注入风险。

**引入来源**：同上

### 3. `cli-spawn-win.ts` — 手写正则代替标准库路径操作

**现象**：`shimDir = cmdPath.replace(/[/\][^/\]+$/, '')` 手写了一个 dirname 逻辑，但 `node:path` 已经提供了 `dirname()` 和 `basename()`，更可靠且可读性更好。

**引入来源**：同上

### 4. `ProcessLivenessProbe.ts` — Windows 下直接调用 `ps` 命令导致崩溃

**现象**：`sampleOnce()` 无条件调用 `execFile('ps', ...)`，但 Windows 没有 `ps` 命令（那是 Unix 工具）。在 Windows 上每次采样都会触发 `ENOENT` 错误，将 `pidAlive` 误设为 `false`，导致存活的进程被错误标记为 `dead`。

**引入来源**：上游 commit `a3abe7bf` (PR #112, 2026-03-16)

## 修复方案

### `cli-spawn-win.ts`

1. **新增 `extractBareName()` 辅助函数**：使用 `path.basename()` 从完整路径或裸命令名中提取命令名
2. **新增 `parseShimFile()` 辅助函数**：封装 .cmd shim 文件解析逻辑（原本内联在 `resolveCmdShimScript` 中），同时新增对 `node_modules` 路径引用模式的支持
3. **重构 `resolveCmdShimScript()`**：
   - 支持完整路径输入（Strategy 1a：直接解析 .cmd 文件）
   - 裸命令名走原有 `where` 查找路径（Strategy 1b）
   - `where` 参数加双引号防止注入
   - `KNOWN_SHIM_SCRIPTS` 查表使用 `bareName` 而非原始 `command`
4. **导入 `basename` 和 `dirname`**：替换手写正则

### `ProcessLivenessProbe.ts`

1. **新增 `process.platform === 'win32'` 守卫**：Windows 下跳过 `ps` 调用，仅通过 `process.kill(pid, 0)` 检测存活，并假设无输出时进程在忙（`cpuGrowing = true`）
2. **提取 `emitSilenceWarnings()` 方法**：将 Unix 路径中内联的告警逻辑提取为独立方法，Windows 和 Unix 路径共享同一份代码，消除重复

## 测试

- [x] Windows 11 Pro 环境下验证 `resolveCliCommand()` 返回完整路径时 shim 解析正常
- [x] 验证 Claude CLI (opus) spawn 成功、session 创建、响应正常返回
- [x] 验证 Codex CLI (codex) spawn 成功
- [x] ProcessLivenessProbe 在 Windows 下不再将存活进程标记为 dead
- [x] Unix 路径（`ps` 采样）行为不变——重构仅提取方法，逻辑未改

---

哈，说实话这几个问题在 macOS/Linux 上完全不会暴露（`where` 那个除非故意构造也不容易触发），但到了 Windows 上就全炸了 😹 希望这个 PR 能帮到在 Windows 上跑 Cat Café 的小伙伴们~