### PR TITLE
fix(#233): PowerShell Start-Job UTF-8 encoding for CJK locales

### DIFF
--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -24,6 +24,12 @@ param(
 
 $ErrorActionPreference = "Stop"
 
+# -- UTF-8 encoding (#233) ----------------------------------
+# Ensure main script outputs UTF-8 for CJK locale systems
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+[Console]::InputEncoding  = [System.Text.Encoding]::UTF8
+$OutputEncoding = [System.Text.Encoding]::UTF8
+
 # -- Helpers -------------------------------------------------
 function Write-Step  { param([string]$msg) Write-Host "`n==> $msg" -ForegroundColor Cyan }
 function Write-Ok    { param([string]$msg) Write-Host "  [OK] $msg" -ForegroundColor Green }
@@ -345,6 +351,9 @@ try {
     Write-Host "  Starting API Server (port $ApiPort)..."
     $apiJob = Start-Job -Name "api" -ScriptBlock {
         param($root, $envFile, $runtimeEnvOverrides, $apiEntry, $debugFlag)
+        # #233: Start-Job runs in isolated runspace; re-set UTF-8 for CJK locales
+        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+        $OutputEncoding = [System.Text.Encoding]::UTF8
         Set-Location (Join-Path $root "packages/api")
         # Load .env into job process (Start-Job inherits parent env,
         # but re-load to be safe if process env was not fully propagated)
@@ -385,6 +394,9 @@ try {
         Write-Host "  Starting Frontend (port $WebPort, dev)..."
         $webJob = Start-Job -Name "web" -ScriptBlock {
             param($root, $port, $nextCli)
+            # #233: UTF-8 for isolated runspace
+            [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+            $OutputEncoding = [System.Text.Encoding]::UTF8
             $env:PORT = $port
             $env:NEXT_IGNORE_INCORRECT_LOCKFILE = "1"
             & node $nextCli dev (Join-Path $root "packages/web") -p $port 2>&1
@@ -394,6 +406,9 @@ try {
         Write-Host "  Starting Frontend (port $WebPort, production)..."
         $webJob = Start-Job -Name "web" -ScriptBlock {
             param($root, $port, $nextCli)
+            # #233: UTF-8 for isolated runspace
+            [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+            $OutputEncoding = [System.Text.Encoding]::UTF8
             $env:PORT = $port
             & node $nextCli start (Join-Path $root "packages/web") -p $port -H 0.0.0.0 2>&1
         } -ArgumentList $ProjectRoot, $WebPort, $nextCli


### PR DESCRIPTION
## Summary
- Add `[Console]::OutputEncoding` and `$OutputEncoding` UTF-8 settings to main script and all 3 `Start-Job` scriptblocks
- `Start-Job` creates isolated runspaces that default to system code page (GBK on Chinese Windows), causing Node.js UTF-8 output to render as garbled text
- Affects: API job, web dev job, web production job

## Root Cause
PowerShell `Start-Job` runs in a separate runspace that doesn't inherit encoding config from the parent script. Chinese Windows defaults to code page 936 (GBK), so UTF-8 bytes from Node.js get decoded incorrectly.

## Test plan
- [ ] Run `start-windows.ps1` on Chinese-locale Windows and verify console output shows Chinese characters correctly
- [ ] Verify `Receive-Job` output from all 3 jobs displays UTF-8 without garbling

Closes #233

🐾 [宪宪/Opus-46🐾]