### PR TITLE
fix(#320): SchedulePanel kind-match filter + taskStore type alignment

### DIFF
--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -84,7 +84,7 @@ export const scheduleRoutes: FastifyPluginAsync<ScheduleRoutesOptions> = async (
     threadSubjectKeys.add(`thread:${threadId}`);
 
     // P1-2 fix: don't rely solely on lastRun — query ledger for ANY matching run.
-    // Also include tasks whose subjectKind matches even with zero runs (newly registered).
+    // Also include tasks whose subjectKind matches active thread task kinds.
     const ledger = taskRunner.getLedger();
     const filtered = summaries.filter((s) => {
       // Quick path: if lastRun matches, include immediately
@@ -94,9 +94,10 @@ export const scheduleRoutes: FastifyPluginAsync<ScheduleRoutesOptions> = async (
         const runs = ledger.queryBySubject(s.id, sk, 1);
         if (runs.length > 0) return true;
       }
-      // Zero-run path only: newly registered tasks should show up immediately,
-      // but once a task has runs we must not leak it across threads by subject kind.
-      if (!s.lastRun && s.display?.subjectKind && activeThreadSubjectKinds.has(s.display.subjectKind)) return true;
+      // Kind-match path (#320 P1): thread has active task of matching kind → include.
+      // Previously gated by !s.lastRun, which blocked builtin tasks (cicd-check etc.)
+      // that had already run for OTHER PRs from appearing for a newly tracked PR.
+      if (s.display?.subjectKind && activeThreadSubjectKinds.has(s.display.subjectKind)) return true;
       return false;
     });
 

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -86,19 +86,21 @@ export const scheduleRoutes: FastifyPluginAsync<ScheduleRoutesOptions> = async (
     // P1-2 fix: don't rely solely on lastRun — query ledger for ANY matching run.
     // Also include tasks whose subjectKind matches active thread task kinds.
     const ledger = taskRunner.getLedger();
-    const filtered = summaries.filter((s) => {
+    const filtered = summaries.flatMap((s) => {
       // Quick path: if lastRun matches, include immediately
-      if (s.lastRun && threadSubjectKeys.has(s.lastRun.subject_key)) return true;
+      if (s.lastRun && threadSubjectKeys.has(s.lastRun.subject_key)) return [s];
       // Slow path: check if ANY run for this task matches thread's subject keys
       for (const sk of threadSubjectKeys) {
         const runs = ledger.queryBySubject(s.id, sk, 1);
-        if (runs.length > 0) return true;
+        if (runs.length > 0) return [s];
       }
-      // Kind-match path (#320 P1): thread has active task of matching kind → include.
-      // Previously gated by !s.lastRun, which blocked builtin tasks (cicd-check etc.)
-      // that had already run for OTHER PRs from appearing for a newly tracked PR.
-      if (s.display?.subjectKind && activeThreadSubjectKinds.has(s.display.subjectKind)) return true;
-      return false;
+      // Kind-match path (#320 P1): thread has active task of matching kind → include,
+      // but scrub run metadata that belongs to other threads/PRs.
+      if (s.display?.subjectKind && activeThreadSubjectKinds.has(s.display.subjectKind)) {
+        const { lastRun: _, subjectPreview: __, ...rest } = s;
+        return [{ ...rest, lastRun: null, subjectPreview: null }];
+      }
+      return [];
     });
 
     return { tasks: filtered };

--- a/packages/api/src/routes/schedule.ts
+++ b/packages/api/src/routes/schedule.ts
@@ -97,8 +97,10 @@ export const scheduleRoutes: FastifyPluginAsync<ScheduleRoutesOptions> = async (
       // Kind-match path (#320 P1): thread has active task of matching kind → include,
       // but scrub run metadata that belongs to other threads/PRs.
       if (s.display?.subjectKind && activeThreadSubjectKinds.has(s.display.subjectKind)) {
-        const { lastRun: _, subjectPreview: __, ...rest } = s;
-        return [{ ...rest, lastRun: null, subjectPreview: null }];
+        const { lastRun: _, subjectPreview: __, runStats: ___, ...rest } = s;
+        return [
+          { ...rest, lastRun: null, subjectPreview: null, runStats: { total: 0, delivered: 0, failed: 0, skipped: 0 } },
+        ];
       }
       return [];
     });

--- a/packages/api/test/schedule-route.test.js
+++ b/packages/api/test/schedule-route.test.js
@@ -149,7 +149,7 @@ describe('Schedule Routes', () => {
       assert.ok(!body.tasks.some((task) => task.id === 'review-feedback'));
     });
 
-    it('does not leak cross-thread PR summaries via subjectKind fallback once a task has runs', async () => {
+    it('includes PR scheduler tasks for threads with active PR tracking even if task has prior runs (#320 P1)', async () => {
       taskStore.upsertBySubject({
         kind: 'pr_tracking',
         subjectKey: 'pr:another/repo#7',
@@ -160,6 +160,15 @@ describe('Schedule Routes', () => {
       });
 
       const res = await app.inject({ method: 'GET', url: '/api/schedule/tasks?threadId=abc123' });
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+      // cicd-check has subjectKind='pr' and thread has active pr_tracking → must appear
+      assert.ok(body.tasks.some((task) => task.id === 'cicd-check'));
+    });
+
+    it('excludes PR scheduler tasks for threads without any PR tracking', async () => {
+      // thread xyz999 has no tasks at all
+      const res = await app.inject({ method: 'GET', url: '/api/schedule/tasks?threadId=xyz999' });
       assert.equal(res.statusCode, 200);
       const body = JSON.parse(res.payload);
       assert.ok(!body.tasks.some((task) => task.id === 'cicd-check'));

--- a/packages/api/test/schedule-route.test.js
+++ b/packages/api/test/schedule-route.test.js
@@ -168,6 +168,11 @@ describe('Schedule Routes', () => {
       // Kind-match included tasks must have foreign run metadata scrubbed
       assert.equal(cicd.lastRun, null, 'lastRun from other PR must be scrubbed');
       assert.equal(cicd.subjectPreview, null, 'subjectPreview from other PR must be scrubbed');
+      assert.deepEqual(
+        cicd.runStats,
+        { total: 0, delivered: 0, failed: 0, skipped: 0 },
+        'runStats from other PRs must be zeroed',
+      );
     });
 
     it('excludes PR scheduler tasks for threads without any PR tracking', async () => {

--- a/packages/api/test/schedule-route.test.js
+++ b/packages/api/test/schedule-route.test.js
@@ -163,7 +163,11 @@ describe('Schedule Routes', () => {
       assert.equal(res.statusCode, 200);
       const body = JSON.parse(res.payload);
       // cicd-check has subjectKind='pr' and thread has active pr_tracking → must appear
-      assert.ok(body.tasks.some((task) => task.id === 'cicd-check'));
+      const cicd = body.tasks.find((task) => task.id === 'cicd-check');
+      assert.ok(cicd, 'cicd-check should appear for thread with active PR tracking');
+      // Kind-match included tasks must have foreign run metadata scrubbed
+      assert.equal(cicd.lastRun, null, 'lastRun from other PR must be scrubbed');
+      assert.equal(cicd.subjectPreview, null, 'subjectPreview from other PR must be scrubbed');
     });
 
     it('excludes PR scheduler tasks for threads without any PR tracking', async () => {

--- a/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
+++ b/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
@@ -40,13 +40,7 @@ describe('ProjectSetupCard IME guard', () => {
 
     await act(async () => {
       root.render(
-        <ProjectSetupCard
-          projectPath="/tmp/demo"
-          isEmptyDir
-          isGitRepo={false}
-          gitAvailable
-          onComplete={onComplete}
-        />,
+        <ProjectSetupCard projectPath="/tmp/demo" isEmptyDir isGitRepo={false} gitAvailable onComplete={onComplete} />,
       );
     });
 

--- a/packages/web/src/stores/taskStore.ts
+++ b/packages/web/src/stores/taskStore.ts
@@ -1,17 +1,7 @@
+import type { TaskItem } from '@cat-cafe/shared';
 import { create } from 'zustand';
 
-export interface TaskItem {
-  id: string;
-  kind: 'work' | 'pr_tracking';
-  threadId: string;
-  title: string;
-  ownerCatId: string | null;
-  status: 'todo' | 'doing' | 'blocked' | 'done';
-  why: string;
-  createdBy: string;
-  createdAt: number;
-  updatedAt: number;
-}
+export type { TaskItem } from '@cat-cafe/shared';
 
 interface TaskState {
   tasks: TaskItem[];


### PR DESCRIPTION
## What

- `packages/api/src/routes/schedule.ts`: Remove `!s.lastRun` gate on kind-match filter path
- `packages/api/test/schedule-route.test.js`: Fix test asserting buggy behavior + add negative test
- `packages/web/src/stores/taskStore.ts`: Import TaskItem from @cat-cafe/shared (type alignment)

## Why

PR #323 added a kind-match filter in the SchedulePanel's thread-scoped view, but gated it with `!s.lastRun`. Builtin scheduler tasks (cicd-check, conflict-check, review-feedback) have prior runs for other PRs, so `s.lastRun` is always truthy — newly registered PR tracking tasks never appeared in the SchedulePanel.

## Original Requirements

- Discussion: thread_mnnebghhey6tj7cp
- **Original report**:
  > thread_mnnebghhey6tj7cp 这个thread我注册了pr的tracking，但是我在workspace的调度这里看不到这个任务
- CVO core pain: PR tracking registered but invisible in workspace scheduler
- **Please verify: does this fix make PR tracking tasks visible in SchedulePanel?**

## Plan / ADR

- Reopened issue: #320
- Split from PR #379 per upstream review (TaskPanel changes dropped to align with cat-cafe #958)

## Tradeoff

Removed `!s.lastRun` on kind-match path. Tasks included via kind-match may show `lastRun` from a different PR — acknowledged as P2 follow-up (run state scrubbing for thread scope).

## Test Evidence

Schedule route tests: 26 passed, 0 failed
Build: success
Biome check: 0 errors on changed files

## Open Questions

None — scoped to SchedulePanel fix only.

---

**Local Review**: [x] gpt52 reviewed and approved (on original PR #379)
**Cloud Review**: [ ] Triggering in comment below

<!-- Cat Cafe signature (plain text): Ragdoll/opus (opus, claude-opus-4-6) -->