### PR TITLE
feat(F153): TELEMETRY_DEBUG console span exporter

### DIFF
--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1290,6 +1290,13 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'telemetry',
     sensitive: false,
   },
+  {
+    name: 'TELEMETRY_DEBUG',
+    defaultValue: '(未设置 → 关闭)',
+    description: '设为 true 将 span 输出到终端（ConsoleSpanExporter，未脱敏，仅限本地调试）',
+    category: 'telemetry',
+    sensitive: false,
+  },
 ];
 
 /** Mask credentials in a URL while preserving host/port/db for debugging. */

--- a/packages/api/src/infrastructure/telemetry/init.ts
+++ b/packages/api/src/infrastructure/telemetry/init.ts
@@ -17,7 +17,7 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { createModuleLogger } from '../logger.js';
 import { validateSalt } from './hmac.js';
@@ -33,6 +33,8 @@ export interface TelemetryConfig {
   prometheusPort?: number;
   /** Set true to also export via OTLP (requires OTEL_EXPORTER_OTLP_ENDPOINT). */
   otlpEnabled?: boolean;
+  /** Set true to print spans to console (TELEMETRY_DEBUG=true). Unredacted. */
+  debugMode?: boolean;
 }
 
 const DEFAULT_CONFIG: Required<TelemetryConfig> = {
@@ -40,6 +42,7 @@ const DEFAULT_CONFIG: Required<TelemetryConfig> = {
   serviceVersion: '0.1.0',
   prometheusPort: process.env.PROMETHEUS_PORT ? Number(process.env.PROMETHEUS_PORT) : 9464,
   otlpEnabled: !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  debugMode: process.env.TELEMETRY_DEBUG === 'true',
 };
 
 let sdk: NodeSDK | null = null;
@@ -71,10 +74,14 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
     [ATTR_SERVICE_VERSION]: cfg.serviceVersion,
   });
 
-  // --- Traces: Redacting processor wraps OTLP exporter ---
-  const spanProcessor = cfg.otlpEnabled
-    ? new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()))
-    : undefined;
+  // --- Traces: OTLP (redacted) + optional console debug (unredacted) ---
+  const spanProcessors: import('@opentelemetry/sdk-trace-node').SpanProcessor[] = [];
+  if (cfg.otlpEnabled) {
+    spanProcessors.push(new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter())));
+  }
+  if (cfg.debugMode) {
+    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+  }
 
   // --- Metrics: Prometheus scrape + optional OTLP push ---
   const prometheusExporter = new PrometheusExporter({
@@ -102,7 +109,7 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
 
   sdk = new NodeSDK({
     resource,
-    spanProcessors: spanProcessor ? [spanProcessor] : [],
+    spanProcessors,
     metricReaders,
     logRecordProcessors: logProcessor ? [logProcessor] : [],
     views,
@@ -113,6 +120,7 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
     {
       prometheus: cfg.prometheusPort,
       otlp: cfg.otlpEnabled,
+      debug: cfg.debugMode,
     },
     'OTel SDK initialized',
   );


### PR DESCRIPTION
## Summary
- Add `TELEMETRY_DEBUG=true` env var that attaches `ConsoleSpanExporter` via `SimpleSpanProcessor` to print spans to terminal in real time
- When neither OTLP nor debug is enabled, `spanProcessors` is `[]` (unchanged behavior — spans discarded)
- OTLP and debug modes can coexist: OTLP path uses `RedactingSpanProcessor`, debug path prints unredacted (local terminal only)
- Register `TELEMETRY_DEBUG` in env-registry under telemetry category

## Usage
```bash
TELEMETRY_DEBUG=true pnpm start
```

## Files changed
- `packages/api/src/infrastructure/telemetry/init.ts` — add `debugMode` config + `ConsoleSpanExporter` path
- `packages/api/src/config/env-registry.ts` — register `TELEMETRY_DEBUG`

## Test plan
- [ ] `pnpm check` passes (verified)
- [ ] `pnpm lint` passes (verified)
- [ ] Start API with `TELEMETRY_DEBUG=true`, trigger a cat invocation, verify spans appear in terminal stdout
- [ ] Start API without `TELEMETRY_DEBUG`, verify no console span output (existing behavior)
- [ ] Start API with both `TELEMETRY_DEBUG=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` set, verify both exporters active

Closes #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)