### PR TITLE
fix: add MESSAGE_TTL_SECONDS=0 to prevent message expiry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ NEXT_PUBLIC_BRAND_NAME="Clowder AI"
 REDIS_PORT=6399
 REDIS_URL=redis://localhost:6399
 
+# Message TTL (seconds). Default is 7 days — messages auto-expire!
+# Set to 0 for permanent storage (recommended).
+# 消息存储 TTL（秒）。默认 7 天，消息会过期删除！设为 0 = 永久保存。
+MESSAGE_TTL_SECONDS=0
+
 # ── Model API Keys 模型密钥（按需填写）────────────────────────
 # Only needed if calling model APIs directly. If you use Claude Code CLI
 # subscription, the CLI manages auth for you — no key needed here.


### PR DESCRIPTION
## Summary
- Add `MESSAGE_TTL_SECONDS=0` to `.env.example` so users get **permanent message storage** by default
- Default Redis message TTL is 7 days — many users report messages "disappearing" because of this silent expiry
- Users who copy `.env.example` will now get the recommended setting automatically

## Context
Multiple community reports of "Redis messages lost" — root cause is the 7-day default TTL in `RedisMessageStore`. This is a documentation/config fix; code already supports `MESSAGE_TTL_SECONDS=0` correctly (maps to `ttlSeconds = null` = no expiry).

Closes #343 (partial — auto-summary removal will come in next sync)

## Test plan
- [ ] Copy fresh `.env.example` → `.env`, start with Redis → verify messages persist beyond 7 days
- [ ] Existing users: add `MESSAGE_TTL_SECONDS=0` to `.env` → verify no regression

[宪宪/Opus-46🐾]

🤖 Generated with [Claude Code](https://claude.com/claude-code)