### PR TITLE
feat: paste fold — auto-fold long text (>20 lines) into .md attachment

### DIFF
--- a/packages/api/src/routes/image-upload.ts
+++ b/packages/api/src/routes/image-upload.ts
@@ -6,9 +6,10 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import type { ImageContent } from '@cat-cafe/shared';
+import type { ImageContent, PasteContent } from '@cat-cafe/shared';
 
 const ALLOWED_MIMES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp']);
+const PASTE_MIMES = new Set(['text/markdown', 'text/plain']);
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 const MAX_FILES = 5;
 
@@ -76,6 +77,57 @@ function mimeToExt(mime: string): string {
     default:
       return '.bin';
   }
+}
+
+export interface SavedPaste {
+  absPath: string;
+  urlPath: string;
+  content: PasteContent;
+}
+
+const DEFAULT_PREVIEW_LINES = 5;
+
+/**
+ * Validate and save an uploaded paste file (.md / .txt).
+ * Returns paste metadata for contentBlocks.
+ */
+export async function saveUploadedPaste(file: UploadImageFile, uploadDir: string): Promise<SavedPaste> {
+  if (!PASTE_MIMES.has(file.mimetype)) {
+    throw new ImageUploadError(`Unsupported paste type: ${file.mimetype}`);
+  }
+
+  const buffer = await file.toBuffer();
+  if (buffer.byteLength > MAX_FILE_SIZE) {
+    throw new ImageUploadError(`Paste too large: ${buffer.byteLength} bytes (max ${MAX_FILE_SIZE})`);
+  }
+
+  await mkdir(uploadDir, { recursive: true });
+
+  const filename = `${Date.now()}-${randomUUID().slice(0, 8)}.md`;
+  const absPath = resolve(join(uploadDir, filename));
+  await writeFile(absPath, buffer);
+
+  const text = buffer.toString('utf-8');
+  const lines = text.split('\n');
+  const MAX_PREVIEW_CHARS = 2000;
+  const preview = lines.slice(0, DEFAULT_PREVIEW_LINES).join('\n').slice(0, MAX_PREVIEW_CHARS);
+
+  return {
+    absPath,
+    urlPath: `/uploads/${filename}`,
+    content: {
+      type: 'paste',
+      url: `/uploads/${filename}`,
+      lineCount: lines.length,
+      charCount: text.length,
+      preview,
+    },
+  };
+}
+
+/** Check if a MIME type is a paste (text/markdown or text/plain) */
+export function isPasteMime(mime: string): boolean {
+  return PASTE_MIMES.has(mime);
 }
 
 export class ImageUploadError extends Error {

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -124,7 +124,7 @@ const getMessagesSchema = z.object({
 });
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-const MAX_FILES = 5;
+const MAX_FILES = 6; // 5 images + 1 paste file
 
 const DECISION_NOTIFICATION_RE = /\b(review|lgtm|merge|pr)\b/i;
 

--- a/packages/api/src/routes/parse-multipart.ts
+++ b/packages/api/src/routes/parse-multipart.ts
@@ -4,9 +4,15 @@
  * 从 messages.ts 提取，降低文件复杂度。
  */
 
-import type { ImageContent, MessageContent, TextContent } from '@cat-cafe/shared';
+import type { ImageContent, MessageContent, PasteContent, TextContent } from '@cat-cafe/shared';
 import type { Multipart } from '@fastify/multipart';
-import { ImageUploadError, saveUploadedImages, type UploadImageFile } from './image-upload.js';
+import {
+  ImageUploadError,
+  isPasteMime,
+  saveUploadedImages,
+  saveUploadedPaste,
+  type UploadImageFile,
+} from './image-upload.js';
 import { sendMessageSchema } from './messages.schema.js';
 
 export type ParsedMultipart =
@@ -67,10 +73,20 @@ export async function parseMultipart(
   const blocks: MessageContent[] = [{ type: 'text', text: content } as TextContent];
 
   if (files.length > 0) {
+    // Split files into images and pastes
+    const imageFiles = files.filter((f) => !isPasteMime(f.mimetype));
+    const pasteFiles = files.filter((f) => isPasteMime(f.mimetype));
+
     try {
-      const saved = await saveUploadedImages(files, uploadDir);
-      for (const img of saved) {
-        blocks.push(img.content as ImageContent);
+      if (imageFiles.length > 0) {
+        const saved = await saveUploadedImages(imageFiles, uploadDir);
+        for (const img of saved) {
+          blocks.push(img.content as ImageContent);
+        }
+      }
+      for (const pasteFile of pasteFiles) {
+        const saved = await saveUploadedPaste(pasteFile, uploadDir);
+        blocks.push(saved.content as PasteContent);
       }
     } catch (err) {
       if (err instanceof ImageUploadError) {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -18,6 +18,7 @@ export {
   MessageSchema,
   MessageSenderSchema,
   MessageStatusSchema,
+  PasteContentSchema,
   SendMessageRequestSchema,
   TextContentSchema,
   ToolCallContentSchema,

--- a/packages/shared/src/schemas/message.schema.ts
+++ b/packages/shared/src/schemas/message.schema.ts
@@ -76,6 +76,17 @@ export const ToolResultContentSchema = z.object({
 });
 
 /**
+ * Paste content schema — long text folded into a .md attachment
+ */
+export const PasteContentSchema = z.object({
+  type: z.literal('paste'),
+  url: z.string(),
+  lineCount: z.number().int().min(1),
+  charCount: z.number().int().min(1),
+  preview: z.string().max(2000),
+});
+
+/**
  * Message content schema - discriminated union
  */
 export const MessageContentSchema = z.discriminatedUnion('type', [
@@ -84,6 +95,7 @@ export const MessageContentSchema = z.discriminatedUnion('type', [
   CodeContentSchema,
   ToolCallContentSchema,
   ToolResultContentSchema,
+  PasteContentSchema,
 ]);
 
 /**

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -262,6 +262,7 @@ export type {
   MessageContent,
   MessageSender,
   MessageStatus,
+  PasteContent,
   TextContent,
   ToolCallContent,
   ToolResultContent,

--- a/packages/shared/src/types/message.ts
+++ b/packages/shared/src/types/message.ts
@@ -61,9 +61,26 @@ export interface ToolResultContent {
 }
 
 /**
+ * Paste content — long text folded into a .md attachment
+ */
+export interface PasteContent {
+  readonly type: 'paste';
+  readonly url: string;
+  readonly lineCount: number;
+  readonly charCount: number;
+  readonly preview: string;
+}
+
+/**
  * Message content - union of all content types
  */
-export type MessageContent = TextContent | ImageContent | CodeContent | ToolCallContent | ToolResultContent;
+export type MessageContent =
+  | TextContent
+  | ImageContent
+  | CodeContent
+  | ToolCallContent
+  | ToolResultContent
+  | PasteContent;
 
 /**
  * Message status

--- a/packages/web/src/components/ChatInput.tsx
+++ b/packages/web/src/components/ChatInput.tsx
@@ -12,6 +12,7 @@ import { useChatStore } from '@/stores/chatStore';
 import { useInputHistoryStore } from '@/stores/inputHistoryStore';
 import { apiFetch } from '@/utils/api-client';
 import { compressImage } from '@/utils/compressImage';
+import { createPasteFile, shouldFoldPaste } from '@/utils/pasteDetection';
 import { ChatInputActionButton } from './ChatInputActionButton';
 import { ChatInputMenus } from './ChatInputMenus';
 import { buildCatOptions, type CatOption, detectMenuTrigger, GAME_LIST, WEREWOLF_MODES } from './chat-input-options';
@@ -21,6 +22,7 @@ import { HistorySearchModal } from './HistorySearchModal';
 import { ImagePreview } from './ImagePreview';
 import { AttachIcon } from './icons/AttachIcon';
 import { MobileInputToolbar } from './MobileInputToolbar';
+import { PastePreview } from './PastePreview';
 import { PathCompletionMenu } from './PathCompletionMenu';
 import { WhisperCatSelector, WhisperTargetChips } from './WhisperCatSelector';
 
@@ -82,6 +84,8 @@ export function ChatInput({
   const [mentionFilter, setMentionFilter] = useState('');
   const [images, setImages] = useState<File[]>(() => (threadId ? (threadImageDrafts.get(threadId) ?? []) : []));
   const [isPreparingImages, setIsPreparingImages] = useState(false);
+  const [pastedFile, setPastedFile] = useState<File | null>(null);
+  const [pastedRawText, setPastedRawText] = useState<string>('');
   const [whisperMode, setWhisperMode] = useState(false);
   const [whisperTargets, setWhisperTargets] = useState<Set<string>>(new Set());
 
@@ -151,22 +155,38 @@ export function ChatInput({
       if (sendTemporarilyDisabled) return;
       if (whisperMode && whisperTargets.size === 0) return;
       const trimmed = input.trim();
-      if (trimmed && !disabled) {
-        addHistoryEntry(trimmed);
+      // Allow send if there's text OR a paste file (paste-only messages are valid)
+      if ((trimmed || pastedFile) && !disabled) {
+        if (trimmed) addHistoryEntry(trimmed);
         const whisper =
           whisperMode && whisperTargets.size > 0
             ? { visibility: 'whisper' as const, whisperTo: [...whisperTargets] }
             : undefined;
-        onSend(trimmed, images.length > 0 ? images : undefined, whisper, deliveryMode);
+        // Merge paste file into the files array sent to backend
+        const allFiles = [...images, ...(pastedFile ? [pastedFile] : [])];
+        const content = trimmed || '(pasted text)';
+        onSend(content, allFiles.length > 0 ? allFiles : undefined, whisper, deliveryMode);
         setInput('');
         ghostRef.current = null;
         setGhostSuggestion(null);
         setImages([]);
+        setPastedFile(null);
+        setPastedRawText('');
         setShowMentions(false);
         setShowGameMenu(false);
       }
     },
-    [input, disabled, onSend, images, sendTemporarilyDisabled, whisperMode, whisperTargets, addHistoryEntry],
+    [
+      input,
+      disabled,
+      onSend,
+      images,
+      pastedFile,
+      sendTemporarilyDisabled,
+      whisperMode,
+      whisperTargets,
+      addHistoryEntry,
+    ],
   );
 
   const handleSend = useCallback(() => doSend(undefined), [doSend]);
@@ -417,6 +437,17 @@ export function ChatInput({
     async (e: React.ClipboardEvent) => {
       const items = e.clipboardData?.items;
       if (!items) return;
+
+      // Check for long text paste first
+      const textData = e.clipboardData?.getData('text/plain');
+      if (textData && shouldFoldPaste(textData)) {
+        e.preventDefault();
+        setPastedFile(createPasteFile(textData));
+        setPastedRawText(textData);
+        return;
+      }
+
+      // Existing image paste logic
       const imageFiles: File[] = [];
       for (let i = 0; i < items.length; i++) {
         if (items[i].type.startsWith('image/')) {
@@ -440,6 +471,11 @@ export function ChatInput({
     },
     [images],
   );
+
+  const handleRemovePaste = useCallback(() => {
+    setPastedFile(null);
+    setPastedRawText('');
+  }, []);
 
   const handleRemoveImage = useCallback((index: number) => {
     setImages((prev) => prev.filter((_, i) => i !== index));
@@ -619,6 +655,7 @@ export function ChatInput({
         <WhisperTargetChips cats={whisperCats} selected={whisperTargets} onToggle={toggleWhisperTarget} />
       )}
 
+      {pastedFile && <PastePreview file={pastedFile} rawText={pastedRawText} onRemove={handleRemovePaste} />}
       <ImagePreview files={images} onRemove={handleRemoveImage} />
 
       <input
@@ -752,7 +789,7 @@ export function ChatInput({
           disabled={disabled}
           sendDisabled={sendTemporarilyDisabled}
           hasActiveInvocation={whisperTargetsAllIdle ? false : hasActiveInvocation}
-          hasText={!!input.trim()}
+          hasText={!!input.trim() || !!pastedFile}
         />
       </div>
 

--- a/packages/web/src/components/ContentBlocks.tsx
+++ b/packages/web/src/components/ContentBlocks.tsx
@@ -1,10 +1,54 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import type { MessageContent } from '@/stores/chatStore';
 import { API_URL } from '@/utils/api-client';
 import { Lightbox } from './Lightbox';
 import { MarkdownContent } from './MarkdownContent';
+
+function PasteBlock({ block }: { block: { url: string; lineCount: number; charCount: number; preview: string } }) {
+  const [expanded, setExpanded] = useState(false);
+  const [fullText, setFullText] = useState<string | null>(null);
+
+  const handleExpand = useCallback(async () => {
+    if (expanded) {
+      setExpanded(false);
+      return;
+    }
+    if (!fullText) {
+      const url = block.url.startsWith('/uploads/') ? `${API_URL}${block.url}` : block.url;
+      const res = await fetch(url);
+      setFullText(await res.text());
+    }
+    setExpanded(true);
+  }, [expanded, fullText, block.url]);
+
+  return (
+    <div className="mt-2 rounded-lg border border-cafe overflow-hidden">
+      <button
+        onClick={handleExpand}
+        className="w-full flex items-center justify-between px-3 py-1.5 bg-cafe-surface/80 hover:bg-cafe-surface transition-colors text-left"
+      >
+        <span className="text-xs text-cafe-muted">
+          Pasted text &middot; {block.lineCount} lines &middot; {(block.charCount / 1024).toFixed(1)}KB
+        </span>
+        <span className="text-xs text-cafe-muted">{expanded ? 'Collapse' : 'Expand'}</span>
+      </button>
+      {!expanded && (
+        <pre className="px-3 py-2 text-xs text-cafe-secondary font-mono whitespace-pre-wrap max-h-20 overflow-hidden">
+          {block.preview}
+          {'\n'}
+          <span className="text-cafe-muted">...</span>
+        </pre>
+      )}
+      {expanded && fullText && (
+        <div className="max-h-96 overflow-auto">
+          <MarkdownContent content={`\`\`\`\n${fullText}\n\`\`\``} />
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function ContentBlocks({ blocks }: { blocks: MessageContent[] }) {
   const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
@@ -27,6 +71,9 @@ export function ContentBlocks({ blocks }: { blocks: MessageContent[] }) {
               onClick={() => setLightboxSrc(src)}
             />
           );
+        }
+        if (block.type === 'paste') {
+          return <PasteBlock key={i} block={block} />;
         }
         return null;
       })}

--- a/packages/web/src/components/PastePreview.tsx
+++ b/packages/web/src/components/PastePreview.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { getPastePreview, getPasteStats } from '@/utils/pasteDetection';
+
+interface PastePreviewProps {
+  file: File;
+  rawText: string;
+  onRemove: () => void;
+}
+
+export function PastePreview({ file, rawText, onRemove }: PastePreviewProps) {
+  const stats = getPasteStats(rawText);
+  const preview = getPastePreview(rawText, 4);
+
+  return (
+    <div className="mx-4 my-2 rounded-lg border border-cafe bg-cafe-surface/50 overflow-hidden">
+      <div className="flex items-center justify-between px-3 py-1.5 bg-cafe-surface/80 border-b border-cafe">
+        <span className="text-xs text-cafe-muted truncate">
+          {file.name} &middot; {stats.lineCount} lines &middot; {(stats.charCount / 1024).toFixed(1)}KB
+        </span>
+        <button
+          onClick={onRemove}
+          className="ml-2 w-5 h-5 rounded-full bg-red-500 text-white text-xs flex items-center justify-center hover:bg-red-600 transition-colors flex-shrink-0"
+          title="Remove pasted text"
+          aria-label="Remove pasted text"
+        >
+          x
+        </button>
+      </div>
+      <pre className="px-3 py-2 text-xs text-cafe-secondary overflow-hidden max-h-24 font-mono whitespace-pre-wrap">
+        {preview}
+        {'\n'}
+        <span className="text-cafe-muted">... +{stats.lineCount - 4} more lines</span>
+      </pre>
+    </div>
+  );
+}

--- a/packages/web/src/hooks/useSendMessage.ts
+++ b/packages/web/src/hooks/useSendMessage.ts
@@ -86,13 +86,24 @@ export function useSendMessage(activeThreadId?: string) {
         ...(whisper ? { visibility: whisper.visibility, whisperTo: whisper.whisperTo } : {}),
       };
       if (images && images.length > 0) {
-        userMsg.contentBlocks = [
-          { type: 'text' as const, text: content },
-          ...images.map((img) => ({
-            type: 'image' as const,
-            url: URL.createObjectURL(img),
-          })),
-        ];
+        const imageBlocks = images
+          .filter((f) => f.type.startsWith('image/'))
+          .map((img) => ({ type: 'image' as const, url: URL.createObjectURL(img) }));
+        const pasteFiles = images.filter((f) => f.type === 'text/markdown' || f.type === 'text/plain');
+        const pasteBlocks = await Promise.all(
+          pasteFiles.map(async (f) => {
+            const text = await f.text();
+            const lines = text.split('\n');
+            return {
+              type: 'paste' as const,
+              url: URL.createObjectURL(f),
+              lineCount: lines.length,
+              charCount: text.length,
+              preview: lines.slice(0, 5).join('\n').slice(0, 2000),
+            };
+          }),
+        );
+        userMsg.contentBlocks = [{ type: 'text' as const, text: content }, ...imageBlocks, ...pasteBlocks];
       }
       // F117: Queue sends skip optimistic insert — bubble appears only on messages_delivered
       // (prevents queued message from showing in chat timeline before delivery)

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -9,7 +9,15 @@ export interface ImageContent {
   url: string;
 }
 
-export type MessageContent = TextContent | ImageContent;
+export interface PasteContent {
+  type: 'paste';
+  url: string;
+  lineCount: number;
+  charCount: number;
+  preview: string;
+}
+
+export type MessageContent = TextContent | ImageContent | PasteContent;
 
 /** F8: Token usage data from CLI invocations.
  *  inputTokens = TOTAL input (normalised across providers).

--- a/packages/web/src/stores/chatStore.ts
+++ b/packages/web/src/stores/chatStore.ts
@@ -152,13 +152,18 @@ export function resolveBubbleExpanded(
   return globalDefault === 'expanded';
 }
 
+function getBlobUrl(block: ChatMessage['contentBlocks'] extends (infer B)[] | undefined ? B : never): string | null {
+  if (block.type === 'image' && block.url.startsWith('blob:')) return block.url;
+  if (block.type === 'paste' && block.url.startsWith('blob:')) return block.url;
+  return null;
+}
+
 function revokeBlobUrls(messages: ChatMessage[]) {
   for (const msg of messages) {
     if (msg.contentBlocks) {
       for (const block of msg.contentBlocks) {
-        if (block.type === 'image' && block.url.startsWith('blob:')) {
-          URL.revokeObjectURL(block.url);
-        }
+        const url = getBlobUrl(block);
+        if (url) URL.revokeObjectURL(url);
       }
     }
   }
@@ -169,9 +174,8 @@ function collectBlobUrls(messages: ChatMessage[]): Set<string> {
   for (const msg of messages) {
     if (!msg.contentBlocks) continue;
     for (const block of msg.contentBlocks) {
-      if (block.type === 'image' && block.url.startsWith('blob:')) {
-        blobUrls.add(block.url);
-      }
+      const url = getBlobUrl(block);
+      if (url) blobUrls.add(url);
     }
   }
   return blobUrls;
@@ -182,9 +186,8 @@ function revokeRemovedBlobUrls(previousMessages: ChatMessage[], nextMessages: Ch
   for (const msg of previousMessages) {
     if (!msg.contentBlocks) continue;
     for (const block of msg.contentBlocks) {
-      if (block.type === 'image' && block.url.startsWith('blob:') && !retainedBlobUrls.has(block.url)) {
-        URL.revokeObjectURL(block.url);
-      }
+      const url = getBlobUrl(block);
+      if (url && !retainedBlobUrls.has(url)) URL.revokeObjectURL(url);
     }
   }
 }

--- a/packages/web/src/utils/__tests__/pasteDetection.test.ts
+++ b/packages/web/src/utils/__tests__/pasteDetection.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPasteFile,
+  getPastePreview,
+  getPasteStats,
+  PASTE_FOLD_THRESHOLD,
+  shouldFoldPaste,
+} from '@/utils/pasteDetection';
+
+describe('pasteDetection', () => {
+  const shortText = 'line 1\nline 2\nline 3';
+  const exactThresholdText = Array.from({ length: PASTE_FOLD_THRESHOLD }, (_, i) => `line ${i + 1}`).join('\n');
+  const longText = Array.from(
+    { length: 100 },
+    (_, i) => `2026-04-10 20:09:32.${i} AndroidRuntime E FATAL EXCEPTION line ${i}`,
+  ).join('\n');
+
+  describe('shouldFoldPaste', () => {
+    it('returns false for short text', () => {
+      expect(shouldFoldPaste(shortText)).toBe(false);
+    });
+
+    it('returns false for exactly threshold lines', () => {
+      expect(shouldFoldPaste(exactThresholdText)).toBe(false);
+    });
+
+    it('returns true for text exceeding threshold', () => {
+      expect(shouldFoldPaste(longText)).toBe(true);
+    });
+
+    it('returns false for empty string', () => {
+      expect(shouldFoldPaste('')).toBe(false);
+    });
+
+    it('returns false for single line', () => {
+      expect(shouldFoldPaste('hello world')).toBe(false);
+    });
+  });
+
+  describe('createPasteFile', () => {
+    it('creates a File with .md extension', () => {
+      const file = createPasteFile(longText);
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toMatch(/\.md$/);
+    });
+
+    it('has text/markdown MIME type', () => {
+      const file = createPasteFile(longText);
+      expect(file.type).toBe('text/markdown');
+    });
+
+    it('contains raw text without code block wrapper', async () => {
+      const file = createPasteFile(longText);
+      const content = await new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsText(file);
+      });
+      expect(content).toBe(longText);
+      expect(content).not.toMatch(/^```/);
+    });
+
+    it('generates unique filenames', () => {
+      const file1 = createPasteFile(longText);
+      const file2 = createPasteFile(longText);
+      expect(file1.name).not.toBe(file2.name);
+    });
+  });
+
+  describe('getPastePreview', () => {
+    it('returns first 5 lines by default', () => {
+      const preview = getPastePreview(longText);
+      const lines = preview.split('\n');
+      expect(lines).toHaveLength(5);
+    });
+
+    it('returns custom number of lines', () => {
+      const preview = getPastePreview(longText, 3);
+      const lines = preview.split('\n');
+      expect(lines).toHaveLength(3);
+    });
+
+    it('returns full text if fewer lines than requested', () => {
+      const preview = getPastePreview(shortText, 10);
+      expect(preview).toBe(shortText);
+    });
+  });
+
+  describe('getPasteStats', () => {
+    it('returns correct line count', () => {
+      const stats = getPasteStats(longText);
+      expect(stats.lineCount).toBe(100);
+    });
+
+    it('returns correct char count', () => {
+      const stats = getPasteStats(shortText);
+      expect(stats.charCount).toBe(shortText.length);
+    });
+
+    it('handles single line', () => {
+      const stats = getPasteStats('hello');
+      expect(stats.lineCount).toBe(1);
+      expect(stats.charCount).toBe(5);
+    });
+  });
+});

--- a/packages/web/src/utils/pasteDetection.ts
+++ b/packages/web/src/utils/pasteDetection.ts
@@ -1,0 +1,35 @@
+/** Paste fold threshold — text exceeding this many lines gets folded */
+export const PASTE_FOLD_THRESHOLD = 20;
+
+/** Default number of preview lines shown in the folded card */
+const DEFAULT_PREVIEW_LINES = 5;
+
+/** Check whether pasted text should be folded (exceeds threshold) */
+export function shouldFoldPaste(text: string): boolean {
+  if (!text) return false;
+  const lineCount = text.split('\n').length;
+  return lineCount > PASTE_FOLD_THRESHOLD;
+}
+
+/** Create a .md File from pasted text (raw content, no wrapper) */
+export function createPasteFile(text: string): File {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 8);
+  const fileName = `paste-${timestamp}-${random}.md`;
+  return new File([text], fileName, { type: 'text/markdown' });
+}
+
+/** Get the first N lines of text for preview display */
+export function getPastePreview(text: string, maxLines = DEFAULT_PREVIEW_LINES): string {
+  const lines = text.split('\n');
+  if (lines.length <= maxLines) return text;
+  return lines.slice(0, maxLines).join('\n');
+}
+
+/** Get line count and character count stats for pasted text */
+export function getPasteStats(text: string): { lineCount: number; charCount: number } {
+  return {
+    lineCount: text.split('\n').length,
+    charCount: text.length,
+  };
+}


### PR DESCRIPTION
## What

Pasting text exceeding 20 lines auto-folds it into a `.md` file attachment, bypassing the backend 10,000 char limit. 3 new files + 12 modified files across shared/api/web packages.

Core changes:
- **shared**: `PasteContent` type + Zod schema (preview max 2000), added to `MessageContent` union
- **api**: `saveUploadedPaste()` in image-upload.ts; parse-multipart.ts splits files by MIME (image vs paste); MAX_FILES 5 to 6
- **web**: `pasteDetection.ts` detection logic; `PastePreview.tsx` input preview card; `ChatInput.tsx` paste intercept + hasText for paste-only; `ContentBlocks.tsx` collapsible paste block; `useSendMessage.ts` accurate optimistic stats; `chatStore.ts` blob URL revoke for paste

## Why

Users pasting Android logcat logs (100+ lines) hit the backend `z.string().max(10000)` validation and get a 400 error. This feature converts long pastes into file attachments via the existing multipart upload channel.

## Original Requirements

> I need to paste logcat logs during Android development, but long input causes 'Failed to send message: Server error: 400'. Can we fold long text like CLI Claude Code does with '[Pasted text #1 +93 lines]'?
> I want all the text pasted in, show first few lines + [... 928 more lines] as folded preview. Click to see the full content.

- Core pain point: long text paste hits 10K char limit, cannot send logs to cats for analysis

## Tradeoff

- Chose Approach A (reuse file upload channel) over Approach B (frontend truncate + backend store) for minimal change
- `.md` format for syntax highlighting on expand
- Raw text in file (no wrapper), code fence added at render time to keep stats accurate

## Test Evidence

```
vitest run pasteDetection.test.ts  -- 15 passed, 0 failed
tsc --noEmit (shared)              -- clean
tsc --noEmit (web)                 -- clean
tsc --noEmit (api)                 -- clean
pnpm check                        -- 0 errors
```

## Open Questions

None remaining. All P1/P2 issues from review resolved.

---

**Local Review**: [x] codex reviewed and approved (2 rounds, 3xP1 + 2xP2 + 2xP2-new all fixed)
**Cloud Review**: [ ] To be triggered via comment after PR creation

CVO Bootcamp task Q16 -- implemented by Ragdoll/Opus-46