### PR TITLE
fix(#340): migrate legacy credentials from homedir when globalRoot differs

### DIFF
--- a/packages/api/src/config/catalog-accounts.ts
+++ b/packages/api/src/config/catalog-accounts.ts
@@ -329,15 +329,40 @@ function migrateProjectAccountsToGlobal(projectRoot: string): void {
   }
 }
 
+// ── Homedir legacy migration (picks up secrets written by pre-F340 installer without --project-dir) ──
+
+let homedirLegacyDone = false;
+
+function migrateHomedirLegacyProviderProfiles(projectRoot?: string): void {
+  if (homedirLegacyDone) return;
+  const globalRoot = resolveGlobalRoot(projectRoot);
+  const home = homedir();
+  if (resolve(globalRoot) === resolve(home)) {
+    // Global root IS homedir — already covered by migrateLegacyProviderProfiles.
+    homedirLegacyDone = true;
+    return;
+  }
+  try {
+    migrateLegacyFrom(home, projectRoot);
+    homedirLegacyDone = true;
+  } catch (err) {
+    // Best-effort: don't block startup if homedir legacy files are corrupt.
+    console.error('[catalog-accounts] homedir legacy→global migration failed:', err);
+    homedirLegacyDone = true;
+  }
+}
+
 function ensureMigrated(projectRoot: string): void {
   migrateLegacyProviderProfiles(projectRoot);
   migrateProjectLegacyProviderProfiles(projectRoot);
+  migrateHomedirLegacyProviderProfiles(projectRoot);
   migrateProjectAccountsToGlobal(projectRoot);
 }
 
 /** Reset migration state (for tests). */
 export function resetMigrationState(): void {
   legacyMigrationDone = false;
+  homedirLegacyDone = false;
   migratedProjects.clear();
   migratedProjectLegacy.clear();
 }

--- a/packages/api/src/config/catalog-accounts.ts
+++ b/packages/api/src/config/catalog-accounts.ts
@@ -331,24 +331,25 @@ function migrateProjectAccountsToGlobal(projectRoot: string): void {
 
 // ── Homedir legacy migration (picks up secrets written by pre-F340 installer without --project-dir) ──
 
-let homedirLegacyDone = false;
+const migratedHomedirLegacy = new Set<string>();
 
 function migrateHomedirLegacyProviderProfiles(projectRoot?: string): void {
-  if (homedirLegacyDone) return;
   const globalRoot = resolveGlobalRoot(projectRoot);
+  const resolvedTarget = resolve(globalRoot);
+  if (migratedHomedirLegacy.has(resolvedTarget)) return;
   const home = homedir();
-  if (resolve(globalRoot) === resolve(home)) {
+  if (resolvedTarget === resolve(home)) {
     // Global root IS homedir — already covered by migrateLegacyProviderProfiles.
-    homedirLegacyDone = true;
+    migratedHomedirLegacy.add(resolvedTarget);
     return;
   }
   try {
     migrateLegacyFrom(home, projectRoot);
-    homedirLegacyDone = true;
+    migratedHomedirLegacy.add(resolvedTarget);
   } catch (err) {
     // Best-effort: don't block startup if homedir legacy files are corrupt.
     console.error('[catalog-accounts] homedir legacy→global migration failed:', err);
-    homedirLegacyDone = true;
+    migratedHomedirLegacy.add(resolvedTarget);
   }
 }
 
@@ -362,7 +363,7 @@ function ensureMigrated(projectRoot: string): void {
 /** Reset migration state (for tests). */
 export function resetMigrationState(): void {
   legacyMigrationDone = false;
-  homedirLegacyDone = false;
+  migratedHomedirLegacy.clear();
   migratedProjects.clear();
   migratedProjectLegacy.clear();
 }

--- a/packages/api/src/config/catalog-accounts.ts
+++ b/packages/api/src/config/catalog-accounts.ts
@@ -347,9 +347,14 @@ function migrateHomedirLegacyProviderProfiles(projectRoot?: string): void {
     migrateLegacyFrom(home, projectRoot);
     migratedHomedirLegacy.add(resolvedTarget);
   } catch (err) {
-    // Best-effort: don't block startup if homedir legacy files are corrupt.
-    console.error('[catalog-accounts] homedir legacy→global migration failed:', err);
-    migratedHomedirLegacy.add(resolvedTarget);
+    // Only swallow parse/read errors (corrupt homedir files). Re-throw account
+    // conflicts and other migration errors so callers get a fail-fast signal.
+    if (err instanceof SyntaxError || (err instanceof Error && err.message.includes('ENOENT'))) {
+      console.error('[catalog-accounts] homedir legacy→global migration failed (corrupt source, skipped):', err);
+      migratedHomedirLegacy.add(resolvedTarget);
+    } else {
+      throw err;
+    }
   }
 }
 

--- a/packages/api/test/account-resolver.test.js
+++ b/packages/api/test/account-resolver.test.js
@@ -7,7 +7,13 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 describe('account-resolver (4b unified runtime resolution)', () => {
   let projectRoot;
   let previousGlobalRoot;
-  const ENV_KEYS_TO_ISOLATE = ['CAT_CAFE_GLOBAL_CONFIG_ROOT', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY', 'GOOGLE_API_KEY'];
+  const ENV_KEYS_TO_ISOLATE = [
+    'CAT_CAFE_GLOBAL_CONFIG_ROOT',
+    'ANTHROPIC_API_KEY',
+    'OPENAI_API_KEY',
+    'GOOGLE_API_KEY',
+    'HOME',
+  ];
   const savedEnv = {};
 
   beforeEach(async () => {
@@ -18,6 +24,8 @@ describe('account-resolver (4b unified runtime resolution)', () => {
       delete process.env[key];
     }
     process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = projectRoot;
+    // Isolate homedir so the homedir migration doesn't pick up real ~/.cat-cafe/ files
+    process.env.HOME = projectRoot;
     await mkdir(join(projectRoot, '.cat-cafe'), { recursive: true });
   });
 

--- a/packages/api/test/account-startup.test.js
+++ b/packages/api/test/account-startup.test.js
@@ -8,12 +8,16 @@ describe('accountStartupHook (F340 fail-fast)', () => {
   let globalRoot;
   let projectRoot;
   let previousGlobalRoot;
+  let previousHome;
 
   beforeEach(async () => {
     globalRoot = await mkdtemp(join(tmpdir(), 'acct-startup-'));
     projectRoot = await mkdtemp(join(tmpdir(), 'acct-startup-proj-'));
     previousGlobalRoot = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    previousHome = process.env.HOME;
     process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = globalRoot;
+    // Isolate homedir so the homedir migration doesn't pick up real ~/.cat-cafe/ files
+    process.env.HOME = globalRoot;
     await mkdir(join(globalRoot, '.cat-cafe'), { recursive: true });
     await mkdir(join(projectRoot, '.cat-cafe'), { recursive: true });
   });
@@ -21,6 +25,7 @@ describe('accountStartupHook (F340 fail-fast)', () => {
   afterEach(async () => {
     if (previousGlobalRoot === undefined) delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
     else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = previousGlobalRoot;
+    process.env.HOME = previousHome;
     await rm(globalRoot, { recursive: true, force: true });
     await rm(projectRoot, { recursive: true, force: true });
   });

--- a/packages/api/test/account-startup.test.js
+++ b/packages/api/test/account-startup.test.js
@@ -25,7 +25,8 @@ describe('accountStartupHook (F340 fail-fast)', () => {
   afterEach(async () => {
     if (previousGlobalRoot === undefined) delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
     else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = previousGlobalRoot;
-    process.env.HOME = previousHome;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     await rm(globalRoot, { recursive: true, force: true });
     await rm(projectRoot, { recursive: true, force: true });
   });

--- a/packages/api/test/catalog-accounts.test.js
+++ b/packages/api/test/catalog-accounts.test.js
@@ -26,7 +26,8 @@ describe('global accounts (F340)', () => {
   afterEach(async () => {
     if (previousGlobalRoot === undefined) delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
     else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = previousGlobalRoot;
-    process.env.HOME = previousHome;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     await rm(globalRoot, { recursive: true, force: true });
     await rm(projectRoot, { recursive: true, force: true });
   });

--- a/packages/api/test/catalog-accounts.test.js
+++ b/packages/api/test/catalog-accounts.test.js
@@ -556,4 +556,55 @@ describe('global accounts (F340)', () => {
       await rm(fakeHome, { recursive: true, force: true });
     }
   });
+
+  it('migrates homedir credentials to multiple projects in the same process', async () => {
+    const { readCatalogAccounts, resetMigrationState } = await import('../dist/config/catalog-accounts.js');
+    resetMigrationState();
+
+    delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+
+    const fakeHome = await mkdtemp(join(tmpdir(), 'fake-home-'));
+    await mkdir(join(fakeHome, '.cat-cafe'), { recursive: true });
+    const projectB = await mkdtemp(join(tmpdir(), 'project-b-'));
+    await mkdir(join(projectB, '.cat-cafe'), { recursive: true });
+    const savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      await writeFile(
+        join(fakeHome, '.cat-cafe', 'provider-profiles.json'),
+        JSON.stringify({
+          version: 2,
+          providers: [{ id: 'homedir-account', authType: 'api_key', baseUrl: 'https://home.api/v1' }],
+        }),
+        'utf-8',
+      );
+      await writeFile(
+        join(fakeHome, '.cat-cafe', 'provider-profiles.secrets.local.json'),
+        JSON.stringify({ profiles: { 'homedir-account': { apiKey: 'sk-from-homedir' } } }),
+        'utf-8',
+      );
+
+      // First project migrates successfully
+      const resultA = readCatalogAccounts(projectRoot);
+      assert.equal(resultA['homedir-account']?.baseUrl, 'https://home.api/v1', 'projectA must get homedir account');
+
+      // Second project must ALSO get the homedir credentials (not skipped by boolean cache)
+      const resultB = readCatalogAccounts(projectB);
+      assert.equal(
+        resultB['homedir-account']?.baseUrl,
+        'https://home.api/v1',
+        'projectB must also get homedir account',
+      );
+
+      const credRawB = await readFile(join(projectB, '.cat-cafe', 'credentials.json'), 'utf-8');
+      const credsB = JSON.parse(credRawB);
+      assert.equal(credsB['homedir-account']?.apiKey, 'sk-from-homedir', 'projectB must also get homedir API key');
+    } finally {
+      process.env.HOME = savedHome;
+      process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = globalRoot;
+      await rm(fakeHome, { recursive: true, force: true });
+      await rm(projectB, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/api/test/catalog-accounts.test.js
+++ b/packages/api/test/catalog-accounts.test.js
@@ -9,12 +9,16 @@ describe('global accounts (F340)', () => {
   let globalRoot;
   let projectRoot;
   let previousGlobalRoot;
+  let previousHome;
 
   beforeEach(async () => {
     globalRoot = await mkdtemp(join(tmpdir(), 'global-accounts-'));
     projectRoot = await mkdtemp(join(tmpdir(), 'project-accounts-'));
     previousGlobalRoot = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+    previousHome = process.env.HOME;
     process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = globalRoot;
+    // Isolate homedir so the homedir migration doesn't pick up real ~/.cat-cafe/ files
+    process.env.HOME = globalRoot;
     await mkdir(join(globalRoot, '.cat-cafe'), { recursive: true });
     await mkdir(join(projectRoot, '.cat-cafe'), { recursive: true });
   });
@@ -22,6 +26,7 @@ describe('global accounts (F340)', () => {
   afterEach(async () => {
     if (previousGlobalRoot === undefined) delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
     else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = previousGlobalRoot;
+    process.env.HOME = previousHome;
     await rm(globalRoot, { recursive: true, force: true });
     await rm(projectRoot, { recursive: true, force: true });
   });
@@ -504,6 +509,51 @@ describe('global accounts (F340)', () => {
     if (existsSync(credPath)) {
       const creds = JSON.parse(await readFile(credPath, 'utf-8'));
       assert.equal(creds.shared, undefined, 'legacy secret must NOT be attached to different-source api_key account');
+    }
+  });
+
+  it('migrates legacy credentials from homedir when globalRoot differs from homedir', async () => {
+    const { readCatalogAccounts, resetMigrationState } = await import('../dist/config/catalog-accounts.js');
+    resetMigrationState();
+
+    // Simulate: CAT_CAFE_GLOBAL_CONFIG_ROOT is unset, projectRoot != homedir.
+    // Old installer (pre-F340) wrote secrets to homedir when --project-dir was not given.
+    delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+
+    const fakeHome = await mkdtemp(join(tmpdir(), 'fake-home-'));
+    await mkdir(join(fakeHome, '.cat-cafe'), { recursive: true });
+    const savedHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      // Legacy provider-profiles + secrets in homedir (old installer output)
+      await writeFile(
+        join(fakeHome, '.cat-cafe', 'provider-profiles.json'),
+        JSON.stringify({
+          version: 2,
+          providers: [{ id: 'homedir-account', authType: 'api_key', baseUrl: 'https://home.api/v1' }],
+        }),
+        'utf-8',
+      );
+      await writeFile(
+        join(fakeHome, '.cat-cafe', 'provider-profiles.secrets.local.json'),
+        JSON.stringify({ profiles: { 'homedir-account': { apiKey: 'sk-from-homedir' } } }),
+        'utf-8',
+      );
+
+      // projectRoot is a separate directory — no legacy files there
+      const result = readCatalogAccounts(projectRoot);
+      assert.equal(result['homedir-account']?.baseUrl, 'https://home.api/v1', 'account from homedir must be migrated');
+
+      // Credentials should be migrated to globalRoot (= projectRoot when env unset)
+      const credRaw = await readFile(join(projectRoot, '.cat-cafe', 'credentials.json'), 'utf-8');
+      const creds = JSON.parse(credRaw);
+      assert.equal(creds['homedir-account']?.apiKey, 'sk-from-homedir', 'API key from homedir must be migrated');
+    } finally {
+      process.env.HOME = savedHome;
+      // Restore env for subsequent tests
+      process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = globalRoot;
+      await rm(fakeHome, { recursive: true, force: true });
     }
   });
 });

--- a/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
+++ b/packages/web/src/components/__tests__/project-setup-card-ime.test.tsx
@@ -40,13 +40,7 @@ describe('ProjectSetupCard IME guard', () => {
 
     await act(async () => {
       root.render(
-        <ProjectSetupCard
-          projectPath="/tmp/demo"
-          isEmptyDir
-          isGitRepo={false}
-          gitAvailable
-          onComplete={onComplete}
-        />,
+        <ProjectSetupCard projectPath="/tmp/demo" isEmptyDir isGitRepo={false} gitAvailable onComplete={onComplete} />,
       );
     });
 

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -336,6 +336,21 @@ function migrateLegacyProfiles(projectDir) {
   }
 }
 
+/** Run all legacy migration sources: projectDir, globalRoot, and homedir (if different). */
+function migrateAllLegacySources(projectDir) {
+  if (projectDir) migrateLegacyProfiles(projectDir);
+  migrateLegacyProfiles(null); // reads from globalDir() = resolveGlobalRoot()
+  // Also try homedir: pre-F340 installer without --project-dir wrote there.
+  const home = homedir();
+  if (path.resolve(resolveGlobalRoot()) !== path.resolve(home)) {
+    try {
+      migrateLegacyProfiles(home);
+    } catch {
+      // Best-effort: don't block operation if homedir legacy files are corrupt.
+    }
+  }
+}
+
 // ── Commands ──
 
 function setClientAuth(client, mode, options) {
@@ -453,8 +468,7 @@ try {
     // Migrate legacy files before applying
     const projDir = getOptional(values, 'project-dir', '');
     _activeProjectDir = projDir;
-    if (projDir) migrateLegacyProfiles(projDir);
-    migrateLegacyProfiles(null);
+    migrateAllLegacySources(projDir);
     const mode = getRequired(values, 'mode');
     if (mode === 'oauth') {
       setClientAuth(client, 'oauth', {});
@@ -486,8 +500,7 @@ try {
     const projectDir = getRequired(values, 'project-dir');
     _activeProjectDir = projectDir;
     // Migrate legacy files before removal so accounts/credentials are in global store
-    if (projectDir) migrateLegacyProfiles(projectDir);
-    migrateLegacyProfiles(null);
+    migrateAllLegacySources(projectDir);
     const force = values.get('force')?.[0] === 'true';
     removeClientAuth(client, `installer-${client}`, projectDir, { force });
     process.exit(0);
@@ -497,8 +510,7 @@ try {
     const projectDir = getOptional(values, 'project-dir', '');
     _activeProjectDir = projectDir;
     // Migrate legacy files before applying new setting
-    if (projectDir) migrateLegacyProfiles(projectDir);
-    migrateLegacyProfiles(null);
+    migrateAllLegacySources(projectDir);
     const apiKey = getOptional(values, 'api-key', '') || process.env._INSTALLER_API_KEY || '';
     if (!apiKey) {
       console.error('Error: API key required via --api-key or _INSTALLER_API_KEY env var');


### PR DESCRIPTION
## Summary
- **Bug**: When `CAT_CAFE_GLOBAL_CONFIG_ROOT` is unset and `projectRoot` ≠ `homedir()`, the F340 legacy migration only searched `projectRoot` for `provider-profiles.secrets.local.json`, missing API keys written to `~/.cat-cafe/` by the pre-F340 installer (which defaulted to homedir without `--project-dir`)
- **Fix**: Added `migrateHomedirLegacyProviderProfiles()` as a third migration source in `ensureMigrated()` (runtime) and `migrateAllLegacySources()` in `install-auth-config.mjs` (CLI installer). Both are best-effort — corrupt homedir files log warnings but don't block startup
- **Tests**: Added regression test for the homedir migration scenario; fixed HOME isolation in existing test suites to prevent interference from real `~/.cat-cafe/` files

## Test plan
- [x] New test: "migrates legacy credentials from homedir when globalRoot differs from homedir" — 17/17 pass
- [x] account-startup.test.js — 6/6 pass (was 2/6 without HOME isolation fix)
- [x] account-resolver.test.js — 15/15 pass
- [x] `pnpm check` clean
- [x] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)