### PR TITLE
fix: sanitize leaked tool-call payloads in routing

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
@@ -228,6 +228,64 @@ export function isUserFacingSystemInfoContent(content: string): boolean {
   }
 }
 
+function looksLikeLeakedToolCallPayload(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed.startsWith('{')) return false;
+
+  const compact = trimmed.replace(/\s+/g, '');
+  if (
+    (compact.startsWith('{"tool_uses":[') && compact.includes('"recipient_name":"functions.')) ||
+    compact.startsWith('{"recipient_name":"functions.') ||
+    compact.startsWith('{"recipient_name":"mcp__') ||
+    compact.startsWith('{"recipient_name":"multi_tool_use.')
+  ) {
+    return true;
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as {
+      tool_uses?: Array<{ recipient_name?: unknown }>;
+      recipient_name?: unknown;
+    };
+    if (Array.isArray(parsed.tool_uses)) {
+      return parsed.tool_uses.some(
+        (item) =>
+          typeof item?.recipient_name === 'string' &&
+          (item.recipient_name.startsWith('functions.') ||
+            item.recipient_name.startsWith('mcp__') ||
+            item.recipient_name.startsWith('multi_tool_use.')),
+      );
+    }
+    return (
+      typeof parsed.recipient_name === 'string' &&
+      (parsed.recipient_name.startsWith('functions.') ||
+        parsed.recipient_name.startsWith('mcp__') ||
+        parsed.recipient_name.startsWith('multi_tool_use.'))
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Strip internal tool-call argument payloads that occasionally leak into stream text.
+ * Per-chunk stripping is best-effort; final sanitize on the complete text catches leftovers.
+ */
+export function stripLeakedToolCallPayload(content: string): string {
+  if (!content) return content;
+
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    if (!line.trimStart().startsWith('{')) continue;
+    const candidate = lines.slice(i).join('\n');
+    if (!looksLikeLeakedToolCallPayload(candidate)) continue;
+    return lines.slice(0, i).join('\n').replace(/\s+$/, '');
+  }
+
+  return content;
+}
+
 export function sanitizeInjectedContent(content: string): string {
   const lines = content.split('\n');
   const kept: string[] = [];
@@ -257,7 +315,7 @@ export function sanitizeInjectedContent(content: string): string {
     kept.push(line);
   }
 
-  return kept.join('\n').trim();
+  return stripLeakedToolCallPayload(kept.join('\n')).trim();
 }
 
 /**

--- a/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
@@ -232,16 +232,6 @@ function looksLikeLeakedToolCallPayload(candidate: string): boolean {
   const trimmed = candidate.trim();
   if (!trimmed.startsWith('{')) return false;
 
-  const compact = trimmed.replace(/\s+/g, '');
-  if (
-    (compact.startsWith('{"tool_uses":[') && compact.includes('"recipient_name":"functions.')) ||
-    compact.startsWith('{"recipient_name":"functions.') ||
-    compact.startsWith('{"recipient_name":"mcp__') ||
-    compact.startsWith('{"recipient_name":"multi_tool_use.')
-  ) {
-    return true;
-  }
-
   try {
     const parsed = JSON.parse(trimmed) as {
       tool_uses?: Array<{ recipient_name?: unknown }>;

--- a/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-helpers.ts
@@ -267,6 +267,49 @@ function looksLikeLeakedToolCallPayload(candidate: string): boolean {
   }
 }
 
+const LEAKED_TOOL_CALL_SIGNATURES = [
+  '{"tool_uses":[{"recipient_name":"functions.',
+  '{"tool_uses":[{"recipient_name":"mcp__',
+  '{"tool_uses":[{"recipient_name":"multi_tool_use.',
+  '{"recipient_name":"functions.',
+  '{"recipient_name":"mcp__',
+  '{"recipient_name":"multi_tool_use.',
+];
+
+function looksLikePotentialLeakedToolCallPayloadPrefix(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed.startsWith('{')) return false;
+
+  const compact = trimmed.replace(/\s+/g, '');
+  return LEAKED_TOOL_CALL_SIGNATURES.some((signature) => signature.startsWith(compact));
+}
+
+function findLineStartPayloadIndex(
+  content: string,
+  predicate: (candidate: string) => boolean,
+): { index: number; candidate: string } | null {
+  const lines = content.split('\n');
+  let offset = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? '';
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith('{')) {
+      offset += line.length + 1;
+      continue;
+    }
+
+    const leadingWhitespace = line.length - trimmed.length;
+    const candidate = lines.slice(i).join('\n');
+    if (predicate(candidate)) {
+      return { index: offset + leadingWhitespace, candidate };
+    }
+    offset += line.length + 1;
+  }
+
+  return null;
+}
+
 /**
  * Strip internal tool-call argument payloads that occasionally leak into stream text.
  * Per-chunk stripping is best-effort; final sanitize on the complete text catches leftovers.
@@ -274,16 +317,54 @@ function looksLikeLeakedToolCallPayload(candidate: string): boolean {
 export function stripLeakedToolCallPayload(content: string): string {
   if (!content) return content;
 
-  const lines = content.split('\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? '';
-    if (!line.trimStart().startsWith('{')) continue;
-    const candidate = lines.slice(i).join('\n');
-    if (!looksLikeLeakedToolCallPayload(candidate)) continue;
-    return lines.slice(0, i).join('\n').replace(/\s+$/, '');
+  const match = findLineStartPayloadIndex(content, looksLikeLeakedToolCallPayload);
+  if (match) {
+    return content.slice(0, match.index).replace(/\s+$/, '');
   }
 
   return content;
+}
+
+export interface LeakedToolCallStreamStripper {
+  push(content: string): string;
+  flush(): string;
+}
+
+/**
+ * Track suspicious line-start `{...}` fragments across stream chunks so leaked tool-call
+ * payloads can be suppressed before they become user-visible text.
+ */
+export function createLeakedToolCallStreamStripper(): LeakedToolCallStreamStripper {
+  let pending = '';
+
+  return {
+    push(content: string): string {
+      if (!content) return content;
+
+      const combined = pending + content;
+      pending = '';
+
+      const stripped = stripLeakedToolCallPayload(combined);
+      if (stripped !== combined) {
+        return stripped;
+      }
+
+      const match = findLineStartPayloadIndex(combined, looksLikePotentialLeakedToolCallPayloadPrefix);
+      if (!match) {
+        return combined;
+      }
+
+      pending = match.candidate;
+      return combined.slice(0, match.index).replace(/\s+$/, '');
+    },
+    flush(): string {
+      if (!pending) return '';
+
+      const remaining = pending;
+      pending = '';
+      return stripLeakedToolCallPayload(remaining);
+    },
+  };
 }
 
 export function sanitizeInjectedContent(content: string): string {

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -39,6 +39,7 @@ import {
   isUserFacingSystemInfoContent,
   routeContentBlocksForCat,
   sanitizeInjectedContent,
+  stripLeakedToolCallPayload,
   toStoredToolEvent,
   upsertMaxBoundary,
 } from './route-helpers.js';
@@ -504,15 +505,23 @@ export async function* routeParallel(
   for await (const msg of mergeStreams(streams, (idx, err) => {
     log.error({ streamIndex: idx, err }, 'Parallel stream error');
   })) {
+    const effectiveMsg =
+      msg.type === 'text' && msg.content ? { ...msg, content: stripLeakedToolCallPayload(msg.content) } : msg;
+
     // F22 R2 P1-1: Capture invocationId from the initial system_info per cat.
     // Keep forwarding this boundary event so frontend can reset stale task progress.
-    if (msg.type === 'system_info' && msg.content && msg.catId && !catInvocationId.has(msg.catId)) {
+    if (
+      effectiveMsg.type === 'system_info' &&
+      effectiveMsg.content &&
+      effectiveMsg.catId &&
+      !catInvocationId.has(effectiveMsg.catId)
+    ) {
       try {
-        const parsed = JSON.parse(msg.content);
+        const parsed = JSON.parse(effectiveMsg.content);
         if (parsed.type === 'invocation_created') {
-          catInvocationId.set(msg.catId, parsed.invocationId);
+          catInvocationId.set(effectiveMsg.catId, parsed.invocationId);
           // #80 fix: seed flush baseline so interval triggers after FLUSH_INTERVAL_MS
-          catFlushTime.set(msg.catId, Date.now());
+          catFlushTime.set(effectiveMsg.catId, Date.now());
           // Issue #83: Start a single keepalive timer that touches all active drafts.
           if (deps.draftStore && !keepaliveStarted) {
             keepaliveStarted = true;
@@ -527,103 +536,103 @@ export async function* routeParallel(
         /* ignore parse errors */
       }
     }
-    if (msg.type === 'text' && msg.content && msg.catId) {
-      catText.set(msg.catId, (catText.get(msg.catId) ?? '') + msg.content);
+    if (effectiveMsg.type === 'text' && effectiveMsg.content && effectiveMsg.catId) {
+      catText.set(effectiveMsg.catId, (catText.get(effectiveMsg.catId) ?? '') + effectiveMsg.content);
     }
     // F045: Accumulate thinking blocks per cat for persistence (F5 recovery)
-    if (msg.type === 'system_info' && msg.content && msg.catId) {
-      if (isUserFacingSystemInfoContent(msg.content)) {
-        catSawUserFacingSystemInfo.set(msg.catId, true);
+    if (effectiveMsg.type === 'system_info' && effectiveMsg.content && effectiveMsg.catId) {
+      if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
+        catSawUserFacingSystemInfo.set(effectiveMsg.catId, true);
       }
       try {
-        const parsed = JSON.parse(msg.content);
+        const parsed = JSON.parse(effectiveMsg.content);
         if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
-          const prev = catThinking.get(msg.catId) ?? '';
-          catThinking.set(msg.catId, prev ? `${prev}\n\n---\n\n${parsed.text}` : parsed.text);
+          const prev = catThinking.get(effectiveMsg.catId) ?? '';
+          catThinking.set(effectiveMsg.catId, prev ? `${prev}\n\n---\n\n${parsed.text}` : parsed.text);
         }
         // F060: Collect inline rich_block for persistence (P1 fix)
         if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
-          const arr = catStreamRichBlocks.get(msg.catId) ?? [];
+          const arr = catStreamRichBlocks.get(effectiveMsg.catId) ?? [];
           arr.push(parsed.block);
-          catStreamRichBlocks.set(msg.catId, arr);
+          catStreamRichBlocks.set(effectiveMsg.catId, arr);
         }
       } catch {
         /* ignore parse errors */
       }
     }
-    if (msg.type === 'error' && msg.catId) {
-      catHadError.add(msg.catId);
+    if (effectiveMsg.type === 'error' && effectiveMsg.catId) {
+      catHadError.add(effectiveMsg.catId);
       // #267: errors before abort are real provider failures; errors after abort are cleanup
-      if (!signal?.aborted) catHadProviderError.add(msg.catId);
-      if (msg.error) {
-        const prev = catErrorText.get(msg.catId) ?? '';
-        catErrorText.set(msg.catId, `${prev}${prev ? '\n' : ''}${msg.error}`);
+      if (!signal?.aborted) catHadProviderError.add(effectiveMsg.catId);
+      if (effectiveMsg.error) {
+        const prev = catErrorText.get(effectiveMsg.catId) ?? '';
+        catErrorText.set(effectiveMsg.catId, `${prev}${prev ? '\n' : ''}${effectiveMsg.error}`);
       }
     }
     // Accumulate tool events per cat
-    const toolEvt = toStoredToolEvent(msg);
-    if (toolEvt && msg.catId) {
-      const arr = catToolEvents.get(msg.catId) ?? [];
+    const toolEvt = toStoredToolEvent(effectiveMsg);
+    if (toolEvt && effectiveMsg.catId) {
+      const arr = catToolEvents.get(effectiveMsg.catId) ?? [];
       arr.push(toolEvt);
-      catToolEvents.set(msg.catId, arr);
+      catToolEvents.set(effectiveMsg.catId, arr);
     }
 
     // F148 OQ-2: Collect tool names for context eval
-    if (msg.type === 'tool_use' && msg.toolName && msg.catId) {
-      const names = catToolNames.get(msg.catId) ?? [];
-      names.push(msg.toolName);
-      catToolNames.set(msg.catId, names);
+    if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName && effectiveMsg.catId) {
+      const names = catToolNames.get(effectiveMsg.catId) ?? [];
+      names.push(effectiveMsg.toolName);
+      catToolNames.set(effectiveMsg.catId, names);
     }
 
     // F150: Fire-and-forget tool usage counter
-    if (msg.type === 'tool_use' && deps.toolUsageCounter && msg.catId) {
+    if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
       deps.toolUsageCounter.recordToolUse(
-        msg.catId as string,
-        msg.toolName ?? 'unknown',
-        msg.toolInput as Record<string, unknown> | undefined,
+        effectiveMsg.catId as string,
+        effectiveMsg.toolName ?? 'unknown',
+        effectiveMsg.toolInput as Record<string, unknown> | undefined,
       );
     }
-    if (msg.metadata && msg.catId && !catMeta.has(msg.catId)) {
-      catMeta.set(msg.catId, msg.metadata);
+    if (effectiveMsg.metadata && effectiveMsg.catId && !catMeta.has(effectiveMsg.catId)) {
+      catMeta.set(effectiveMsg.catId, effectiveMsg.metadata);
     }
 
     // #80: Draft flush — fire-and-forget periodic persistence per cat
-    if (deps.draftStore && msg.catId && catInvocationId.has(msg.catId)) {
-      const invId = catInvocationId.get(msg.catId)!;
+    if (deps.draftStore && effectiveMsg.catId && catInvocationId.has(effectiveMsg.catId)) {
+      const invId = catInvocationId.get(effectiveMsg.catId)!;
       const now = Date.now();
-      const lastFlush = catFlushTime.get(msg.catId) ?? now;
-      const lastLen = catFlushLen.get(msg.catId) ?? 0;
-      const curText = catText.get(msg.catId) ?? '';
+      const lastFlush = catFlushTime.get(effectiveMsg.catId) ?? now;
+      const lastLen = catFlushLen.get(effectiveMsg.catId) ?? 0;
+      const curText = catText.get(effectiveMsg.catId) ?? '';
       const charDelta = curText.length - lastLen;
 
-      const lastToolLen = catFlushToolLen.get(msg.catId) ?? 0;
-      const curTools = catToolEvents.get(msg.catId);
+      const lastToolLen = catFlushToolLen.get(effectiveMsg.catId) ?? 0;
+      const curTools = catToolEvents.get(effectiveMsg.catId);
       const curToolLen = curTools?.length ?? 0;
 
       const neverFlushedCat = lastLen === 0 && lastToolLen === 0;
       if (
-        msg.type === 'text' &&
+        effectiveMsg.type === 'text' &&
         charDelta > 0 &&
         (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
       ) {
-        const curThinking = catThinking.get(msg.catId);
+        const curThinking = catThinking.get(effectiveMsg.catId);
         deps.draftStore
           .upsert({
             userId,
             threadId,
             invocationId: invId,
-            catId: msg.catId as CatId,
+            catId: effectiveMsg.catId as CatId,
             content: curText,
             ...(curTools && curToolLen > 0 ? { toolEvents: curTools } : {}),
             ...(curThinking ? { thinking: curThinking } : {}),
             updatedAt: now,
           })
           ?.catch?.(noop);
-        catFlushTime.set(msg.catId, now);
-        catFlushLen.set(msg.catId, curText.length);
-        catFlushToolLen.set(msg.catId, curToolLen);
+        catFlushTime.set(effectiveMsg.catId, now);
+        catFlushLen.set(effectiveMsg.catId, curText.length);
+        catFlushToolLen.set(effectiveMsg.catId, curToolLen);
       } else if (
-        (msg.type === 'tool_use' || msg.type === 'tool_result') &&
+        (effectiveMsg.type === 'tool_use' || effectiveMsg.type === 'tool_result') &&
         // Cloud R7 P1: bypass interval for the very first flush — tool-first invocations
         // must create a draft immediately, not wait 2s for the interval gate.
         (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS)
@@ -631,25 +640,25 @@ export async function* routeParallel(
         // Cloud R6 P1: upsert when there's unsaved text OR new tool events —
         // tool-first invocations (no text yet) must still create a draft record.
         if (curText.length > lastLen || curToolLen > lastToolLen) {
-          const curThinkingTool = catThinking.get(msg.catId);
+          const curThinkingTool = catThinking.get(effectiveMsg.catId);
           deps.draftStore
             .upsert({
               userId,
               threadId,
               invocationId: invId,
-              catId: msg.catId as CatId,
+              catId: effectiveMsg.catId as CatId,
               content: curText,
               ...(curTools && curToolLen > 0 ? { toolEvents: curTools } : {}),
               ...(curThinkingTool ? { thinking: curThinkingTool } : {}),
               updatedAt: now,
             })
             ?.catch?.(noop);
-          catFlushLen.set(msg.catId, curText.length);
-          catFlushToolLen.set(msg.catId, curToolLen);
+          catFlushLen.set(effectiveMsg.catId, curText.length);
+          catFlushToolLen.set(effectiveMsg.catId, curToolLen);
         } else {
           deps.draftStore.touch(userId, threadId, invId)?.catch?.(noop);
         }
-        catFlushTime.set(msg.catId, now);
+        catFlushTime.set(effectiveMsg.catId, now);
       }
     }
 
@@ -1093,10 +1102,14 @@ export async function* routeParallel(
         }
       }
 
-      yield { ...msg, isFinal };
+      if (!(effectiveMsg.type === 'text' && !effectiveMsg.content)) {
+        yield { ...effectiveMsg, isFinal };
+      }
       if (isFinal) yieldedFinalDone = true;
     } else {
-      yield msg;
+      if (!(effectiveMsg.type === 'text' && !effectiveMsg.content)) {
+        yield effectiveMsg;
+      }
     }
   }
 

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -519,6 +519,9 @@ export async function* routeParallel(
     if (msg.type === 'text' && msg.content && msg.catId) {
       effectiveMsgs.push({ ...msg, content: getPayloadStripper(msg.catId).push(msg.content) });
     } else if (msg.type === 'done' && msg.catId) {
+      if (msg.metadata && !catMeta.has(msg.catId)) {
+        catMeta.set(msg.catId, msg.metadata);
+      }
       const flushedText = getPayloadStripper(msg.catId).flush();
       if (flushedText) {
         effectiveMsgs.push({

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -34,12 +34,12 @@ import { extractRichFromText, isValidRichBlock } from './rich-block-extract.js';
 import type { RouteOptions, RouteStrategyDeps } from './route-helpers.js';
 import {
   assembleIncrementalContext,
+  createLeakedToolCallStreamStripper,
   detectContextDegradation,
   getService,
   isUserFacingSystemInfoContent,
   routeContentBlocksForCat,
   sanitizeInjectedContent,
-  stripLeakedToolCallPayload,
   toStoredToolEvent,
   upsertMaxBoundary,
 } from './route-helpers.js';
@@ -485,6 +485,7 @@ export async function* routeParallel(
   const catHadProviderError = new Set<string>();
   // F22 R2 P1-1: Capture own invocationId per cat from stream
   const catInvocationId = new Map<string, string>();
+  const catPayloadStrippers = new Map<string, ReturnType<typeof createLeakedToolCallStreamStripper>>();
   let completedCount = 0;
   let yieldedFinalDone = false;
 
@@ -502,145 +503,144 @@ export async function* routeParallel(
   // Track which cats have had their keepalive started
   let keepaliveStarted = false;
 
+  function getPayloadStripper(catId: string) {
+    let stripper = catPayloadStrippers.get(catId);
+    if (!stripper) {
+      stripper = createLeakedToolCallStreamStripper();
+      catPayloadStrippers.set(catId, stripper);
+    }
+    return stripper;
+  }
+
   for await (const msg of mergeStreams(streams, (idx, err) => {
     log.error({ streamIndex: idx, err }, 'Parallel stream error');
   })) {
-    const effectiveMsg =
-      msg.type === 'text' && msg.content ? { ...msg, content: stripLeakedToolCallPayload(msg.content) } : msg;
-
-    // F22 R2 P1-1: Capture invocationId from the initial system_info per cat.
-    // Keep forwarding this boundary event so frontend can reset stale task progress.
-    if (
-      effectiveMsg.type === 'system_info' &&
-      effectiveMsg.content &&
-      effectiveMsg.catId &&
-      !catInvocationId.has(effectiveMsg.catId)
-    ) {
-      try {
-        const parsed = JSON.parse(effectiveMsg.content);
-        if (parsed.type === 'invocation_created') {
-          catInvocationId.set(effectiveMsg.catId, parsed.invocationId);
-          // #80 fix: seed flush baseline so interval triggers after FLUSH_INTERVAL_MS
-          catFlushTime.set(effectiveMsg.catId, Date.now());
-          // Issue #83: Start a single keepalive timer that touches all active drafts.
-          if (deps.draftStore && !keepaliveStarted) {
-            keepaliveStarted = true;
-            keepaliveTimer = setInterval(() => {
-              for (const [, invId] of catInvocationId) {
-                deps.draftStore!.touch(userId, threadId, invId)?.catch?.(noop);
-              }
-            }, KEEPALIVE_INTERVAL_MS);
-          }
-        }
-      } catch {
-        /* ignore parse errors */
+    const effectiveMsgs: AgentMessage[] = [];
+    if (msg.type === 'text' && msg.content && msg.catId) {
+      effectiveMsgs.push({ ...msg, content: getPayloadStripper(msg.catId).push(msg.content) });
+    } else if (msg.type === 'done' && msg.catId) {
+      const flushedText = getPayloadStripper(msg.catId).flush();
+      if (flushedText) {
+        effectiveMsgs.push({
+          type: 'text',
+          catId: msg.catId,
+          content: flushedText,
+          timestamp: msg.timestamp,
+        });
       }
-    }
-    if (effectiveMsg.type === 'text' && effectiveMsg.content && effectiveMsg.catId) {
-      catText.set(effectiveMsg.catId, (catText.get(effectiveMsg.catId) ?? '') + effectiveMsg.content);
-    }
-    // F045: Accumulate thinking blocks per cat for persistence (F5 recovery)
-    if (effectiveMsg.type === 'system_info' && effectiveMsg.content && effectiveMsg.catId) {
-      if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
-        catSawUserFacingSystemInfo.set(effectiveMsg.catId, true);
-      }
-      try {
-        const parsed = JSON.parse(effectiveMsg.content);
-        if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
-          const prev = catThinking.get(effectiveMsg.catId) ?? '';
-          catThinking.set(effectiveMsg.catId, prev ? `${prev}\n\n---\n\n${parsed.text}` : parsed.text);
-        }
-        // F060: Collect inline rich_block for persistence (P1 fix)
-        if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
-          const arr = catStreamRichBlocks.get(effectiveMsg.catId) ?? [];
-          arr.push(parsed.block);
-          catStreamRichBlocks.set(effectiveMsg.catId, arr);
-        }
-      } catch {
-        /* ignore parse errors */
-      }
-    }
-    if (effectiveMsg.type === 'error' && effectiveMsg.catId) {
-      catHadError.add(effectiveMsg.catId);
-      // #267: errors before abort are real provider failures; errors after abort are cleanup
-      if (!signal?.aborted) catHadProviderError.add(effectiveMsg.catId);
-      if (effectiveMsg.error) {
-        const prev = catErrorText.get(effectiveMsg.catId) ?? '';
-        catErrorText.set(effectiveMsg.catId, `${prev}${prev ? '\n' : ''}${effectiveMsg.error}`);
-      }
-    }
-    // Accumulate tool events per cat
-    const toolEvt = toStoredToolEvent(effectiveMsg);
-    if (toolEvt && effectiveMsg.catId) {
-      const arr = catToolEvents.get(effectiveMsg.catId) ?? [];
-      arr.push(toolEvt);
-      catToolEvents.set(effectiveMsg.catId, arr);
+    } else {
+      effectiveMsgs.push(msg);
     }
 
-    // F148 OQ-2: Collect tool names for context eval
-    if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName && effectiveMsg.catId) {
-      const names = catToolNames.get(effectiveMsg.catId) ?? [];
-      names.push(effectiveMsg.toolName);
-      catToolNames.set(effectiveMsg.catId, names);
-    }
-
-    // F150: Fire-and-forget tool usage counter
-    if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
-      deps.toolUsageCounter.recordToolUse(
-        effectiveMsg.catId as string,
-        effectiveMsg.toolName ?? 'unknown',
-        effectiveMsg.toolInput as Record<string, unknown> | undefined,
-      );
-    }
-    if (effectiveMsg.metadata && effectiveMsg.catId && !catMeta.has(effectiveMsg.catId)) {
-      catMeta.set(effectiveMsg.catId, effectiveMsg.metadata);
-    }
-
-    // #80: Draft flush — fire-and-forget periodic persistence per cat
-    if (deps.draftStore && effectiveMsg.catId && catInvocationId.has(effectiveMsg.catId)) {
-      const invId = catInvocationId.get(effectiveMsg.catId)!;
-      const now = Date.now();
-      const lastFlush = catFlushTime.get(effectiveMsg.catId) ?? now;
-      const lastLen = catFlushLen.get(effectiveMsg.catId) ?? 0;
-      const curText = catText.get(effectiveMsg.catId) ?? '';
-      const charDelta = curText.length - lastLen;
-
-      const lastToolLen = catFlushToolLen.get(effectiveMsg.catId) ?? 0;
-      const curTools = catToolEvents.get(effectiveMsg.catId);
-      const curToolLen = curTools?.length ?? 0;
-
-      const neverFlushedCat = lastLen === 0 && lastToolLen === 0;
+    for (const effectiveMsg of effectiveMsgs) {
+      // F22 R2 P1-1: Capture invocationId from the initial system_info per cat.
+      // Keep forwarding this boundary event so frontend can reset stale task progress.
       if (
-        effectiveMsg.type === 'text' &&
-        charDelta > 0 &&
-        (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
+        effectiveMsg.type === 'system_info' &&
+        effectiveMsg.content &&
+        effectiveMsg.catId &&
+        !catInvocationId.has(effectiveMsg.catId)
       ) {
-        const curThinking = catThinking.get(effectiveMsg.catId);
-        deps.draftStore
-          .upsert({
-            userId,
-            threadId,
-            invocationId: invId,
-            catId: effectiveMsg.catId as CatId,
-            content: curText,
-            ...(curTools && curToolLen > 0 ? { toolEvents: curTools } : {}),
-            ...(curThinking ? { thinking: curThinking } : {}),
-            updatedAt: now,
-          })
-          ?.catch?.(noop);
-        catFlushTime.set(effectiveMsg.catId, now);
-        catFlushLen.set(effectiveMsg.catId, curText.length);
-        catFlushToolLen.set(effectiveMsg.catId, curToolLen);
-      } else if (
-        (effectiveMsg.type === 'tool_use' || effectiveMsg.type === 'tool_result') &&
-        // Cloud R7 P1: bypass interval for the very first flush — tool-first invocations
-        // must create a draft immediately, not wait 2s for the interval gate.
-        (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS)
-      ) {
-        // Cloud R6 P1: upsert when there's unsaved text OR new tool events —
-        // tool-first invocations (no text yet) must still create a draft record.
-        if (curText.length > lastLen || curToolLen > lastToolLen) {
-          const curThinkingTool = catThinking.get(effectiveMsg.catId);
+        try {
+          const parsed = JSON.parse(effectiveMsg.content);
+          if (parsed.type === 'invocation_created') {
+            catInvocationId.set(effectiveMsg.catId, parsed.invocationId);
+            // #80 fix: seed flush baseline so interval triggers after FLUSH_INTERVAL_MS
+            catFlushTime.set(effectiveMsg.catId, Date.now());
+            // Issue #83: Start a single keepalive timer that touches all active drafts.
+            if (deps.draftStore && !keepaliveStarted) {
+              keepaliveStarted = true;
+              keepaliveTimer = setInterval(() => {
+                for (const [, invId] of catInvocationId) {
+                  deps.draftStore!.touch(userId, threadId, invId)?.catch?.(noop);
+                }
+              }, KEEPALIVE_INTERVAL_MS);
+            }
+          }
+        } catch {
+          /* ignore parse errors */
+        }
+      }
+      if (effectiveMsg.type === 'text' && effectiveMsg.content && effectiveMsg.catId) {
+        catText.set(effectiveMsg.catId, (catText.get(effectiveMsg.catId) ?? '') + effectiveMsg.content);
+      }
+      // F045: Accumulate thinking blocks per cat for persistence (F5 recovery)
+      if (effectiveMsg.type === 'system_info' && effectiveMsg.content && effectiveMsg.catId) {
+        if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
+          catSawUserFacingSystemInfo.set(effectiveMsg.catId, true);
+        }
+        try {
+          const parsed = JSON.parse(effectiveMsg.content);
+          if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
+            const prev = catThinking.get(effectiveMsg.catId) ?? '';
+            catThinking.set(effectiveMsg.catId, prev ? `${prev}\n\n---\n\n${parsed.text}` : parsed.text);
+          }
+          // F060: Collect inline rich_block for persistence (P1 fix)
+          if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
+            const arr = catStreamRichBlocks.get(effectiveMsg.catId) ?? [];
+            arr.push(parsed.block);
+            catStreamRichBlocks.set(effectiveMsg.catId, arr);
+          }
+        } catch {
+          /* ignore parse errors */
+        }
+      }
+      if (effectiveMsg.type === 'error' && effectiveMsg.catId) {
+        catHadError.add(effectiveMsg.catId);
+        // #267: errors before abort are real provider failures; errors after abort are cleanup
+        if (!signal?.aborted) catHadProviderError.add(effectiveMsg.catId);
+        if (effectiveMsg.error) {
+          const prev = catErrorText.get(effectiveMsg.catId) ?? '';
+          catErrorText.set(effectiveMsg.catId, `${prev}${prev ? '\n' : ''}${effectiveMsg.error}`);
+        }
+      }
+      // Accumulate tool events per cat
+      const toolEvt = toStoredToolEvent(effectiveMsg);
+      if (toolEvt && effectiveMsg.catId) {
+        const arr = catToolEvents.get(effectiveMsg.catId) ?? [];
+        arr.push(toolEvt);
+        catToolEvents.set(effectiveMsg.catId, arr);
+      }
+
+      // F148 OQ-2: Collect tool names for context eval
+      if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName && effectiveMsg.catId) {
+        const names = catToolNames.get(effectiveMsg.catId) ?? [];
+        names.push(effectiveMsg.toolName);
+        catToolNames.set(effectiveMsg.catId, names);
+      }
+
+      // F150: Fire-and-forget tool usage counter
+      if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
+        deps.toolUsageCounter.recordToolUse(
+          effectiveMsg.catId as string,
+          effectiveMsg.toolName ?? 'unknown',
+          effectiveMsg.toolInput as Record<string, unknown> | undefined,
+        );
+      }
+      if (effectiveMsg.metadata && effectiveMsg.catId && !catMeta.has(effectiveMsg.catId)) {
+        catMeta.set(effectiveMsg.catId, effectiveMsg.metadata);
+      }
+
+      // #80: Draft flush — fire-and-forget periodic persistence per cat
+      if (deps.draftStore && effectiveMsg.catId && catInvocationId.has(effectiveMsg.catId)) {
+        const invId = catInvocationId.get(effectiveMsg.catId)!;
+        const now = Date.now();
+        const lastFlush = catFlushTime.get(effectiveMsg.catId) ?? now;
+        const lastLen = catFlushLen.get(effectiveMsg.catId) ?? 0;
+        const curText = catText.get(effectiveMsg.catId) ?? '';
+        const charDelta = curText.length - lastLen;
+
+        const lastToolLen = catFlushToolLen.get(effectiveMsg.catId) ?? 0;
+        const curTools = catToolEvents.get(effectiveMsg.catId);
+        const curToolLen = curTools?.length ?? 0;
+
+        const neverFlushedCat = lastLen === 0 && lastToolLen === 0;
+        if (
+          effectiveMsg.type === 'text' &&
+          charDelta > 0 &&
+          (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
+        ) {
+          const curThinking = catThinking.get(effectiveMsg.catId);
           deps.draftStore
             .upsert({
               userId,
@@ -649,17 +649,46 @@ export async function* routeParallel(
               catId: effectiveMsg.catId as CatId,
               content: curText,
               ...(curTools && curToolLen > 0 ? { toolEvents: curTools } : {}),
-              ...(curThinkingTool ? { thinking: curThinkingTool } : {}),
+              ...(curThinking ? { thinking: curThinking } : {}),
               updatedAt: now,
             })
             ?.catch?.(noop);
+          catFlushTime.set(effectiveMsg.catId, now);
           catFlushLen.set(effectiveMsg.catId, curText.length);
           catFlushToolLen.set(effectiveMsg.catId, curToolLen);
-        } else {
-          deps.draftStore.touch(userId, threadId, invId)?.catch?.(noop);
+        } else if (
+          (effectiveMsg.type === 'tool_use' || effectiveMsg.type === 'tool_result') &&
+          // Cloud R7 P1: bypass interval for the very first flush — tool-first invocations
+          // must create a draft immediately, not wait 2s for the interval gate.
+          (neverFlushedCat || now - lastFlush >= FLUSH_INTERVAL_MS)
+        ) {
+          // Cloud R6 P1: upsert when there's unsaved text OR new tool events —
+          // tool-first invocations (no text yet) must still create a draft record.
+          if (curText.length > lastLen || curToolLen > lastToolLen) {
+            const curThinkingTool = catThinking.get(effectiveMsg.catId);
+            deps.draftStore
+              .upsert({
+                userId,
+                threadId,
+                invocationId: invId,
+                catId: effectiveMsg.catId as CatId,
+                content: curText,
+                ...(curTools && curToolLen > 0 ? { toolEvents: curTools } : {}),
+                ...(curThinkingTool ? { thinking: curThinkingTool } : {}),
+                updatedAt: now,
+              })
+              ?.catch?.(noop);
+            catFlushLen.set(effectiveMsg.catId, curText.length);
+            catFlushToolLen.set(effectiveMsg.catId, curToolLen);
+          } else {
+            deps.draftStore.touch(userId, threadId, invId)?.catch?.(noop);
+          }
+          catFlushTime.set(effectiveMsg.catId, now);
         }
-        catFlushTime.set(effectiveMsg.catId, now);
       }
+
+      if (effectiveMsg.type === 'text' && !effectiveMsg.content) continue;
+      yield effectiveMsg;
     }
 
     if (msg.type === 'done' && msg.catId) {
@@ -1102,14 +1131,8 @@ export async function* routeParallel(
         }
       }
 
-      if (!(effectiveMsg.type === 'text' && !effectiveMsg.content)) {
-        yield { ...effectiveMsg, isFinal };
-      }
+      yield { ...msg, isFinal };
       if (isFinal) yieldedFinalDone = true;
-    } else {
-      if (!(effectiveMsg.type === 'text' && !effectiveMsg.content)) {
-        yield effectiveMsg;
-      }
     }
   }
 

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -50,6 +50,7 @@ import {
   isUserFacingSystemInfoContent,
   routeContentBlocksForCat,
   sanitizeInjectedContent,
+  stripLeakedToolCallPayload,
   toStoredToolEvent,
   upsertMaxBoundary,
 } from './route-helpers.js';
@@ -571,11 +572,14 @@ export async function* routeSerial(
         // F39 bugfix: stop yielding after cancel (pipe buffer may still drain)
         if (signal?.aborted) break;
 
+        const effectiveMsg =
+          msg.type === 'text' && msg.content ? { ...msg, content: stripLeakedToolCallPayload(msg.content) } : msg;
+
         // F22 R2 P1-1: Capture invocationId from the initial system_info.
         // Keep forwarding this boundary event so frontend can reset stale task progress.
-        if (msg.type === 'system_info' && msg.content && !ownInvocationId) {
+        if (effectiveMsg.type === 'system_info' && effectiveMsg.content && !ownInvocationId) {
           try {
-            const parsed = JSON.parse(msg.content);
+            const parsed = JSON.parse(effectiveMsg.content);
             if (parsed.type === 'invocation_created') {
               ownInvocationId = parsed.invocationId;
               // F111 Phase B: Start streaming TTS when we have an invocationId
@@ -606,17 +610,17 @@ export async function* routeSerial(
             /* ignore parse errors */
           }
         }
-        if (msg.type === 'text' && msg.content) {
-          textContent += msg.content;
-          voiceChunker?.feed(msg.content);
+        if (effectiveMsg.type === 'text' && effectiveMsg.content) {
+          textContent += effectiveMsg.content;
+          voiceChunker?.feed(effectiveMsg.content);
         }
         // F045: Accumulate thinking blocks for persistence (F5 recovery)
-        if (msg.type === 'system_info' && msg.content) {
-          if (isUserFacingSystemInfoContent(msg.content)) {
+        if (effectiveMsg.type === 'system_info' && effectiveMsg.content) {
+          if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
             sawUserFacingSystemInfo = true;
           }
           try {
-            const parsed = JSON.parse(msg.content);
+            const parsed = JSON.parse(effectiveMsg.content);
             if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
               thinkingContent += (thinkingContent ? '\n\n---\n\n' : '') + parsed.text;
             }
@@ -629,22 +633,22 @@ export async function* routeSerial(
           }
         }
         // Accumulate tool events for persistence (before draft flush so current event is available)
-        const toolEvt = toStoredToolEvent(msg);
+        const toolEvt = toStoredToolEvent(effectiveMsg);
         if (toolEvt) {
           collectedToolEvents.push(toolEvt);
         }
 
         // F148 OQ-2: Collect tool names for context eval
-        if (msg.type === 'tool_use' && msg.toolName) {
-          collectedToolNames.push(msg.toolName);
+        if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName) {
+          collectedToolNames.push(effectiveMsg.toolName);
         }
 
         // F150: Fire-and-forget tool usage counter
-        if (msg.type === 'tool_use' && deps.toolUsageCounter && msg.catId) {
+        if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
           deps.toolUsageCounter.recordToolUse(
-            msg.catId as string,
-            msg.toolName ?? 'unknown',
-            msg.toolInput as Record<string, unknown> | undefined,
+            effectiveMsg.catId as string,
+            effectiveMsg.toolName ?? 'unknown',
+            effectiveMsg.toolInput as Record<string, unknown> | undefined,
           );
         }
 
@@ -654,7 +658,7 @@ export async function* routeSerial(
           const charDelta = textContent.length - lastFlushLen;
           const neverFlushed = lastFlushLen === 0 && lastFlushToolLen === 0;
           if (
-            msg.type === 'text' &&
+            effectiveMsg.type === 'text' &&
             charDelta > 0 &&
             (neverFlushed || now - lastFlushTime >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
           ) {
@@ -704,29 +708,32 @@ export async function* routeSerial(
           }
         }
 
-        if (msg.type === 'error') {
+        if (effectiveMsg.type === 'error') {
           hadError = true;
           // #267: errors before abort are real provider failures; errors after abort are cleanup
           if (!signal?.aborted) hadProviderError = true;
-          if (msg.error) {
-            collectedErrorText += `${collectedErrorText ? '\n' : ''}${msg.error}`;
+          if (effectiveMsg.error) {
+            collectedErrorText += `${collectedErrorText ? '\n' : ''}${effectiveMsg.error}`;
           }
         }
-        if (msg.metadata && !firstMetadata) {
-          firstMetadata = msg.metadata;
+        if (effectiveMsg.metadata && !firstMetadata) {
+          firstMetadata = effectiveMsg.metadata;
         }
-        if (msg.type === 'done') {
-          doneMsg = msg; // Buffer — yield after A2A detection
+        if (effectiveMsg.type === 'done') {
+          doneMsg = effectiveMsg; // Buffer — yield after A2A detection
         } else {
+          if (effectiveMsg.type === 'text' && !effectiveMsg.content) {
+            continue;
+          }
           // Tag CLI stdout text with origin: 'stream' (thinking/internal)
-          yield msg.type === 'text'
+          yield effectiveMsg.type === 'text'
             ? {
-                ...msg,
+                ...effectiveMsg,
                 origin: 'stream' as const,
                 ...(streamReplyTo ? { replyTo: streamReplyTo } : {}),
                 ...(streamReplyPreview ? { replyPreview: streamReplyPreview } : {}),
               }
-            : msg;
+            : effectiveMsg;
         }
       }
 

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -45,12 +45,12 @@ import { extractRichFromText, isValidRichBlock } from './rich-block-extract.js';
 import type { RouteOptions, RouteStrategyDeps } from './route-helpers.js';
 import {
   assembleIncrementalContext,
+  createLeakedToolCallStreamStripper,
   detectContextDegradation,
   getService,
   isUserFacingSystemInfoContent,
   routeContentBlocksForCat,
   sanitizeInjectedContent,
-  stripLeakedToolCallPayload,
   toStoredToolEvent,
   upsertMaxBoundary,
 } from './route-helpers.js';
@@ -552,6 +552,7 @@ export async function* routeSerial(
         { catId: catId as string, threadId, promptLength: prompt.length, index, worklistSize: worklist.length },
         'Invoking cat via invokeSingleCat',
       );
+      const leakedPayloadStripper = createLeakedToolCallStreamStripper();
       for await (const msg of invokeSingleCat(deps.invocationDeps, {
         catId,
         service: getService(deps.services, catId),
@@ -572,121 +573,113 @@ export async function* routeSerial(
         // F39 bugfix: stop yielding after cancel (pipe buffer may still drain)
         if (signal?.aborted) break;
 
-        const effectiveMsg =
-          msg.type === 'text' && msg.content ? { ...msg, content: stripLeakedToolCallPayload(msg.content) } : msg;
+        const effectiveMsgs: AgentMessage[] = [];
+        if (msg.type === 'text' && msg.content) {
+          effectiveMsgs.push({ ...msg, content: leakedPayloadStripper.push(msg.content) });
+        } else if (msg.type === 'done') {
+          const flushedText = leakedPayloadStripper.flush();
+          if (flushedText) {
+            effectiveMsgs.push({
+              type: 'text',
+              catId,
+              content: flushedText,
+              timestamp: msg.timestamp,
+            });
+          }
+          effectiveMsgs.push(msg);
+        } else {
+          effectiveMsgs.push(msg);
+        }
 
-        // F22 R2 P1-1: Capture invocationId from the initial system_info.
-        // Keep forwarding this boundary event so frontend can reset stale task progress.
-        if (effectiveMsg.type === 'system_info' && effectiveMsg.content && !ownInvocationId) {
-          try {
-            const parsed = JSON.parse(effectiveMsg.content);
-            if (parsed.type === 'invocation_created') {
-              ownInvocationId = parsed.invocationId;
-              // F111 Phase B: Start streaming TTS when we have an invocationId
-              if (voiceMode && deps.socketManager) {
-                const ttsRegistry = getStreamingTtsRegistry();
-                if (ttsRegistry) {
-                  voiceChunker = new StreamingTtsChunker({
-                    catId: catId as string,
-                    invocationId: ownInvocationId!,
-                    threadId,
-                    voiceConfig: getCatVoice(catId as string),
-                    broadcaster: deps.socketManager,
-                    ttsRegistry,
-                    signal,
-                  });
+        for (const effectiveMsg of effectiveMsgs) {
+          // F22 R2 P1-1: Capture invocationId from the initial system_info.
+          // Keep forwarding this boundary event so frontend can reset stale task progress.
+          if (effectiveMsg.type === 'system_info' && effectiveMsg.content && !ownInvocationId) {
+            try {
+              const parsed = JSON.parse(effectiveMsg.content);
+              if (parsed.type === 'invocation_created') {
+                ownInvocationId = parsed.invocationId;
+                // F111 Phase B: Start streaming TTS when we have an invocationId
+                if (voiceMode && deps.socketManager) {
+                  const ttsRegistry = getStreamingTtsRegistry();
+                  if (ttsRegistry) {
+                    voiceChunker = new StreamingTtsChunker({
+                      catId: catId as string,
+                      invocationId: ownInvocationId!,
+                      threadId,
+                      voiceConfig: getCatVoice(catId as string),
+                      broadcaster: deps.socketManager,
+                      ttsRegistry,
+                      signal,
+                    });
+                  }
+                }
+                // Issue #83: Start keepalive timer once we have an invocationId.
+                // This ensures draft TTL is renewed even during long silent tool calls.
+                if (deps.draftStore && !keepaliveTimer) {
+                  const keepInvId = ownInvocationId!;
+                  keepaliveTimer = setInterval(() => {
+                    deps.draftStore!.touch(userId, threadId, keepInvId)?.catch?.(noop);
+                  }, KEEPALIVE_INTERVAL_MS);
                 }
               }
-              // Issue #83: Start keepalive timer once we have an invocationId.
-              // This ensures draft TTL is renewed even during long silent tool calls.
-              if (deps.draftStore && !keepaliveTimer) {
-                const keepInvId = ownInvocationId!;
-                keepaliveTimer = setInterval(() => {
-                  deps.draftStore!.touch(userId, threadId, keepInvId)?.catch?.(noop);
-                }, KEEPALIVE_INTERVAL_MS);
+            } catch {
+              /* ignore parse errors */
+            }
+          }
+
+          if (effectiveMsg.type === 'text' && effectiveMsg.content) {
+            textContent += effectiveMsg.content;
+            voiceChunker?.feed(effectiveMsg.content);
+          }
+          // F045: Accumulate thinking blocks for persistence (F5 recovery)
+          if (effectiveMsg.type === 'system_info' && effectiveMsg.content) {
+            if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
+              sawUserFacingSystemInfo = true;
+            }
+            try {
+              const parsed = JSON.parse(effectiveMsg.content);
+              if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
+                thinkingContent += (thinkingContent ? '\n\n---\n\n' : '') + parsed.text;
               }
+              // F060: Collect inline rich_block for persistence (P1 fix)
+              if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
+                streamRichBlocks.push(parsed.block);
+              }
+            } catch {
+              /* ignore parse errors */
             }
-          } catch {
-            /* ignore parse errors */
           }
-        }
-        if (effectiveMsg.type === 'text' && effectiveMsg.content) {
-          textContent += effectiveMsg.content;
-          voiceChunker?.feed(effectiveMsg.content);
-        }
-        // F045: Accumulate thinking blocks for persistence (F5 recovery)
-        if (effectiveMsg.type === 'system_info' && effectiveMsg.content) {
-          if (isUserFacingSystemInfoContent(effectiveMsg.content)) {
-            sawUserFacingSystemInfo = true;
+          // Accumulate tool events for persistence (before draft flush so current event is available)
+          const toolEvt = toStoredToolEvent(effectiveMsg);
+          if (toolEvt) {
+            collectedToolEvents.push(toolEvt);
           }
-          try {
-            const parsed = JSON.parse(effectiveMsg.content);
-            if (parsed.type === 'thinking' && typeof parsed.text === 'string') {
-              thinkingContent += (thinkingContent ? '\n\n---\n\n' : '') + parsed.text;
-            }
-            // F060: Collect inline rich_block for persistence (P1 fix)
-            if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
-              streamRichBlocks.push(parsed.block);
-            }
-          } catch {
-            /* ignore parse errors */
+
+          // F148 OQ-2: Collect tool names for context eval
+          if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName) {
+            collectedToolNames.push(effectiveMsg.toolName);
           }
-        }
-        // Accumulate tool events for persistence (before draft flush so current event is available)
-        const toolEvt = toStoredToolEvent(effectiveMsg);
-        if (toolEvt) {
-          collectedToolEvents.push(toolEvt);
-        }
 
-        // F148 OQ-2: Collect tool names for context eval
-        if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName) {
-          collectedToolNames.push(effectiveMsg.toolName);
-        }
+          // F150: Fire-and-forget tool usage counter
+          if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
+            deps.toolUsageCounter.recordToolUse(
+              effectiveMsg.catId as string,
+              effectiveMsg.toolName ?? 'unknown',
+              effectiveMsg.toolInput as Record<string, unknown> | undefined,
+            );
+          }
 
-        // F150: Fire-and-forget tool usage counter
-        if (effectiveMsg.type === 'tool_use' && deps.toolUsageCounter && effectiveMsg.catId) {
-          deps.toolUsageCounter.recordToolUse(
-            effectiveMsg.catId as string,
-            effectiveMsg.toolName ?? 'unknown',
-            effectiveMsg.toolInput as Record<string, unknown> | undefined,
-          );
-        }
-
-        // #80: Draft flush — fire-and-forget periodic persistence for F5 recovery
-        if (deps.draftStore && ownInvocationId) {
-          const now = Date.now();
-          const charDelta = textContent.length - lastFlushLen;
-          const neverFlushed = lastFlushLen === 0 && lastFlushToolLen === 0;
-          if (
-            effectiveMsg.type === 'text' &&
-            charDelta > 0 &&
-            (neverFlushed || now - lastFlushTime >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
-          ) {
-            deps.draftStore
-              .upsert({
-                userId,
-                threadId,
-                invocationId: ownInvocationId,
-                catId,
-                content: textContent,
-                ...(collectedToolEvents.length > 0 ? { toolEvents: collectedToolEvents } : {}),
-                ...(thinkingContent ? { thinking: thinkingContent } : {}),
-                updatedAt: now,
-              })
-              ?.catch?.(noop);
-            lastFlushTime = now;
-            lastFlushLen = textContent.length;
-            lastFlushToolLen = collectedToolEvents.length;
-          } else if (
-            (msg.type === 'tool_use' || msg.type === 'tool_result') &&
-            // Cloud R7 P1: bypass interval for the very first flush — tool-first invocations
-            // must create a draft immediately, not wait 2s for the interval gate.
-            (neverFlushed || now - lastFlushTime >= FLUSH_INTERVAL_MS)
-          ) {
-            // Heartbeat for non-text events: keep draft alive during long tool calls.
-            // Cloud R6 P1: upsert when there's unsaved text OR new tool events —
-            // tool-first invocations (no text yet) must still create a draft record.
-            if (textContent.length > lastFlushLen || collectedToolEvents.length > lastFlushToolLen) {
+          // #80: Draft flush — fire-and-forget periodic persistence for F5 recovery
+          if (deps.draftStore && ownInvocationId) {
+            const now = Date.now();
+            const charDelta = textContent.length - lastFlushLen;
+            const neverFlushed = lastFlushLen === 0 && lastFlushToolLen === 0;
+            if (
+              effectiveMsg.type === 'text' &&
+              charDelta > 0 &&
+              (neverFlushed || now - lastFlushTime >= FLUSH_INTERVAL_MS || charDelta >= FLUSH_CHAR_DELTA)
+            ) {
               deps.draftStore
                 .upsert({
                   userId,
@@ -699,41 +692,67 @@ export async function* routeSerial(
                   updatedAt: now,
                 })
                 ?.catch?.(noop);
+              lastFlushTime = now;
               lastFlushLen = textContent.length;
               lastFlushToolLen = collectedToolEvents.length;
-            } else {
-              deps.draftStore.touch(userId, threadId, ownInvocationId)?.catch?.(noop);
-            }
-            lastFlushTime = now;
-          }
-        }
-
-        if (effectiveMsg.type === 'error') {
-          hadError = true;
-          // #267: errors before abort are real provider failures; errors after abort are cleanup
-          if (!signal?.aborted) hadProviderError = true;
-          if (effectiveMsg.error) {
-            collectedErrorText += `${collectedErrorText ? '\n' : ''}${effectiveMsg.error}`;
-          }
-        }
-        if (effectiveMsg.metadata && !firstMetadata) {
-          firstMetadata = effectiveMsg.metadata;
-        }
-        if (effectiveMsg.type === 'done') {
-          doneMsg = effectiveMsg; // Buffer — yield after A2A detection
-        } else {
-          if (effectiveMsg.type === 'text' && !effectiveMsg.content) {
-            continue;
-          }
-          // Tag CLI stdout text with origin: 'stream' (thinking/internal)
-          yield effectiveMsg.type === 'text'
-            ? {
-                ...effectiveMsg,
-                origin: 'stream' as const,
-                ...(streamReplyTo ? { replyTo: streamReplyTo } : {}),
-                ...(streamReplyPreview ? { replyPreview: streamReplyPreview } : {}),
+            } else if (
+              (effectiveMsg.type === 'tool_use' || effectiveMsg.type === 'tool_result') &&
+              // Cloud R7 P1: bypass interval for the very first flush — tool-first invocations
+              // must create a draft immediately, not wait 2s for the interval gate.
+              (neverFlushed || now - lastFlushTime >= FLUSH_INTERVAL_MS)
+            ) {
+              // Heartbeat for non-text events: keep draft alive during long tool calls.
+              // Cloud R6 P1: upsert when there's unsaved text OR new tool events —
+              // tool-first invocations (no text yet) must still create a draft record.
+              if (textContent.length > lastFlushLen || collectedToolEvents.length > lastFlushToolLen) {
+                deps.draftStore
+                  .upsert({
+                    userId,
+                    threadId,
+                    invocationId: ownInvocationId,
+                    catId,
+                    content: textContent,
+                    ...(collectedToolEvents.length > 0 ? { toolEvents: collectedToolEvents } : {}),
+                    ...(thinkingContent ? { thinking: thinkingContent } : {}),
+                    updatedAt: now,
+                  })
+                  ?.catch?.(noop);
+                lastFlushLen = textContent.length;
+                lastFlushToolLen = collectedToolEvents.length;
+              } else {
+                deps.draftStore.touch(userId, threadId, ownInvocationId)?.catch?.(noop);
               }
-            : effectiveMsg;
+              lastFlushTime = now;
+            }
+          }
+
+          if (effectiveMsg.type === 'error') {
+            hadError = true;
+            // #267: errors before abort are real provider failures; errors after abort are cleanup
+            if (!signal?.aborted) hadProviderError = true;
+            if (effectiveMsg.error) {
+              collectedErrorText += `${collectedErrorText ? '\n' : ''}${effectiveMsg.error}`;
+            }
+          }
+          if (effectiveMsg.metadata && !firstMetadata) {
+            firstMetadata = effectiveMsg.metadata;
+          }
+          if (effectiveMsg.type === 'done') {
+            doneMsg = effectiveMsg; // Buffer — yield after A2A detection
+          } else {
+            if (effectiveMsg.type === 'text' && !effectiveMsg.content) {
+              continue;
+            }
+            // Tag CLI stdout text with origin: 'stream' (thinking/internal)
+            yield effectiveMsg.type === 'text'
+              ? {
+                  ...effectiveMsg,
+                  origin: 'stream' as const,
+                  ...(streamReplyTo ? { replyTo: streamReplyTo } : {}),
+                  ...(streamReplyPreview ? { replyPreview: streamReplyPreview } : {}),
+                }
+              : effectiveMsg;
+          }
         }
       }
 

--- a/packages/api/test/f148-assemble-incremental.test.js
+++ b/packages/api/test/f148-assemble-incremental.test.js
@@ -499,6 +499,17 @@ After text`;
     assert.ok(cleaned.includes('After text'), 'text after envelope preserved');
   });
 
+  test('P2-2: sanitizeInjectedContent strips leaked tool-call payload suffix', async () => {
+    const { sanitizeInjectedContent } = await import('../dist/domains/cats/services/agents/routing/route-helpers.js');
+
+    const injected = `继续落到实现。先补链路和测试。
+
+{"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"sed -n '1,220p' foo.ts"}}]}`;
+
+    const cleaned = sanitizeInjectedContent(injected);
+    assert.equal(cleaned, '继续落到实现。先补链路和测试。');
+  });
+
   // --- Phase D: Coverage Map + Thread Memory injection ---
 
   test('AC-D2: smart window includes coverage map JSON', async () => {

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -246,6 +246,47 @@ describe('routeSerial', () => {
     assert.equal(appendCalls.length, 1, 'should persist one final message');
     assert.equal(appendCalls[0].content, '先看实现，再补测试。');
   });
+
+  it('strips leaked tool-call payloads split across streamed text chunks', async () => {
+    const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+
+    const contaminatedService = {
+      async *invoke() {
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `先看实现，再补测试。
+
+{`,
+          timestamp: 1000,
+        };
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"echo leaked"}}]}`,
+          timestamp: 1001,
+        };
+        yield { type: 'done', catId: 'opus', timestamp: 1002 };
+      },
+    };
+
+    const appendCalls = [];
+    const deps = createMockDeps({ opus: contaminatedService }, appendCalls);
+
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'read a.ts', 'user1', 'thread1')) {
+      messages.push(msg);
+    }
+
+    const textMsgs = messages.filter((m) => m.type === 'text');
+    assert.equal(textMsgs.length, 1, 'should yield only the prose chunk');
+    assert.equal(textMsgs[0].content, '先看实现，再补测试。');
+    assert.ok(textMsgs.every((m) => !m.content.includes('tool_uses')));
+    assert.ok(textMsgs.every((m) => !m.content.includes('recipient_name')));
+
+    assert.equal(appendCalls.length, 1, 'should persist one final message');
+    assert.equal(appendCalls[0].content, '先看实现，再补测试。');
+  });
 });
 
 describe('routeSerial A2A worklist', () => {
@@ -833,6 +874,47 @@ describe('routeParallel resilience', () => {
     const textMsgs = messages.filter((m) => m.type === 'text');
     assert.equal(textMsgs.length, 1, 'should still yield one text message');
     assert.equal(textMsgs[0].content, '继续落实现，别把内部参数露出去。');
+
+    assert.equal(appendCalls.length, 1, 'should persist one final message');
+    assert.equal(appendCalls[0].content, '继续落实现，别把内部参数露出去。');
+  });
+
+  it('strips leaked tool-call payloads split across parallel text chunks', async () => {
+    const { routeParallel } = await import('../dist/domains/cats/services/agents/routing/route-parallel.js');
+
+    const contaminatedService = {
+      async *invoke() {
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `继续落实现，别把内部参数露出去。
+
+{`,
+          timestamp: 1000,
+        };
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"echo leaked"}}]}`,
+          timestamp: 1001,
+        };
+        yield { type: 'done', catId: 'opus', timestamp: 1002 };
+      },
+    };
+
+    const appendCalls = [];
+    const deps = createMockDeps({ opus: contaminatedService }, appendCalls);
+
+    const messages = [];
+    for await (const msg of routeParallel(deps, ['opus'], 'read a.ts', 'user1', 'thread1')) {
+      messages.push(msg);
+    }
+
+    const textMsgs = messages.filter((m) => m.type === 'text');
+    assert.equal(textMsgs.length, 1, 'should yield only the prose chunk');
+    assert.equal(textMsgs[0].content, '继续落实现，别把内部参数露出去。');
+    assert.ok(textMsgs.every((m) => !m.content.includes('tool_uses')));
+    assert.ok(textMsgs.every((m) => !m.content.includes('recipient_name')));
 
     assert.equal(appendCalls.length, 1, 'should persist one final message');
     assert.equal(appendCalls[0].content, '继续落实现，别把内部参数露出去。');

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -287,6 +287,19 @@ describe('routeSerial', () => {
     assert.equal(appendCalls.length, 1, 'should persist one final message');
     assert.equal(appendCalls[0].content, '先看实现，再补测试。');
   });
+
+  it('keeps legitimate tool-use JSON examples when prose continues afterwards', async () => {
+    const {
+      stripLeakedToolCallPayload,
+    } = await import('../dist/domains/cats/services/agents/routing/route-helpers.js');
+
+    const example = `示例 payload：
+
+{"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"echo hi"}}]}
+上面只是文档示例，不是泄漏。`;
+
+    assert.equal(stripLeakedToolCallPayload(example), example);
+  });
 });
 
 describe('routeSerial A2A worklist', () => {

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -919,6 +919,31 @@ describe('routeParallel resilience', () => {
     assert.equal(appendCalls.length, 1, 'should persist one final message');
     assert.equal(appendCalls[0].content, '继续落实现，别把内部参数露出去。');
   });
+
+  it('preserves metadata when parallel provider only attaches it to done', async () => {
+    const { routeParallel } = await import('../dist/domains/cats/services/agents/routing/route-parallel.js');
+
+    const doneMetadata = {
+      model: 'codex-test',
+      usage: { inputTokens: 12, outputTokens: 7 },
+    };
+
+    const metadataOnDoneService = {
+      async *invoke() {
+        yield { type: 'text', catId: 'opus', content: 'metadata should survive', timestamp: 1000 };
+        yield { type: 'done', catId: 'opus', metadata: doneMetadata, timestamp: 1001 };
+      },
+    };
+
+    const appendCalls = [];
+    const deps = createMockDeps({ opus: metadataOnDoneService }, appendCalls);
+
+    for await (const _ of routeParallel(deps, ['opus'], 'test metadata', 'user1', 'thread1')) {
+    }
+
+    assert.equal(appendCalls.length, 1, 'should persist one final message');
+    assert.deepEqual(appendCalls[0].metadata, doneMetadata);
+  });
 });
 
 describe('routeParallel abort marks healthy (#267)', () => {

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -289,9 +289,9 @@ describe('routeSerial', () => {
   });
 
   it('keeps legitimate tool-use JSON examples when prose continues afterwards', async () => {
-    const {
-      stripLeakedToolCallPayload,
-    } = await import('../dist/domains/cats/services/agents/routing/route-helpers.js');
+    const { stripLeakedToolCallPayload } = await import(
+      '../dist/domains/cats/services/agents/routing/route-helpers.js'
+    );
 
     const example = `示例 payload：
 

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -212,6 +212,40 @@ describe('routeSerial', () => {
     assert.ok(stored.toolEvents[0].label.includes('Read'));
     assert.equal(stored.toolEvents[1].type, 'tool_result');
   });
+
+  it('strips leaked tool-call payloads from streamed text before yielding and persisting', async () => {
+    const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+
+    const contaminatedService = {
+      async *invoke() {
+        yield { type: 'tool_use', catId: 'opus', toolName: 'Read', toolInput: { path: '/a.ts' }, timestamp: 1000 };
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `先看实现，再补测试。
+
+{"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"sed -n '1,220p' foo.ts"}}]}`,
+          timestamp: 1001,
+        };
+        yield { type: 'done', catId: 'opus', timestamp: 1002 };
+      },
+    };
+
+    const appendCalls = [];
+    const deps = createMockDeps({ opus: contaminatedService }, appendCalls);
+
+    const messages = [];
+    for await (const msg of routeSerial(deps, ['opus'], 'read a.ts', 'user1', 'thread1')) {
+      messages.push(msg);
+    }
+
+    const textMsgs = messages.filter((m) => m.type === 'text');
+    assert.equal(textMsgs.length, 1, 'should still yield one text message');
+    assert.equal(textMsgs[0].content, '先看实现，再补测试。');
+
+    assert.equal(appendCalls.length, 1, 'should persist one final message');
+    assert.equal(appendCalls[0].content, '先看实现，再补测试。');
+  });
 });
 
 describe('routeSerial A2A worklist', () => {
@@ -768,6 +802,40 @@ describe('routeParallel resilience', () => {
       doneMsgs.some((m) => m.isFinal),
       'one done should be isFinal',
     );
+  });
+
+  it('strips leaked tool-call payloads from parallel text before yielding and persisting', async () => {
+    const { routeParallel } = await import('../dist/domains/cats/services/agents/routing/route-parallel.js');
+
+    const contaminatedService = {
+      async *invoke() {
+        yield { type: 'tool_use', catId: 'opus', toolName: 'Read', toolInput: { path: '/a.ts' }, timestamp: 1000 };
+        yield {
+          type: 'text',
+          catId: 'opus',
+          content: `继续落实现，别把内部参数露出去。
+
+{"tool_uses":[{"recipient_name":"functions.exec_command","parameters":{"cmd":"sed -n '1,220p' foo.ts"}}]}`,
+          timestamp: 1001,
+        };
+        yield { type: 'done', catId: 'opus', timestamp: 1002 };
+      },
+    };
+
+    const appendCalls = [];
+    const deps = createMockDeps({ opus: contaminatedService }, appendCalls);
+
+    const messages = [];
+    for await (const msg of routeParallel(deps, ['opus'], 'read a.ts', 'user1', 'thread1')) {
+      messages.push(msg);
+    }
+
+    const textMsgs = messages.filter((m) => m.type === 'text');
+    assert.equal(textMsgs.length, 1, 'should still yield one text message');
+    assert.equal(textMsgs[0].content, '继续落实现，别把内部参数露出去。');
+
+    assert.equal(appendCalls.length, 1, 'should persist one final message');
+    assert.equal(appendCalls[0].content, '继续落实现，别把内部参数露出去。');
   });
 });
 


### PR DESCRIPTION
## Summary
- strip leaked internal tool-call payload JSON from routed text chunks before yielding and persisting
- apply the same cleanup in both `routeSerial` and `routeParallel`, and skip empty text chunks after stripping
- add regressions for stream-time stripping and final `sanitizeInjectedContent` cleanup

## Context
- Refs #462
- User-visible bug: routed message text could include leaked internal payload like `{\"tool_uses\":[...]}` during streaming

## Verification
- `pnpm --dir packages/api build`
- `node --test packages/api/test/route-strategies.test.js packages/api/test/f148-assemble-incremental.test.js`
- `pnpm lint`
- `pnpm check`
- `pnpm -r --if-present run build`

## Known baseline / environment failures
- `pnpm test` still fails in `packages/mcp-server/test/tool-registration.test.js` because the branch already contains unreflected guide-tool registrations unrelated to this change
- `pnpm --filter @cat-cafe/api test` still fails on unrelated repo/env expectations (`.claude/hooks/shared-doc-push-guard.sh`, `scripts/signal-fetcher-launchd.sh`, and Redis-isolated tests that require `pnpm --filter @cat-cafe/api test:redis`)
