### PR TITLE
fix: prohibit git stash -u in merge-gate to prevent silent data loss

### DIFF
--- a/cat-cafe-skills/deep-research/SKILL.md
+++ b/cat-cafe-skills/deep-research/SKILL.md
@@ -161,6 +161,17 @@ docs/prompts/YYYY-MM-DD-{topic}-research-prompt.md
 | 忽略三方分歧 | 分歧 = 最有价值的信号，必须分析 |
 | Coder 猫盲信 web 报告 | 必须对照实际 codebase 验证 |
 
+## Step 5 — 持久化产出（2026-04-09 教训）
+
+**调研产出必须 commit，Write ≠ 持久化。**
+
+产出文档写完后，立刻 `git add` + `git commit`。
+- 在 worktree 里：commit 到分支
+- 在 main 上：commit + push（确保其他猫能看到）
+- 多次 Edit 更新：每次重大更新后追加 commit
+
+**验证**：`git log --oneline -1` 显示刚才的 commit。没有 commit SHA = 没有完成。
+
 ## Next Step
 
 → `collaborative-thinking`（讨论调研结论，形成决策）

--- a/cat-cafe-skills/merge-gate/SKILL.md
+++ b/cat-cafe-skills/merge-gate/SKILL.md
@@ -125,7 +125,27 @@ gh pr merge {PR_NUMBER} --squash --delete-branch
 # → 见下方「Phase 文档同步」章节
 
 # 8. 更新本地 + 清理
+# ⚠️ LL (2026-04-09): 禁止 git stash -u！
+# git stash -u 会 clean 所有 untracked 文件，如果其他 session
+# 在 main 上有未 commit 的产出，会被静默删除且 pop 时可能
+# 因同名文件冲突导致 ALL untracked files 不恢复（连坐丢失）。
+#
+# 正确做法：先检查 untracked 新文件，有就先 commit 再 pull。
+UNTRACKED_NEW=$(git ls-files --others --exclude-standard -- docs/ | head -5)
+if [ -n "$UNTRACKED_NEW" ]; then
+  echo "⚠️ 发现 untracked 新文件（可能是其他 session 的产出）："
+  echo "$UNTRACKED_NEW"
+  echo "→ 先 commit 这些文件再继续，防止 stash/pull 丢失"
+  git add $UNTRACKED_NEW && git commit -m "docs: rescue untracked files before merge-gate pull
+
+Why: prevent data loss from git stash -u (see agent-mesh#25)
+
+[merge-gate/auto🐾]"
+fi
+# 只 stash tracked 修改（绝不用 -u）
+git stash --quiet 2>/dev/null || true
 git checkout main && git pull origin main
+git stash pop --quiet 2>/dev/null || true
 git worktree remove ../cat-cafe-{feature-name}
 git branch -d {branch-name} && git worktree prune
 

--- a/cat-cafe-skills/refs/shared-rules.md
+++ b/cat-cafe-skills/refs/shared-rules.md
@@ -143,6 +143,18 @@ AI agent 100x 执行速度下，**方向正确性**的价值远大于**启动便
 
 完成一个可验证的子任务就提交。
 
+**Write ≠ 持久化（2026-04-09 教训）**：
+- `Write`/`Edit` 工具写文件只是写到文件系统，不等于持久化
+- **只有 `git commit` 才是持久化**——session 结束、`git stash -u`、`git clean` 都会让未 commit 的文件永久丢失
+- 产出 ≥10 行的文件，Write 之后**同一个 turn 内必须 commit**
+- 不 commit 就回复铲屎官 = 假完成（违反 P5 可验证）
+
+**禁止 `git stash -u`/`git stash --include-untracked` 对 main 工作目录**：
+- `git stash -u` 内部执行 `git clean`，会删除所有 untracked 文件
+- 多 session 共享 main 工作目录时，其他 session 的未 commit 产出会被静默删除
+- `git stash pop` 对 untracked files 是 all-or-nothing：一个文件冲突 = 全部不恢复
+- **只用 `git stash`（不带 -u）**，或先 commit untracked 文件再 stash
+
 **签名（强制）**：commit message body 必须带猫猫签名，格式 `[昵称/模型🐾]`。
 签名必须包含**模型型号**，不能只写 `[Ragdoll🐾]`——同族有多个模型（Opus 4.6 / Opus 4.5 / Sonnet），不带型号无法区分是谁干的。
 签名表见 `refs/commit-signatures.md`。示例：`[Ragdoll/Opus-46🐾]`、`[Maine Coon/GPT-52🐾]`。


### PR DESCRIPTION
## Summary

Fixes #402

- **merge-gate/SKILL.md**: Step 8 now checks for untracked `docs/` files and auto-commits them before `git pull`; stash uses plain `git stash` (never `-u`)
- **shared-rules.md**: §5 Commit 纪律 adds "Write ≠ persistence" rule + explicit ban on `git stash -u` / `--include-untracked` for shared main worktree
- **deep-research/SKILL.md**: New Step 5 requires `git commit` immediately after writing research output files

## Context

2026-04-09 incident: a 480-line research document was silently destroyed by `git stash -u` during merge-gate cleanup. The root cause chain:

1. Session A wrote file via `Write` tool but didn't commit
2. Session B ran `git stash -u` (internally does `git clean`) → untracked file deleted from disk
3. `git pull` brought a same-name file from merged PR
4. `git stash pop` failed on conflict → **all-or-nothing**: zero untracked files restored
5. Innocent document lost as collateral damage

File recovered from git dangling object (`git show e45ebba:...`).

## Test plan

- [ ] Verify merge-gate Step 8 no longer contains `git stash -u`
- [ ] Verify shared-rules.md §5 contains "Write ≠ 持久化" and "禁止 git stash -u" paragraphs
- [ ] Verify deep-research/SKILL.md has Step 5 before "Next Step"
- [ ] Grep entire repo for `stash -u` or `stash --include-untracked` to ensure no other occurrences

[宪宪/Opus-46🐾]