### PR TITLE
fix(antigravity): use getComputedStyle for visibility, regex icon cleanup

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
@@ -80,7 +80,7 @@ export const POLL_RESPONSE_JS = `(() => {
       }
     }
     // Strip hidden subtrees, icons, scripts, styles
-    clone.querySelectorAll('style, script, [aria-hidden="true"], .google-symbols, [class*="symbol"], [class*="material-symbols"]').forEach((el) => el.remove());
+    clone.querySelectorAll('style, script, [aria-hidden="true"], [inert], .google-symbols, [class*="symbol"], [class*="material-symbols"]').forEach((el) => el.remove());
     for (const el of clone.querySelectorAll('*')) {
       const cls = el.className || '';
       if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls) || /\\bhidden\\b/.test(cls))) {

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
@@ -23,6 +23,27 @@
  *                  └ ...
  */
 export const POLL_RESPONSE_JS = `(() => {
+  // --- 0. Visibility helpers ---
+  // Check if an element is visually hidden using computed styles (reliable),
+  // not class names alone (fragile — e.g. opacity-0 can be overridden by state classes).
+  const isVisiblyHidden = (el) => {
+    if (!el || !el.ownerDocument || !el.ownerDocument.defaultView) return false;
+    try {
+      const cs = el.ownerDocument.defaultView.getComputedStyle(el);
+      if (cs.display === 'none' || cs.visibility === 'hidden') return true;
+      if (parseFloat(cs.opacity) < 0.01) return true;
+      if (parseInt(cs.maxHeight, 10) === 0 && cs.overflow !== 'visible') return true;
+      if (el.getAttribute('aria-hidden') === 'true') return true;
+      if (el.hasAttribute('inert')) return true;
+      if (el.clientHeight === 0 && el.scrollHeight > 0) return true;
+    } catch(e) { /* detached node or cross-origin — fall through */ }
+    return false;
+  };
+
+  // Icon names used by Material Symbols — matched individually OR as concatenated runs
+  const ICON_NAMES = ['content_copy','thumb_up','thumb_down','check','close','chevron_right','chevron_left','undo','keyboard_arrow_up','expand_more','expand_less','more_vert','more_horiz','edit','delete','share','download','play_arrow','stop','send','arrow_upward','arrow_downward','refresh','settings','info','warning','error','help','search','menu','add','remove','visibility','visibility_off','lock','lock_open','star','star_border','favorite','favorite_border'];
+  const ICON_CONCAT_RE = new RegExp('(' + ICON_NAMES.join('|') + '){2,}', 'gi');
+
   // --- 1. Identify user messages ---
   // User messages are DIV.whitespace-pre-wrap inside DIV.max-h-[20vh] inside DIV.group.pt-4
   // Must filter out: PRE (terminal output), CODE (inline code), system context blocks
@@ -48,12 +69,15 @@ export const POLL_RESPONSE_JS = `(() => {
   const lastUserMsg = userMsgs[userMsgs.length - 1];
 
   // --- 2. Text extraction helper ---
-  const extractBlockText = (block) => {
+  const extractBlockText = (block, skipRootGuard) => {
     const clone = block.cloneNode(true);
     // Guard: if root element itself is hidden/invisible, return empty
-    const rootCls = (typeof clone.className === 'string') ? clone.className : '';
-    if (/\\bopacity-0\\b/.test(rootCls) || /\\bmax-h-0\\b/.test(rootCls) || /\\bhidden\\b/.test(rootCls) || /\\bpointer-events-none\\b/.test(rootCls)) {
-      return '';
+    // (skipped for thinking containers which are intentionally collapsed)
+    if (!skipRootGuard) {
+      const rootCls = (typeof clone.className === 'string') ? clone.className : '';
+      if (/\\bopacity-0\\b/.test(rootCls) || /\\bmax-h-0\\b/.test(rootCls) || /\\bhidden\\b/.test(rootCls) || /\\bpointer-events-none\\b/.test(rootCls)) {
+        return '';
+      }
     }
     // Strip hidden subtrees, icons, scripts, styles
     clone.querySelectorAll('style, script, [aria-hidden="true"], .google-symbols, [class*="symbol"], [class*="material-symbols"]').forEach((el) => el.remove());
@@ -109,9 +133,8 @@ export const POLL_RESPONSE_JS = `(() => {
       if (hasSibWithResponse) {
         return afterMe.filter(s => {
           if (!s.textContent?.trim()) return false;
-          // Skip invisible status indicators (opacity-0, hidden, pointer-events-none)
-          const c = (typeof s.className === 'string') ? s.className : '';
-          if (/\\bopacity-0\\b/.test(c) || /\\bhidden\\b/.test(c) || /\\bpointer-events-none\\b/.test(c)) return false;
+          // Skip invisible status indicators using computed styles
+          if (isVisiblyHidden(s)) return false;
           return true;
         });
       }
@@ -124,11 +147,8 @@ export const POLL_RESPONSE_JS = `(() => {
           const turn = siblings[j];
           const nextUserGroup = turn.querySelector('.group.pt-4 .whitespace-pre-wrap');
           if (nextUserGroup) break;
-          if (turn.textContent?.trim()) {
-            const tc = (typeof turn.className === 'string') ? turn.className : '';
-            if (!/\\bopacity-0\\b/.test(tc) && !/\\bhidden\\b/.test(tc) && !/\\bpointer-events-none\\b/.test(tc)) {
+          if (turn.textContent?.trim() && !isVisiblyHidden(turn)) {
               blocks.push(turn);
-            }
           }
         }
         return blocks;
@@ -146,11 +166,8 @@ export const POLL_RESPONSE_JS = `(() => {
       const turn = allTurns[i];
       if (turn.classList.contains('group') && turn.classList.contains('pt-4')
           && turn.querySelector('.whitespace-pre-wrap')) break;
-      if (turn.textContent?.trim()) {
-        const tc = (typeof turn.className === 'string') ? turn.className : '';
-        if (!/\\bopacity-0\\b/.test(tc) && !/\\bhidden\\b/.test(tc) && !/\\bpointer-events-none\\b/.test(tc)) {
+      if (turn.textContent?.trim() && !isVisiblyHidden(turn)) {
           blocks.push(turn);
-        }
       }
     }
     return blocks;
@@ -163,9 +180,15 @@ export const POLL_RESPONSE_JS = `(() => {
     // Check for .leading-relaxed.select-text — this is the main response text block
     // Filter out any that are inside collapsed thinking containers (max-h-0/opacity-0)
     const responseEls = [...b.querySelectorAll('.leading-relaxed.select-text')].filter(el => {
-      const hiddenAncestor = el.closest('.max-h-0, .opacity-0');
-      // Only exclude if the hidden ancestor is within this block (not the block itself)
-      return !hiddenAncestor || !b.contains(hiddenAncestor);
+      // Primary: check computed visibility on original DOM element (handles class overrides)
+      if (isVisiblyHidden(el)) return false;
+      // Walk ancestors up to block boundary — if any ancestor is hidden, exclude
+      let ancestor = el.parentElement;
+      while (ancestor && ancestor !== b) {
+        if (isVisiblyHidden(ancestor)) return false;
+        ancestor = ancestor.parentElement;
+      }
+      return true;
     });
     // Detect thinking: <details>, [class*="thinking"], [class*="thought"],
     // or "Thought for Xs" button + adjacent collapsed container, or opacity-70 blocks
@@ -179,7 +202,7 @@ export const POLL_RESPONSE_JS = `(() => {
     if (hasThinking) {
       if (isOpacityThinking && responseEls.length === 0) {
         // Pure thinking block (opacity-70 only, no response text)
-        thinkingParts.push(extractBlockText(b));
+        thinkingParts.push(extractBlockText(b, true));
       } else {
         // Collect thinking text from recognized thinking elements
         for (const el of thinkEls) thinkingParts.push((el.textContent || '').trim());
@@ -189,7 +212,7 @@ export const POLL_RESPONSE_JS = `(() => {
           while (sib) {
             const cls = sib.className || '';
             if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls))) {
-              thinkingParts.push(extractBlockText(sib));
+              thinkingParts.push(extractBlockText(sib, true));
             } else { break; }
             sib = sib.nextElementSibling;
           }
@@ -236,7 +259,16 @@ export const POLL_RESPONSE_JS = `(() => {
       if (txt) responseParts.push(txt);
     }
   }
-  const responseText = responseParts.join('\\n').trim();
+  // --- Final text normalization: strip icon text artifacts ---
+  const stripIconArtifacts = (text) => {
+    let cleaned = text;
+    // Remove concatenated icon runs (e.g. 'content_copythumb_upthumb_down')
+    cleaned = cleaned.replace(ICON_CONCAT_RE, '');
+    // Collapse multiple blank lines left by removals
+    cleaned = cleaned.replace(/\\n{3,}/g, '\\n\\n').trim();
+    return cleaned;
+  };
+  const responseText = stripIconArtifacts(responseParts.join('\\n').trim());
   const thinkingText = thinkingParts.filter(Boolean).join('\\n').trim();
 
   // --- 5. Detect loading / stop button ---

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
@@ -50,8 +50,13 @@ export const POLL_RESPONSE_JS = `(() => {
   // --- 2. Text extraction helper ---
   const extractBlockText = (block) => {
     const clone = block.cloneNode(true);
+    // Guard: if root element itself is hidden/invisible, return empty
+    const rootCls = (typeof clone.className === 'string') ? clone.className : '';
+    if (/\\bopacity-0\\b/.test(rootCls) || /\\bmax-h-0\\b/.test(rootCls) || /\\bhidden\\b/.test(rootCls) || /\\bpointer-events-none\\b/.test(rootCls)) {
+      return '';
+    }
     // Strip hidden subtrees, icons, scripts, styles
-    clone.querySelectorAll('style, script, [aria-hidden="true"], .google-symbols, [class*="symbol"]').forEach((el) => el.remove());
+    clone.querySelectorAll('style, script, [aria-hidden="true"], .google-symbols, [class*="symbol"], [class*="material-symbols"]').forEach((el) => el.remove());
     for (const el of clone.querySelectorAll('*')) {
       const cls = el.className || '';
       if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls) || /\\bhidden\\b/.test(cls))) {
@@ -59,12 +64,14 @@ export const POLL_RESPONSE_JS = `(() => {
       }
       // Strip UI icon text (Material Symbols icon labels rendered as text)
       const txt = (el.textContent || '').trim();
-      if (['content_copy','thumb_up','thumb_down','check','close','chevron_right','chevron_left','undo','keyboard_arrow_up'].includes(txt)) {
+      if (['content_copy','thumb_up','thumb_down','check','close','chevron_right','chevron_left','undo','keyboard_arrow_up','expand_more','expand_less','more_vert','more_horiz','edit','delete','share','download','play_arrow','stop','send'].includes(txt)) {
         el.remove();
       }
     }
     // Strip buttons (e.g. "Thought for Xs" toggle, action buttons)
     clone.querySelectorAll('button').forEach((el) => el.remove());
+    // Strip toolbar/action-bar containers (copy/vote buttons area)
+    clone.querySelectorAll('[class*="justify-between"][class*="cursor-default"]').forEach((el) => el.remove());
     const structured = [...clone.querySelectorAll('p, li, pre, code, h1, h2, h3, h4, h5, h6')]
       .map((el) => el.textContent?.trim()).filter(Boolean);
     if (structured.length > 0) return structured.join('\\n');
@@ -100,7 +107,13 @@ export const POLL_RESPONSE_JS = `(() => {
         s.querySelector && s.querySelector('.leading-relaxed')
       );
       if (hasSibWithResponse) {
-        return afterMe.filter(s => s.textContent?.trim());
+        return afterMe.filter(s => {
+          if (!s.textContent?.trim()) return false;
+          // Skip invisible status indicators (opacity-0, hidden, pointer-events-none)
+          const c = (typeof s.className === 'string') ? s.className : '';
+          if (/\\bopacity-0\\b/.test(c) || /\\bhidden\\b/.test(c) || /\\bpointer-events-none\\b/.test(c)) return false;
+          return true;
+        });
       }
       // Also check if parent is the per-turn conversation container (gap-y-3)
       const parentCls = parent.className || '';
@@ -111,7 +124,12 @@ export const POLL_RESPONSE_JS = `(() => {
           const turn = siblings[j];
           const nextUserGroup = turn.querySelector('.group.pt-4 .whitespace-pre-wrap');
           if (nextUserGroup) break;
-          if (turn.textContent?.trim()) blocks.push(turn);
+          if (turn.textContent?.trim()) {
+            const tc = (typeof turn.className === 'string') ? turn.className : '';
+            if (!/\\bopacity-0\\b/.test(tc) && !/\\bhidden\\b/.test(tc) && !/\\bpointer-events-none\\b/.test(tc)) {
+              blocks.push(turn);
+            }
+          }
         }
         return blocks;
       }
@@ -128,7 +146,12 @@ export const POLL_RESPONSE_JS = `(() => {
       const turn = allTurns[i];
       if (turn.classList.contains('group') && turn.classList.contains('pt-4')
           && turn.querySelector('.whitespace-pre-wrap')) break;
-      if (turn.textContent?.trim()) blocks.push(turn);
+      if (turn.textContent?.trim()) {
+        const tc = (typeof turn.className === 'string') ? turn.className : '';
+        if (!/\\bopacity-0\\b/.test(tc) && !/\\bhidden\\b/.test(tc) && !/\\bpointer-events-none\\b/.test(tc)) {
+          blocks.push(turn);
+        }
+      }
     }
     return blocks;
   })();
@@ -138,7 +161,12 @@ export const POLL_RESPONSE_JS = `(() => {
   const responseParts = [];
   for (const b of assistantBlocks) {
     // Check for .leading-relaxed.select-text — this is the main response text block
-    const responseEls = b.querySelectorAll('.leading-relaxed.select-text');
+    // Filter out any that are inside collapsed thinking containers (max-h-0/opacity-0)
+    const responseEls = [...b.querySelectorAll('.leading-relaxed.select-text')].filter(el => {
+      const hiddenAncestor = el.closest('.max-h-0, .opacity-0');
+      // Only exclude if the hidden ancestor is within this block (not the block itself)
+      return !hiddenAncestor || !b.contains(hiddenAncestor);
+    });
     // Detect thinking: <details>, [class*="thinking"], [class*="thought"],
     // or "Thought for Xs" button + adjacent collapsed container, or opacity-70 blocks
     const thinkEls = b.querySelectorAll('details, [class*="thinking"], [class*="thought"]');

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
@@ -29,13 +29,19 @@ export const POLL_RESPONSE_JS = `(() => {
   const userMsgs = [...document.querySelectorAll('.whitespace-pre-wrap')].filter((el) => {
     // Skip terminal output (PRE tags) and code blocks (CODE tags)
     if (el.tagName === 'PRE' || el.tagName === 'CODE') return false;
-    // Skip context-injected system prompt blocks (very long, contain 'Identity:')
+    // Skip context-injected system prompt blocks — but NOT legitimate user messages.
+    // Cat-cafe prompts may contain 'Identity:' in the user message body, so we cannot
+    // simply reject long text with that keyword. Instead: if the element is inside a
+    // recognised user-turn group (.group.pt-4), keep it regardless of length/content.
+    // Only reject if it matches ALL of: very long, has system-prompt markers, AND is
+    // NOT inside a user-turn group.
     const text = el.textContent || '';
-    if (text.length > 2000 && text.includes('Identity:')) return false;
+    const group = el.closest('.group');
+    const inUserTurnGroup = group && group.classList.contains('pt-4');
+    if (!inUserTurnGroup && text.length > 2000 && text.includes('Identity:')) return false;
     // Skip elements inside opacity-70 (thinking blocks)
     if (el.closest('.opacity-70')) return false;
     // Must be inside a user turn group (.group with .pt-4) to be a real user message
-    const group = el.closest('.group');
     if (group && !group.classList.contains('pt-4')) return false;
     return true;
   });

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/cdp-dom-scripts.ts
@@ -6,98 +6,209 @@
  */
 
 /** Extract assistant response state from the DOM after a user message.
- *  Returns JSON: { userMsgCount, responseText, hasInlineLoading } */
+ *  Returns JSON: { userMsgCount, responseText, thinkingText, hasInlineLoading, hasStopButton }
+ *
+ *  Antigravity IDE DOM structure (as of 2026-04):
+ *    .antigravity-agent-side-panel
+ *      └ .overflow-y-auto
+ *          └ .mx-auto.w-full > div
+ *              └ .flex.min-w-0.grow.flex-col          ← turn container
+ *                  ├ div.group.pt-4                   ← user turn (contains .whitespace-pre-wrap in .max-h-[20vh])
+ *                  ├ div (relative)                   ← assistant: "Worked for Xs" + response blocks
+ *                  │   ├ .group "Worked for Xs"
+ *                  │   ├ .relative > .group "Thought for Xs" + collapsed thinking
+ *                  │   ├ .leading-relaxed.select-text  ← main response text
+ *                  │   └ ...tool-use, terminal, file-diff blocks
+ *                  ├ div.group.pt-4                   ← next user turn
+ *                  └ ...
+ */
 export const POLL_RESPONSE_JS = `(() => {
-  const userMsgs = [...document.querySelectorAll('.whitespace-pre-wrap')];
+  // --- 1. Identify user messages ---
+  // User messages are DIV.whitespace-pre-wrap inside DIV.max-h-[20vh] inside DIV.group.pt-4
+  // Must filter out: PRE (terminal output), CODE (inline code), system context blocks
+  const userMsgs = [...document.querySelectorAll('.whitespace-pre-wrap')].filter((el) => {
+    // Skip terminal output (PRE tags) and code blocks (CODE tags)
+    if (el.tagName === 'PRE' || el.tagName === 'CODE') return false;
+    // Skip context-injected system prompt blocks (very long, contain 'Identity:')
+    const text = el.textContent || '';
+    if (text.length > 2000 && text.includes('Identity:')) return false;
+    // Skip elements inside opacity-70 (thinking blocks)
+    if (el.closest('.opacity-70')) return false;
+    // Must be inside a user turn group (.group with .pt-4) to be a real user message
+    const group = el.closest('.group');
+    if (group && !group.classList.contains('pt-4')) return false;
+    return true;
+  });
   const lastUserMsg = userMsgs[userMsgs.length - 1];
+
+  // --- 2. Text extraction helper ---
   const extractBlockText = (block) => {
     const clone = block.cloneNode(true);
-    // Strip hidden subtrees: collapsed thought containers, invisible elements
-    clone.querySelectorAll('style, script, [aria-hidden="true"]').forEach((el) => el.remove());
+    // Strip hidden subtrees, icons, scripts, styles
+    clone.querySelectorAll('style, script, [aria-hidden="true"], .google-symbols, [class*="symbol"]').forEach((el) => el.remove());
     for (const el of clone.querySelectorAll('*')) {
       const cls = el.className || '';
       if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls) || /\\bhidden\\b/.test(cls))) {
         el.remove();
       }
+      // Strip UI icon text (Material Symbols icon labels rendered as text)
+      const txt = (el.textContent || '').trim();
+      if (['content_copy','thumb_up','thumb_down','check','close','chevron_right','chevron_left','undo','keyboard_arrow_up'].includes(txt)) {
+        el.remove();
+      }
     }
-    // Also strip buttons (e.g. "Thought for Xs" toggle) from text extraction
+    // Strip buttons (e.g. "Thought for Xs" toggle, action buttons)
     clone.querySelectorAll('button').forEach((el) => el.remove());
     const structured = [...clone.querySelectorAll('p, li, pre, code, h1, h2, h3, h4, h5, h6')]
       .map((el) => el.textContent?.trim()).filter(Boolean);
     if (structured.length > 0) return structured.join('\\n');
     return clone.textContent?.trim() || '';
   };
+
+  // --- 3. Find assistant response blocks ---
+  // DOM structure per conversation turn:
+  //   div.flex.flex-col.gap-0.5  (turn wrapper)
+  //     sticky header -> flex-row -> min-w-0 -> group.pt-4 (user message)
+  //     div (assistant: "Worked for Xs", .leading-relaxed blocks, tool-use)
+  //     div.whitespace-nowrap (status indicator, opacity-0)
+  // Multiple turn wrappers are children of:
+  //   div.relative.flex.flex-col.gap-y-3.px-4 (conversation container)
+  // Strategy: walk up from userTurnGroup to find the level where assistant blocks are siblings.
   const assistantBlocks = (() => {
     if (!lastUserMsg) return [];
-    const thread = lastUserMsg.closest('.relative.flex.flex-col.gap-y-3.px-4');
-    if (thread) {
-      const wrapper = [...thread.children].find((c) => c.contains(lastUserMsg)) || thread.firstElementChild;
-      if (wrapper) {
-        const blocks = [...wrapper.children].filter((c) => {
-          return (c.textContent?.trim() || '').length > 0 && !c.classList.contains('hidden');
-        });
-        const idx = blocks.findIndex((c) => c.contains(lastUserMsg));
-        if (idx >= 0) return blocks.slice(idx + 1).filter((c) => !c.contains(lastUserMsg));
+    const userTurnGroup = lastUserMsg.closest('.group.pt-4')
+      || lastUserMsg.closest('.group')
+      || lastUserMsg.parentElement;
+    if (!userTurnGroup) return [];
+
+    // Walk up ancestor levels until we find siblings with .leading-relaxed
+    let current = userTurnGroup;
+    for (let depth = 0; depth < 6; depth++) {
+      const parent = current.parentElement;
+      if (!parent) break;
+      const siblings = [...parent.children];
+      const myIdx = siblings.indexOf(current);
+      const afterMe = siblings.slice(myIdx + 1);
+      // Check if any sibling has a .leading-relaxed response block
+      const hasSibWithResponse = afterMe.some(s =>
+        s.querySelector && s.querySelector('.leading-relaxed')
+      );
+      if (hasSibWithResponse) {
+        return afterMe.filter(s => s.textContent?.trim());
       }
+      // Also check if parent is the per-turn conversation container (gap-y-3)
+      const parentCls = parent.className || '';
+      if (parentCls.includes('gap-y-3')) {
+        const turnIdx = siblings.indexOf(current);
+        const blocks = [];
+        for (let j = turnIdx + 1; j < siblings.length; j++) {
+          const turn = siblings[j];
+          const nextUserGroup = turn.querySelector('.group.pt-4 .whitespace-pre-wrap');
+          if (nextUserGroup) break;
+          if (turn.textContent?.trim()) blocks.push(turn);
+        }
+        return blocks;
+      }
+      current = parent;
     }
-    const userGroup = lastUserMsg.closest('.group') || lastUserMsg.parentElement;
-    if (!userGroup) return [];
+    // Fallback: sibling-walk from userTurnGroup parent
+    const fp = userTurnGroup.parentElement;
+    if (!fp) return [];
+    const allTurns = [...fp.children];
+    const ui = allTurns.indexOf(userTurnGroup);
+    if (ui < 0) return [];
     const blocks = [];
-    let sib = userGroup.nextElementSibling;
-    while (sib) { blocks.push(sib); sib = sib.nextElementSibling; }
+    for (let i = ui + 1; i < allTurns.length; i++) {
+      const turn = allTurns[i];
+      if (turn.classList.contains('group') && turn.classList.contains('pt-4')
+          && turn.querySelector('.whitespace-pre-wrap')) break;
+      if (turn.textContent?.trim()) blocks.push(turn);
+    }
     return blocks;
   })();
+
+  // --- 4. Extract thinking and response text ---
   const thinkingParts = [];
   const responseParts = [];
   for (const b of assistantBlocks) {
+    // Check for .leading-relaxed.select-text — this is the main response text block
+    const responseEls = b.querySelectorAll('.leading-relaxed.select-text');
     // Detect thinking: <details>, [class*="thinking"], [class*="thought"],
-    // or Antigravity-style: button("Thought for Xs") + adjacent collapsed container
+    // or "Thought for Xs" button + adjacent collapsed container, or opacity-70 blocks
     const thinkEls = b.querySelectorAll('details, [class*="thinking"], [class*="thought"]');
     const thoughtBtn = [...b.querySelectorAll('button')].find((btn) =>
       /^Thought\\s+for\\s/i.test((btn.textContent || '').trim())
     );
-    const hasThinking = thinkEls.length > 0 || !!thoughtBtn;
+    const isOpacityThinking = b.classList.contains('opacity-70') || !!b.querySelector('.opacity-70');
+    const hasThinking = thinkEls.length > 0 || !!thoughtBtn || isOpacityThinking;
+
     if (hasThinking) {
-      // Collect thinking text from all recognized thinking elements
-      for (const el of thinkEls) thinkingParts.push((el.textContent || '').trim());
-      if (thoughtBtn) {
-        // Antigravity thought: collect text from collapsed sibling containers
-        let sib = thoughtBtn.nextElementSibling;
-        while (sib) {
-          const cls = sib.className || '';
-          if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls))) {
-            thinkingParts.push(extractBlockText(sib));
-          } else { break; }
-          sib = sib.nextElementSibling;
-        }
-      }
-      // Extract remaining visible text as response (strip thinking elements)
-      const clone = b.cloneNode(true);
-      clone.querySelectorAll('details, [class*="thinking"], [class*="thought"]').forEach((el) => el.remove());
-      // Also strip "Thought for" buttons and their collapsed containers
-      for (const btn of [...clone.querySelectorAll('button')]) {
-        if (/^Thought\\s+for\\s/i.test((btn.textContent || '').trim())) {
-          let ns = btn.nextElementSibling;
-          while (ns) {
-            const c = ns.className || '';
-            if (typeof c === 'string' && (/\\bmax-h-0\\b/.test(c) || /\\bopacity-0\\b/.test(c))) {
-              const next = ns.nextElementSibling; ns.remove(); ns = next;
+      if (isOpacityThinking && responseEls.length === 0) {
+        // Pure thinking block (opacity-70 only, no response text)
+        thinkingParts.push(extractBlockText(b));
+      } else {
+        // Collect thinking text from recognized thinking elements
+        for (const el of thinkEls) thinkingParts.push((el.textContent || '').trim());
+        if (thoughtBtn) {
+          // Antigravity thought: collect from collapsed sibling containers
+          let sib = thoughtBtn.nextElementSibling;
+          while (sib) {
+            const cls = sib.className || '';
+            if (typeof cls === 'string' && (/\\bmax-h-0\\b/.test(cls) || /\\bopacity-0\\b/.test(cls))) {
+              thinkingParts.push(extractBlockText(sib));
             } else { break; }
+            sib = sib.nextElementSibling;
           }
-          btn.remove();
         }
       }
-      const remaining = extractBlockText(clone).trim();
-      if (remaining) responseParts.push(remaining);
+
+      // Extract response text from .leading-relaxed blocks if present
+      if (responseEls.length > 0) {
+        for (const rel of responseEls) {
+          // Skip if inside a collapsed/hidden thinking container
+          const parentCls = rel.parentElement?.className || '';
+          if (/\\bmax-h-0\\b/.test(parentCls) || /\\bopacity-0\\b/.test(parentCls)) continue;
+          const txt = extractBlockText(rel).trim();
+          if (txt) responseParts.push(txt);
+        }
+      } else if (!isOpacityThinking) {
+        // Fallback: clone block, strip thinking elements, extract remainder
+        const clone = b.cloneNode(true);
+        clone.querySelectorAll('details, [class*="thinking"], [class*="thought"]').forEach((el) => el.remove());
+        for (const btn of [...clone.querySelectorAll('button')]) {
+          if (/^Thought\\s+for\\s/i.test((btn.textContent || '').trim())) {
+            let ns = btn.nextElementSibling;
+            while (ns) {
+              const c = ns.className || '';
+              if (typeof c === 'string' && (/\\bmax-h-0\\b/.test(c) || /\\bopacity-0\\b/.test(c))) {
+                const next = ns.nextElementSibling; ns.remove(); ns = next;
+              } else { break; }
+            }
+            btn.remove();
+          }
+        }
+        const remaining = extractBlockText(clone).trim();
+        if (remaining) responseParts.push(remaining);
+      }
+    } else if (responseEls.length > 0) {
+      // No thinking, but has .leading-relaxed response blocks
+      for (const rel of responseEls) {
+        const txt = extractBlockText(rel).trim();
+        if (txt) responseParts.push(txt);
+      }
     } else {
+      // Generic block — extract all text
       const txt = extractBlockText(b).trim();
       if (txt) responseParts.push(txt);
     }
   }
   const responseText = responseParts.join('\\n').trim();
   const thinkingText = thinkingParts.filter(Boolean).join('\\n').trim();
+
+  // --- 5. Detect loading / stop button ---
   const hasInlineLoading = assistantBlocks.some((b) => !!b.querySelector('.codicon-loading, [aria-busy="true"]'));
-  const chatScope = document.querySelector('[role="textbox"]')?.closest('.overflow-y-auto, [class*="chat"], [class*="conversation"]')?.parentElement;
+  const panel = document.querySelector('.antigravity-agent-side-panel');
+  const chatScope = panel || document.querySelector('[role="textbox"]')?.closest('.overflow-y-auto, [class*="chat"], [class*="conversation"]')?.parentElement;
   let hasStopButton = false;
   if (chatScope) {
     const stopBtn = chatScope.querySelector('button[aria-label*="stop" i]:not([disabled]), button[aria-label*="cancel" i]:not([disabled]), button[title*="stop" i]:not([disabled])');

--- a/packages/api/test/f061-thinking-dom.test.js
+++ b/packages/api/test/f061-thinking-dom.test.js
@@ -205,3 +205,86 @@ describe('F061: POLL_RESPONSE_JS structure smoke tests', () => {
     assert.ok(POLL_RESPONSE_JS.includes("clone.querySelectorAll('button')"), 'buttons stripped from clone');
   });
 });
+
+// ── P2 behavioral tests: isVisiblyHidden JSDOM/browser gap ─────────────
+// Requested by codex re-review of commit 4ae89c68
+
+describe('F061: isVisiblyHidden JSDOM/browser behavioral consistency', () => {
+  it('ancestor aria-hidden/inert hides child even if child has visible classes', () => {
+    // Risk: isVisiblyHidden only checks the direct element, not ancestors.
+    // The ancestor-walk in assistantBlocks extraction (lines 186-190) should catch this.
+    const result = runPollInDom(`
+			<div>
+				<div class="leading-relaxed select-text">
+					<div aria-hidden="true">
+						<p class="text-base font-normal">Should be hidden despite visible classes</p>
+					</div>
+					<div inert>
+						<p>Also hidden via inert</p>
+					</div>
+					<p>Visible answer alongside hidden ancestors.</p>
+				</div>
+			</div>
+		`);
+    assert.ok(!result.responseText.includes('Should be hidden'), 'aria-hidden ancestor must suppress child text');
+    assert.ok(!result.responseText.includes('Also hidden via inert'), 'inert ancestor must suppress child text');
+    assert.ok(result.responseText.includes('Visible answer'), 'text outside hidden subtrees must survive');
+  });
+
+  it('animation-class opacity-0 on wrapper does not leak into response', () => {
+    // Scenario: element has Tailwind opacity-0 class (enter-animation or collapsed).
+    // In JSDOM, getComputedStyle returns '' for opacity → parseFloat('') = NaN,
+    // NaN < 0.01 is false → isVisiblyHidden returns false.
+    // BUT extractBlockText's class-name regex guard (line 86-88) strips opacity-0 subtrees.
+    // Both paths converge: opacity-0 content removed from final text. Correct behavior.
+    const result = runPollInDom(`
+			<div>
+				<div class="opacity-0 transition-opacity">
+					<p>Animated content that should be stripped by class-name guard</p>
+				</div>
+				<div class="leading-relaxed select-text">
+					<p>The real visible answer.</p>
+				</div>
+			</div>
+		`);
+    assert.ok(!result.responseText.includes('Animated content'), 'opacity-0 class elements stripped from text extraction');
+    assert.ok(result.responseText.includes('real visible answer'), 'non-opacity-0 response text preserved');
+  });
+
+  it('JSDOM geometry-all-zero does not false-positive hide normal replies', () => {
+    // JSDOM quirk: clientHeight=0 and scrollHeight=0 for ALL elements.
+    // isVisiblyHidden check: el.clientHeight === 0 && el.scrollHeight > 0 → 0===0 && 0>0 → false
+    // Geometry heuristic is effectively disabled in JSDOM — safer direction (no false kills).
+    const result = runPollInDom(`
+			<div>
+				<div class="leading-relaxed select-text">
+					<p>Normal paragraph one.</p>
+					<p>Normal paragraph two.</p>
+					<pre>Code block content</pre>
+				</div>
+			</div>
+		`);
+    assert.ok(result.responseText.includes('Normal paragraph one'), 'first paragraph survives JSDOM geometry quirk');
+    assert.ok(result.responseText.includes('Normal paragraph two'), 'second paragraph survives');
+    assert.ok(result.responseText.includes('Code block content'), 'pre block survives');
+    assert.equal(result.userMsgCount, 1, 'exactly one user message detected');
+  });
+
+  it('icon concat mixed with real text: only icons stripped, prose preserved', () => {
+    // Risk: ICON_CONCAT_RE or stripIconArtifacts might eat surrounding text.
+    const result = runPollInDom(`
+			<div>
+				<div class="leading-relaxed select-text">
+					<p>Here is the answer to your question.</p>
+					<p>content_copythumb_upthumb_down</p>
+					<p>And here is additional context.</p>
+				</div>
+			</div>
+		`);
+    assert.ok(result.responseText.includes('answer to your question'), 'prose before icons preserved');
+    assert.ok(result.responseText.includes('additional context'), 'prose after icons preserved');
+    assert.ok(!result.responseText.includes('content_copy'), 'individual icon stripped');
+    assert.ok(!result.responseText.includes('thumb_up'), 'individual icon stripped');
+    assert.ok(!result.responseText.includes('content_copythumb_upthumb_down'), 'concatenated icon run stripped');
+  });
+});

--- a/packages/api/test/f061-thinking-dom.test.js
+++ b/packages/api/test/f061-thinking-dom.test.js
@@ -25,7 +25,7 @@ import { POLL_RESPONSE_JS } from '../dist/domains/cats/services/agents/providers
  */
 function runPollInDom(assistantHtml, userMsg = 'User question') {
   const html = `
-		<div class="group">
+		<div class="group pt-4">
 			<div class="whitespace-pre-wrap">${userMsg}</div>
 		</div>
 		${assistantHtml}
@@ -132,6 +132,53 @@ describe('F061: POLL_RESPONSE_JS behavioral DOM fixtures', () => {
     assert.ok(result.thinkingText.includes('Actual thinking content'), 'thinkingText has thought content');
     assert.ok(!result.thinkingText.includes('color: red'), 'thinkingText has no CSS');
     assert.ok(!result.thinkingText.includes('should be stripped'), 'thinkingText has no script content');
+  });
+});
+
+// ── Regression tests (code review P1 items) ────────────────────────────
+
+describe('F061: POLL_RESPONSE_JS regression tests (code review)', () => {
+  it('concatenated icon text is stripped from responseText', () => {
+    // Simulates the toolbar icon leak: content_copythumb_upthumb_down
+    const result = runPollInDom(`
+			<div>
+				<div class="leading-relaxed select-text">
+					<p>Actual response content here.</p>
+				</div>
+				<div class="flex justify-between cursor-default">
+					<span>content_copy</span><span>thumb_up</span><span>thumb_down</span>
+				</div>
+			</div>
+		`);
+    assert.ok(result.responseText.includes('Actual response content'), 'responseText has real content');
+    assert.ok(!result.responseText.includes('content_copy'), 'icon text stripped individually');
+    assert.ok(!result.responseText.includes('thumb_up'), 'icon text stripped');
+    assert.ok(!result.responseText.includes('content_copythumb_upthumb_down'), 'concatenated icon text stripped');
+  });
+
+  it('icon-only blocks should not trigger response completion', () => {
+    // When thinking leaks and only toolbar icons remain, responseText should be empty
+    const result = runPollInDom(`
+			<div>
+				<button>Thought for 12s</button>
+				<div class="max-h-0 opacity-0">
+					<p>Internal thinking about the problem...</p>
+				</div>
+			</div>
+		`);
+    // Only thinking content exists — responseText must be empty
+    assert.ok(!result.responseText.includes('Internal thinking'), 'thinking text must not leak to responseText');
+    assert.ok(result.thinkingText.includes('Internal thinking'), 'thinkingText should contain thinking');
+  });
+
+  it('uses getComputedStyle-based isVisiblyHidden helper', () => {
+    assert.ok(POLL_RESPONSE_JS.includes('getComputedStyle'), 'script should use getComputedStyle for visibility');
+    assert.ok(POLL_RESPONSE_JS.includes('isVisiblyHidden'), 'script should define isVisiblyHidden helper');
+  });
+
+  it('has icon concatenation regex cleanup', () => {
+    assert.ok(POLL_RESPONSE_JS.includes('ICON_CONCAT_RE'), 'script should have ICON_CONCAT_RE pattern');
+    assert.ok(POLL_RESPONSE_JS.includes('stripIconArtifacts'), 'script should have stripIconArtifacts function');
   });
 });
 


### PR DESCRIPTION
## Summary
Addresses code review feedback from @codex on commit 45483082.

### Changes
**P1 - Visibility detection:**
- Replace class-name matching with `isVisiblyHidden()` helper using `getComputedStyle` + `clientHeight` + `aria-hidden` + `inert`
- Handles edge case where `opacity-0` class is overridden by state classes

**P1 - Icon text leak:**
- Add `ICON_CONCAT_RE` regex to strip concatenated icon name runs
- Expand icon name list (+20 entries)

**Bug fixes discovered during testing:**
- `extractBlockText` root guard blocking thinking extraction; added `skipRootGuard` parameter
- Test fixture DOM `.group` → `.group.pt-4`

### Verification
- 13/13 tests pass ✅
- TypeScript: zero errors ✅
