### PR TITLE
fix(web): add API/socket.io rewrites for cloud deployments

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -29,6 +29,14 @@ const nextConfig = {
   async rewrites() {
     return [
       {
+        source: '/api/:path*',
+        destination: `${apiBaseUrl}/api/:path*`,
+      },
+      {
+        source: '/socket.io/:path*',
+        destination: `${apiBaseUrl}/socket.io/:path*`,
+      },
+      {
         source: '/uploads/:path*',
         destination: `${apiBaseUrl}/uploads/:path*`,
       },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "vitest run && node eslint-plugins/no-hardcoded-colors.test.js",
+    "test": "vitest run && node --test test/next-config.test.cjs && node eslint-plugins/no-hardcoded-colors.test.js",
     "test:lint-rules": "node eslint-plugins/no-hardcoded-colors.test.js"
   },
   "dependencies": {

--- a/packages/web/test/next-config.test.cjs
+++ b/packages/web/test/next-config.test.cjs
@@ -25,17 +25,38 @@ function withEnv(overrides, run) {
   }
 }
 
-describe('next.config uploads rewrite', () => {
-  it('falls back to the default API port when env vars are unset', async () => {
+describe('next.config rewrites', () => {
+  it('proxies /api, /socket.io, and /uploads to default API port', async () => {
     await withEnv({}, async (config) => {
       const rewrites = await config.rewrites();
-      assert.deepEqual(
-        rewrites.find((entry) => entry.source === '/uploads/:path*'),
-        {
-          source: '/uploads/:path*',
-          destination: 'http://localhost:3004/uploads/:path*',
-        },
-      );
+      assert.deepEqual(rewrites, [
+        { source: '/api/:path*', destination: 'http://localhost:3004/api/:path*' },
+        { source: '/socket.io/:path*', destination: 'http://localhost:3004/socket.io/:path*' },
+        { source: '/uploads/:path*', destination: 'http://localhost:3004/uploads/:path*' },
+      ]);
+    });
+  });
+
+  it('respects NEXT_PUBLIC_API_URL', async () => {
+    await withEnv({ NEXT_PUBLIC_API_URL: 'http://myhost:9000' }, async (config) => {
+      const rewrites = await config.rewrites();
+      assert.equal(rewrites[0].destination, 'http://myhost:9000/api/:path*');
+      assert.equal(rewrites[1].destination, 'http://myhost:9000/socket.io/:path*');
+      assert.equal(rewrites[2].destination, 'http://myhost:9000/uploads/:path*');
+    });
+  });
+
+  it('respects API_SERVER_PORT', async () => {
+    await withEnv({ API_SERVER_PORT: '4000' }, async (config) => {
+      const rewrites = await config.rewrites();
+      assert.equal(rewrites[0].destination, 'http://localhost:4000/api/:path*');
+    });
+  });
+
+  it('respects FRONTEND_PORT (API = frontend + 1)', async () => {
+    await withEnv({ FRONTEND_PORT: '5000' }, async (config) => {
+      const rewrites = await config.rewrites();
+      assert.equal(rewrites[0].destination, 'http://localhost:5001/api/:path*');
     });
   });
 });


### PR DESCRIPTION
## Summary

- **P1 bugfix**: Cloud deployments (Codespace, HF Spaces, Docker) show "配置加载失败" because `next.config.js` only proxied `/uploads/*`, missing `/api/*` and `/socket.io/*`
- Added rewrite rules so same-origin proxy works in portless environments
- Fixed and wired up `next-config.test.cjs` (was broken and not in CI)

## Upstream

Cherry-picked from internal repo: zts212653/cat-cafe#1019

## Test plan

- [x] `node --test test/next-config.test.cjs` — 4/4 pass
- [ ] Deploy to Codespace/HF Space and verify config loads

Generated with [Claude Code](https://claude.com/claude-code)