### PR TITLE
docs: add persistence and fail-closed cleanup guardrails

### DIFF
--- a/cat-cafe-skills/deep-research/SKILL.md
+++ b/cat-cafe-skills/deep-research/SKILL.md
@@ -161,6 +161,15 @@ docs/prompts/YYYY-MM-DD-{topic}-research-prompt.md
 | 忽略三方分歧 | 分歧 = 最有价值的信号，必须分析 |
 | Coder 猫盲信 web 报告 | 必须对照实际 codebase 验证 |
 
+## Step 5 — 在交接前持久化调研产出
+
+如果调研结果需要被后续 session、其他猫、或人类继续使用，就在结束该流程前 commit。
+- 在 worktree 里：commit 到当前分支
+- 在共享 main worktree：commit + push，确保其他 session 能看到
+- 多次 Edit 更新：每次重大更新后追加 commit
+
+**验证**：在总结 / handoff 里记录 commit SHA。`git log --oneline -1` 显示刚才的 commit。
+
 ## Next Step
 
 → `collaborative-thinking`（讨论调研结论，形成决策）

--- a/cat-cafe-skills/merge-gate/SKILL.md
+++ b/cat-cafe-skills/merge-gate/SKILL.md
@@ -124,7 +124,16 @@ gh pr merge {PR_NUMBER} --squash --delete-branch
 # 7.5 Phase 文档同步（每次 merge 必做！）🔴
 # → 见下方「Phase 文档同步」章节
 
-# 8. 更新本地 + 清理
+# 8. 更新本地 + 清理（fail-closed）
+# ⚠️ 发现脏工作树就停止，不要“即兴”用 git stash -u 清理。
+# 原因：git stash -u/--include-untracked 会删除 untracked 文件（内部 git clean），
+# 在多 session 共享工作目录时可能导致其他 session 的未 commit 产出丢失。
+if [ -n "$(git status --porcelain)" ]; then
+  echo "❌ 工作树不干净，停止 merge-gate（fail-closed）"
+  echo "请先处理改动后再继续。禁止使用 git stash -u/--include-untracked。"
+  git status --short
+  exit 1
+fi
 git checkout main && git pull origin main
 git worktree remove ../cat-cafe-{feature-name}
 git branch -d {branch-name} && git worktree prune

--- a/cat-cafe-skills/refs/shared-rules.md
+++ b/cat-cafe-skills/refs/shared-rules.md
@@ -143,6 +143,15 @@ AI agent 100x 执行速度下，**方向正确性**的价值远大于**启动便
 
 完成一个可验证的子任务就提交。
 
+**Write ≠ 持久化**：
+- `Write`/`Edit` 只是把内容写到文件系统，不等于持久化
+- 如果一个产出需要跨 session 保留，或需要被其他猫 / workflow / 人类后续消费，那么在任务完成前必须 commit
+
+**共享工作目录中禁止对 untracked 文件做破坏性清理**：
+- `git stash -u`、`git clean` 等命令会删除所有 untracked 文件，在多 session 共享工作目录时会静默破坏其他 session 的产出
+- 执行这类操作前必须先检查 untracked 文件并明确保全（commit 或确认无需保留）
+- **只用 `git stash`（不带 -u）**，或先 commit untracked 文件再 stash
+
 **签名（强制）**：commit message body 必须带猫猫签名，格式 `[昵称/模型🐾]`。
 签名必须包含**模型型号**，不能只写 `[Ragdoll🐾]`——同族有多个模型（Opus 4.6 / Opus 4.5 / Sonnet），不带型号无法区分是谁干的。
 签名表见 `refs/commit-signatures.md`。示例：`[Ragdoll/Opus-46🐾]`、`[Maine Coon/GPT-52🐾]`。


### PR DESCRIPTION
## Summary

Refines our guardrails around persistence and shared-worktree cleanup.

- `cat-cafe-skills/refs/shared-rules.md`: add a generalized `Write/Edit ≠ persistence` rule and a guard against destructive cleanup of untracked files in shared worktrees
- `cat-cafe-skills/deep-research/SKILL.md`: add Step 5 to persist research outputs before handoff and record the resulting commit SHA
- `cat-cafe-skills/merge-gate/SKILL.md`: make Step 8 fail closed when the worktree is dirty, instead of allowing improvised cleanup

## Notes

- Closes #428
- Incident details stay in #402; this PR only carries the distilled rule and workflow changes
- This PR now only touches the three docs/skill files above

## Test plan

- [x] Verify `shared-rules.md` wording is generalized and does not encode incident-specific dates or local policy thresholds
- [x] Verify `deep-research/SKILL.md` places persistence before handoff / next-step transition
- [x] Verify `merge-gate/SKILL.md` stops on a dirty worktree and prints `git status --short`
