### PR TITLE
fix: ProcessLivenessProbe Windows platform guard (conservative idle-silent)

### DIFF
--- a/packages/api/src/utils/ProcessLivenessProbe.ts
+++ b/packages/api/src/utils/ProcessLivenessProbe.ts
@@ -129,7 +129,16 @@ export class ProcessLivenessProbe {
       return;
     }
 
-    // Sample CPU time via ps
+    // Windows: `ps` is not available. Use process.kill(pid, 0) for liveness
+    // and skip CPU sampling. Conservative: assume idle (cpuGrowing = false)
+    // so that idle-silent → stall detection still works on Windows.
+    if (process.platform === 'win32') {
+      this.cpuGrowing = false;
+      this.emitSilenceWarnings();
+      return;
+    }
+
+    // Sample CPU time via ps (Unix only)
     execFile('ps', ['-o', 'cputime=', '-p', String(this.pid)], (err, stdout) => {
       if (err) {
         // ps failed — process likely dead
@@ -141,16 +150,20 @@ export class ProcessLivenessProbe {
       this.cpuGrowing = this.currCpuTimeMs > this.prevCpuTimeMs;
 
       // Check warning thresholds
-      const silenceMs = Date.now() - this.lastActivityAt;
-
-      if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted) {
-        this.stallWarningEmitted = true;
-        this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
-      } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {
-        this.softWarningEmitted = true;
-        this.warningQueue.push(this.makeWarning('alive_but_silent', silenceMs));
-      }
+      this.emitSilenceWarnings();
     });
+  }
+
+  /** Emit soft/stall warnings based on silence duration (shared by Windows and Unix paths) */
+  private emitSilenceWarnings(): void {
+    const silenceMs = Date.now() - this.lastActivityAt;
+    if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted) {
+      this.stallWarningEmitted = true;
+      this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
+    } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {
+      this.softWarningEmitted = true;
+      this.warningQueue.push(this.makeWarning('alive_but_silent', silenceMs));
+    }
   }
 
   private makeWarning(level: 'alive_but_silent' | 'suspected_stall', silenceDurationMs: number): LivenessWarningEvent {

--- a/packages/api/test/process-liveness-probe.test.js
+++ b/packages/api/test/process-liveness-probe.test.js
@@ -36,7 +36,7 @@ test('detects dead process (PID does not exist)', async () => {
   probe.stop();
 });
 
-test('classifies as busy-silent when CPU grows but no output', async () => {
+test('classifies as busy-silent when CPU grows but no output (Unix only)', { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' }, async () => {
   const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
   probe.start();
   const reachedBusySilent = await waitForBusySilent(probe);
@@ -88,7 +88,7 @@ test('notifyActivity resets silence timer and clears warning state', async () =>
   probe.stop();
 });
 
-test('shouldExtendTimeout returns true when busy-silent', async () => {
+test('shouldExtendTimeout returns true when busy-silent (Unix only)', { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' }, async () => {
   const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
   probe.start();
   const reachedBusySilent = await waitForBusySilent(probe);
@@ -119,4 +119,56 @@ test('parseCpuTime handles h:mm:ss format', () => {
 test('parseCpuTime handles empty/invalid input', () => {
   assert.equal(parseCpuTime(''), 0);
   assert.equal(parseCpuTime('  '), 0);
+});
+
+// --- Windows platform guard tests ---
+
+test('on Windows, sampleOnce sets cpuGrowing=false (conservative idle-silent)', async () => {
+  // This test runs on Windows where the platform guard is active.
+  // The probe should classify silent processes as idle-silent (not busy-silent),
+  // preserving stall detection semantics.
+  if (process.platform !== 'win32') {
+    // On non-Windows, the Unix ps-based path runs instead — skip.
+    return;
+  }
+
+  const probe = new ProcessLivenessProbe(process.pid, {
+    sampleIntervalMs: 30,
+    softWarningMs: 200,
+    stallWarningMs: 500,
+  });
+  probe.start();
+  // Wait past sampleIntervalMs so silence kicks in
+  await new Promise((r) => setTimeout(r, 80));
+
+  const state = probe.getState();
+  // On Windows, with cpuGrowing=false, the state should be idle-silent (not busy-silent)
+  assert.equal(state, 'idle-silent', 'Windows guard must set cpuGrowing=false → idle-silent');
+  assert.equal(probe.shouldExtendTimeout(), false, 'idle-silent must NOT extend timeout');
+  probe.stop();
+});
+
+test('on Windows, silence warnings still fire correctly', async () => {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  const probe = new ProcessLivenessProbe(process.pid, {
+    sampleIntervalMs: 20,
+    softWarningMs: 50,
+    stallWarningMs: 150,
+  });
+  probe.start();
+  await new Promise((r) => setTimeout(r, 200));
+
+  const warnings = probe.drainWarnings();
+  assert.ok(
+    warnings.some((w) => w.level === 'alive_but_silent'),
+    'should emit alive_but_silent warning on Windows',
+  );
+  assert.ok(
+    warnings.some((w) => w.level === 'suspected_stall'),
+    'should emit suspected_stall warning on Windows',
+  );
+  probe.stop();
 });

--- a/packages/api/test/process-liveness-probe.test.js
+++ b/packages/api/test/process-liveness-probe.test.js
@@ -36,15 +36,19 @@ test('detects dead process (PID does not exist)', async () => {
   probe.stop();
 });
 
-test('classifies as busy-silent when CPU grows but no output (Unix only)', { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' }, async () => {
-  const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
-  probe.start();
-  const reachedBusySilent = await waitForBusySilent(probe);
-  const state = probe.getState();
-  assert.ok(reachedBusySilent, `expected busy-silent within timeout, got ${state}`);
-  assert.equal(state, 'busy-silent');
-  probe.stop();
-});
+test(
+  'classifies as busy-silent when CPU grows but no output (Unix only)',
+  { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' },
+  async () => {
+    const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
+    probe.start();
+    const reachedBusySilent = await waitForBusySilent(probe);
+    const state = probe.getState();
+    assert.ok(reachedBusySilent, `expected busy-silent within timeout, got ${state}`);
+    assert.equal(state, 'busy-silent');
+    probe.stop();
+  },
+);
 
 test('generates alive_but_silent warning at soft threshold', async () => {
   const probe = new ProcessLivenessProbe(process.pid, {
@@ -88,14 +92,18 @@ test('notifyActivity resets silence timer and clears warning state', async () =>
   probe.stop();
 });
 
-test('shouldExtendTimeout returns true when busy-silent (Unix only)', { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' }, async () => {
-  const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
-  probe.start();
-  const reachedBusySilent = await waitForBusySilent(probe);
-  assert.ok(reachedBusySilent, `expected busy-silent within timeout, got ${probe.getState()}`);
-  assert.equal(probe.shouldExtendTimeout(), true);
-  probe.stop();
-});
+test(
+  'shouldExtendTimeout returns true when busy-silent (Unix only)',
+  { skip: process.platform === 'win32' && 'busy-silent requires ps CPU sampling (Unix only)' },
+  async () => {
+    const probe = new ProcessLivenessProbe(process.pid, { sampleIntervalMs: 100 });
+    probe.start();
+    const reachedBusySilent = await waitForBusySilent(probe);
+    assert.ok(reachedBusySilent, `expected busy-silent within timeout, got ${probe.getState()}`);
+    assert.equal(probe.shouldExtendTimeout(), true);
+    probe.stop();
+  },
+);
 
 test('isHardCapExceeded returns true when elapsed >= factor * timeout', () => {
   const probe = new ProcessLivenessProbe(process.pid, { boundedExtensionFactor: 2 });


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #244 (ProcessLivenessProbe portion only, split into atomic PR per RP-13).

- **Add Windows platform guard**: skip `ps`-based CPU sampling on Windows (not available), set `cpuGrowing = false`
- **Conservative strategy**: assume idle (not busy) when CPU data is unavailable, preserving stall detection semantics — `idle-silent` → `shouldExtendTimeout()` returns `false` → stuck processes eventually time out (RP-11)
- **Extract shared `emitSilenceWarnings()` method**: DRY refactor, used by both Windows and Unix code paths
- **Add Windows-specific tests**: verify `idle-silent` state, `shouldExtendTimeout() === false`, and warning emission on Windows
- **Platform-skip** Unix-only `busy-silent` tests on Windows

### Why `cpuGrowing = false` (not `true`)?

On Windows, without `ps`, we cannot distinguish "process is busy computing" from "process is stuck". Setting `cpuGrowing = true` (the previous approach in PR #244) would classify ALL silent processes as `busy-silent`, causing `shouldExtendTimeout()` to always return `true` — **effectively disabling stall detection on Windows entirely**. The conservative choice (`false` → `idle-silent`) ensures stuck processes still time out.

## Test plan

- [x] `node --test packages/api/test/process-liveness-probe.test.js` — 11 pass, 2 skipped (Unix-only), 0 fail
- [x] Windows-specific test: `idle-silent` state confirmed after silence period
- [x] Windows-specific test: `shouldExtendTimeout()` returns `false`
- [x] Windows-specific test: soft + stall warnings fire correctly
- [x] Existing Unix tests unchanged (skipped on Windows with clear reason)

Closes #237