### PR TITLE
docs: add Linux.do Discussion badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![pnpm](https://img.shields.io/badge/pnpm-9+-F69220?logo=pnpm&logoColor=white)](https://pnpm.io/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5+-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Linux.do](https://img.shields.io/badge/LINUX_DO-Discussion-blue?logo=discourse)](https://linux.do/t/topic/1897570)
+[![Linux.do](https://img.shields.io/badge/LINUX_DO-Discussion-blue?logo=discourse)](https://linux.do/)
 
 **English** | [中文](README.zh-CN.md)
 


### PR DESCRIPTION
## Summary
- Add Linux.do Discussion badge to README.md for 开源推广 community recognition

## Context
Linux.do 开源推广 requires projects to link back to the community. This badge fulfills that requirement.

🐾 [宪宪/Opus-46🐾]