### PR TITLE
fix(scheduler): reject reminder tasks without deliveryThreadId

### DIFF
--- a/packages/api/src/infrastructure/scheduler/templates/reminder.ts
+++ b/packages/api/src/infrastructure/scheduler/templates/reminder.ts
@@ -24,7 +24,10 @@ export const reminderTemplate: TaskTemplate = {
       trigger: p.trigger,
       admission: {
         async gate() {
-          if (!threadId) return { run: false, reason: 'no deliveryThreadId' };
+          if (!threadId) {
+            console.warn(`[reminder:${instanceId}] skipped — no deliveryThreadId configured`);
+            return { run: false, reason: 'no deliveryThreadId' };
+          }
           return { run: true, workItems: [{ signal: message, subjectKey: `thread-${threadId}` }] };
         },
       },

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -215,13 +215,22 @@ export const scheduleRoutes: FastifyPluginAsync<ScheduleRoutesOptions> = async (
         }
       : { label: template.label, category: template.category, description: template.description };
 
+    const deliveryThreadId = body.deliveryThreadId ?? null;
+
+    // Fail fast: reminder template requires deliveryThreadId (#333)
+    if (template.templateId === 'reminder' && !deliveryThreadId) {
+      return reply.status(400).send({
+        error: 'deliveryThreadId is required for reminder template — without it the task will never execute',
+      });
+    }
+
     const def = {
       id,
       templateId: body.templateId,
       trigger,
       params,
       display,
-      deliveryThreadId: body.deliveryThreadId ?? null,
+      deliveryThreadId,
       enabled: true,
       createdBy: body.createdBy ?? 'unknown',
       createdAt: new Date().toISOString(),

--- a/packages/mcp-server/src/tools/schedule-tools.ts
+++ b/packages/mcp-server/src/tools/schedule-tools.ts
@@ -113,7 +113,7 @@ export async function handleRegisterScheduledTask(input: {
     params,
   };
 
-  if (input.deliveryThreadId) body.deliveryThreadId = input.deliveryThreadId;
+  body.deliveryThreadId = input.deliveryThreadId ?? null;
   if (currentCatId) body.createdBy = currentCatId;
 
   if (input.label || input.category || input.description) {
@@ -163,7 +163,7 @@ export async function handlePreviewScheduledTask(input: {
     trigger,
     params,
   };
-  if (input.deliveryThreadId) body.deliveryThreadId = input.deliveryThreadId;
+  body.deliveryThreadId = input.deliveryThreadId ?? null;
 
   return callbackPost('/api/schedule/tasks/preview', body);
 }


### PR DESCRIPTION
## Summary

Fixes #333 — scheduled reminder tasks silently fail when `deliveryThreadId` is omitted.

**Root cause chain:**
1. MCP tool (`schedule-tools.ts`) only adds `deliveryThreadId` to body if truthy → field is missing when omitted
2. API (`schedule.ts`) defaults missing field to `null` → task is created "successfully"
3. Reminder template gate (`reminder.ts`) checks `if (!threadId)` → returns `{ run: false }` with no logging
4. `outcome.whenNoSignal: 'drop'` → cron fires, gate rejects, task silently discards

**Fix (3 files):**
- **MCP tool**: always include `deliveryThreadId` in body (null if omitted), so the API can validate
- **API route**: return 400 for reminder template when `deliveryThreadId` is missing — fail fast instead of creating a doomed task
- **Reminder template**: add `console.warn` when gate rejects, so existing tasks without threadId are observable in logs

## Test plan

- [ ] Create reminder task without `deliveryThreadId` → expect 400 error with clear message
- [ ] Create reminder task with `deliveryThreadId` → works as before
- [ ] Preview endpoint also sends null deliveryThreadId correctly
- [ ] Existing tasks with null threadId now log warning on each cron tick

🐾 Generated with [Claude Code](https://claude.com/claude-code)