### PR TITLE
feat(F153): inline @mention detection observability — counters + shadow detection

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
@@ -276,9 +276,10 @@ export function detectInlineActionMentionsWithShadow(
   if (!text) return { strictHits: [], shadowMisses: [], routedSetSkips: 0 };
 
   const strictHits = detectInlineActionMentions(text, currentCatId, routedMentions);
-  const strictCatIds = new Set(strictHits.map((h) => h.catId));
 
-  // Relaxed pass: find ALL inline @mentions (no action keyword required)
+  // Relaxed pass: find ALL inline @mentions, classify per occurrence.
+  // P2-1 fix: check action keywords per occurrence instead of global catId diff.
+  // P2-2 fix: only count routedSetSkip when action keyword present, dedup per (catId, line).
   const stripped = text.replace(/```[\s\S]*?```/g, '');
   const allConfigs = Object.keys(catRegistry.getAllConfigs()).length > 0 ? catRegistry.getAllConfigs() : CAT_CONFIGS;
 
@@ -294,13 +295,16 @@ export function detectInlineActionMentionsWithShadow(
 
   const routedSet = new Set(routedMentions ?? []);
   const shadowMisses: ShadowMiss[] = [];
-  const seenShadow = new Set<string>();
   let routedSetSkips = 0;
 
   for (const rawLine of stripped.split(/\r?\n/)) {
     const trimmed = rawLine.trimStart();
     const normalized = trimmed.toLowerCase();
     if (normalized.startsWith('>')) continue;
+
+    // Per-line dedup: same cat on same line only counted once per category
+    const lineShadowSeen = new Set<string>();
+    const lineRoutedSkipSeen = new Set<string>();
 
     for (const entry of entries) {
       let searchFrom = 0;
@@ -314,13 +318,22 @@ export function detectInlineActionMentionsWithShadow(
         const isBoundary = !charAfter || TOKEN_BOUNDARY_RE.test(charAfter) || !HANDLE_CONTINUATION_RE.test(charAfter);
         if (!isBoundary) continue;
 
+        // Per-occurrence action keyword check
+        const before = normalized.slice(0, idx);
+        const after = normalized.slice(idx + entry.pattern.length);
+        const hasActionKeyword = BEFORE_HANDOFF_RE.test(before) || AFTER_HANDOFF_RE.test(after);
+
         if (routedSet.has(entry.catId)) {
-          routedSetSkips++;
+          // P2-2: only count skip when action keyword present (genuine overlap)
+          if (hasActionKeyword && !lineRoutedSkipSeen.has(entry.catId)) {
+            lineRoutedSkipSeen.add(entry.catId);
+            routedSetSkips++;
+          }
           break;
         }
-        // Not a strict hit and not already seen → shadow miss
-        if (!strictCatIds.has(entry.catId) && !seenShadow.has(entry.catId)) {
-          seenShadow.add(entry.catId);
+        // Shadow miss = inline @mention WITHOUT action keyword (vocab gap candidate)
+        if (!hasActionKeyword && !lineShadowSeen.has(entry.catId)) {
+          lineShadowSeen.add(entry.catId);
           shadowMisses.push({
             catId: entry.catId,
             contextHash: hashContext(rawLine.trim()),

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
@@ -11,7 +11,6 @@
  * 6. 只在猫回复完整结束后解析 (由调用方保证)
  */
 
-import { createHash } from 'node:crypto';
 import type { CatId } from '@cat-cafe/shared';
 import { CAT_CONFIGS, catRegistry } from '@cat-cafe/shared';
 import { isCatAvailable } from '../../../../../config/cat-config-loader.js';
@@ -23,10 +22,10 @@ export function getMaxA2ADepth(): number {
 
 /** Max number of distinct cats a single message can @mention (F27 safety limit) */
 const MAX_A2A_MENTION_TARGETS = 2;
-const TOKEN_BOUNDARY_RE = /[\s,.:;!?()[\]{}<>，。！？、：；（）【】《》「」『』〈〉]/;
-// If the next char looks like part of a handle token, treat it as NOT a boundary.
-// This avoids prefix-matching `@opus-45` as `@opus`, while still allowing `@opus请看`.
-const HANDLE_CONTINUATION_RE = /[a-z0-9_.-]/;
+/** @internal Exported for a2a-shadow-detection.ts. */
+export const TOKEN_BOUNDARY_RE = /[\s,.:;!?()[\]{}<>，。！？、：；（）【】《》「」『』〈〉]/;
+/** @internal Exported for a2a-shadow-detection.ts. */
+export const HANDLE_CONTINUATION_RE = /[a-z0-9_.-]/;
 const LEADING_MARKDOWN_MENTION_PREFIX_RE = /^(?:(?:>\s*)|(?:[-*+]\s+)|(?:\d+[.)]\s+))+/;
 
 interface MentionPatternEntry {
@@ -160,13 +159,15 @@ export function analyzeA2AMentions(
  * Action patterns that appear immediately BEFORE @mention (e.g. "Ready for @xxx").
  * Chinese 请 uses negative lookbehind to exclude compounds (邀请 = invite, 申请 = apply).
  */
-const BEFORE_HANDOFF_RE = /(?:ready\s+for|交接给?|转给|(?<![邀申敬])请|帮)\s*$/i;
+/** @internal Exported for a2a-shadow-detection.ts. */
+export const BEFORE_HANDOFF_RE = /(?:ready\s+for|交接给?|转给|(?<![邀申敬])请|帮)\s*$/i;
 /**
  * Action patterns immediately AFTER @mention (e.g. "@xxx review").
  * English verbs use (?![a-z]) to reject continuations ("reviewed", "checklist").
  * Chinese verbs use negative lookahead to exclude completion suffixes (过/了/完/好/掉).
  */
-const AFTER_HANDOFF_RE =
+/** @internal Exported for a2a-shadow-detection.ts. */
+export const AFTER_HANDOFF_RE =
   /^\s*(?:(?:review|check|fix|merge)(?![a-z])|(?:确认|处理|来处理|来看)(?![过了完好掉])|看一?下|帮忙|请(?![教示假求问]))/i;
 
 export function detectInlineActionMentions(
@@ -239,111 +240,6 @@ export function detectInlineActionMentions(
   return found;
 }
 
-// --- F479: Shadow detection (in-process, metadata-only) ---
-
-/** Shadow miss metadata — no raw text, per data minimization (mindfn #479). */
-export interface ShadowMiss {
-  readonly catId: CatId;
-  /** SHA-256 of the line context, truncated to 16 hex chars. */
-  readonly contextHash: string;
-  /** Length of the raw line. */
-  readonly contextLength: number;
-}
-
-export interface ShadowDetectionResult {
-  readonly strictHits: InlineActionMention[];
-  readonly shadowMisses: ShadowMiss[];
-  /** Count of mentions skipped because routedSet already covered them. */
-  readonly routedSetSkips: number;
-}
-
-function hashContext(line: string): string {
-  return createHash('sha256').update(line).digest('hex').slice(0, 16);
-}
-
-/**
- * F479: Run strict detection + relaxed shadow detection in one pass.
- *
- * Shadow detection = "any inline @mention not caught by strict detection and
- * not in routedSet". These are vocab gap candidates where the action keyword
- * is present but not in our regex.
- */
-export function detectInlineActionMentionsWithShadow(
-  text: string,
-  currentCatId?: CatId,
-  routedMentions?: CatId[],
-): ShadowDetectionResult {
-  if (!text) return { strictHits: [], shadowMisses: [], routedSetSkips: 0 };
-
-  const strictHits = detectInlineActionMentions(text, currentCatId, routedMentions);
-
-  // Relaxed pass: find ALL inline @mentions, classify per occurrence.
-  // P2-1 fix: check action keywords per occurrence instead of global catId diff.
-  // P2-2 fix: only count routedSetSkip when action keyword present, dedup per (catId, line).
-  const stripped = text.replace(/```[\s\S]*?```/g, '');
-  const allConfigs = Object.keys(catRegistry.getAllConfigs()).length > 0 ? catRegistry.getAllConfigs() : CAT_CONFIGS;
-
-  const entries: MentionPatternEntry[] = [];
-  for (const [id, config] of Object.entries(allConfigs)) {
-    if (currentCatId && id === currentCatId) continue;
-    if (!isCatAvailable(id)) continue;
-    for (const pattern of config.mentionPatterns) {
-      entries.push({ catId: id as CatId, pattern: pattern.toLowerCase() });
-    }
-  }
-  entries.sort((a, b) => b.pattern.length - a.pattern.length);
-
-  const routedSet = new Set(routedMentions ?? []);
-  const shadowMisses: ShadowMiss[] = [];
-  let routedSetSkips = 0;
-
-  for (const rawLine of stripped.split(/\r?\n/)) {
-    const trimmed = rawLine.trimStart();
-    const normalized = trimmed.toLowerCase();
-    if (normalized.startsWith('>')) continue;
-
-    // Per-line dedup: same cat on same line only counted once per category
-    const lineShadowSeen = new Set<string>();
-    const lineRoutedSkipSeen = new Set<string>();
-
-    for (const entry of entries) {
-      let searchFrom = 0;
-      while (searchFrom < normalized.length) {
-        const idx = normalized.indexOf(entry.pattern, searchFrom);
-        if (idx < 0) break;
-        searchFrom = idx + 1;
-        if (idx === 0) continue; // line-start → handled by parseA2AMentions
-        if (HANDLE_CONTINUATION_RE.test(normalized[idx - 1]!)) continue;
-        const charAfter = normalized[idx + entry.pattern.length];
-        const isBoundary = !charAfter || TOKEN_BOUNDARY_RE.test(charAfter) || !HANDLE_CONTINUATION_RE.test(charAfter);
-        if (!isBoundary) continue;
-
-        // Per-occurrence action keyword check
-        const before = normalized.slice(0, idx);
-        const after = normalized.slice(idx + entry.pattern.length);
-        const hasActionKeyword = BEFORE_HANDOFF_RE.test(before) || AFTER_HANDOFF_RE.test(after);
-
-        if (routedSet.has(entry.catId)) {
-          // P2-2: only count skip when action keyword present (genuine overlap)
-          if (hasActionKeyword && !lineRoutedSkipSeen.has(entry.catId)) {
-            lineRoutedSkipSeen.add(entry.catId);
-            routedSetSkips++;
-          }
-          break;
-        }
-        // Shadow miss = inline @mention WITHOUT action keyword (vocab gap candidate)
-        if (!hasActionKeyword && !lineShadowSeen.has(entry.catId)) {
-          lineShadowSeen.add(entry.catId);
-          shadowMisses.push({
-            catId: entry.catId,
-            contextHash: hashContext(rawLine.trim()),
-            contextLength: rawLine.trim().length,
-          });
-        }
-        break;
-      }
-    }
-  }
-
-  return { strictHits, shadowMisses, routedSetSkips };
-}
+// --- F479: Shadow detection — extracted to a2a-shadow-detection.ts ---
+export type { ShadowDetectionResult, ShadowMiss } from './a2a-shadow-detection.js';
+export { detectInlineActionMentionsWithShadow } from './a2a-shadow-detection.js';

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
@@ -11,6 +11,7 @@
  * 6. 只在猫回复完整结束后解析 (由调用方保证)
  */
 
+import { createHash } from 'node:crypto';
 import type { CatId } from '@cat-cafe/shared';
 import { CAT_CONFIGS, catRegistry } from '@cat-cafe/shared';
 import { isCatAvailable } from '../../../../../config/cat-config-loader.js';
@@ -236,4 +237,100 @@ export function detectInlineActionMentions(
   }
 
   return found;
+}
+
+// --- F479: Shadow detection (in-process, metadata-only) ---
+
+/** Shadow miss metadata — no raw text, per data minimization (mindfn #479). */
+export interface ShadowMiss {
+  readonly catId: CatId;
+  /** SHA-256 of the line context, truncated to 16 hex chars. */
+  readonly contextHash: string;
+  /** Length of the raw line. */
+  readonly contextLength: number;
+}
+
+export interface ShadowDetectionResult {
+  readonly strictHits: InlineActionMention[];
+  readonly shadowMisses: ShadowMiss[];
+  /** Count of mentions skipped because routedSet already covered them. */
+  readonly routedSetSkips: number;
+}
+
+function hashContext(line: string): string {
+  return createHash('sha256').update(line).digest('hex').slice(0, 16);
+}
+
+/**
+ * F479: Run strict detection + relaxed shadow detection in one pass.
+ *
+ * Shadow detection = "any inline @mention not caught by strict detection and
+ * not in routedSet". These are vocab gap candidates where the action keyword
+ * is present but not in our regex.
+ */
+export function detectInlineActionMentionsWithShadow(
+  text: string,
+  currentCatId?: CatId,
+  routedMentions?: CatId[],
+): ShadowDetectionResult {
+  if (!text) return { strictHits: [], shadowMisses: [], routedSetSkips: 0 };
+
+  const strictHits = detectInlineActionMentions(text, currentCatId, routedMentions);
+  const strictCatIds = new Set(strictHits.map((h) => h.catId));
+
+  // Relaxed pass: find ALL inline @mentions (no action keyword required)
+  const stripped = text.replace(/```[\s\S]*?```/g, '');
+  const allConfigs = Object.keys(catRegistry.getAllConfigs()).length > 0 ? catRegistry.getAllConfigs() : CAT_CONFIGS;
+
+  const entries: MentionPatternEntry[] = [];
+  for (const [id, config] of Object.entries(allConfigs)) {
+    if (currentCatId && id === currentCatId) continue;
+    if (!isCatAvailable(id)) continue;
+    for (const pattern of config.mentionPatterns) {
+      entries.push({ catId: id as CatId, pattern: pattern.toLowerCase() });
+    }
+  }
+  entries.sort((a, b) => b.pattern.length - a.pattern.length);
+
+  const routedSet = new Set(routedMentions ?? []);
+  const shadowMisses: ShadowMiss[] = [];
+  const seenShadow = new Set<string>();
+  let routedSetSkips = 0;
+
+  for (const rawLine of stripped.split(/\r?\n/)) {
+    const trimmed = rawLine.trimStart();
+    const normalized = trimmed.toLowerCase();
+    if (normalized.startsWith('>')) continue;
+
+    for (const entry of entries) {
+      let searchFrom = 0;
+      while (searchFrom < normalized.length) {
+        const idx = normalized.indexOf(entry.pattern, searchFrom);
+        if (idx < 0) break;
+        searchFrom = idx + 1;
+        if (idx === 0) continue; // line-start → handled by parseA2AMentions
+        if (HANDLE_CONTINUATION_RE.test(normalized[idx - 1]!)) continue;
+        const charAfter = normalized[idx + entry.pattern.length];
+        const isBoundary = !charAfter || TOKEN_BOUNDARY_RE.test(charAfter) || !HANDLE_CONTINUATION_RE.test(charAfter);
+        if (!isBoundary) continue;
+
+        if (routedSet.has(entry.catId)) {
+          routedSetSkips++;
+          break;
+        }
+        // Not a strict hit and not already seen → shadow miss
+        if (!strictCatIds.has(entry.catId) && !seenShadow.has(entry.catId)) {
+          seenShadow.add(entry.catId);
+          shadowMisses.push({
+            catId: entry.catId,
+            contextHash: hashContext(rawLine.trim()),
+            contextLength: rawLine.trim().length,
+          });
+        }
+        break;
+      }
+    }
+  }
+
+  return { strictHits, shadowMisses, routedSetSkips };
 }

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-shadow-detection.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-shadow-detection.ts
@@ -118,8 +118,9 @@ export function detectInlineActionMentionsWithShadow(
           if (hasActionKeyword && !lineRoutedSkipSeen.has(entry.catId)) {
             lineRoutedSkipSeen.add(entry.catId);
             routedSetSkips++;
+            break; // classified — stop scanning this pattern
           }
-          break;
+          continue; // narrative routed mention — keep scanning for actionable occurrence
         }
         const hasRelaxedAction = RELAXED_BEFORE_ACTION_RE.test(before) || RELAXED_AFTER_ACTION_RE.test(after);
         if (!hasActionKeyword && hasRelaxedAction && !lineShadowSeen.has(entry.catId)) {
@@ -130,7 +131,9 @@ export function detectInlineActionMentionsWithShadow(
             contextLength: rawLine.trim().length,
           });
         }
-        break;
+        // Stop scanning only if this occurrence was classified (strict/relaxed/shadow).
+        // Narrative occurrences (no action signal at all) should not block later occurrences.
+        if (hasActionKeyword || hasRelaxedAction) break;
       }
     }
   }

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-shadow-detection.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-shadow-detection.ts
@@ -1,0 +1,139 @@
+/**
+ * F479: Shadow detection for inline @mention observability.
+ *
+ * Split from a2a-mentions.ts for file-size compliance.
+ * Provides relaxed detection to identify "vocab gap" candidates —
+ * inline @mentions with handoff-like context that strict regex missed.
+ */
+
+import { createHash } from 'node:crypto';
+import type { CatId } from '@cat-cafe/shared';
+import { CAT_CONFIGS, catRegistry } from '@cat-cafe/shared';
+import { isCatAvailable } from '../../../../../config/cat-config-loader.js';
+import {
+  AFTER_HANDOFF_RE,
+  BEFORE_HANDOFF_RE,
+  detectInlineActionMentions,
+  HANDLE_CONTINUATION_RE,
+  type InlineActionMention,
+  TOKEN_BOUNDARY_RE,
+} from './a2a-mentions.js';
+
+interface MentionPatternEntry {
+  readonly catId: CatId;
+  readonly pattern: string;
+}
+
+/**
+ * Relaxed action heuristic for shadow detection.
+ * Superset of strict BEFORE/AFTER_HANDOFF_RE — catches broader patterns
+ * that suggest handoff/request intent. Used to gate shadow misses so that
+ * pure narrative mentions ("之前 @codex 提出的方案不错") are excluded.
+ */
+const RELAXED_BEFORE_ACTION_RE =
+  /(?:ready\s+for|ask|ping|cc|let|need|交接给?|转给|(?<![邀申敬])请|帮|让|叫|问一?下?|找|麻烦|通知)\s*$/i;
+const RELAXED_AFTER_ACTION_RE =
+  /^\s*(?:(?:review|check|fix|merge|look|help|handle|test|verify)(?![a-z])|(?:确认|处理|来处理|来看|看一?下|看看)(?![过了完好掉])|帮忙|请(?![教示假求问])|修(?![改辞])|验证|负责|跟进)/i;
+
+/** Shadow miss metadata — no raw text, per data minimization (mindfn #479). */
+export interface ShadowMiss {
+  readonly catId: CatId;
+  /** SHA-256 of the line context, truncated to 16 hex chars. */
+  readonly contextHash: string;
+  /** Length of the raw line. */
+  readonly contextLength: number;
+}
+
+export interface ShadowDetectionResult {
+  readonly strictHits: InlineActionMention[];
+  readonly shadowMisses: ShadowMiss[];
+  /** Count of mentions skipped because routedSet already covered them. */
+  readonly routedSetSkips: number;
+}
+
+function hashContext(line: string): string {
+  return createHash('sha256').update(line).digest('hex').slice(0, 16);
+}
+
+/**
+ * F479: Run strict detection + relaxed shadow detection in one pass.
+ *
+ * Shadow detection = "any inline @mention with relaxed action signal but not
+ * caught by strict detection and not in routedSet". These are vocab gap
+ * candidates — the user likely has handoff intent (per RELAXED_*_ACTION_RE)
+ * but their wording isn't in the strict regex. Pure narrative mentions
+ * (e.g. "之前 @codex 提出的方案不错") are excluded.
+ */
+export function detectInlineActionMentionsWithShadow(
+  text: string,
+  currentCatId?: CatId,
+  routedMentions?: CatId[],
+): ShadowDetectionResult {
+  if (!text) return { strictHits: [], shadowMisses: [], routedSetSkips: 0 };
+
+  const strictHits = detectInlineActionMentions(text, currentCatId, routedMentions);
+
+  const stripped = text.replace(/```[\s\S]*?```/g, '');
+  const allConfigs = Object.keys(catRegistry.getAllConfigs()).length > 0 ? catRegistry.getAllConfigs() : CAT_CONFIGS;
+
+  const entries: MentionPatternEntry[] = [];
+  for (const [id, config] of Object.entries(allConfigs)) {
+    if (currentCatId && id === currentCatId) continue;
+    if (!isCatAvailable(id)) continue;
+    for (const pattern of config.mentionPatterns) {
+      entries.push({ catId: id as CatId, pattern: pattern.toLowerCase() });
+    }
+  }
+  entries.sort((a, b) => b.pattern.length - a.pattern.length);
+
+  const routedSet = new Set(routedMentions ?? []);
+  const shadowMisses: ShadowMiss[] = [];
+  let routedSetSkips = 0;
+
+  for (const rawLine of stripped.split(/\r?\n/)) {
+    const trimmed = rawLine.trimStart();
+    const normalized = trimmed.toLowerCase();
+    if (normalized.startsWith('>')) continue;
+
+    const lineShadowSeen = new Set<string>();
+    const lineRoutedSkipSeen = new Set<string>();
+
+    for (const entry of entries) {
+      let searchFrom = 0;
+      while (searchFrom < normalized.length) {
+        const idx = normalized.indexOf(entry.pattern, searchFrom);
+        if (idx < 0) break;
+        searchFrom = idx + 1;
+        if (idx === 0) continue; // line-start → handled by parseA2AMentions
+        if (HANDLE_CONTINUATION_RE.test(normalized[idx - 1]!)) continue;
+        const charAfter = normalized[idx + entry.pattern.length];
+        const isBoundary = !charAfter || TOKEN_BOUNDARY_RE.test(charAfter) || !HANDLE_CONTINUATION_RE.test(charAfter);
+        if (!isBoundary) continue;
+
+        const before = normalized.slice(0, idx);
+        const after = normalized.slice(idx + entry.pattern.length);
+        const hasActionKeyword = BEFORE_HANDOFF_RE.test(before) || AFTER_HANDOFF_RE.test(after);
+
+        if (routedSet.has(entry.catId)) {
+          if (hasActionKeyword && !lineRoutedSkipSeen.has(entry.catId)) {
+            lineRoutedSkipSeen.add(entry.catId);
+            routedSetSkips++;
+          }
+          break;
+        }
+        const hasRelaxedAction = RELAXED_BEFORE_ACTION_RE.test(before) || RELAXED_AFTER_ACTION_RE.test(after);
+        if (!hasActionKeyword && hasRelaxedAction && !lineShadowSeen.has(entry.catId)) {
+          lineShadowSeen.add(entry.catId);
+          shadowMisses.push({
+            catId: entry.catId,
+            contextHash: hashContext(rawLine.trim()),
+            contextLength: rawLine.trim().length,
+          });
+        }
+        break;
+      }
+    }
+  }
+
+  return { strictHits, shadowMisses, routedSetSkips };
+}

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -16,6 +16,17 @@ import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { getCatVoice } from '../../../../../config/cat-voices.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import {
+  inlineActionChecked,
+  inlineActionDetected,
+  inlineActionFeedbackWriteFailed,
+  inlineActionFeedbackWritten,
+  inlineActionHintEmitFailed,
+  inlineActionHintEmitted,
+  inlineActionRoutedSetSkip,
+  inlineActionShadowMiss,
+  lineStartDetected,
+} from '../../../../../infrastructure/telemetry/instruments.js';
 import { detectUserMention } from '../../../../../routes/user-mention.js';
 import { estimateTokens } from '../../../../../utils/token-counter.js';
 import {
@@ -41,7 +52,7 @@ import { invokeSingleCat } from '../invocation/invoke-single-cat.js';
 import { buildMcpCallbackInstructions, needsMcpInjection } from '../invocation/McpPromptInjector.js';
 import { getRichBlockBuffer } from '../invocation/RichBlockBuffer.js';
 import { resolveDefaultClaudeMcpServerPath } from '../providers/ClaudeAgentService.js';
-import { detectInlineActionMentions, getMaxA2ADepth, parseA2AMentions } from '../routing/a2a-mentions.js';
+import { detectInlineActionMentionsWithShadow, getMaxA2ADepth, parseA2AMentions } from '../routing/a2a-mentions.js';
 import { registerWorklist, unregisterWorklist } from '../routing/WorklistRegistry.js';
 import { extractContextEvalSignals } from './context-eval.js';
 import { buildBriefingMessage } from './format-briefing.js';
@@ -717,21 +728,38 @@ export async function* routeSerial(
         // Line-start @mention = always actionable (no keyword gate)
         a2aMentions = parseA2AMentions(storedContent, catId);
 
+        // F479: baseline counter — line-start mentions
+        if (a2aMentions.length > 0) {
+          lineStartDetected.add(a2aMentions.length, { 'agent.id': catId as string });
+        }
+
         // #417 / F064 AC-B3: Write-side feedback for inline action-like @mentions
+        // F479: counters for detection, shadow, feedback, hint
         if (deps.invocationDeps.threadStore) {
-          const inlineHits = detectInlineActionMentions(storedContent, catId, a2aMentions);
+          const {
+            strictHits: inlineHits,
+            shadowMisses,
+            routedSetSkips,
+          } = detectInlineActionMentionsWithShadow(storedContent, catId, a2aMentions);
+          const agentAttr = { 'agent.id': catId as string };
+          inlineActionChecked.add(1, agentAttr);
+          if (inlineHits.length > 0) inlineActionDetected.add(inlineHits.length, agentAttr);
+          if (shadowMisses.length > 0) inlineActionShadowMiss.add(shadowMisses.length, agentAttr);
+          if (routedSetSkips > 0) inlineActionRoutedSetSkip.add(routedSetSkips, agentAttr);
+
           if (inlineHits.length > 0) {
             try {
               await deps.invocationDeps.threadStore.setMentionRoutingFeedback(threadId, catId, {
                 sourceTimestamp: Date.now(),
                 items: inlineHits.map((m) => ({ targetCatId: m.catId, reason: 'inline_action' as const })),
               });
+              inlineActionFeedbackWritten.add(1, agentAttr);
               log.info(
                 { catId: catId as string, threadId, targets: inlineHits.map((h) => h.catId) },
                 'Inline action @mention detected — wrote routing feedback',
               );
             } catch {
-              /* best-effort */
+              inlineActionFeedbackWriteFailed.add(1, agentAttr);
             }
             // #1062: User-visible system message when chain would break
             // (inline action detected but no line-start @ = no routing will happen)
@@ -748,6 +776,7 @@ export async function* routeSerial(
                   timestamp: Date.now(),
                   source: hintSource,
                 });
+                inlineActionHintEmitted.add(1, agentAttr);
                 // Broadcast so frontend sees it in real-time (same pattern as vote result)
                 if (deps.socketManager) {
                   deps.socketManager.broadcastToRoom(`thread:${threadId}`, 'connector_message', {
@@ -762,7 +791,7 @@ export async function* routeSerial(
                   });
                 }
               } catch {
-                /* best-effort */
+                inlineActionHintEmitFailed.add(1, agentAttr);
               }
             }
           }

--- a/packages/api/src/infrastructure/telemetry/instruments.ts
+++ b/packages/api/src/infrastructure/telemetry/instruments.ts
@@ -45,6 +45,53 @@ export const guideTransitions = meter.createCounter('cat_cafe.guide.transitions'
   description: 'Guide lifecycle state transitions',
 });
 
+// --- F479: Inline @mention detection observability ---
+
+/** Counter: total inline action mention detection runs. */
+export const inlineActionChecked = meter.createCounter('cat_cafe.a2a.inline_action.checked', {
+  description: 'Total inline action @mention detection invocations',
+});
+
+/** Counter: inline action mention detected (strict match). */
+export const inlineActionDetected = meter.createCounter('cat_cafe.a2a.inline_action.detected', {
+  description: 'Inline action @mention strict detection hits',
+});
+
+/** Counter: shadow miss — relaxed match found but strict missed. */
+export const inlineActionShadowMiss = meter.createCounter('cat_cafe.a2a.inline_action.shadow_miss', {
+  description: 'Shadow detection: inline @ found but no action keyword (potential vocab gap)',
+});
+
+/** Counter: routing feedback written successfully. */
+export const inlineActionFeedbackWritten = meter.createCounter('cat_cafe.a2a.inline_action.feedback_written', {
+  description: 'Inline action mention routing feedback persisted',
+});
+
+/** Counter: routing feedback write failed. */
+export const inlineActionFeedbackWriteFailed = meter.createCounter('cat_cafe.a2a.inline_action.feedback_write_failed', {
+  description: 'Inline action mention routing feedback write failure',
+});
+
+/** Counter: hint system message emitted. */
+export const inlineActionHintEmitted = meter.createCounter('cat_cafe.a2a.inline_action.hint_emitted', {
+  description: 'Inline action hint system message sent to user',
+});
+
+/** Counter: hint emit failed. */
+export const inlineActionHintEmitFailed = meter.createCounter('cat_cafe.a2a.inline_action.hint_emit_failed', {
+  description: 'Inline action hint system message send failure',
+});
+
+/** Counter: routedSet already covered the mention — skipped. */
+export const inlineActionRoutedSetSkip = meter.createCounter('cat_cafe.a2a.inline_action.routed_set_skip', {
+  description: 'Inline action @mention skipped because already routed via line-start',
+});
+
+/** Counter: baseline — line-start @mention detected (model compliance). */
+export const lineStartDetected = meter.createCounter('cat_cafe.a2a.line_start.detected', {
+  description: 'Line-start @mention detected (baseline for model format compliance)',
+});
+
 /** Liveness state type. */
 export type LivenessState = 'dead' | 'idle-silent' | 'busy-silent' | 'active';
 

--- a/packages/api/test/mention-observability.test.js
+++ b/packages/api/test/mention-observability.test.js
@@ -158,6 +158,33 @@ describe('F479: shadow detection', () => {
     assert.equal(result.shadowMisses.length, 0, 'already-routed mention should be excluded from shadow');
   });
 
+  // --- P2-3 regression: narrative inline mention must NOT count as shadow miss ---
+
+  it('pure narrative inline mention is not a shadow miss', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "之前 @codex 提出的方案不错" — pure narrative, no action-like context
+    const result = detectInlineActionMentionsWithShadow('之前 @缅因猫 提出的方案不错', 'opus', []);
+
+    assert.equal(result.strictHits.length, 0, 'no strict hits (narrative)');
+    assert.equal(result.shadowMisses.length, 0, 'narrative mention must not be shadow miss');
+  });
+
+  it('relaxed action context still triggers shadow miss (vocab gap candidate)', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "麻烦 @codex 过目一下" — relaxed action ("麻烦") but not in strict regex
+    const result = detectInlineActionMentionsWithShadow('麻烦 @缅因猫 验证一下', 'opus', []);
+
+    assert.equal(result.strictHits.length, 0, 'not caught by strict regex');
+    assert.equal(result.shadowMisses.length, 1, 'relaxed action context → shadow miss');
+    assert.equal(result.shadowMisses[0].catId, 'codex');
+  });
+
   // --- P2-1 regression: mixed strict + shadow same cat across lines ---
 
   it('shadow detection reports shadow miss even when same cat has strict hit on another line', async () => {

--- a/packages/api/test/mention-observability.test.js
+++ b/packages/api/test/mention-observability.test.js
@@ -1,0 +1,179 @@
+/**
+ * F479: Inline @mention detection observability — counter + shadow detection tests.
+ *
+ * Tests the OTel counter instruments and in-process shadow detection added for
+ * issue #479 (inline @mention detection observability).
+ *
+ * Requires dist/ build — run `pnpm build` in packages/api first.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it, mock } from 'node:test';
+
+// --- 1. Counter instrument existence ---
+
+describe('F479: mention observability counters', () => {
+  it('exports all 8+1 inline mention counters from instruments.ts', async () => {
+    const instruments = await import('../dist/infrastructure/telemetry/instruments.js');
+
+    const expectedCounters = [
+      'inlineActionChecked',
+      'inlineActionDetected',
+      'inlineActionShadowMiss',
+      'inlineActionFeedbackWritten',
+      'inlineActionFeedbackWriteFailed',
+      'inlineActionHintEmitted',
+      'inlineActionHintEmitFailed',
+      'inlineActionRoutedSetSkip',
+      'lineStartDetected',
+    ];
+
+    for (const name of expectedCounters) {
+      assert.ok(instruments[name], `instruments.ts should export counter: ${name}`);
+      assert.equal(typeof instruments[name].add, 'function', `${name} should have .add() method`);
+    }
+  });
+
+  it('counter names follow cat_cafe.a2a.* prefix convention', async () => {
+    const instruments = await import('../dist/infrastructure/telemetry/instruments.js');
+
+    // Verify the counter descriptions exist (they are created with correct names)
+    assert.ok(instruments.inlineActionChecked, 'inlineActionChecked should exist');
+    assert.ok(instruments.lineStartDetected, 'lineStartDetected should exist');
+  });
+});
+
+// --- 2. Shadow detection ---
+
+describe('F479: shadow detection', () => {
+  it('detectInlineActionMentionsWithShadow returns both strict hits and shadow misses', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+    assert.equal(
+      typeof detectInlineActionMentionsWithShadow,
+      'function',
+      'should export detectInlineActionMentionsWithShadow',
+    );
+  });
+
+  it('shadow detection finds @ mention without action keyword as shadow miss', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "我问一下 @codex 这个问题" — has inline @mention but NO action keyword → shadow miss
+    const result = detectInlineActionMentionsWithShadow('我问一下 @缅因猫 这个问题', 'opus', []);
+
+    assert.ok(result, 'should return result object');
+    assert.ok(Array.isArray(result.strictHits), 'should have strictHits array');
+    assert.ok(Array.isArray(result.shadowMisses), 'should have shadowMisses array');
+    assert.equal(result.strictHits.length, 0, 'no strict hits (no action keyword)');
+    assert.equal(result.shadowMisses.length, 1, 'one shadow miss (inline @ without action keyword)');
+    assert.equal(result.shadowMisses[0].catId, 'codex');
+  });
+
+  it('shadow detection returns empty when strict detection already catches the mention', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "Ready for @codex review" — strict detection catches this → no shadow miss
+    const result = detectInlineActionMentionsWithShadow('Ready for @缅因猫 review', 'opus', []);
+
+    assert.ok(result.strictHits.length > 0, 'strict should catch this (action keyword present)');
+    assert.equal(result.shadowMisses.length, 0, 'no shadow miss when strict catches it');
+  });
+
+  it('shadow detection excludes line-start mentions (already routed)', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "@codex 请看一下" — line-start mention, should not be shadow miss
+    const result = detectInlineActionMentionsWithShadow('@缅因猫 请看一下', 'opus', []);
+
+    assert.equal(result.strictHits.length, 0, 'strict: line-start mentions handled by parseA2AMentions');
+    assert.equal(result.shadowMisses.length, 0, 'shadow: line-start mentions should be excluded');
+  });
+
+  it('shadow detection excludes mentions in code blocks', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    const text = '看看这个代码\n```\n@缅因猫 review\n```\n没别的了';
+    const result = detectInlineActionMentionsWithShadow(text, 'opus', []);
+
+    assert.equal(result.strictHits.length, 0, 'no strict hits in code block');
+    assert.equal(result.shadowMisses.length, 0, 'no shadow misses in code block');
+  });
+
+  it('shadow detection excludes mentions in blockquotes', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    const text = '> 之前 @缅因猫 说过这个问题';
+    const result = detectInlineActionMentionsWithShadow(text, 'opus', []);
+
+    assert.equal(result.strictHits.length, 0, 'no strict hits in blockquote');
+    assert.equal(result.shadowMisses.length, 0, 'no shadow misses in blockquote');
+  });
+
+  it('shadow miss metadata contains hash and length, not raw text', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    const result = detectInlineActionMentionsWithShadow('我问一下 @缅因猫 这个问题', 'opus', []);
+
+    assert.equal(result.shadowMisses.length, 1);
+    const miss = result.shadowMisses[0];
+    assert.equal(miss.catId, 'codex');
+    assert.ok(miss.contextHash, 'should have contextHash');
+    assert.ok(typeof miss.contextLength === 'number', 'should have contextLength');
+    // Must NOT contain raw lineText (data minimization per mindfn's feedback)
+    assert.equal(miss.lineText, undefined, 'shadow miss must not contain raw lineText');
+  });
+
+  it('shadow detection skips self-mentions', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    const result = detectInlineActionMentionsWithShadow('我 @opus 说过这个', 'opus', []);
+
+    assert.equal(result.shadowMisses.length, 0, 'self-mention should be excluded');
+  });
+
+  it('shadow detection skips already-routed mentions', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // codex is already routed via line-start → should not appear in shadow
+    const result = detectInlineActionMentionsWithShadow('这里 @缅因猫 也提到了', 'opus', ['codex']);
+
+    assert.equal(result.shadowMisses.length, 0, 'already-routed mention should be excluded from shadow');
+  });
+});
+
+// --- 3. routedSet skip detection ---
+
+describe('F479: routedSet skip tracking', () => {
+  it('detectInlineActionMentionsWithShadow reports routedSetSkips', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "Ready for @codex review" — action keyword present, but codex already routed
+    const result = detectInlineActionMentionsWithShadow(
+      'Ready for @缅因猫 review',
+      'opus',
+      ['codex'], // codex already in routedSet
+    );
+
+    assert.ok(result.routedSetSkips >= 1, 'should report routedSet skip count');
+  });
+});

--- a/packages/api/test/mention-observability.test.js
+++ b/packages/api/test/mention-observability.test.js
@@ -157,6 +157,23 @@ describe('F479: shadow detection', () => {
 
     assert.equal(result.shadowMisses.length, 0, 'already-routed mention should be excluded from shadow');
   });
+
+  // --- P2-1 regression: mixed strict + shadow same cat across lines ---
+
+  it('shadow detection reports shadow miss even when same cat has strict hit on another line', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // Line 1: strict hit (action keyword "review")
+    // Line 2: shadow miss (no action keyword — vocab gap candidate)
+    const text = 'Ready for @缅因猫 review\n我问一下 @缅因猫 这个问题';
+    const result = detectInlineActionMentionsWithShadow(text, 'opus', []);
+
+    assert.ok(result.strictHits.length > 0, 'line 1 should be strict hit');
+    assert.equal(result.shadowMisses.length, 1, 'line 2 should be shadow miss (per-occurrence, not per-catId)');
+    assert.equal(result.shadowMisses[0].catId, 'codex');
+  });
 });
 
 // --- 3. routedSet skip detection ---
@@ -175,5 +192,19 @@ describe('F479: routedSet skip tracking', () => {
     );
 
     assert.ok(result.routedSetSkips >= 1, 'should report routedSet skip count');
+  });
+
+  // --- P2-2 regression: narrative mention must not inflate routedSetSkips ---
+
+  it('narrative routed mention without action keyword must not increment routedSetSkips', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // "这里 @codex 也提到了" — no action keyword, pure narrative
+    const result = detectInlineActionMentionsWithShadow('这里 @缅因猫 也提到了', 'opus', ['codex']);
+
+    assert.equal(result.routedSetSkips, 0, 'narrative mention must not count as routed overlap');
+    assert.equal(result.shadowMisses.length, 0, 'routed cat still excluded from shadow');
   });
 });

--- a/packages/api/test/mention-observability.test.js
+++ b/packages/api/test/mention-observability.test.js
@@ -185,6 +185,20 @@ describe('F479: shadow detection', () => {
     assert.equal(result.shadowMisses[0].catId, 'codex');
   });
 
+  // --- P2-4 regression: same-line dual mention — narrative then shadow miss ---
+
+  it('same-line: narrative first, relaxed-action second → shadow miss found', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // First @缅因猫 is narrative ("提过"); second has relaxed action ("麻烦") but not strict
+    const result = detectInlineActionMentionsWithShadow('之前 @缅因猫 提过，麻烦 @缅因猫 验证一下', 'opus', []);
+
+    assert.equal(result.shadowMisses.length, 1, 'second occurrence should be shadow miss');
+    assert.equal(result.shadowMisses[0].catId, 'codex');
+  });
+
   // --- P2-1 regression: mixed strict + shadow same cat across lines ---
 
   it('shadow detection reports shadow miss even when same cat has strict hit on another line', async () => {
@@ -219,6 +233,21 @@ describe('F479: routedSet skip tracking', () => {
     );
 
     assert.ok(result.routedSetSkips >= 1, 'should report routedSet skip count');
+  });
+
+  // --- P2-4 regression: same-line dual mention — narrative then actionable ---
+
+  it('same-line: narrative first, actionable second → routedSetSkip counted', async () => {
+    const { detectInlineActionMentionsWithShadow } = await import(
+      '../dist/domains/cats/services/agents/routing/a2a-mentions.js'
+    );
+
+    // First @缅因猫 is narrative (no action); second has "Ready for" → actionable but routed
+    const result = detectInlineActionMentionsWithShadow('之前 @缅因猫 提过，Ready for @缅因猫 review', 'opus', [
+      'codex',
+    ]);
+
+    assert.equal(result.routedSetSkips, 1, 'second occurrence is actionable + routed → skip');
   });
 
   // --- P2-2 regression: narrative mention must not inflate routedSetSkips ---


### PR DESCRIPTION
## Summary

- 8+1 OTel counters for inline action @mention detection pipeline (checked/detected/shadow_miss/feedback_written/feedback_write_failed/hint_emitted/hint_emit_failed/routed_set_skip + line_start baseline)
- In-process shadow detection: relaxed regex pass diffs with strict detection to find vocab gap candidates
- Shadow miss metadata is hash+length only (no raw text), per data minimization feedback from mindfn (#479)
- Silent `catch {}` blocks now increment failure counters, making pipeline faults visible

## Test plan

- [x] 12/12 new mention-observability tests pass
- [x] 68/68 existing a2a-mentions tests pass (regression)
- [x] 82/82 route-strategies tests pass (regression)
- [x] `pnpm check` lint clean
- [x] All counter names follow `cat_cafe.a2a.*` prefix, attributes only use `agent.id` (F152 metric allowlist compliant)

Refs: #479

🐾 Generated with [Claude Code](https://claude.com/claude-code)