### PR TITLE
fix(api): always propagate invocationId in callback broadcasts (#454)

### DIFF
--- a/packages/api/src/routes/callback-document-routes.ts
+++ b/packages/api/src/routes/callback-document-routes.ts
@@ -91,12 +91,14 @@ export function registerCallbackDocumentRoutes(
 
     const isNew = getRichBlockBuffer().add(record.threadId, record.catId as string, fileBlock, invocationId);
 
+    // #454: include invocationId so frontend can exact-match callback to stream bubble
     if (isNew) {
       deps.socketManager.broadcastAgentMessage(
         {
           type: 'system_info' as const,
           catId: record.catId,
           content: JSON.stringify({ type: 'rich_block', block: fileBlock }),
+          invocationId,
           timestamp: Date.now(),
         },
         record.threadId,

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -514,7 +514,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
         content: storedContent,
         origin: 'callback',
         messageId: storedMsg.id,
-        ...(invocationId ? { invocationId } : {}),
+        invocationId, // #454: always propagate — required by callback auth
         // F52+F098-C1: Include crossPost + targetCats in real-time broadcast
         ...(isCrossThread || validExplicitTargets.length
           ? {
@@ -536,12 +536,14 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
     // #83: Broadcast each extracted rich block as SSE event for live rendering
     // P2 cloud-review: include messageId for frontend correlation
+    // #454: include invocationId so frontend can exact-match callback to stream bubble
     for (const block of richBlocks) {
       socketManager.broadcastAgentMessage(
         {
           type: 'system_info' as const,
           catId: record.catId,
           content: JSON.stringify({ type: 'rich_block', block, messageId: storedMsg.id }),
+          invocationId,
           timestamp: Date.now(),
         },
         effectiveThreadId,
@@ -1126,12 +1128,14 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     const isNew = getRichBlockBuffer().add(record.threadId, record.catId as string, resolvedBlock, invocationId);
 
     // Only broadcast new blocks (dedup retries at server to prevent frontend duplicates)
+    // #454: include invocationId so frontend can exact-match callback to stream bubble
     if (isNew) {
       socketManager.broadcastAgentMessage(
         {
           type: 'system_info' as const,
           catId: record.catId,
           content: JSON.stringify({ type: 'rich_block', block: resolvedBlock }),
+          invocationId,
           timestamp: Date.now(),
         },
         record.threadId,

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -1751,6 +1751,41 @@ describe('Callback Routes', () => {
     assert.equal(msgs[0].invocationId, invocationId, 'create-rich-block broadcast must include invocationId');
   });
 
+  test('#454: generate-document broadcast includes invocationId', async () => {
+    const { tmpdir } = await import('node:os');
+    const { rm } = await import('node:fs/promises');
+    const uploadDir = `${tmpdir()}/cat-cafe-test-uploads-454`;
+    process.env.UPLOAD_DIR = uploadDir;
+    try {
+      const app = await createApp();
+      const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-454-doc');
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/callbacks/generate-document',
+        payload: {
+          invocationId,
+          callbackToken,
+          markdown: '# Test Doc\nHello from #454',
+          format: 'md',
+          baseName: 'test-454',
+        },
+      });
+
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.status, 'ok');
+
+      const msgs = socketManager.getMessages();
+      const docMsg = msgs.find((m) => m.type === 'system_info' && JSON.parse(m.content).type === 'rich_block');
+      assert.ok(docMsg, 'generate-document should broadcast system_info with rich_block');
+      assert.equal(docMsg.invocationId, invocationId, 'generate-document broadcast must include invocationId');
+    } finally {
+      delete process.env.UPLOAD_DIR;
+      await rm(uploadDir, { recursive: true, force: true }).catch(() => {});
+    }
+  });
+
   test('POST post-message without cc_rich blocks stores content as-is (no extra.rich)', async () => {
     const app = await createApp();
     const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-rb3');

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -1692,6 +1692,65 @@ describe('Callback Routes', () => {
     assert.equal(typeof parsed.messageId, 'string');
   });
 
+  // ---- #454: All callback broadcasts must include invocationId ----
+
+  test('#454: text broadcast always includes invocationId', async () => {
+    const app = await createApp();
+    const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-454-text');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/post-message',
+      payload: { invocationId, callbackToken, content: 'Hello' },
+    });
+
+    const msgs = socketManager.getMessages();
+    const textMsg = msgs.find((m) => m.type === 'text');
+    assert.ok(textMsg, 'text broadcast should exist');
+    assert.equal(textMsg.invocationId, invocationId, 'text broadcast must include invocationId');
+  });
+
+  test('#454: rich_block system_info broadcast includes invocationId', async () => {
+    const app = await createApp();
+    const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-454-rich');
+
+    const richPayload = JSON.stringify({
+      v: 1,
+      blocks: [{ id: 'diff-454', kind: 'diff', v: 1, filePath: 'src/bar.ts', diff: '- a\n+ b' }],
+    });
+    const content = `Fix:\n\`\`\`cc_rich\n${richPayload}\n\`\`\``;
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/post-message',
+      payload: { invocationId, callbackToken, content },
+    });
+
+    const msgs = socketManager.getMessages();
+    const richMsg = msgs.find((m) => m.type === 'system_info');
+    assert.ok(richMsg, 'rich_block system_info broadcast should exist');
+    assert.equal(richMsg.invocationId, invocationId, 'rich_block system_info broadcast must include invocationId');
+  });
+
+  test('#454: create-rich-block broadcast includes invocationId', async () => {
+    const app = await createApp();
+    const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-454-crb');
+
+    await app.inject({
+      method: 'POST',
+      url: '/api/callbacks/create-rich-block',
+      payload: {
+        invocationId,
+        callbackToken,
+        block: { id: 'card-454', kind: 'card', v: 1, title: 'Test', bodyMarkdown: 'hi' },
+      },
+    });
+
+    const msgs = socketManager.getMessages();
+    assert.ok(msgs.length >= 1, 'should have at least 1 broadcast');
+    assert.equal(msgs[0].invocationId, invocationId, 'create-rich-block broadcast must include invocationId');
+  });
+
   test('POST post-message without cc_rich blocks stores content as-is (no extra.rich)', async () => {
     const app = await createApp();
     const { invocationId, callbackToken } = registry.create('user-1', 'opus', 'thread-rb3');


### PR DESCRIPTION
## What

- `callbacks.ts`: unconditionally propagate `invocationId` in text broadcast, rich_block system_info broadcast (post-message), and create-rich-block broadcast
- `callback-document-routes.ts`: add `invocationId` to generate-document file block broadcast
- `callback-routes.test.js`: 4 regression tests covering all callback broadcast paths

## Why

Callback-origin websocket payloads were missing `invocationId`, forcing the frontend into heuristic content-matching to deduplicate late-arriving callback bubbles. Since every callback route already has `invocationId` in scope (required for auth), propagating it is zero-cost and gives the frontend an exact-match key.

Closes #454

## Original Requirements

- **原始需求摘录**：
  > 怎么前端还有重复消息显示的问题的；#378 #266 这两个pr不都反复改了的
- 铲屎官核心痛点：Hub UI 重复显示消息气泡（callback broadcast 缺 invocationId 导致前端无法精确匹配）
- **请 Reviewer 对照上面的摘录判断：交付物是否解决了铲屎官的问题？**

## Plan / ADR

- Issue: #454
- BACKLOG: #454

## Tradeoff

放弃了 PR #410 的客户端 heuristic 方案（time+content fence），选择协议层修复。原因：铲屎官明确要求根治而非缓解，且 invocationId 已在 callback auth scope 内，零新增字段。

## Test Evidence

node --test packages/api/test/callback-routes.test.js  # 80 passed, 0 failed
pnpm check                                             # green
pnpm lint                                              # green (only pre-existing web warnings)
pnpm -r --if-present run build                         # success

## Open Questions

- 全量 test:public 有 pre-existing exit code 2 failure（main 上同样存在），与本 PR 无关

---

**本地 Review**: [x] gpt52 已 review 并放行（两轮，P2 已修复）
**云端 Review**: [ ] PR 创建后在 **comment** 中触发（见下方模板）

<!-- 签名: Ragdoll/宪宪 (opus-46) -->