### PR TITLE
fix(F151): renumber F148→F151 — F148 already assigned internally

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,4 +56,4 @@ created: 2026-02-26
 | F144 | PPT Forge — AI 演示文稿生成引擎 | in-progress | 三猫 | internal | [F144](features/F144-ppt-forge.md) |
 | F146 | MCP Marketplace Control Plane — 一键接入 + 多生态聚合 | spec | Maine Coon + Ragdoll | internal | [F146](features/F146-mcp-marketplace-control-plane.md) |
 | F147 | i18n — Hub 界面中英文切换 | idea | 待定 | internal | — |
-| F148 | XiaoYi Channel Gateway — 小艺渠道 OpenClaw 模式接入 | spec | Ragdoll | internal | [F148](features/F148-xiaoyi-channel-gateway.md) |
+| F151 | XiaoYi Channel Gateway — 小艺渠道 OpenClaw 模式接入 | spec | Community | community | [F151](features/F151-xiaoyi-channel-gateway.md) |

--- a/docs/features/F151-xiaoyi-channel-gateway.md
+++ b/docs/features/F151-xiaoyi-channel-gateway.md
@@ -1,5 +1,5 @@
 ---
-feature_ids: [F148]
+feature_ids: [F151]
 related_features: [F088, F132, F137, F143, F146]
 topics: [connector, channel, xiaoyi, huawei, a2a, websocket]
 doc_kind: spec
@@ -7,7 +7,7 @@ status: spec
 created: 2026-04-01
 ---
 
-# F148: XiaoYi Channel Gateway — 小艺渠道接入
+# F151: XiaoYi Channel Gateway — 小艺渠道接入
 
 > **Status**: spec | **Owner**: Ragdoll | **Priority**: P1
 >


### PR DESCRIPTION
## Summary

- F148 编号在内部仓已分配给 Hierarchical Context Transport
- 将 #337 引入的小艺渠道接入 spec 从 F148 重编号为 F151
- 文件重命名 + frontmatter + ROADMAP 条目更新

## Changes

- `docs/features/F148-xiaoyi-channel-gateway.md` → `docs/features/F151-xiaoyi-channel-gateway.md`
- `feature_ids: [F148]` → `feature_ids: [F151]`
- ROADMAP.md F148 行 → F151

Tracking: #341

🐾 [宪宪/Opus-46]