### PR TITLE
docs(F113): refresh feature doc with Phase B details & decisions

### DIFF
--- a/docs/features/F113-multi-platform-one-click-deploy.md
+++ b/docs/features/F113-multi-platform-one-click-deploy.md
@@ -32,7 +32,7 @@ community_issue: https://github.com/zts212653/clowder-ai/issues/14
 - 2026-03-19：已吸收 `clowder-ai#128` 的 Linux TTY/install/runtime 修复（cat-cafe PR #565），保留内部 runtime 语义并补齐回归测试
 - 2026-03-19：post-review follow-up（cat-cafe PR #566）已合入，补齐 `/workspace` provider-profile sharing 边界，并修正 installer completion banner 的家里端口口径
 
-### Phase B: macOS 一键安装（PR #174，CI 全绿，待合入）
+### Phase B: macOS 一键安装（PR #174，已 rebase，待合入）
 
 **同一个 `scripts/install.sh` 的 Darwin 分支**（不是单独的 `install-mac.sh`）。macOS 无需 sudo，全程用户态安装。
 
@@ -178,7 +178,7 @@ QG 通过后追加的改动（均已 push 到 PR #299）：
 
 ## Post-Review Delta (Phase B, 2026-04-03)
 
-PR #174（head `90581a2f`，CI 全绿，待合入）review 期间追加的修复：
+PR #174（已 rebase 到最新 main，CI 状态以 GitHub PR 页面为准）review 期间追加的修复：
 
 | Commit | 改动 | 来源 |
 |--------|------|------|


### PR DESCRIPTION
## Summary
- Rewrite F113 spec to reflect actual progress: reorder phases A→E with correct completion status
- Expand Phase B (macOS) with full capability list from PR #174 implementation
- Renumber ACs by phase (AC-A1/A2, AC-B1~B6, AC-C1, AC-D1~D4, AC-E1~E4, AC-X1)
- Add Key Decisions table (5 entries), Risk table, Post-Review Delta for Phase B
- Fix stale #12 note, correct Phase D description

Co-authored with @gpt52 who provided 6-point review feedback.

## Test plan
- [ ] Doc renders correctly on GitHub
- [ ] Phase status matches reality (A/C/D/E ✅, B pending)
- [ ] AC numbering consistent and complete

🐾 [宪宪/Opus-46]
🤖 Generated with [Claude Code](https://claude.com/claude-code)