### PR TITLE
fix(connector): show open_id hint for non-admin permission commands

### DIFF
--- a/packages/api/src/infrastructure/connectors/ConnectorCommandLayer.ts
+++ b/packages/api/src/infrastructure/connectors/ConnectorCommandLayer.ts
@@ -311,7 +311,10 @@ export class ConnectorCommandLayer {
     chatIdArg?: string,
   ): Promise<CommandResult> {
     if (!(await this.isAdminSender(connectorId, senderId))) {
-      return { kind: 'allow-group', response: '🔒 此命令仅管理员可用。' };
+      const hint = senderId
+        ? `你的 open_id: ${senderId}，请在 Hub 权限管理中添加此 ID。`
+        : '无法识别发送者（请从群聊中发送此命令）。';
+      return { kind: 'allow-group', response: `🔒 此命令仅管理员可用。${hint}` };
     }
     const store = this.deps.permissionStore;
     if (!store) {
@@ -333,7 +336,10 @@ export class ConnectorCommandLayer {
     chatIdArg?: string,
   ): Promise<CommandResult> {
     if (!(await this.isAdminSender(connectorId, senderId))) {
-      return { kind: 'deny-group', response: '🔒 此命令仅管理员可用。' };
+      const hint = senderId
+        ? `你的 open_id: ${senderId}，请在 Hub 权限管理中添加此 ID。`
+        : '无法识别发送者（请从群聊中发送此命令）。';
+      return { kind: 'deny-group', response: `🔒 此命令仅管理员可用。${hint}` };
     }
     const store = this.deps.permissionStore;
     if (!store) {


### PR DESCRIPTION
## Summary
- When a non-admin user runs `allow-group` or `deny-group` commands, the error message now shows their `open_id` so they know which ID to add in Hub permission management.
- If the sender cannot be identified, a clear message tells them to use the command from a group chat.

## Motivation
Previously the error was a dead-end "此命令仅管理员可用" with no actionable next step. Users had to separately look up their open_id. This makes the flow self-service.

## Changes
- `ConnectorCommandLayer.ts`: Enhanced error response in `handleAllowGroup` and `handleDenyGroup` to include sender hint.

## Test plan
- [x] Verified non-admin user sees their open_id in the error message
- [x] Verified unknown sender gets appropriate fallback message

🐾 [宪宪/Opus-46]
🤖 Generated with [Claude Code](https://claude.com/claude-code)