### PR TITLE
feat(F159): Phase B prework — injection guard + audit bridge primitives

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
@@ -131,8 +131,8 @@ export function mapAnthropicResponse(
     }
   }
 
-  // Only emit done for whitelisted terminal stop reasons (end_turn, max_tokens).
-  // Everything else (tool_use, pause_turn, null, future reasons) is NOT terminal.
+  // Only emit done for whitelisted terminal stop reasons (see TERMINAL_STOP_REASONS).
+  // Non-terminal (tool_use, pause_turn, null, future reasons) must NOT trigger done.
   if (response.stop_reason != null && TERMINAL_STOP_REASONS.has(response.stop_reason)) {
     messages.push({
       type: 'done',

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
@@ -1,0 +1,145 @@
+/**
+ * CatAgent Event Bridge — F159: Native Provider Security Baseline (AC-B4)
+ *
+ * Maps Anthropic Messages API responses to Cat Cafe AgentMessage events,
+ * ensuring done/error/usage signals enter the existing audit chain.
+ *
+ * Inline types for Anthropic API shapes — no @anthropic-ai/sdk dependency.
+ * Usage normalization follows the same convention as claude-ndjson-parser.ts:
+ *   inputTokens = raw + cache_read + cache_creation (total input).
+ */
+
+import type { CatId } from '@cat-cafe/shared';
+import type { AgentMessage, TokenUsage } from '../../../types.js';
+
+// ── Anthropic API shapes (inline, no SDK dependency) ──
+
+export interface AnthropicUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+export interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface AnthropicToolUseBlock {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: Record<string, unknown>;
+}
+
+export type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
+
+export interface AnthropicMessageResponse {
+  id: string;
+  model: string;
+  stop_reason: 'end_turn' | 'tool_use' | 'max_tokens' | null;
+  content: AnthropicContentBlock[];
+  usage?: AnthropicUsage;
+}
+
+// ── Usage mapping ──
+
+/**
+ * Convert Anthropic API usage to internal TokenUsage format.
+ *
+ * Normalises inputTokens to total input (raw + cache_read + cache_creation),
+ * matching the convention in claude-ndjson-parser.ts extractClaudeUsage().
+ *
+ * Returns a valid (possibly zero-valued) TokenUsage even if the input is
+ * undefined or missing fields — never crashes on partial data.
+ */
+export function mapAnthropicUsage(usage: AnthropicUsage | undefined): TokenUsage {
+  if (!usage) return { inputTokens: 0, outputTokens: 0 };
+
+  const rawInput = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const cacheRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
+  const cacheCreate = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+  const totalInput = rawInput + cacheRead + cacheCreate;
+
+  const result: TokenUsage = {
+    inputTokens: totalInput,
+    outputTokens: typeof usage.output_tokens === 'number' ? usage.output_tokens : 0,
+  };
+  if (cacheRead > 0) result.cacheReadTokens = cacheRead;
+  if (cacheCreate > 0) result.cacheCreationTokens = cacheCreate;
+  return result;
+}
+
+// ── Response mapping ──
+
+/**
+ * Map a successful Anthropic Messages API response to AgentMessage events.
+ *
+ * Produces:
+ * - One AgentMessage per content block (text / tool_use)
+ * - A final `done` message with usage metadata
+ *
+ * The caller (Phase C provider) yields these into the invocation stream,
+ * where invoke-single-cat.ts routes them to audit/OTel/metrics automatically.
+ */
+export function mapAnthropicResponse(
+  response: AnthropicMessageResponse,
+  catId: CatId,
+  provider: string,
+): AgentMessage[] {
+  const now = Date.now();
+  const usage = mapAnthropicUsage(response.usage);
+  const messages: AgentMessage[] = [];
+
+  for (const block of response.content) {
+    if (block.type === 'text') {
+      messages.push({ type: 'text', catId, content: block.text, timestamp: now });
+    } else if (block.type === 'tool_use') {
+      messages.push({
+        type: 'tool_use',
+        catId,
+        toolName: block.name,
+        toolInput: block.input,
+        timestamp: now,
+      });
+    }
+  }
+
+  messages.push({
+    type: 'done',
+    catId,
+    metadata: { provider, model: response.model, usage },
+    timestamp: now,
+  });
+
+  return messages;
+}
+
+/**
+ * Map an Anthropic API error to AgentMessage events.
+ *
+ * Always produces error + done (two events) — no dangling sessions.
+ * The error message includes the HTTP status for audit traceability.
+ */
+export function mapAnthropicError(
+  error: { status?: number; message?: string },
+  catId: CatId,
+  provider: string,
+  model: string,
+): AgentMessage[] {
+  const now = Date.now();
+  const status = error.status ?? 0;
+  const msg = error.message ?? 'Unknown API error';
+  const errorText = `Anthropic API error (${status}): ${msg}`;
+
+  return [
+    { type: 'error', catId, error: errorText, timestamp: now },
+    {
+      type: 'done',
+      catId,
+      metadata: { provider, model, usage: { inputTokens: 0, outputTokens: 0 } },
+      timestamp: now,
+    },
+  ];
+}

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
@@ -38,10 +38,18 @@ export type AnthropicContentBlock = AnthropicTextBlock | AnthropicToolUseBlock;
 export interface AnthropicMessageResponse {
   id: string;
   model: string;
-  stop_reason: 'end_turn' | 'tool_use' | 'max_tokens' | null;
+  stop_reason: string | null;
   content: AnthropicContentBlock[];
   usage?: AnthropicUsage;
 }
+
+/**
+ * Terminal stop reasons — whitelist, not blacklist.
+ * Only these trigger a `done` event. Everything else (tool_use, pause_turn,
+ * null from streaming message_start, or future new reasons) is NOT terminal.
+ * Ref: https://docs.anthropic.com/en/api/handling-stop-reasons
+ */
+const TERMINAL_STOP_REASONS: ReadonlySet<string> = new Set(['end_turn', 'max_tokens']);
 
 // ── Usage mapping ──
 
@@ -109,8 +117,9 @@ export function mapAnthropicResponse(
     }
   }
 
-  // Only emit done for terminal stop reasons — tool_use is a turn boundary, not terminal
-  if (response.stop_reason !== 'tool_use') {
+  // Only emit done for whitelisted terminal stop reasons (end_turn, max_tokens).
+  // Everything else (tool_use, pause_turn, null, future reasons) is NOT terminal.
+  if (response.stop_reason != null && TERMINAL_STOP_REASONS.has(response.stop_reason)) {
     messages.push({
       type: 'done',
       catId,

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
@@ -78,7 +78,10 @@ export function mapAnthropicUsage(usage: AnthropicUsage | undefined): TokenUsage
  *
  * Produces:
  * - One AgentMessage per content block (text / tool_use)
- * - A final `done` message with usage metadata
+ * - A terminal `done` message with usage ONLY when stop_reason is terminal
+ *   (end_turn / max_tokens / null). NOT for tool_use — that is a turn boundary,
+ *   not a terminal state. Emitting done on tool_use would prematurely trigger
+ *   CAT_RESPONDED audit in invoke-single-cat.ts before the tool loop finishes.
  *
  * The caller (Phase C provider) yields these into the invocation stream,
  * where invoke-single-cat.ts routes them to audit/OTel/metrics automatically.
@@ -106,12 +109,15 @@ export function mapAnthropicResponse(
     }
   }
 
-  messages.push({
-    type: 'done',
-    catId,
-    metadata: { provider, model: response.model, usage },
-    timestamp: now,
-  });
+  // Only emit done for terminal stop reasons — tool_use is a turn boundary, not terminal
+  if (response.stop_reason !== 'tool_use') {
+    messages.push({
+      type: 'done',
+      catId,
+      metadata: { provider, model: response.model, usage },
+      timestamp: now,
+    });
+  }
 
   return messages;
 }

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-event-bridge.ts
@@ -47,9 +47,23 @@ export interface AnthropicMessageResponse {
  * Terminal stop reasons — whitelist, not blacklist.
  * Only these trigger a `done` event. Everything else (tool_use, pause_turn,
  * null from streaming message_start, or future new reasons) is NOT terminal.
+ *
+ * Complete set per Anthropic docs:
+ * - end_turn: model finished naturally
+ * - max_tokens: output length limit hit
+ * - stop_sequence: custom stop sequence matched
+ * - refusal: model refused to respond (safety)
+ * - model_context_window_exceeded: input too large
+ *
  * Ref: https://docs.anthropic.com/en/api/handling-stop-reasons
  */
-const TERMINAL_STOP_REASONS: ReadonlySet<string> = new Set(['end_turn', 'max_tokens']);
+const TERMINAL_STOP_REASONS: ReadonlySet<string> = new Set([
+  'end_turn',
+  'max_tokens',
+  'stop_sequence',
+  'refusal',
+  'model_context_window_exceeded',
+]);
 
 // ── Usage mapping ──
 
@@ -86,10 +100,10 @@ export function mapAnthropicUsage(usage: AnthropicUsage | undefined): TokenUsage
  *
  * Produces:
  * - One AgentMessage per content block (text / tool_use)
- * - A terminal `done` message with usage ONLY when stop_reason is terminal
- *   (end_turn / max_tokens / null). NOT for tool_use — that is a turn boundary,
- *   not a terminal state. Emitting done on tool_use would prematurely trigger
- *   CAT_RESPONDED audit in invoke-single-cat.ts before the tool loop finishes.
+ * - A terminal `done` message with usage ONLY when stop_reason is in the
+ *   TERMINAL_STOP_REASONS whitelist (end_turn, max_tokens, stop_sequence,
+ *   refusal, model_context_window_exceeded). NOT for tool_use, pause_turn,
+ *   null (streaming initial), or future non-terminal reasons.
  *
  * The caller (Phase C provider) yields these into the invocation stream,
  * where invoke-single-cat.ts routes them to audit/OTel/metrics automatically.

--- a/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tool-guard.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/catagent/catagent-tool-guard.ts
@@ -1,0 +1,94 @@
+/**
+ * CatAgent Tool Guard — F159: Native Provider Security Baseline (AC-B3)
+ *
+ * Injection prevention at the host/provider integration layer:
+ * 1. Schema validation — reject undeclared fields, enforce types, require required fields
+ * 2. Shell-safe command building — enforce `--` separator, reject flag injection
+ *
+ * These guards are consumed by Phase D tool implementations (read_file, list_files, search_content).
+ * No @anthropic-ai/sdk dependency — uses inline types from catagent-tools.ts.
+ */
+
+import type { ToolSchema } from './catagent-tools.js';
+
+/** Validation error with structured context for audit/logging */
+export class ToolInputValidationError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly reason: string,
+  ) {
+    super(`Tool input validation failed for "${toolName}": ${reason}`);
+    this.name = 'ToolInputValidationError';
+  }
+}
+
+/** Reject fields not declared in schema.properties */
+function rejectUndeclaredFields(name: string, input: Record<string, unknown>, declared: Set<string>): void {
+  for (const key of Object.keys(input)) {
+    if (!declared.has(key)) {
+      throw new ToolInputValidationError(name, `undeclared field "${key}"`);
+    }
+  }
+}
+
+/** Ensure required fields are present and non-empty */
+function checkRequiredFields(name: string, input: Record<string, unknown>, required: readonly string[]): void {
+  for (const key of required) {
+    const val = input[key];
+    if (val === undefined || val === null) {
+      throw new ToolInputValidationError(name, `required field "${key}" is missing`);
+    }
+    if (typeof val === 'string' && val.trim() === '') {
+      throw new ToolInputValidationError(name, `required field "${key}" is empty`);
+    }
+  }
+}
+
+/** Type-check declared fields that are present */
+function checkFieldTypes(name: string, input: Record<string, unknown>, properties: Record<string, unknown>): void {
+  for (const [key, spec] of Object.entries(properties)) {
+    const val = input[key];
+    if (val === undefined || val === null) continue;
+    const expectedType = (spec as { type?: string }).type;
+    if (!expectedType) continue;
+
+    const actualType = Array.isArray(val) ? 'array' : typeof val;
+    if (actualType !== expectedType) {
+      throw new ToolInputValidationError(name, `field "${key}" expected type "${expectedType}", got "${actualType}"`);
+    }
+  }
+}
+
+/**
+ * Validate tool input against declared JSON schema.
+ *
+ * Rejects undeclared fields, missing/empty required fields, and type mismatches.
+ * Intentionally strict: unknown fields are rejected, not silently dropped.
+ */
+export function validateToolInput(schema: ToolSchema, input: Record<string, unknown>): void {
+  const { properties, required = [] } = schema.input_schema;
+  rejectUndeclaredFields(schema.name, input, new Set(Object.keys(properties)));
+  checkRequiredFields(schema.name, input, required);
+  checkFieldTypes(schema.name, input, properties);
+}
+
+/**
+ * Build a shell-safe command array for execFile.
+ *
+ * Enforces:
+ * - `--` separator before any user-supplied arguments
+ * - Rejection of flag injection in user args (strings starting with `-`)
+ * - All arguments as array elements (never concatenated into shell string)
+ */
+export function buildSafeCommand(
+  binary: string,
+  fixedArgs: readonly string[],
+  userArgs: readonly string[],
+): [bin: string, args: string[]] {
+  for (const arg of userArgs) {
+    if (arg.startsWith('-')) {
+      throw new ToolInputValidationError(binary, `user argument "${arg}" looks like a flag — potential injection`);
+    }
+  }
+  return [binary, [...fixedArgs, '--', ...userArgs]];
+}

--- a/packages/api/test/catagent-phase-b-completion.test.js
+++ b/packages/api/test/catagent-phase-b-completion.test.js
@@ -272,6 +272,54 @@ test('B4: mapAnthropicResponse emits done for max_tokens (terminal)', () => {
   assert.equal(msgs[1].type, 'done');
 });
 
+test('B4: mapAnthropicResponse emits done for stop_sequence (terminal)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_stop_seq',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'stop_sequence',
+      content: [{ type: 'text', text: 'Output until stop' }],
+      usage: { input_tokens: 15, output_tokens: 8 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 2, 'text + done for stop_sequence');
+  assert.equal(msgs[1].type, 'done');
+});
+
+test('B4: mapAnthropicResponse emits done for refusal (terminal)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_refuse',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'refusal',
+      content: [],
+      usage: { input_tokens: 20, output_tokens: 0 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 1, 'done only for refusal');
+  assert.equal(msgs[0].type, 'done');
+});
+
+test('B4: mapAnthropicResponse emits done for model_context_window_exceeded (terminal)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_ctx',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'model_context_window_exceeded',
+      content: [],
+      usage: { input_tokens: 200000, output_tokens: 0 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 1, 'done only for context window exceeded');
+  assert.equal(msgs[0].type, 'done');
+});
+
 test('B4: mapAnthropicResponse does NOT emit done for pause_turn (server tools)', () => {
   const msgs = mapAnthropicResponse(
     {

--- a/packages/api/test/catagent-phase-b-completion.test.js
+++ b/packages/api/test/catagent-phase-b-completion.test.js
@@ -200,7 +200,7 @@ test('B4: mapAnthropicResponse maps text content to text message', () => {
   assert.equal(msgs[1].metadata.usage.inputTokens, 10);
 });
 
-test('B4: mapAnthropicResponse maps tool_use content', () => {
+test('B4: mapAnthropicResponse does NOT emit done for stop_reason tool_use (turn boundary)', () => {
   const msgs = mapAnthropicResponse(
     {
       id: 'msg_2',
@@ -212,14 +212,13 @@ test('B4: mapAnthropicResponse maps tool_use content', () => {
     'ragdoll',
     'catagent',
   );
-  assert.equal(msgs.length, 2, 'tool_use + done');
+  assert.equal(msgs.length, 1, 'tool_use only — no done for turn boundary');
   assert.equal(msgs[0].type, 'tool_use');
   assert.equal(msgs[0].toolName, 'read_file');
   assert.deepEqual(msgs[0].toolInput, { path: 'index.ts' });
-  assert.equal(msgs[1].type, 'done');
 });
 
-test('B4: mapAnthropicResponse maps mixed content (text + tool_use)', () => {
+test('B4: mapAnthropicResponse omits done for mixed content with tool_use stop', () => {
   const msgs = mapAnthropicResponse(
     {
       id: 'msg_3',
@@ -234,10 +233,43 @@ test('B4: mapAnthropicResponse maps mixed content (text + tool_use)', () => {
     'ragdoll',
     'catagent',
   );
-  assert.equal(msgs.length, 3, 'text + tool_use + done');
+  assert.equal(msgs.length, 2, 'text + tool_use — no done for turn boundary');
   assert.equal(msgs[0].type, 'text');
   assert.equal(msgs[1].type, 'tool_use');
-  assert.equal(msgs[2].type, 'done');
+});
+
+test('B4: mapAnthropicResponse emits done for end_turn (terminal)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_term',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'Done.' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 2, 'text + done for terminal');
+  assert.equal(msgs[0].type, 'text');
+  assert.equal(msgs[1].type, 'done');
+  assert.equal(msgs[1].metadata.usage.inputTokens, 10);
+});
+
+test('B4: mapAnthropicResponse emits done for max_tokens (terminal)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_max',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'max_tokens',
+      content: [{ type: 'text', text: 'Truncat' }],
+      usage: { input_tokens: 50, output_tokens: 4096 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 2, 'text + done for max_tokens');
+  assert.equal(msgs[1].type, 'done');
 });
 
 test('B4: mapAnthropicResponse handles empty content', () => {

--- a/packages/api/test/catagent-phase-b-completion.test.js
+++ b/packages/api/test/catagent-phase-b-completion.test.js
@@ -272,6 +272,38 @@ test('B4: mapAnthropicResponse emits done for max_tokens (terminal)', () => {
   assert.equal(msgs[1].type, 'done');
 });
 
+test('B4: mapAnthropicResponse does NOT emit done for pause_turn (server tools)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_pause',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'pause_turn',
+      content: [{ type: 'text', text: 'Thinking...' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 1, 'text only — no done for pause_turn');
+  assert.equal(msgs[0].type, 'text');
+});
+
+test('B4: mapAnthropicResponse does NOT emit done for null stop_reason (streaming initial)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_null',
+      model: 'claude-opus-4-20250514',
+      stop_reason: null,
+      content: [{ type: 'text', text: 'streaming...' }],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 1, 'text only — no done for null stop_reason');
+  assert.equal(msgs[0].type, 'text');
+});
+
 test('B4: mapAnthropicResponse handles empty content', () => {
   const msgs = mapAnthropicResponse(
     {

--- a/packages/api/test/catagent-phase-b-completion.test.js
+++ b/packages/api/test/catagent-phase-b-completion.test.js
@@ -1,0 +1,317 @@
+/**
+ * CatAgent Phase B Completion Tests — F159 AC-B3 + AC-B4
+ *
+ * AC-B3: Tool parameter injection prevention
+ *   - Schema validation (undeclared fields, type mismatch, missing required)
+ *   - Shell-safe command building (flag injection, -- separator)
+ *
+ * AC-B4: Provider terminal state audit bridge
+ *   - Anthropic usage → TokenUsage mapping
+ *   - Anthropic response → AgentMessage mapping (text, tool_use, done)
+ *   - Error → error + done (no dangling sessions)
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+// ── AC-B3: Tool Guard ──
+
+const { validateToolInput, buildSafeCommand, ToolInputValidationError } = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/catagent-tool-guard.js'
+);
+
+const READ_FILE_SCHEMA = {
+  name: 'read_file',
+  description: 'Read a file',
+  input_schema: {
+    type: 'object',
+    properties: {
+      path: { type: 'string', description: 'File path' },
+      offset: { type: 'number', description: 'Start line' },
+    },
+    required: ['path'],
+  },
+};
+
+// ── B3: Schema validation ──
+
+test('B3: validateToolInput accepts valid input', () => {
+  assert.doesNotThrow(() => validateToolInput(READ_FILE_SCHEMA, { path: 'src/index.ts' }));
+});
+
+test('B3: validateToolInput accepts valid input with optional fields', () => {
+  assert.doesNotThrow(() => validateToolInput(READ_FILE_SCHEMA, { path: 'src/index.ts', offset: 10 }));
+});
+
+test('B3: validateToolInput rejects undeclared fields (constructor pollution)', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, { path: 'src/index.ts', constructor: 'polluted' }),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('undeclared field "constructor"'),
+  );
+});
+
+test('B3: validateToolInput rejects extra unknown field', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, { path: 'src/index.ts', deleteAll: true }),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('undeclared field "deleteAll"'),
+  );
+});
+
+test('B3: validateToolInput rejects missing required field', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, {}),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('required field "path" is missing'),
+  );
+});
+
+test('B3: validateToolInput rejects empty required string field', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, { path: '   ' }),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('required field "path" is empty'),
+  );
+});
+
+test('B3: validateToolInput rejects type mismatch (string expected, number given)', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, { path: 42 }),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('expected type "string", got "number"'),
+  );
+});
+
+test('B3: validateToolInput rejects type mismatch (number expected, string given)', () => {
+  assert.throws(
+    () => validateToolInput(READ_FILE_SCHEMA, { path: 'ok', offset: 'not-a-number' }),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('expected type "number", got "string"'),
+  );
+});
+
+test('B3: validateToolInput skips type check for absent optional fields', () => {
+  assert.doesNotThrow(() => validateToolInput(READ_FILE_SCHEMA, { path: 'src/index.ts' }));
+});
+
+// ── B3: Shell-safe command building ──
+
+test('B3: buildSafeCommand produces correct array with -- separator', () => {
+  const [bin, args] = buildSafeCommand('rg', ['--json', '-n'], ['hello world']);
+  assert.equal(bin, 'rg');
+  assert.deepEqual(args, ['--json', '-n', '--', 'hello world']);
+});
+
+test('B3: buildSafeCommand rejects flag injection in user args (--delete)', () => {
+  assert.throws(
+    () => buildSafeCommand('rg', ['--json'], ['--delete']),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('looks like a flag'),
+  );
+});
+
+test('B3: buildSafeCommand rejects flag injection (-e)', () => {
+  assert.throws(
+    () => buildSafeCommand('rg', [], ['-e', 'malicious']),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('looks like a flag'),
+  );
+});
+
+test('B3: buildSafeCommand rejects single dash flag', () => {
+  assert.throws(
+    () => buildSafeCommand('rg', [], ['-n']),
+    (err) => err instanceof ToolInputValidationError && err.reason.includes('looks like a flag'),
+  );
+});
+
+test('B3: buildSafeCommand allows normal patterns', () => {
+  const [, args] = buildSafeCommand('rg', ['--json'], ['function\\s+\\w+']);
+  assert.deepEqual(args, ['--json', '--', 'function\\s+\\w+']);
+});
+
+test('B3: buildSafeCommand allows patterns with special chars', () => {
+  const [, args] = buildSafeCommand('rg', [], ['hello; rm -rf /']);
+  // Shell injection harmless: execFile doesn't interpret shell metacharacters
+  assert.deepEqual(args, ['--', 'hello; rm -rf /']);
+});
+
+// ── AC-B4: Event Bridge ──
+
+const { mapAnthropicUsage, mapAnthropicResponse, mapAnthropicError } = await import(
+  '../dist/domains/cats/services/agents/providers/catagent/catagent-event-bridge.js'
+);
+
+// ── B4: Usage mapping ──
+
+test('B4: mapAnthropicUsage converts full usage correctly', () => {
+  const result = mapAnthropicUsage({
+    input_tokens: 100,
+    output_tokens: 50,
+    cache_read_input_tokens: 20,
+    cache_creation_input_tokens: 10,
+  });
+  assert.equal(result.inputTokens, 130, 'inputTokens = 100 + 20 + 10');
+  assert.equal(result.outputTokens, 50);
+  assert.equal(result.cacheReadTokens, 20);
+  assert.equal(result.cacheCreationTokens, 10);
+});
+
+test('B4: mapAnthropicUsage handles no cache tokens', () => {
+  const result = mapAnthropicUsage({ input_tokens: 80, output_tokens: 40 });
+  assert.equal(result.inputTokens, 80);
+  assert.equal(result.outputTokens, 40);
+  assert.equal(result.cacheReadTokens, undefined);
+  assert.equal(result.cacheCreationTokens, undefined);
+});
+
+test('B4: mapAnthropicUsage returns zeros for undefined usage', () => {
+  const result = mapAnthropicUsage(undefined);
+  assert.equal(result.inputTokens, 0);
+  assert.equal(result.outputTokens, 0);
+});
+
+test('B4: mapAnthropicUsage returns zeros for empty object', () => {
+  const result = mapAnthropicUsage({});
+  assert.equal(result.inputTokens, 0);
+  assert.equal(result.outputTokens, 0);
+});
+
+test('B4: mapAnthropicUsage handles non-numeric fields gracefully', () => {
+  const result = mapAnthropicUsage({ input_tokens: 'bad', output_tokens: null });
+  assert.equal(result.inputTokens, 0);
+  assert.equal(result.outputTokens, 0);
+});
+
+// ── B4: Response mapping ──
+
+test('B4: mapAnthropicResponse maps text content to text message', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_1',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'Hello world' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 2, 'text + done');
+  assert.equal(msgs[0].type, 'text');
+  assert.equal(msgs[0].content, 'Hello world');
+  assert.equal(msgs[0].catId, 'ragdoll');
+  assert.equal(msgs[1].type, 'done');
+  assert.equal(msgs[1].metadata.provider, 'catagent');
+  assert.equal(msgs[1].metadata.model, 'claude-opus-4-20250514');
+  assert.equal(msgs[1].metadata.usage.inputTokens, 10);
+});
+
+test('B4: mapAnthropicResponse maps tool_use content', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_2',
+      model: 'claude-sonnet-4-20250514',
+      stop_reason: 'tool_use',
+      content: [{ type: 'tool_use', id: 'toolu_1', name: 'read_file', input: { path: 'index.ts' } }],
+      usage: { input_tokens: 20, output_tokens: 15 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 2, 'tool_use + done');
+  assert.equal(msgs[0].type, 'tool_use');
+  assert.equal(msgs[0].toolName, 'read_file');
+  assert.deepEqual(msgs[0].toolInput, { path: 'index.ts' });
+  assert.equal(msgs[1].type, 'done');
+});
+
+test('B4: mapAnthropicResponse maps mixed content (text + tool_use)', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_3',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'tool_use',
+      content: [
+        { type: 'text', text: 'Let me read that file.' },
+        { type: 'tool_use', id: 'toolu_2', name: 'read_file', input: { path: 'a.ts' } },
+      ],
+      usage: { input_tokens: 30, output_tokens: 20 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 3, 'text + tool_use + done');
+  assert.equal(msgs[0].type, 'text');
+  assert.equal(msgs[1].type, 'tool_use');
+  assert.equal(msgs[2].type, 'done');
+});
+
+test('B4: mapAnthropicResponse handles empty content', () => {
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_4',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'end_turn',
+      content: [],
+      usage: { input_tokens: 5, output_tokens: 0 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs.length, 1, 'only done');
+  assert.equal(msgs[0].type, 'done');
+});
+
+test('B4: mapAnthropicResponse includes usage in done message even with missing usage', () => {
+  const msgs = mapAnthropicResponse(
+    { id: 'msg_5', model: 'claude-opus-4-20250514', stop_reason: 'end_turn', content: [] },
+    'ragdoll',
+    'catagent',
+  );
+  assert.equal(msgs[0].type, 'done');
+  assert.equal(msgs[0].metadata.usage.inputTokens, 0, 'graceful zero for missing usage');
+  assert.equal(msgs[0].metadata.usage.outputTokens, 0);
+});
+
+// ── B4: Error mapping ──
+
+test('B4: mapAnthropicError produces error + done (two events)', () => {
+  const msgs = mapAnthropicError(
+    { status: 429, message: 'Rate limited' },
+    'ragdoll',
+    'catagent',
+    'claude-opus-4-20250514',
+  );
+  assert.equal(msgs.length, 2, 'error + done');
+  assert.equal(msgs[0].type, 'error');
+  assert.ok(msgs[0].error.includes('429'));
+  assert.ok(msgs[0].error.includes('Rate limited'));
+  assert.equal(msgs[1].type, 'done');
+  assert.equal(msgs[1].metadata.usage.inputTokens, 0, 'zero usage on error');
+});
+
+test('B4: mapAnthropicError handles missing status and message', () => {
+  const msgs = mapAnthropicError({}, 'ragdoll', 'catagent', 'claude-opus-4-20250514');
+  assert.equal(msgs.length, 2);
+  assert.ok(msgs[0].error.includes('0'));
+  assert.ok(msgs[0].error.includes('Unknown API error'));
+});
+
+test('B4: mapAnthropicError includes provider metadata in done', () => {
+  const msgs = mapAnthropicError({ status: 500 }, 'ragdoll', 'catagent', 'claude-opus-4-20250514');
+  assert.equal(msgs[1].metadata.provider, 'catagent');
+  assert.equal(msgs[1].metadata.model, 'claude-opus-4-20250514');
+});
+
+test('B4: all messages have timestamp', () => {
+  const before = Date.now();
+  const msgs = mapAnthropicResponse(
+    {
+      id: 'msg_ts',
+      model: 'claude-opus-4-20250514',
+      stop_reason: 'end_turn',
+      content: [{ type: 'text', text: 'hi' }],
+      usage: { input_tokens: 1, output_tokens: 1 },
+    },
+    'ragdoll',
+    'catagent',
+  );
+  const after = Date.now();
+  for (const msg of msgs) {
+    assert.ok(msg.timestamp >= before && msg.timestamp <= after, `timestamp ${msg.timestamp} in range`);
+  }
+});


### PR DESCRIPTION
## Summary

Completes F159 Phase B (Security Baseline) by delivering the remaining two acceptance criteria:

- **AC-B3**: Tool parameter injection prevention — `catagent-tool-guard.ts`
  - `validateToolInput()`: schema validation (reject undeclared fields, enforce types, require required)
  - `buildSafeCommand()`: shell-safe command building with `--` separator, flag injection rejection
  
- **AC-B4**: Provider terminal state audit bridge — `catagent-event-bridge.ts`
  - `mapAnthropicUsage()`: Anthropic API usage → `TokenUsage` (same normalization as `claude-ndjson-parser.ts`)
  - `mapAnthropicResponse()`: content blocks → `AgentMessage[]` with `done` + usage
  - `mapAnthropicError()`: error → `error` + `done` (no dangling sessions)

29 tests covering schema validation, injection attempts, usage mapping, response mapping, error handling, and graceful degradation.

Prior: PR #460 delivered AC-B1 (account-binding fail-closed) + AC-B2 (symlink-safe sandbox).

With this PR, all four Phase B acceptance criteria are satisfied. Phase C (Minimal Native Provider) can proceed.

Closes #491

## Test plan

- [ ] 29/29 unit tests pass (`node --test packages/api/test/catagent-phase-b-completion.test.js`)
- [ ] 17/17 B1+B2 regression tests pass (`node --test packages/api/test/catagent-security-baseline.test.js`)
- [ ] `pnpm check` clean (biome)
- [ ] `pnpm --filter @cat-cafe/api build` clean (tsc)
- [ ] `pnpm --filter @cat-cafe/api run test:public` all pass

🐾 Generated with [Claude Code](https://claude.com/claude-code)