### PR TITLE
fix(#264): builtin profile update silently ignores non-model fields [宪宪/Opus-46🐾]

### DIFF
--- a/packages/api/src/config/provider-profiles.ts
+++ b/packages/api/src/config/provider-profiles.ts
@@ -998,18 +998,8 @@ export async function updateProviderProfile(
     if (!profile) throw new Error('profile not found');
     assertProviderSelector(profile, provider);
     if (profile.kind === 'builtin') {
-      const hasNonModelUpdates =
-        input.name !== undefined ||
-        input.displayName !== undefined ||
-        input.mode !== undefined ||
-        input.authType !== undefined ||
-        input.protocol !== undefined ||
-        input.baseUrl !== undefined ||
-        input.apiKey !== undefined ||
-        input.modelOverride !== undefined;
-      if (hasNonModelUpdates) {
-        throw new Error('builtin accounts only support model updates');
-      }
+      // #264: silently ignore non-model fields for builtin profiles.
+      // UI sends the full payload; only model changes are meaningful here.
       if (input.models !== undefined) {
         profile.models = normalizeModels(input.models);
       }

--- a/packages/api/test/provider-profiles-store.test.js
+++ b/packages/api/test/provider-profiles-store.test.js
@@ -279,13 +279,16 @@ describe('provider profile store', () => {
     }
   });
 
-  it('builtin accounts only allow model-list updates', async () => {
-    await assert.rejects(
-      updateProviderProfile(projectRoot, 'claude', 'claude', {
-        displayName: 'Nope',
-      }),
-      /builtin accounts only support model updates/i,
-    );
+  it('builtin accounts silently ignore non-model fields (#264)', async () => {
+    // Before fix: this would throw "builtin accounts only support model updates"
+    const result = await updateProviderProfile(projectRoot, 'claude', 'claude', {
+      displayName: 'Nope',
+      models: ['claude-sonnet-4-5-20250514'],
+    });
+    // Non-model field silently ignored; model update applied
+    assert.ok(result);
+    assert.ok(result.models.includes('claude-sonnet-4-5-20250514'));
+    assert.notStrictEqual(result.displayName, 'Nope', 'displayName must not change for builtin');
   });
 
   it('readProviderProfiles and getProviderProfile do not rewrite normalized files', async () => {


### PR DESCRIPTION
## Summary

- `updateProviderProfile()` no longer throws for builtin accounts when non-model fields are present — silently ignores them, applies only model changes
- Fixes Hub UI failing to update models for builtin accounts (Claude, OpenAI, etc.)
- Root cause: PR #221 described "silently ignore" but only implemented it in migration path, not update path

## Changes

- `provider-profiles.ts`: Remove `hasNonModelUpdates` throw guard for builtin profiles, keep model-only update logic
- `provider-profiles-store.test.js`: Replace throw-expectation test with silent-ignore + model-update-applied test

## Root Cause Analysis

PR #221 was a large PR (13 files, 856+ adds) focused on migrating profiles to global `~/.cat-cafe/`. The "silently ignore" intent in the PR description was only implemented for the migration path (skip builtins during merge), not the `updateProviderProfile()` function. The existing test verified the throw behavior, so the gap wasn't caught.

Closes #264

## Test plan

- [x] `builtin accounts silently ignore non-model fields (#264)` test passes
- [x] Non-model fields (displayName) confirmed unchanged after update
- [x] Model field correctly updated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)