### PR TITLE
fix(#421): route pnpm start through cross-platform entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "init": "./scripts/init-cafe.sh",
     "gate": "bash ./scripts/pre-merge-check.sh",
     "guards:install": "bash ./scripts/install-git-guards.sh",
-    "start": "./scripts/runtime-worktree.sh start",
+    "start": "node ./scripts/start-entry.mjs start",
     "stop": "./scripts/start-dev.sh --stop",
     "start:status": "./scripts/start-dev.sh --status",
     "start:direct": "node ./scripts/start-entry.mjs start:direct --profile=opensource",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "init": "./scripts/init-cafe.sh",
     "gate": "bash ./scripts/pre-merge-check.sh",
     "guards:install": "bash ./scripts/install-git-guards.sh",
-    "start": "node ./scripts/start-entry.mjs start",
+    "start": "node ./scripts/start-entry.mjs start --profile=opensource",
     "stop": "./scripts/start-dev.sh --stop",
     "start:status": "./scripts/start-dev.sh --status",
     "start:direct": "node ./scripts/start-entry.mjs start:direct --profile=opensource",

--- a/packages/api/test/telemetry/observability-coverage.test.js
+++ b/packages/api/test/telemetry/observability-coverage.test.js
@@ -16,11 +16,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // --- Liveness probe registration tests ---
 
 test('F153: liveness probe register/unregister lifecycle', async (t) => {
-  const {
-    registerLivenessProbe,
-    unregisterLivenessProbe,
-    livenessStateToNumber,
-  } = await import('../../dist/infrastructure/telemetry/instruments.js');
+  const { registerLivenessProbe, unregisterLivenessProbe, livenessStateToNumber } = await import(
+    '../../dist/infrastructure/telemetry/instruments.js'
+  );
 
   await t.test('livenessStateToNumber maps correctly', () => {
     assert.equal(livenessStateToNumber('dead'), 0);
@@ -41,20 +39,11 @@ test('F153: liveness probe register/unregister lifecycle', async (t) => {
 });
 
 test('F153: cli-spawn wires liveness probes', () => {
-  const source = readFileSync(
-    resolve(__dirname, '../../src/utils/cli-spawn.ts'),
-    'utf8',
-  );
+  const source = readFileSync(resolve(__dirname, '../../src/utils/cli-spawn.ts'), 'utf8');
 
   // Must import both register and unregister
-  assert.ok(
-    source.includes('registerLivenessProbe'),
-    'cli-spawn must import registerLivenessProbe',
-  );
-  assert.ok(
-    source.includes('unregisterLivenessProbe'),
-    'cli-spawn must import unregisterLivenessProbe',
-  );
+  assert.ok(source.includes('registerLivenessProbe'), 'cli-spawn must import registerLivenessProbe');
+  assert.ok(source.includes('unregisterLivenessProbe'), 'cli-spawn must import unregisterLivenessProbe');
 
   // registerLivenessProbe must be called with invocationId
   assert.ok(
@@ -72,9 +61,7 @@ test('F153: cli-spawn wires liveness probes', () => {
 // --- AgentPaneRegistry unit tests ---
 
 test('F153: AgentPaneRegistry marks aborted invocations as crashed', async (t) => {
-  const { AgentPaneRegistry } = await import(
-    '../../dist/domains/terminal/agent-pane-registry.js'
-  );
+  const { AgentPaneRegistry } = await import('../../dist/domains/terminal/agent-pane-registry.js');
 
   const registry = new AgentPaneRegistry();
   const invId = 'inv-abort-test';
@@ -110,10 +97,7 @@ test('F153: AgentPaneRegistry marks aborted invocations as crashed', async (t) =
 
 test('F153: abort path marks pane as crashed (not done)', () => {
   const source = readFileSync(
-    resolve(
-      __dirname,
-      '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts',
-    ),
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
     'utf8',
   );
 
@@ -127,10 +111,7 @@ test('F153: abort path marks pane as crashed (not done)', () => {
 
 test('F153: all three observation systems align on abort', () => {
   const source = readFileSync(
-    resolve(
-      __dirname,
-      '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts',
-    ),
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
     'utf8',
   );
 
@@ -141,10 +122,7 @@ test('F153: all three observation systems align on abort', () => {
   );
 
   // OTel: must set span ERROR for abort
-  assert.ok(
-    source.includes("'invocation_aborted'"),
-    'OTel must emit invocation_aborted log for abort path',
-  );
+  assert.ok(source.includes("'invocation_aborted'"), 'OTel must emit invocation_aborted log for abort path');
 
   // Pane: abort must not silently markDone (checked by previous test)
 });

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -193,6 +193,24 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     );
   });
 
+  it('start-windows.ps1 reapplies profile defaults inside Start-Job after .env reload', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    // API job receives $profileDefaults param and reapplies after .env reload
+    // (mirrors start-dev.sh resolve_config: env override > profile default)
+    assert.ok(ps1.includes('$profileDefaults'), 'start-windows.ps1 must pass $profileDefaults to Start-Job');
+
+    // The job must check if value is empty before applying default (resolve_config pattern)
+    // Look for the pattern inside a ScriptBlock (Start-Job context)
+    const jobBlocks = ps1.match(/Start-Job[\s\S]*?-ScriptBlock\s*\{([\s\S]*?)\}\s*-ArgumentList/g);
+    assert.ok(jobBlocks && jobBlocks.length > 0, 'start-windows.ps1 must have Start-Job blocks');
+    const apiJobBlock = jobBlocks[0];
+    assert.ok(
+      apiJobBlock.includes('profileDefaults') && apiJobBlock.includes('GetEnvironmentVariable'),
+      'API job must reapply profileDefaults with env-check after .env reload',
+    );
+  });
+
   it('start-windows.ps1 runtimeEnvOverrides does not clobber profile vars', () => {
     const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
 

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -129,6 +129,52 @@ describe('start-dev strict profile isolation', () => {
   });
 });
 
+describe('cross-platform pnpm-start profile propagation (#421)', () => {
+  it('package.json scripts.start routes through start-entry.mjs with --profile=opensource', () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
+    assert.match(
+      pkg.scripts.start,
+      /start-entry\.mjs start\b.*--profile=opensource/,
+      'pnpm start must route through start-entry.mjs with --profile=opensource',
+    );
+  });
+
+  it('start-entry.mjs sets CAT_CAFE_PROFILE and CAT_CAFE_STRICT_PROFILE_DEFAULTS for Windows when --profile is present', () => {
+    const source = readFileSync(resolve(ROOT, 'scripts/start-entry.mjs'), 'utf8');
+
+    // Windows branch must extract --profile=* and convert to env vars
+    assert.ok(
+      source.includes("childEnv.CAT_CAFE_PROFILE = profileName"),
+      'Windows path must set CAT_CAFE_PROFILE from --profile arg',
+    );
+    assert.ok(
+      source.includes("childEnv.CAT_CAFE_STRICT_PROFILE_DEFAULTS = '1'"),
+      'Windows path must set CAT_CAFE_STRICT_PROFILE_DEFAULTS=1 when profile is present',
+    );
+
+    // Verify env is passed to child spawn
+    assert.ok(
+      source.includes('env: childEnv'),
+      'Windows spawn must use childEnv (which contains profile env vars)',
+    );
+  });
+
+  it('start-windows.ps1 propagates env vars to child processes via Start-Job', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    // PS1 loads .env into current process env (line ~57-68)
+    // Then Start-Job inherits parent env, and also explicitly re-loads .env + runtimeEnvOverrides
+    assert.ok(
+      ps1.includes('$runtimeEnvOverrides'),
+      'start-windows.ps1 must define runtimeEnvOverrides for child jobs',
+    );
+    assert.ok(
+      ps1.includes('Start-Job'),
+      'start-windows.ps1 must use Start-Job (which inherits parent process env)',
+    );
+  });
+});
+
 describe('sync-to-opensource public launch transforms', { skip: !existsSync(SYNC_SCRIPT) }, () => {
   it('exports opensource-pinned direct launch wrappers and runtime startup', () => {
     const result = spawnSync('bash', [SYNC_SCRIPT, '--dry-run', '--yes'], {

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -156,12 +156,46 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     assert.ok(source.includes('env: childEnv'), 'Windows spawn must use childEnv (which contains profile env vars)');
   });
 
-  it('start-windows.ps1 does not clobber profile env vars inherited from start-entry.mjs', () => {
+  it('start-windows.ps1 clears inherited profile vars when strict mode is on', () => {
     const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
 
-    // start-entry.mjs sets CAT_CAFE_PROFILE + CAT_CAFE_STRICT_PROFILE_DEFAULTS in childEnv,
-    // which becomes the PS1 process env. Start-Job inherits parent env by default.
-    // Verify: runtimeEnvOverrides must NOT contain profile keys (they flow via inheritance).
+    // Mirrors start-dev.sh clear_inherited_profile_env: must clear profile-controlled
+    // vars BEFORE .env loading when CAT_CAFE_STRICT_PROFILE_DEFAULTS=1
+    assert.ok(
+      ps1.includes('CAT_CAFE_STRICT_PROFILE_DEFAULTS'),
+      'start-windows.ps1 must check CAT_CAFE_STRICT_PROFILE_DEFAULTS for strict mode',
+    );
+
+    // Must clear the same vars as start-dev.sh
+    for (const v of [
+      'ANTHROPIC_PROXY_ENABLED',
+      'ASR_ENABLED',
+      'TTS_ENABLED',
+      'LLM_POSTPROCESS_ENABLED',
+      'REDIS_PROFILE',
+    ]) {
+      assert.ok(ps1.includes(v), `start-windows.ps1 must reference profile var ${v}`);
+    }
+  });
+
+  it('start-windows.ps1 applies profile defaults matching start-dev.sh opensource profile', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    // Must define opensource profile defaults that match start-dev.sh apply_profile_defaults
+    assert.match(ps1, /'opensource'/, 'start-windows.ps1 must define opensource profile');
+    assert.match(ps1, /'production'/, 'start-windows.ps1 must define production profile');
+    assert.match(ps1, /'dev'/, 'start-windows.ps1 must define dev profile');
+
+    // Verify resolve_config pattern: env override > profile default
+    assert.ok(
+      ps1.includes('GetEnvironmentVariable'),
+      'start-windows.ps1 must check existing env before applying profile default',
+    );
+  });
+
+  it('start-windows.ps1 runtimeEnvOverrides does not clobber profile vars', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
     const overridesMatch = ps1.match(/\$runtimeEnvOverrides\s*=\s*@\{([^}]+)\}/s);
     assert.ok(overridesMatch, 'start-windows.ps1 must define $runtimeEnvOverrides');
     const overridesBlock = overridesMatch[1];

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -144,7 +144,7 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
 
     // Windows branch must extract --profile=* and convert to env vars
     assert.ok(
-      source.includes("childEnv.CAT_CAFE_PROFILE = profileName"),
+      source.includes('childEnv.CAT_CAFE_PROFILE = profileName'),
       'Windows path must set CAT_CAFE_PROFILE from --profile arg',
     );
     assert.ok(
@@ -153,10 +153,7 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     );
 
     // Verify env is passed to child spawn
-    assert.ok(
-      source.includes('env: childEnv'),
-      'Windows spawn must use childEnv (which contains profile env vars)',
-    );
+    assert.ok(source.includes('env: childEnv'), 'Windows spawn must use childEnv (which contains profile env vars)');
   });
 
   it('start-windows.ps1 propagates env vars to child processes via Start-Job', () => {
@@ -164,14 +161,8 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
 
     // PS1 loads .env into current process env (line ~57-68)
     // Then Start-Job inherits parent env, and also explicitly re-loads .env + runtimeEnvOverrides
-    assert.ok(
-      ps1.includes('$runtimeEnvOverrides'),
-      'start-windows.ps1 must define runtimeEnvOverrides for child jobs',
-    );
-    assert.ok(
-      ps1.includes('Start-Job'),
-      'start-windows.ps1 must use Start-Job (which inherits parent process env)',
-    );
+    assert.ok(ps1.includes('$runtimeEnvOverrides'), 'start-windows.ps1 must define runtimeEnvOverrides for child jobs');
+    assert.ok(ps1.includes('Start-Job'), 'start-windows.ps1 must use Start-Job (which inherits parent process env)');
   });
 });
 

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -156,12 +156,25 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     assert.ok(source.includes('env: childEnv'), 'Windows spawn must use childEnv (which contains profile env vars)');
   });
 
-  it('start-windows.ps1 propagates env vars to child processes via Start-Job', () => {
+  it('start-windows.ps1 does not clobber profile env vars inherited from start-entry.mjs', () => {
     const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
 
-    // PS1 loads .env into current process env (line ~57-68)
-    // Then Start-Job inherits parent env, and also explicitly re-loads .env + runtimeEnvOverrides
-    assert.ok(ps1.includes('$runtimeEnvOverrides'), 'start-windows.ps1 must define runtimeEnvOverrides for child jobs');
+    // start-entry.mjs sets CAT_CAFE_PROFILE + CAT_CAFE_STRICT_PROFILE_DEFAULTS in childEnv,
+    // which becomes the PS1 process env. Start-Job inherits parent env by default.
+    // Verify: runtimeEnvOverrides must NOT contain profile keys (they flow via inheritance).
+    const overridesMatch = ps1.match(/\$runtimeEnvOverrides\s*=\s*@\{([^}]+)\}/s);
+    assert.ok(overridesMatch, 'start-windows.ps1 must define $runtimeEnvOverrides');
+    const overridesBlock = overridesMatch[1];
+    assert.ok(
+      !overridesBlock.includes('CAT_CAFE_PROFILE'),
+      'runtimeEnvOverrides must not override CAT_CAFE_PROFILE (it flows via env inheritance)',
+    );
+    assert.ok(
+      !overridesBlock.includes('CAT_CAFE_STRICT_PROFILE'),
+      'runtimeEnvOverrides must not override CAT_CAFE_STRICT_PROFILE_DEFAULTS (it flows via env inheritance)',
+    );
+
+    // Verify Start-Job is used (PS Start-Job inherits parent process env by default)
     assert.ok(ps1.includes('Start-Job'), 'start-windows.ps1 must use Start-Job (which inherits parent process env)');
   });
 });

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -51,6 +51,22 @@ Write-Host "Cat Cafe - Windows Startup" -ForegroundColor Cyan
 Write-Host "=========================="
 if ($Profile_) { Write-Host "  Profile: $Profile_" -ForegroundColor Cyan }
 
+# -- Clear inherited profile env (mirrors start-dev.sh clear_inherited_profile_env) --
+# When strict mode is on, clear ambient profile-controlled vars before loading .env,
+# so only .env overrides and profile defaults take effect — not leaked shell exports.
+$profileControlledVars = @(
+    'ANTHROPIC_PROXY_ENABLED', 'ASR_ENABLED', 'TTS_ENABLED',
+    'LLM_POSTPROCESS_ENABLED', 'EMBED_ENABLED',
+    'MESSAGE_TTL_SECONDS', 'THREAD_TTL_SECONDS',
+    'TASK_TTL_SECONDS', 'SUMMARY_TTL_SECONDS',
+    'REDIS_PROFILE'
+)
+if ($env:CAT_CAFE_STRICT_PROFILE_DEFAULTS -eq "1" -and $Profile_) {
+    foreach ($var in $profileControlledVars) {
+        [System.Environment]::SetEnvironmentVariable($var, $null, "Process")
+    }
+}
+
 # -- Load .env -----------------------------------------------
 $envFile = Join-Path $ProjectRoot ".env"
 if (Test-Path $envFile) {
@@ -68,6 +84,49 @@ if (Test-Path $envFile) {
     Write-Ok ".env loaded"
 } else {
     Write-Warn ".env not found - using defaults"
+}
+
+# -- Apply profile defaults (mirrors start-dev.sh apply_profile_defaults) --
+# Profile defaults are fallbacks: .env value wins if set, otherwise profile default applies.
+$profileDefaults = @{}
+switch ($Profile_) {
+    'opensource' {
+        $profileDefaults = @{
+            ANTHROPIC_PROXY_ENABLED = '0'; ASR_ENABLED = '0'
+            TTS_ENABLED = '0'; LLM_POSTPROCESS_ENABLED = '0'
+            MESSAGE_TTL_SECONDS = '86400'; THREAD_TTL_SECONDS = '86400'
+            TASK_TTL_SECONDS = '86400'; SUMMARY_TTL_SECONDS = '86400'
+            REDIS_PROFILE = 'opensource'
+        }
+    }
+    'production' {
+        $profileDefaults = @{
+            ANTHROPIC_PROXY_ENABLED = '0'; ASR_ENABLED = '0'
+            TTS_ENABLED = '0'; LLM_POSTPROCESS_ENABLED = '0'
+            MESSAGE_TTL_SECONDS = '0'; THREAD_TTL_SECONDS = '0'
+            TASK_TTL_SECONDS = '0'; SUMMARY_TTL_SECONDS = '0'
+            REDIS_PROFILE = 'opensource'
+        }
+    }
+    'dev' {
+        $profileDefaults = @{
+            ANTHROPIC_PROXY_ENABLED = '1'; ASR_ENABLED = '1'
+            TTS_ENABLED = '1'; LLM_POSTPROCESS_ENABLED = '1'
+            MESSAGE_TTL_SECONDS = '0'; THREAD_TTL_SECONDS = '0'
+            TASK_TTL_SECONDS = '0'; SUMMARY_TTL_SECONDS = '0'
+            REDIS_PROFILE = 'dev'
+        }
+    }
+}
+# resolve_config: env override > profile default
+foreach ($entry in $profileDefaults.GetEnumerator()) {
+    $current = [System.Environment]::GetEnvironmentVariable($entry.Key, "Process")
+    if (-not $current) {
+        [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "Process")
+    }
+}
+if ($Profile_ -and $profileDefaults.Count -gt 0) {
+    Write-Ok "Profile defaults applied ($Profile_)"
 }
 
 $pnpmCommand = Resolve-ToolCommand -Name "pnpm"

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -410,7 +410,7 @@ try {
     # No --env-file needed - avoids depending on Node's --env-file support here.
     Write-Host "  Starting API Server (port $ApiPort)..."
     $apiJob = Start-Job -Name "api" -ScriptBlock {
-        param($root, $envFile, $runtimeEnvOverrides, $apiEntry, $debugFlag)
+        param($root, $envFile, $runtimeEnvOverrides, $profileDefaults, $apiEntry, $debugFlag)
         [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
         $OutputEncoding = [System.Text.Encoding]::UTF8
         Set-Location (Join-Path $root "packages/api")
@@ -436,13 +436,23 @@ try {
                 [System.Environment]::SetEnvironmentVariable($entry.Key, [string]$entry.Value, "Process")
             }
         }
+        # Reapply profile defaults after .env reload (mirrors start-dev.sh resolve_config:
+        # env override > profile default — only apply if current value is empty/null)
+        if ($profileDefaults) {
+            foreach ($entry in $profileDefaults.GetEnumerator()) {
+                $current = [System.Environment]::GetEnvironmentVariable($entry.Key, "Process")
+                if (-not $current) {
+                    [System.Environment]::SetEnvironmentVariable($entry.Key, $entry.Value, "Process")
+                }
+            }
+        }
         if ($debugFlag) {
             $env:LOG_LEVEL = "debug"
             & node $apiEntry --debug 2>&1
         } else {
             & node $apiEntry 2>&1
         }
-    } -ArgumentList $ProjectRoot, $envFile, $runtimeEnvOverrides, $apiEntry, $Debug.IsPresent
+    } -ArgumentList $ProjectRoot, $envFile, $runtimeEnvOverrides, $profileDefaults, $apiEntry, $Debug.IsPresent
     $jobs += $apiJob
 
     Start-Sleep -Seconds 2


### PR DESCRIPTION
## Summary
- route `pnpm start` through the existing cross-platform `start-entry.mjs` wrapper
- keep Unix startup behavior unchanged while allowing Windows to dispatch into `start-windows.ps1`

## Root cause
`package.json` invoked `./scripts/runtime-worktree.sh start` directly for `pnpm start`. That works on Unix shells, but Windows cannot execute the Unix-style `./...sh` entry point from `pnpm`, even though the repository already has a platform-aware Node launcher.

## Impact
Windows users can run `pnpm start` without falling back to `pnpm start:direct`, and Unix users still end up in the same runtime worktree startup path.

## Validation
- `pnpm check:start-profile-isolation`
