### PR TITLE
fix: unify IME enter guard in input hotspots

### DIFF
--- a/packages/web/src/components/ProjectSetupCard.tsx
+++ b/packages/web/src/components/ProjectSetupCard.tsx
@@ -5,6 +5,7 @@
  * Separate from GovernanceBlockedCard (which handles dispatch-failure retry).
  */
 import { useCallback, useState } from 'react';
+import { useIMEGuard } from '@/hooks/useIMEGuard';
 import { apiFetch } from '@/utils/api-client';
 
 /* Anime-style cat illustrations generated via Gemini */
@@ -39,6 +40,7 @@ export function ProjectSetupCard({
   const [state, setState] = useState<CardState>('idle');
   const [cloneUrl, setCloneUrl] = useState('');
   const [errorMsg, setErrorMsg] = useState('');
+  const ime = useIMEGuard();
 
   const dirName = projectPath.split(/[/\\]/).pop() ?? projectPath;
 
@@ -166,10 +168,16 @@ export function ProjectSetupCard({
                     type="text"
                     value={cloneUrl}
                     onChange={(e) => setCloneUrl(e.target.value)}
+                    onCompositionStart={ime.onCompositionStart}
+                    onCompositionEnd={ime.onCompositionEnd}
                     placeholder="https:// 或 git@..."
                     className="flex-1 text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white focus:outline-none focus:ring-1 focus:ring-cocreator-primary"
                     onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.nativeEvent.isComposing && cloneUrl.trim()) handleSetup('clone');
+                      if (ime.isComposing()) {
+                        e.preventDefault();
+                        return;
+                      }
+                      if (e.key === 'Enter' && cloneUrl.trim()) handleSetup('clone');
                     }}
                   />
                   <button

--- a/packages/web/src/components/ProjectSetupCard.tsx
+++ b/packages/web/src/components/ProjectSetupCard.tsx
@@ -173,7 +173,7 @@ export function ProjectSetupCard({
                     placeholder="https:// 或 git@..."
                     className="flex-1 text-xs px-3 py-2 rounded-lg border border-gray-200 bg-white focus:outline-none focus:ring-1 focus:ring-cocreator-primary"
                     onKeyDown={(e) => {
-                      if (ime.isComposing()) {
+                      if (e.key === 'Enter' && ime.isComposing()) {
                         e.preventDefault();
                         return;
                       }

--- a/packages/web/src/components/ThreadSidebar/DirectoryBrowser.tsx
+++ b/packages/web/src/components/ThreadSidebar/DirectoryBrowser.tsx
@@ -226,7 +226,7 @@ export function DirectoryBrowser({ initialPath, activeProjectPath, onSelect, onC
                 onCompositionStart={ime.onCompositionStart}
                 onCompositionEnd={ime.onCompositionEnd}
                 onKeyDown={(e) => {
-                  if (ime.isComposing()) {
+                  if (e.key === 'Enter' && ime.isComposing()) {
                     e.preventDefault();
                     return;
                   }

--- a/packages/web/src/components/ThreadSidebar/DirectoryBrowser.tsx
+++ b/packages/web/src/components/ThreadSidebar/DirectoryBrowser.tsx
@@ -223,8 +223,14 @@ export function DirectoryBrowser({ initialPath, activeProjectPath, onSelect, onC
                 type="text"
                 value={newDirName}
                 onChange={(e) => setNewDirName(e.target.value)}
+                onCompositionStart={ime.onCompositionStart}
+                onCompositionEnd={ime.onCompositionEnd}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.nativeEvent.isComposing) handleCreateDir();
+                  if (ime.isComposing()) {
+                    e.preventDefault();
+                    return;
+                  }
+                  if (e.key === 'Enter') handleCreateDir();
                   if (e.key === 'Escape') {
                     setCreatingDir(false);
                     setMkdirError(null);

--- a/packages/web/src/components/__tests__/directory-browser-ime.test.tsx
+++ b/packages/web/src/components/__tests__/directory-browser-ime.test.tsx
@@ -1,0 +1,86 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DirectoryBrowser } from '@/components/ThreadSidebar/DirectoryBrowser';
+
+const mockApiFetch = vi.fn(async (url: string) => {
+  if (url.startsWith('/api/projects/browse')) {
+    return {
+      ok: true,
+      json: async () => ({
+        current: '/Users/orca',
+        name: 'orca',
+        parent: '/Users',
+        homePath: '/Users/orca',
+        entries: [],
+      }),
+    };
+  }
+  return { ok: true, json: async () => ({ current: '/Users/orca/new-folder' }) };
+});
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: (...args: string[]) => mockApiFetch(args[0], args[1] as unknown as Record<string, unknown>),
+}));
+
+describe('DirectoryBrowser IME guard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApiFetch.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('prevents Enter default and does not create folder while composing', async () => {
+    await act(async () => {
+      root.render(<DirectoryBrowser onSelect={vi.fn()} onCancel={vi.fn()} />);
+    });
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const newButton = Array.from(container.querySelectorAll('button')).find((btn) => btn.textContent?.includes('新建'));
+    if (!newButton) throw new Error('Missing new folder button');
+
+    await act(async () => {
+      newButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const input = container.querySelector('input[placeholder="文件夹名称..."]') as HTMLInputElement | null;
+    if (!input) throw new Error('Missing new folder input');
+
+    await act(async () => {
+      input.value = '测试目录';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    });
+
+    const initialCallCount = mockApiFetch.mock.calls.length;
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    await act(async () => {
+      input.dispatchEvent(enter);
+    });
+
+    expect(enter.defaultPrevented).toBe(true);
+    expect(mockApiFetch.mock.calls.length).toBe(initialCallCount);
+  });
+});

--- a/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
+++ b/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
@@ -1,0 +1,70 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ProjectSetupCard } from '@/components/ProjectSetupCard';
+
+const mockApiFetch = vi.fn(async () => ({ ok: true, json: async () => ({}) }));
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: (...args: string[]) => mockApiFetch(args[0], args[1] as unknown as Record<string, unknown>),
+}));
+
+describe('ProjectSetupCard IME guard', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApiFetch.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('prevents Enter default and does not submit clone while composing', async () => {
+    const onComplete = vi.fn();
+
+    await act(async () => {
+      root.render(
+        <ProjectSetupCard
+          projectPath="/tmp/demo"
+          isEmptyDir
+          isGitRepo={false}
+          gitAvailable
+          onComplete={onComplete}
+        />,
+      );
+    });
+
+    const input = container.querySelector('input[placeholder="https:// 或 git@..."]') as HTMLInputElement | null;
+    if (!input) throw new Error('Missing clone url input');
+
+    await act(async () => {
+      input.value = 'https://example.com/repo.git';
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      input.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    });
+
+    const enter = new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true });
+    await act(async () => {
+      input.dispatchEvent(enter);
+    });
+
+    expect(enter.defaultPrevented).toBe(true);
+    expect(mockApiFetch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## PR Type

- [x] 🐛 **Patch** — Bug fix, typo, test gap (no Feature Doc needed)
- [ ] ✨ **Feature** — New capability or behavior change (requires Feature Doc)
- [ ] 📋 **Protocol** — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #

## What

- switched `ProjectSetupCard` clone URL submission from `nativeEvent.isComposing` to `useIMEGuard()`
- switched `DirectoryBrowser` inline mkdir input to the same `useIMEGuard()` path already used by most other web inputs
- added regression tests that verify Enter is blocked during composition and no API request fires in either flow

## Why

Most of the web app already standardizes IME Enter handling through `useIMEGuard()`, but these two inputs were still using a weaker browser-native check. That left composition handling inconsistent and could reintroduce accidental submit behavior in Chrome-style composition timing.

## Tradeoff

I kept this PR intentionally narrow instead of sweeping every Enter handler in the app. The goal here is to normalize two remaining hotspots and add regression coverage without turning this into a broad refactor.

## Test Evidence

```bash
pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/project-setup-card-ime.test.tsx src/components/__tests__/directory-browser-ime.test.tsx
# 2 passed

pnpm --filter @cat-cafe/web lint
# completed with existing repository warnings unrelated to this PR; no new errors from touched files
```