### PR TITLE
fix(workspace): use path.isAbsolute() for Windows path compatibility

### DIFF
--- a/packages/api/src/routes/workspace.ts
+++ b/packages/api/src/routes/workspace.ts
@@ -280,7 +280,7 @@ export const workspaceRoutes: FastifyPluginAsync<WorkspaceRouteOpts> = async (ap
   app.get<{ Querystring: { repoRoot?: string } }>('/api/workspace/worktrees', async (request, reply) => {
     const { repoRoot } = request.query;
     if (repoRoot) {
-      if (!repoRoot.startsWith('/')) {
+      if (!isAbsolute(repoRoot)) {
         reply.status(400);
         return { error: 'repoRoot must be an absolute path' };
       }

--- a/packages/api/test/workspace-windows-path.test.js
+++ b/packages/api/test/workspace-windows-path.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { isAbsolute } from 'node:path';
+import { describe, it } from 'node:test';
+
+describe('workspace worktrees repoRoot validation (Windows compat)', () => {
+  // The route handler uses isAbsolute() to validate repoRoot.
+  // Previously it used startsWith('/') which rejected Windows paths.
+
+  it('accepts Unix absolute path', () => {
+    assert.ok(isAbsolute('/home/user/project'));
+  });
+
+  it('accepts Windows absolute path with backslash', () => {
+    assert.ok(isAbsolute('C:\\Personal\\AIProjects\\test-project'));
+  });
+
+  it('accepts Windows absolute path with forward slash', () => {
+    assert.ok(isAbsolute('C:/Personal/AIProjects/test-project'));
+  });
+
+  it('accepts UNC path', () => {
+    assert.ok(isAbsolute('\\\\server\\share\\folder'));
+  });
+
+  it('rejects relative path', () => {
+    assert.ok(!isAbsolute('relative/path'));
+  });
+
+  it('rejects dot-relative path', () => {
+    assert.ok(!isAbsolute('./src/index.ts'));
+  });
+
+  it('rejects parent-relative path', () => {
+    assert.ok(!isAbsolute('../etc/passwd'));
+  });
+});


### PR DESCRIPTION
Closes #414

## Summary
- Workspace panel shows empty on Windows because `repoRoot.startsWith('/')` rejects Windows absolute paths like `C:\...`
- Replace with `path.isAbsolute()` (already imported) which handles both Windows and Unix paths
- One-line fix, no new dependencies

## Root Cause
`GET /api/workspace/worktrees?repoRoot=C:\...` returns 400 because the path validation assumes Unix-style absolute paths. Frontend `catch { /* ignore */ }` silently swallows the error, resulting in an empty workspace panel (no files, no changes, no git info).

## Changes
1. `packages/api/src/routes/workspace.ts:283` — `startsWith('/')` → `isAbsolute()`
2. `packages/api/test/workspace-windows-path.test.js` — regression test (7 cases)

## Test Evidence
```
▶ workspace worktrees repoRoot validation (Windows compat)
  ✔ accepts Unix absolute path (1.186ms)
  ✔ accepts Windows absolute path with backslash (0.2177ms)
  ✔ accepts Windows absolute path with forward slash (1.3559ms)
  ✔ accepts UNC path (0.2021ms)
  ✔ rejects relative path (0.2148ms)
  ✔ rejects dot-relative path (0.1911ms)
  ✔ rejects parent-relative path (0.2409ms)
✔ 7 pass, 0 fail
```

## Test plan
- [x] Regression test covers Windows/Unix/UNC/relative paths
- [ ] On Windows: open a project, verify workspace panel shows files/changes/git
- [ ] On macOS/Linux: verify no regression (Unix paths still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)