### PR TITLE
fix(security): redact CLI args from debug log to prevent prompt leakage

### DIFF
--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -467,7 +467,10 @@ function defaultSpawn(
   if (IS_WINDOWS) {
     const shimSpawn = resolveWindowsShimSpawn(command, args);
     if (shimSpawn) {
-      log.debug({ original: command, resolved: shimSpawn.command, args: shimSpawn.args }, 'Windows shim resolved');
+      log.debug(
+        { original: command, resolved: shimSpawn.command, argCount: shimSpawn.args.length },
+        'Windows shim resolved',
+      );
       return nodeSpawn(shimSpawn.command, shimSpawn.args, {
         cwd: options.cwd,
         env: options.env,


### PR DESCRIPTION
Closes #388

## Summary
- Windows shim debug log (`cli-spawn.ts:470`) was printing full `shimSpawn.args` including user prompt
- `effectivePrompt` is passed as CLI args via `['--', effectivePrompt]` in CodexAgentService
- In debug mode, this writes prompt content to log files in plaintext
- Fix: replace `args: shimSpawn.args` → `argCount: shimSpawn.args.length`

## Context
P1 blocker identified by 砚砚 during observability D1 (Telemetry Redaction Policy) design review. This must be fixed before any external telemetry (Sentry/OTel) integration.

References:
- `CodexAgentService.ts:279` — prompt enters CLI args
- `cli-spawn.ts:470` — debug log prints full args (FIXED)

## Test plan
- [x] 131 cli-spawn tests pass, 0 failures
- [x] `pnpm lint` passes
- [x] `pnpm check` (Biome) passes
- [x] CI green (rerun after flaky F149 timing test)

🐾 [宪宪/Opus-46]

🤖 Generated with [Claude Code](https://claude.com/claude-code)