### PR TITLE
fix: keep preflight timeout alive during public gate

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-helpers.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-helpers.ts
@@ -109,7 +109,8 @@ export function preflightRace<T>(promise: Promise<T>, label: string, signal?: Ab
 
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new Error(`preflight_timeout: ${label}`)), PREFLIGHT_TIMEOUT_MS);
-    timer.unref();
+    // Keep the process alive until the preflight guard actually fires.
+    // Unref'ing this timer lets Node exit early when the raced promise never settles.
   });
 
   const parts: Promise<T | never>[] = [promise, timeoutPromise];

--- a/packages/api/test/preflight-race.test.js
+++ b/packages/api/test/preflight-race.test.js
@@ -3,7 +3,9 @@
  * when pre-flight async operations (Redis, session chain) are unresponsive.
  */
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { after, before, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 // Static import for tests that don't need a custom timeout
 import { PREFLIGHT_TIMEOUT_MS, preflightRace } from '../dist/domains/cats/services/agents/invocation/invoke-helpers.js';
@@ -65,5 +67,37 @@ describe('preflightRace timeout (short env override)', () => {
   it('rejects with preflight_timeout when promise hangs past timeout', async () => {
     const neverResolves = new Promise(() => {});
     await assert.rejects(shortPreflightRace(neverResolves, 'test-hang'), /preflight_timeout: test-hang/);
+  });
+
+  it('keeps an otherwise idle process alive until preflight timeout fires', () => {
+    const invokeHelpersUrl = new URL(
+      '../dist/domains/cats/services/agents/invocation/invoke-helpers.js',
+      import.meta.url,
+    ).href;
+    const apiDir = fileURLToPath(new URL('..', import.meta.url));
+    const script = `
+const mod = await import(${JSON.stringify(invokeHelpersUrl)});
+try {
+  await mod.preflightRace(new Promise(() => {}), 'child-hang');
+  console.log('resolved');
+  process.exit(2);
+} catch (err) {
+  console.log('rejected', err.message);
+  process.exit(0);
+}
+`;
+    const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+      cwd: apiDir,
+      env: { ...process.env, CAT_CAFE_PREFLIGHT_TIMEOUT_MS: '100' },
+      encoding: 'utf8',
+      timeout: 2_000,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      `child must stay alive until timeout rejects; stdout=${result.stdout} stderr=${result.stderr}`,
+    );
+    assert.match(result.stdout, /rejected preflight_timeout: child-hang/);
   });
 });


### PR DESCRIPTION
## Summary
- fix `preflightRace()` so the timeout guard stays alive even when the raced preflight promise never settles
- add a child-process regression test that reproduces the GitHub Actions failure mode
- unblock `Test (Public)` on `main`, which currently blocks `v0.4.2`

## Root Cause
`preflightRace()` used `timer.unref()`. In an otherwise idle process, that allows Node to resolve the event loop before the timeout callback fires, so the intended `preflight_timeout:*` rescue path never runs.

## Validation
- `pnpm --filter @cat-cafe/api run build`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 node --test --test-concurrency=1 test/preflight-race.test.js test/preflight-race-integration.test.js`

Fixes #293
