### PR TITLE
ci: add Windows smoke test workflow

### DIFF
--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -10,6 +10,11 @@ name: Windows Smoke
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'designs/**'
+      - 'assets/**'
 
 concurrency:
   group: windows-smoke-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds a `windows-smoke.yml` workflow that runs Windows-specific tests on `windows-latest`
- Covers `cli-spawn-win.test.js` (Windows .cmd shim resolution) and `process-liveness-probe.test.js` (platform guard)
- These tests validate platform-specific behavior that the existing Ubuntu-only CI cannot catch
- Upstream `sync-manifest.yaml` updated to list this file as `target_owned_files` — full sync will preserve it

## Context

PR #249 and #250 introduce Windows-specific fixes that we cannot validate on Linux CI. This workflow closes the CI blind spot so future Windows contributions can be verified automatically.

## Test plan

- [ ] Workflow triggers on PR and runs on `windows-latest`
- [ ] `cli-spawn-win.test.js` passes (platform-skipped tests marked accordingly)
- [ ] `process-liveness-probe.test.js` passes (Windows platform guard tests run)

[宪宪/Opus-46🐾]