### PR TITLE
fix(installer): 初始化安装问题修复

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ NEXT_PUBLIC_BRAND_NAME="Clowder AI"
 # 启动时加 --memory 可跳过 Redis（数据仅存内存，重启丢失）。
 
 REDIS_PORT=6399
-REDIS_URL=redis://localhost:6399
+# REDIS_URL=
 
 # ── Redis Data TTL（数据保留期限）──────────────────────────────
 # Default 0 = persistent (recommended). Set >0 to auto-delete data after N seconds.

--- a/packages/api/test/install-auth-config-script.test.js
+++ b/packages/api/test/install-auth-config-script.test.js
@@ -138,7 +138,7 @@ test('client-auth set oauth stores builtin default models for the selected clien
 
     const { accounts } = readInstallerState(projectRoot);
     assert.equal(accounts.codex?.authType, 'oauth');
-    assert.deepEqual(accounts.codex?.models, ['gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.4']);
+    assert.deepEqual(accounts.codex?.models, ['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.3-codex-spark']);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }
@@ -167,7 +167,7 @@ test('client-auth set oauth sanitizes malformed builtin default models before wr
 
     const { accounts } = readInstallerState(projectRoot);
     assert.equal(accounts.claude?.authType, 'oauth');
-    assert.deepEqual(accounts.claude?.models, ['claude-opus-4-5-20251101', 'claude-opus-4-6', 'claude-sonnet-4-6']);
+    assert.deepEqual(accounts.claude?.models, ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101']);
   } finally {
     rmSync(projectRoot, { recursive: true, force: true });
   }

--- a/packages/api/test/install-auth-config-script.test.js
+++ b/packages/api/test/install-auth-config-script.test.js
@@ -159,6 +159,20 @@ test('client-auth set oauth supports kimi and stores its default models', () => 
   }
 });
 
+test('client-auth set oauth sanitizes malformed builtin default models before writing state', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'clowder-install-client-auth-claude-oauth-models-'));
+
+  try {
+    runHelper(['client-auth', 'set', '--project-dir', projectRoot, '--client', 'anthropic', '--mode', 'oauth']);
+
+    const { accounts } = readInstallerState(projectRoot);
+    assert.equal(accounts.claude?.authType, 'oauth');
+    assert.deepEqual(accounts.claude?.models, ['claude-opus-4-5-20251101', 'claude-opus-4-6', 'claude-sonnet-4-6']);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
 test('claude-profile create and remove keeps installer-managed account in sync', () => {
   const projectRoot = mkdtempSync(join(tmpdir(), 'clowder-install-claude-profile-'));
 

--- a/packages/api/test/install-auth-config-script.test.js
+++ b/packages/api/test/install-auth-config-script.test.js
@@ -130,6 +130,35 @@ test('client-auth set oauth creates builtin accounts for dare and opencode', () 
   }
 });
 
+test('client-auth set oauth stores builtin default models for the selected client', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'clowder-install-client-auth-oauth-models-'));
+
+  try {
+    runHelper(['client-auth', 'set', '--project-dir', projectRoot, '--client', 'codex', '--mode', 'oauth']);
+
+    const { accounts } = readInstallerState(projectRoot);
+    assert.equal(accounts.codex?.authType, 'oauth');
+    assert.deepEqual(accounts.codex?.models, ['gpt-5.3-codex', 'gpt-5.3-codex-spark', 'gpt-5.4']);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
+test('client-auth set oauth supports kimi and stores its default models', () => {
+  const projectRoot = mkdtempSync(join(tmpdir(), 'clowder-install-client-auth-kimi-oauth-'));
+
+  try {
+    runHelper(['client-auth', 'set', '--project-dir', projectRoot, '--client', 'kimi', '--mode', 'oauth']);
+
+    const { accounts } = readInstallerState(projectRoot);
+    assert.equal(accounts.kimi?.authType, 'oauth');
+    assert.equal(accounts.kimi?.displayName, 'Kimi');
+    assert.deepEqual(accounts.kimi?.models, ['kimi-code/kimi-for-coding']);
+  } finally {
+    rmSync(projectRoot, { recursive: true, force: true });
+  }
+});
+
 test('claude-profile create and remove keeps installer-managed account in sync', () => {
   const projectRoot = mkdtempSync(join(tmpdir(), 'clowder-install-claude-profile-'));
 

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -133,6 +133,21 @@ test('empty API key fallback to OAuth does not force-remove global installer acc
   assert.doesNotMatch(emptyKeyBranch, /--force true/);
 });
 
+test('Kimi auth setup offers an explicit skip option instead of forcing OAuth', () => {
+  const installScriptText = readFileSync(installScript, 'utf8');
+  const configureAuthBody = installScriptText.match(/configure_agent_auth\(\) \{([\s\S]*?)^}\n/m)?.[1] ?? '';
+
+  assert.notEqual(configureAuthBody, '', 'expected configure_agent_auth body');
+  assert.match(configureAuthBody, /allow_skip/, 'configure_agent_auth should accept a skip flag');
+  assert.match(configureAuthBody, /Skip auth setup/, 'skip-enabled auth menus should include Skip');
+  assert.match(configureAuthBody, /auth setup skipped/, 'skip branch should return without writing OAuth');
+  assert.match(
+    installScriptText,
+    /configure_agent_auth "Kimi \(月之暗面\)" "kimi" true/,
+    'Kimi should opt into the skip-enabled auth menu',
+  );
+});
+
 test('npm_global_install succeeds when a custom registry is configured', () => {
   const output = runSourceOnlySnippet(`
 SUDO=""

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -64,6 +64,57 @@ cat .env
   }
 });
 
+test('installer auth config root follows an existing runtime worktree', () => {
+  const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-runtime-root-'));
+  const projectRoot = join(parentRoot, 'clowder-ai');
+  const runtimeRoot = join(parentRoot, 'cat-cafe-runtime');
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(runtimeRoot, { recursive: true });
+
+    const output = runSourceOnlySnippet(`
+PROJECT_DIR="${projectRoot}"
+printf '%s' "$(resolve_installer_auth_config_root)"
+`);
+
+    assert.equal(output, runtimeRoot);
+  } finally {
+    rmSync(parentRoot, { recursive: true, force: true });
+  }
+});
+
+test('installer auth config root falls back to project root before runtime exists', () => {
+  const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-project-root-'));
+  const projectRoot = join(parentRoot, 'clowder-ai');
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+
+    const output = runSourceOnlySnippet(`
+PROJECT_DIR="${projectRoot}"
+printf '%s' "$(resolve_installer_auth_config_root)"
+`);
+
+    assert.equal(output, projectRoot);
+  } finally {
+    rmSync(parentRoot, { recursive: true, force: true });
+  }
+});
+
+test('installer auth setup calls install-auth-config through runtime-aware wrapper', () => {
+  const installScriptText = readFileSync(installScript, 'utf8');
+  const configureAuthBody = installScriptText.match(/configure_agent_auth\(\) \{([\s\S]*?)^}\n/m)?.[1] ?? '';
+
+  assert.notEqual(configureAuthBody, '', 'expected configure_agent_auth body');
+  assert.match(configureAuthBody, /run_install_auth_config client-auth set/, 'auth writes should use wrapper');
+  assert.doesNotMatch(
+    configureAuthBody,
+    /node scripts\/install-auth-config\.mjs/,
+    'auth writes must not bypass runtime-aware config root resolution',
+  );
+});
+
 test('Claude empty API key removes stale installer-managed profile', () => {
   const envRoot = mkdtempSync(join(tmpdir(), 'clowder-install-claude-empty-'));
   const catCafeDir = join(envRoot, '.cat-cafe');

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -1,8 +1,10 @@
 import test from 'node:test';
 
 import {
+  addWorktree,
   assert,
   existsSync,
+  initGitRepo,
   installScript,
   join,
   mkdirSync,
@@ -71,7 +73,8 @@ test('installer auth config root follows an existing runtime worktree', () => {
 
   try {
     mkdirSync(projectRoot, { recursive: true });
-    mkdirSync(runtimeRoot, { recursive: true });
+    initGitRepo(projectRoot);
+    addWorktree(projectRoot, runtimeRoot, 'runtime/main-sync');
 
     const output = runSourceOnlySnippet(`
 PROJECT_DIR="${projectRoot}"
@@ -79,6 +82,26 @@ printf '%s' "$(resolve_installer_auth_config_root)"
 `);
 
     assert.equal(output, runtimeRoot);
+  } finally {
+    rmSync(parentRoot, { recursive: true, force: true });
+  }
+});
+
+test('installer auth config root falls back to project root when runtime dir is not an initialized worktree', () => {
+  const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-uninit-runtime-root-'));
+  const projectRoot = join(parentRoot, 'clowder-ai');
+  const runtimeRoot = join(parentRoot, 'cat-cafe-runtime');
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(runtimeRoot, { recursive: true });
+
+    const output = runSourceOnlySnippet(`
+PROJECT_DIR="${projectRoot}"
+printf '%s' "$(resolve_installer_auth_config_root)"
+`);
+
+    assert.equal(output, projectRoot);
   } finally {
     rmSync(parentRoot, { recursive: true, force: true });
   }

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -507,3 +507,26 @@ printf '%s' "$(default_frontend_url)"
     rmSync(envRoot, { recursive: true, force: true });
   }
 });
+
+test('install script retries with PUPPETEER_SKIP_DOWNLOAD only for Puppeteer browser download failures', () => {
+  const installScriptText = readFileSync(installScript, 'utf8');
+
+  assert.match(installScriptText, /run_pnpm_install_capture\(\)/);
+  assert.match(installScriptText, /pnpm_install_needs_puppeteer_skip\(\)/);
+  assert.match(
+    installScriptText,
+    /grep -Eqi 'puppeteer' "\$log_file"\s+\\\s*\n\s*&& grep -Eqi 'Failed to set up chrome\|PUPPETEER_SKIP_DOWNLOAD' "\$log_file"/,
+  );
+  assert.match(
+    installScriptText,
+    /warn "Puppeteer browser download failed — retrying install without bundled Chrome"/,
+  );
+  assert.match(
+    installScriptText,
+    /warn "Thread export \/ screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"/,
+  );
+  assert.match(
+    installScriptText,
+    /env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile/,
+  );
+});

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -129,6 +129,33 @@ printf '%s' "$(resolve_installer_auth_config_root)"
   }
 });
 
+test('installer auth config root ignores parent repo worktrees when project dir has no local git metadata', () => {
+  const parentRepoRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-parent-repo-'));
+  const projectRoot = join(parentRepoRoot, 'deployments', 'clowder-ai');
+  const runtimeRoot = join(tmpdir(), `clowder-parent-runtime-${Date.now()}`);
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(join(projectRoot, 'scripts'), { recursive: true });
+    mkdirSync(join(projectRoot, 'packages', 'api'), { recursive: true });
+    writeFileSync(join(projectRoot, 'package.json'), '{"name":"clowder-ai"}\n', 'utf8');
+
+    initGitRepo(parentRepoRoot);
+    addWorktree(parentRepoRoot, runtimeRoot, 'runtime/main-sync');
+
+    const output = runSourceOnlySnippet(`
+PROJECT_DIR="${projectRoot}"
+CAT_CAFE_RUNTIME_DIR="${runtimeRoot}"
+printf '%s' "$(resolve_installer_auth_config_root)"
+`);
+
+    assert.equal(output, projectRoot);
+  } finally {
+    rmSync(parentRepoRoot, { recursive: true, force: true });
+    rmSync(runtimeRoot, { recursive: true, force: true });
+  }
+});
+
 test('installer auth config root falls back to project root before runtime exists', () => {
   const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-project-root-'));
   const projectRoot = join(parentRoot, 'clowder-ai');

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -107,6 +107,28 @@ printf '%s' "$(resolve_installer_auth_config_root)"
   }
 });
 
+test('installer auth config root ignores initialized sibling repos that are not this project worktrees', () => {
+  const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-foreign-runtime-root-'));
+  const projectRoot = join(parentRoot, 'clowder-ai');
+  const runtimeRoot = join(parentRoot, 'cat-cafe-runtime');
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+    mkdirSync(runtimeRoot, { recursive: true });
+    initGitRepo(projectRoot);
+    initGitRepo(runtimeRoot, 'foreign runtime\n');
+
+    const output = runSourceOnlySnippet(`
+PROJECT_DIR="${projectRoot}"
+printf '%s' "$(resolve_installer_auth_config_root)"
+`);
+
+    assert.equal(output, projectRoot);
+  } finally {
+    rmSync(parentRoot, { recursive: true, force: true });
+  }
+});
+
 test('installer auth config root falls back to project root before runtime exists', () => {
   const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-project-root-'));
   const projectRoot = join(parentRoot, 'clowder-ai');

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 import {
   addWorktree,
@@ -185,6 +186,34 @@ test('installer auth setup calls install-auth-config through runtime-aware wrapp
     /node scripts\/install-auth-config\.mjs/,
     'auth writes must not bypass runtime-aware config root resolution',
   );
+});
+
+test('runtime-aware auth wrapper also updates project-local state for direct start modes', () => {
+  const parentRoot = mkdtempSync(join(tmpdir(), 'clowder-install-auth-direct-mode-'));
+  const projectRoot = join(parentRoot, 'clowder-ai');
+  const runtimeRoot = join(parentRoot, 'cat-cafe-runtime');
+  const repoRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+  try {
+    mkdirSync(projectRoot, { recursive: true });
+    initGitRepo(projectRoot);
+    addWorktree(projectRoot, runtimeRoot, 'runtime/main-sync');
+
+    runSourceOnlySnippet(`
+cd "${repoRoot}"
+PROJECT_DIR="${projectRoot}"
+CAT_CAFE_RUNTIME_DIR="${runtimeRoot}"
+run_install_auth_config client-auth set --project-dir "${projectRoot}" --client codex --mode oauth
+`);
+
+    const runtimeAccounts = JSON.parse(readFileSync(join(runtimeRoot, '.cat-cafe', 'accounts.json'), 'utf8'));
+    const projectAccounts = JSON.parse(readFileSync(join(projectRoot, '.cat-cafe', 'accounts.json'), 'utf8'));
+
+    assert.equal(runtimeAccounts.codex?.authType, 'oauth');
+    assert.equal(projectAccounts.codex?.authType, 'oauth');
+  } finally {
+    rmSync(parentRoot, { recursive: true, force: true });
+  }
 });
 
 test('Claude empty API key removes stale installer-managed profile', () => {

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -517,16 +517,10 @@ test('install script retries with PUPPETEER_SKIP_DOWNLOAD only for Puppeteer bro
     installScriptText,
     /grep -Eqi 'puppeteer' "\$log_file"\s+\\\s*\n\s*&& grep -Eqi 'Failed to set up chrome\|PUPPETEER_SKIP_DOWNLOAD' "\$log_file"/,
   );
-  assert.match(
-    installScriptText,
-    /warn "Puppeteer browser download failed — retrying install without bundled Chrome"/,
-  );
+  assert.match(installScriptText, /warn "Puppeteer browser download failed — retrying install without bundled Chrome"/);
   assert.match(
     installScriptText,
     /warn "Thread export \/ screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"/,
   );
-  assert.match(
-    installScriptText,
-    /env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile/,
-  );
+  assert.match(installScriptText, /env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile/);
 });

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -517,10 +517,18 @@ test('install script retries with PUPPETEER_SKIP_DOWNLOAD only for Puppeteer bro
     installScriptText,
     /grep -Eqi 'puppeteer' "\$log_file"\s+\\\s*\n\s*&& grep -Eqi 'Failed to set up chrome\|PUPPETEER_SKIP_DOWNLOAD' "\$log_file"/,
   );
-  assert.match(installScriptText, /warn "Puppeteer browser download failed — retrying install without bundled Chrome"/);
+  assert.match(installScriptText, /warn "Bundled Chrome download failed — skipped"/);
   assert.match(
     installScriptText,
-    /warn "Thread export \/ screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"/,
+    /warn "Thread export \/ screenshot may be unavailable\. To install later: npx puppeteer browsers install chrome"/,
   );
   assert.match(installScriptText, /env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile/);
+});
+
+test('.env.example leaves REDIS_URL unset by default', () => {
+  const envExamplePath = new URL('../../../.env.example', import.meta.url);
+  const envExampleText = readFileSync(envExamplePath, 'utf8');
+
+  assert.doesNotMatch(envExampleText, /^REDIS_URL=/m);
+  assert.match(envExampleText, /^# REDIS_URL=$/m);
 });

--- a/packages/api/test/install-script-env.test.js
+++ b/packages/api/test/install-script-env.test.js
@@ -148,6 +148,24 @@ test('Kimi auth setup offers an explicit skip option instead of forcing OAuth', 
   );
 });
 
+test('Kimi auth setup defaults to skip so Enter does not choose OAuth when arrows fail', () => {
+  const installScriptText = readFileSync(installScript, 'utf8');
+  const configureAuthBody = installScriptText.match(/configure_agent_auth\(\) \{([\s\S]*?)^}\n/m)?.[1] ?? '';
+
+  assert.notEqual(configureAuthBody, '', 'expected configure_agent_auth body');
+  assert.match(configureAuthBody, /local skip_index=2/, 'skip option should remain the third menu entry');
+  assert.match(
+    configureAuthBody,
+    /\[\[ "\$allow_skip" == true \]\] && default_auth_sel="\$skip_index"/,
+    'skip-enabled auth menus should select Skip by default',
+  );
+  assert.match(
+    configureAuthBody,
+    /TTY_SELECT_DEFAULT_INDEX="\$default_auth_sel"\s+tty_select auth_sel/,
+    'auth selector should pass the computed default index into tty_select',
+  );
+});
+
 test('npm_global_install succeeds when a custom registry is configured', () => {
   const output = runSourceOnlySnippet(`
 SUDO=""

--- a/packages/api/test/install-script-tty.test.js
+++ b/packages/api/test/install-script-tty.test.js
@@ -35,6 +35,16 @@ fi
   assert.equal(output, '0,2,none');
 });
 
+test('tty_select honors a configured default index when no tty is available', () => {
+  const output = runSourceOnlySnippet(`
+HAS_TTY=false
+TTY_SELECT_DEFAULT_INDEX=2 tty_select SELECTED "Pick one:" "OAuth" "API Key" "Skip"
+printf '%s' "$SELECTED"
+`);
+
+  assert.equal(output, '2');
+});
+
 test('tty_read returns empty string when /dev/tty is unavailable (no blocking)', () => {
   const result = spawnSync(
     'bash',

--- a/packages/api/test/install-script-tty.test.js
+++ b/packages/api/test/install-script-tty.test.js
@@ -14,6 +14,27 @@ type tty_multiselect
   assert.match(multiselectSource, /read\s+-rsn1\s+-t\s+\d+/, 'tty_multiselect must have -t timeout on primary read');
 });
 
+test('tty arrow parser accepts normal and application cursor key sequences', () => {
+  const output = runSourceOnlySnippet(`
+printf '%s' "$(tty_arrow_delta '[A'),$(tty_arrow_delta 'OA'),$(tty_arrow_delta '[B'),$(tty_arrow_delta 'OB')"
+`);
+
+  assert.equal(output, '-1,-1,1,1');
+});
+
+test('tty numeric shortcut parser maps visible menu numbers to zero-based indices', () => {
+  const output = runSourceOnlySnippet(`
+printf '%s' "$(tty_numeric_index 1 3),$(tty_numeric_index 3 3),"
+if tty_numeric_index 4 3 >/dev/null; then
+  printf 'unexpected'
+else
+  printf 'none'
+fi
+`);
+
+  assert.equal(output, '0,2,none');
+});
+
 test('tty_read returns empty string when /dev/tty is unavailable (no blocking)', () => {
   const result = spawnSync(
     'bash',

--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -235,14 +235,12 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
 
     assert.equal(result.status, 0, `exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
     const normalizedRuntimeDir = realpathSync(runtimeDir);
-    assert.deepEqual(
-      JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'accounts.json'), 'utf8')),
-      { codex: { authType: 'oauth', models: ['gpt-5.4'] } },
-    );
-    assert.deepEqual(
-      JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'credentials.json'), 'utf8')),
-      { 'installer-openai': { apiKey: 'sk-runtime' } },
-    );
+    assert.deepEqual(JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'accounts.json'), 'utf8')), {
+      codex: { authType: 'oauth', models: ['gpt-5.4'] },
+    });
+    assert.deepEqual(JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'credentials.json'), 'utf8')), {
+      'installer-openai': { apiKey: 'sk-runtime' },
+    });
   });
 
   it('auto-installs missing runtime dependencies before in-place start', () => {

--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -197,6 +197,54 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     assert.doesNotMatch(result.stdout, /running in-place \(deployment mode\)/);
   });
 
+  it('seeds missing runtime auth config from the launcher project during init', () => {
+    const projectDir = createTempProject('runtime-auth-config-seed');
+    const runtimeDir = mkdtempSync(join(tmpdir(), 'runtime-auth-config-worktree-'));
+    const remoteDir = mkdtempSync(join(tmpdir(), 'runtime-auth-config-remote-'));
+    tempDirs.push(runtimeDir, remoteDir);
+
+    execFileSync('git', ['init', '-b', 'main'], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['add', 'scripts', 'packages'], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-m', 'init'], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['init', '--bare', remoteDir], { stdio: 'ignore' });
+    execFileSync('git', ['remote', 'add', 'origin', remoteDir], { cwd: projectDir, stdio: 'ignore' });
+    execFileSync('git', ['push', '-u', 'origin', 'main'], { cwd: projectDir, stdio: 'ignore' });
+
+    mkdirSync(join(projectDir, '.cat-cafe'), { recursive: true });
+    writeFileSync(
+      join(projectDir, '.cat-cafe', 'accounts.json'),
+      `${JSON.stringify({ codex: { authType: 'oauth', models: ['gpt-5.4'] } }, null, 2)}\n`,
+      'utf8',
+    );
+    writeFileSync(
+      join(projectDir, '.cat-cafe', 'credentials.json'),
+      `${JSON.stringify({ 'installer-openai': { apiKey: 'sk-runtime' } }, null, 2)}\n`,
+      'utf8',
+    );
+
+    const result = spawnSync(
+      'bash',
+      [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'init', '--dir', runtimeDir, '--no-install'],
+      {
+        cwd: projectDir,
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 0, `exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    const normalizedRuntimeDir = realpathSync(runtimeDir);
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'accounts.json'), 'utf8')),
+      { codex: { authType: 'oauth', models: ['gpt-5.4'] } },
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(join(normalizedRuntimeDir, '.cat-cafe', 'credentials.json'), 'utf8')),
+      { 'installer-openai': { apiKey: 'sk-runtime' } },
+    );
+  });
+
   it('auto-installs missing runtime dependencies before in-place start', () => {
     const projectDir = createTempProject('runtime-self-heal-install');
     const env = withStubbedPnpmEnv(projectDir);

--- a/packages/api/test/windows-installer-auth.test.js
+++ b/packages/api/test/windows-installer-auth.test.js
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { helpersScript, installScript } from './windows-portable-redis-test-helpers.js';
+
+test('Windows installer carries selected CLI commands into auth setup when command shims are not yet visible', () => {
+  assert.match(installScript, /\$selectedCliCommands = @\(\$toolsToInstall \| ForEach-Object \{ \$_.Cmd \}\)/);
+  assert.match(
+    installScript,
+    /Configure-InstallerAuth -ProjectRoot \$ProjectRoot -State \$authState -SelectedCliCommands \$selectedCliCommands/,
+  );
+  assert.match(
+    helpersScript,
+    /function Configure-InstallerAuth \{\s+param\(\[string\]\$ProjectRoot, \$State, \[string\[\]\]\$SelectedCliCommands = @\(\)\)/s,
+  );
+  assert.match(helpersScript, /\$shouldOfferClaude = \$hasClaude -or \(\$SelectedCliCommands -contains "claude"\)/);
+  assert.match(helpersScript, /\$shouldOfferCodex = \$hasCodex -or \(\$SelectedCliCommands -contains "codex"\)/);
+  assert.match(helpersScript, /\$shouldOfferGemini = \$hasGemini -or \(\$SelectedCliCommands -contains "gemini"\)/);
+  assert.match(helpersScript, /\$shouldOfferKimi = \$hasKimi -or \(\$SelectedCliCommands -contains "kimi"\)/);
+  assert.match(helpersScript, /if \(\$shouldOfferClaude\) \{/);
+  assert.match(helpersScript, /if \(\$shouldOfferCodex\) \{/);
+  assert.match(helpersScript, /if \(\$shouldOfferGemini\) \{/);
+  assert.match(helpersScript, /if \(\$shouldOfferKimi\) \{/);
+});

--- a/packages/api/test/windows-portable-redis-tools.test.js
+++ b/packages/api/test/windows-portable-redis-tools.test.js
@@ -77,32 +77,58 @@ test('Windows installer revalidates Node major version after winget install', ()
   assert.match(installScript, /Write-Warn "Node\.js \$nodeRaw still too old after winget install"/);
 });
 
-test('Windows installer retries plain pnpm install when frozen lockfile mode hits a native command error', () => {
+test('Windows installer retries plain pnpm install when frozen lockfile mode still fails after protected retries', () => {
+  const helperIndex = installScript.indexOf('function Invoke-PnpmInstallWithCapturedOutput');
   const frozenInstallIndex = installScript.indexOf(
-    'Invoke-Pnpm -CommandArgs @("install", "--frozen-lockfile") 2>$null',
+    '$frozenInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install", "--frozen-lockfile")',
   );
-  const tryIndex = installScript.lastIndexOf('try {', frozenInstallIndex);
-  const catchIndex = installScript.indexOf('} catch {', frozenInstallIndex);
-  const capturedErrorIndex = installScript.indexOf('$frozenInstallError = $_', catchIndex);
   const cancelExitIndex = installScript.indexOf(
-    'Exit-InstallerIfCancelled -ErrorRecord $frozenInstallError -Context "pnpm install"',
+    'Exit-InstallerIfCancelled -ErrorRecord $frozenInstallResult.ErrorRecord -Context "pnpm install"',
   );
   const retryWarnIndex = installScript.indexOf('Write-Warn "Frozen lockfile failed, retrying..."');
-  const retryInstallIndex = installScript.indexOf('Invoke-Pnpm -CommandArgs @("install")', retryWarnIndex);
+  const retryInstallIndex = installScript.indexOf(
+    '$plainInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install")',
+    retryWarnIndex,
+  );
 
-  assert.notEqual(frozenInstallIndex, -1, 'expected frozen lockfile install attempt');
-  assert.notEqual(tryIndex, -1, 'expected frozen lockfile attempt to be wrapped in try/catch');
-  assert.notEqual(catchIndex, -1, 'expected frozen lockfile attempt catch block');
-  assert.notEqual(capturedErrorIndex, -1, 'expected frozen lockfile catch to capture the error record');
+  assert.notEqual(helperIndex, -1, 'expected captured install helper');
+  assert.notEqual(frozenInstallIndex, -1, 'expected frozen lockfile install attempt via helper');
   assert.notEqual(cancelExitIndex, -1, 'expected retry path to abort on user cancellation');
-  assert.notEqual(retryWarnIndex, -1, 'expected retry warning after frozen lockfile failure');
-  assert.notEqual(retryInstallIndex, -1, 'expected plain pnpm install retry after frozen lockfile failure');
-  assert.ok(tryIndex < frozenInstallIndex, 'expected try block before frozen lockfile install');
-  assert.ok(frozenInstallIndex < catchIndex, 'expected catch block after frozen lockfile install');
-  assert.ok(catchIndex < capturedErrorIndex, 'expected frozen lockfile catch to save the error record');
-  assert.ok(capturedErrorIndex < cancelExitIndex, 'expected cancellation check before retry warning');
-  assert.ok(cancelExitIndex < retryWarnIndex, 'expected retry warning after protected frozen lockfile path');
+  assert.notEqual(retryWarnIndex, -1, 'expected retry warning after protected frozen lockfile path');
+  assert.notEqual(retryInstallIndex, -1, 'expected plain pnpm install retry after warning');
+  assert.ok(helperIndex < frozenInstallIndex, 'expected helper declaration before frozen install use');
+  assert.ok(frozenInstallIndex < cancelExitIndex, 'expected cancellation check after frozen install result');
+  assert.ok(cancelExitIndex < retryWarnIndex, 'expected retry warning after cancellation guard');
   assert.ok(retryWarnIndex < retryInstallIndex, 'expected plain install retry after warning');
+});
+
+test('Windows installer retries with PUPPETEER_SKIP_DOWNLOAD only for Puppeteer browser download failures', () => {
+  assert.match(installScript, /function Test-PuppeteerBrowserDownloadFailure/);
+  assert.match(
+    installScript,
+    /return \$OutputText -match "puppeteer" -and\s+\(\$OutputText -match "Failed to set up chrome" -or \$OutputText -match "PUPPETEER_SKIP_DOWNLOAD"\)/,
+  );
+  assert.match(installScript, /function Write-PuppeteerSkipWarning/);
+  assert.match(
+    installScript,
+    /Write-Warn "Puppeteer browser download failed - retrying install without bundled Chrome"/,
+  );
+  assert.match(
+    installScript,
+    /Write-Warn "Thread export \/ screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"/,
+  );
+  assert.match(
+    installScript,
+    /\$frozenInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @\("install", "--frozen-lockfile"\)/,
+  );
+  assert.match(
+    installScript,
+    /Invoke-PnpmInstallWithCapturedOutput -CommandArgs @\("install", "--frozen-lockfile"\) -SkipPuppeteerDownload/,
+  );
+  assert.match(
+    installScript,
+    /Invoke-PnpmInstallWithCapturedOutput -CommandArgs @\("install"\) -SkipPuppeteerDownload/,
+  );
 });
 
 test('Windows command forwarding helpers avoid PowerShell automatic $args collisions', () => {

--- a/packages/api/test/windows-portable-redis-tools.test.js
+++ b/packages/api/test/windows-portable-redis-tools.test.js
@@ -109,13 +109,10 @@ test('Windows installer retries with PUPPETEER_SKIP_DOWNLOAD only for Puppeteer 
     /return \$OutputText -match "puppeteer" -and\s+\(\$OutputText -match "Failed to set up chrome" -or \$OutputText -match "PUPPETEER_SKIP_DOWNLOAD"\)/,
   );
   assert.match(installScript, /function Write-PuppeteerSkipWarning/);
+  assert.match(installScript, /Write-Warn "Bundled Chrome download failed - skipped"/);
   assert.match(
     installScript,
-    /Write-Warn "Puppeteer browser download failed - retrying install without bundled Chrome"/,
-  );
-  assert.match(
-    installScript,
-    /Write-Warn "Thread export \/ screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"/,
+    /Write-Warn "Thread export \/ screenshot may be unavailable\. To install later: npx puppeteer browsers install chrome"/,
   );
   assert.match(
     installScript,

--- a/packages/api/test/windows-portable-redis-url.test.js
+++ b/packages/api/test/windows-portable-redis-url.test.js
@@ -34,8 +34,9 @@ test('Windows installer headless Redis planning respects existing external Redis
   assert.match(uiHelpersScript, /Mode = "external"; RedisUrl = \$defaultRedisUrl/);
   assert.match(
     uiHelpersScript,
-    /if \(Test-InstallerConsoleUi\) \{ Read-Host " {2}External Redis URL" \} else \{ \$defaultRedisUrl \}/,
+    /if \(\$mode -eq "external"\) \{\s+if \(Test-InstallerConsoleUi\) \{\s+while \(-not \$redisUrl\) \{\s+\$redisUrl = \(Read-Host " {2}External Redis URL"\)\.Trim\(\)/s,
   );
+  assert.match(uiHelpersScript, /\} else \{\s+\$redisUrl = \$defaultRedisUrl\s+\}/);
 });
 
 test('Windows installer headless rerun preserves local authenticated Redis URL via keep_local mode', () => {
@@ -71,6 +72,16 @@ test('Windows installer validates external Redis URLs before persisting them', (
   assert.match(
     uiHelpersScript,
     /if \(\$Plan\.Mode -eq "external"\) \{\s+\$redisValidationError = Get-InstallerExternalRedisValidationError -RedisUrl \$Plan\.RedisUrl\s+if \(\$redisValidationError\) \{\s+Write-Warn \$redisValidationError\s+return \$false\s+\}\s+\}/s,
+  );
+});
+
+test('Windows installer does not silently fall back to portable Redis when external URL is blank', () => {
+  assert.match(uiHelpersScript, /while \(-not \$redisUrl\) \{/);
+  assert.match(uiHelpersScript, /Write-Warn "External Redis URL is required when you choose external Redis\."/);
+  assert.doesNotMatch(uiHelpersScript, /External Redis URL empty - using local Redis setup/);
+  assert.doesNotMatch(
+    uiHelpersScript,
+    /if \(\$mode -eq "external" -and -not \$redisUrl\) \{\s+Write-Warn .*?\s+\$mode = "portable"\s+\}/s,
   );
 });
 

--- a/packages/web/src/components/HubAccountsTab.tsx
+++ b/packages/web/src/components/HubAccountsTab.tsx
@@ -5,7 +5,7 @@ import { apiFetch } from '@/utils/api-client';
 import { HubAccountItem, type ProfileEditPayload } from './HubAccountItem';
 import { AccountsSummaryCard, CreateApiKeyAccountSection } from './hub-accounts.sections';
 import type { AccountsResponse } from './hub-accounts.types';
-import { ensureBuiltinAccounts, resolveAccountActionId } from './hub-accounts.view';
+import { normalizeBuiltinClientIds, resolveAccountActionId } from './hub-accounts.view';
 
 export function HubAccountsTab() {
   const [loading, setLoading] = useState(true);
@@ -127,7 +127,7 @@ export function HubAccountsTab() {
     [callApi, fetchAccounts],
   );
 
-  const displayAccounts = useMemo(() => ensureBuiltinAccounts(data?.providers ?? []), [data?.providers]);
+  const displayAccounts = useMemo(() => normalizeBuiltinClientIds(data?.providers ?? []), [data?.providers]);
   const builtinAccounts = useMemo(() => displayAccounts.filter((a) => a.builtin), [displayAccounts]);
   const customAccounts = useMemo(() => displayAccounts.filter((a) => !a.builtin), [displayAccounts]);
   const displayCards = useMemo(() => [...builtinAccounts, ...customAccounts], [builtinAccounts, customAccounts]);

--- a/packages/web/src/components/__tests__/cat-cafe-hub-accounts-tab.test.ts
+++ b/packages/web/src/components/__tests__/cat-cafe-hub-accounts-tab.test.ts
@@ -231,8 +231,8 @@ describe('CatCafeHub provider profiles tab', () => {
     expect(container.textContent).toContain('Codex Sponsor');
     expect(container.textContent).not.toContain('【');
     expect(container.textContent).not.toContain('非 UI 直出');
-    expect(container.textContent).toContain('OpenCode (client-auth)');
-    expect(container.textContent).toContain('Dare (client-auth)');
+    expect(container.textContent).not.toContain('OpenCode (client-auth)');
+    expect(container.textContent).not.toContain('Dare (client-auth)');
     expect(container.textContent).not.toContain('OAuth-like');
     expect(container.textContent).not.toContain('内置认证');
     expect(container.textContent).toContain('新建 API Key 账号');
@@ -639,7 +639,7 @@ describe('CatCafeHub provider profiles tab', () => {
     expect((createPayload as unknown as Record<string, unknown>)?.projectPath).toBeUndefined();
   });
 
-  it('shows built-in and custom provider cards together without the old filter tabs', async () => {
+  it('shows only configured provider cards without synthesizing unconfigured builtins', async () => {
     mockApiFetch.mockImplementation((path: string) => {
       if (path.startsWith('/api/accounts')) {
         return Promise.resolve(
@@ -721,8 +721,9 @@ describe('CatCafeHub provider profiles tab', () => {
     expect(profileList?.textContent).toContain('Codex (OAuth)');
     expect(profileList?.textContent).toContain('Gemini (OAuth)');
     expect(profileList?.textContent).toContain('Codex Sponsor');
-    expect(profileList?.textContent).toContain('OpenCode (client-auth)');
-    expect(profileList?.textContent).toContain('Dare (client-auth)');
+    expect(profileList?.textContent).not.toContain('Kimi (OAuth)');
+    expect(profileList?.textContent).not.toContain('OpenCode (client-auth)');
+    expect(profileList?.textContent).not.toContain('Dare (client-auth)');
     expect(container.textContent).not.toContain('全部');
     expect(container.textContent).not.toContain('内置认证');
     expect(

--- a/packages/web/src/components/hub-accounts.view.ts
+++ b/packages/web/src/components/hub-accounts.view.ts
@@ -13,7 +13,7 @@ function inferBuiltinClient(profile: ProfileItem): BuiltinAccountClient | undefi
   return undefined;
 }
 
-export function ensureBuiltinAccounts(profiles: ProfileItem[]): ProfileItem[] {
+export function normalizeBuiltinClientIds(profiles: ProfileItem[]): ProfileItem[] {
   return profiles.map((profile) => {
     if (!profile.builtin) return profile;
     const builtinClient = inferBuiltinClient(profile);

--- a/packages/web/src/components/hub-accounts.view.ts
+++ b/packages/web/src/components/hub-accounts.view.ts
@@ -1,19 +1,5 @@
 import type { BuiltinAccountClient, ProfileItem } from './hub-accounts.types';
 
-const FALLBACK_BUILTIN_PROFILE_SPECS: Array<{
-  clientId: BuiltinAccountClient;
-  id: string;
-  displayName: string;
-  models: string[];
-}> = [
-  { clientId: 'anthropic', id: 'claude', displayName: 'Claude (OAuth)', models: [] },
-  { clientId: 'openai', id: 'codex', displayName: 'Codex (OAuth)', models: [] },
-  { clientId: 'google', id: 'gemini', displayName: 'Gemini (OAuth)', models: [] },
-  { clientId: 'kimi', id: 'kimi', displayName: 'Kimi (OAuth)', models: [] },
-  { clientId: 'dare', id: 'dare', displayName: 'Dare (client-auth)', models: [] },
-  { clientId: 'opencode', id: 'opencode', displayName: 'OpenCode (client-auth)', models: [] },
-];
-
 function inferBuiltinClient(profile: ProfileItem): BuiltinAccountClient | undefined {
   if (profile.clientId) return profile.clientId;
   if (profile.oauthLikeClient === 'dare' || profile.oauthLikeClient === 'opencode') return profile.oauthLikeClient;
@@ -28,39 +14,11 @@ function inferBuiltinClient(profile: ProfileItem): BuiltinAccountClient | undefi
 }
 
 export function ensureBuiltinAccounts(profiles: ProfileItem[]): ProfileItem[] {
-  const normalized = profiles.map((profile) => {
+  return profiles.map((profile) => {
     if (!profile.builtin) return profile;
     const builtinClient = inferBuiltinClient(profile);
     return builtinClient ? { ...profile, clientId: builtinClient } : profile;
   });
-
-  const seenBuiltinClients = new Set(
-    normalized
-      .filter((profile) => profile.builtin)
-      .map((profile) => inferBuiltinClient(profile))
-      .filter(Boolean) as BuiltinAccountClient[],
-  );
-
-  for (const spec of FALLBACK_BUILTIN_PROFILE_SPECS) {
-    if (seenBuiltinClients.has(spec.clientId)) continue;
-    normalized.push({
-      id: spec.id,
-      displayName: spec.displayName,
-      name: spec.displayName,
-      authType: 'oauth',
-      kind: 'builtin',
-      builtin: true,
-      mode: 'subscription',
-      clientId: spec.clientId,
-      models: spec.models,
-      hasApiKey: false,
-      createdAt: '',
-      updatedAt: '',
-      ...(spec.clientId === 'dare' || spec.clientId === 'opencode' ? { oauthLikeClient: spec.clientId } : {}),
-    });
-  }
-
-  return normalized;
 }
 
 export function builtinClientLabel(client?: BuiltinAccountClient): string {

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -20,6 +20,7 @@ const BUILTIN_ACCOUNT_SPECS = [
   },
   { id: 'codex', displayName: 'Codex', client: 'openai', models: ['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.3-codex-spark'] },
   { id: 'gemini', displayName: 'Gemini', client: 'google', models: ['gemini-3.1-pro-preview', 'gemini-2.5-pro'] },
+  { id: 'kimi', displayName: 'Kimi', client: 'kimi', models: ['kimi-code/kimi-for-coding'] },
   { id: 'dare', displayName: 'Dare', client: 'dare', models: ['z-ai/glm-4.7'] },
   { id: 'opencode', displayName: 'OpenCode', client: 'opencode', models: ['claude-opus-4-6', 'claude-sonnet-4-5'] },
 ];
@@ -174,6 +175,7 @@ function normalizeClient(rawClient) {
   if (trimmed === 'anthropic' || trimmed === 'claude') return 'anthropic';
   if (trimmed === 'openai' || trimmed === 'codex') return 'openai';
   if (trimmed === 'google' || trimmed === 'gemini') return 'google';
+  if (trimmed === 'kimi' || trimmed === 'moonshot') return 'kimi';
   if (trimmed === 'dare') return 'dare';
   if (trimmed === 'opencode') return 'opencode';
   return null;
@@ -363,6 +365,7 @@ function setClientAuth(client, mode, options) {
     accounts[accountRef] = {
       authType: 'oauth',
       displayName: BUILTIN_ACCOUNT_SPECS.find((s) => s.client === client)?.displayName ?? accountRef,
+      models: normalizeModels(BUILTIN_ACCOUNT_SPECS.find((s) => s.client === client)?.models) ?? [],
     };
     // Warn about stale installer account that the resolver will prefer (has API key).
     // We intentionally do NOT auto-delete it here: installer accounts are global,

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -200,10 +200,15 @@ function normalizeModelValue(value) {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-function normalizeModels(models) {
+function sanitizeModels(models) {
   if (!Array.isArray(models)) return undefined;
   const normalized = Array.from(new Set(models.map(normalizeModelValue).filter((v) => v && v.length > 0)));
-  return normalized.length > 0 ? normalized.sort() : undefined;
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function normalizeModels(models) {
+  const normalized = sanitizeModels(models);
+  return normalized ? [...normalized].sort() : undefined;
 }
 
 function canonicalizeAccount(account) {
@@ -375,7 +380,7 @@ function setClientAuth(client, mode, options) {
     accounts[accountRef] = {
       authType: 'oauth',
       displayName: spec?.displayName ?? accountRef,
-      models: normalizeModels(spec?.models) ?? [],
+      models: sanitizeModels(spec?.models) ?? [],
     };
     // Warn about stale installer account that the resolver will prefer (has API key).
     // We intentionally do NOT auto-delete it here: installer accounts are global,

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -361,11 +361,12 @@ function setClientAuth(client, mode, options) {
   const accounts = readAccounts();
 
   if (mode === 'oauth') {
+    const spec = BUILTIN_ACCOUNT_SPECS.find((s) => s.client === client);
     // F340: protocol not persisted on new accounts — derived from well-known ID at runtime.
     accounts[accountRef] = {
       authType: 'oauth',
-      displayName: BUILTIN_ACCOUNT_SPECS.find((s) => s.client === client)?.displayName ?? accountRef,
-      models: normalizeModels(BUILTIN_ACCOUNT_SPECS.find((s) => s.client === client)?.models) ?? [],
+      displayName: spec?.displayName ?? accountRef,
+      models: normalizeModels(spec?.models) ?? [],
     };
     // Warn about stale installer account that the resolver will prefer (has API key).
     // We intentionally do NOT auto-delete it here: installer accounts are global,

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -16,7 +16,7 @@ const BUILTIN_ACCOUNT_SPECS = [
     id: 'claude',
     displayName: 'Claude',
     client: 'anthropic',
-    models: ['claude-opus-4-6[1m]', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101'],
+    models: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101'],
   },
   { id: 'codex', displayName: 'Codex', client: 'openai', models: ['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.3-codex-spark'] },
   { id: 'gemini', displayName: 'Gemini', client: 'google', models: ['gemini-3.1-pro-preview', 'gemini-2.5-pro'] },
@@ -191,9 +191,18 @@ function normalizeDisplayName(displayName) {
   return trimmed ? trimmed : undefined;
 }
 
+function normalizeModelValue(value) {
+  const trimmed = String(value ?? '')
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .trim()
+    .replace(/(?:\[[0-9;]*m)+$/g, '')
+    .trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 function normalizeModels(models) {
   if (!Array.isArray(models)) return undefined;
-  const normalized = Array.from(new Set(models.map((v) => String(v).trim()).filter((v) => v.length > 0)));
+  const normalized = Array.from(new Set(models.map(normalizeModelValue).filter((v) => v && v.length > 0)));
   return normalized.length > 0 ? normalized.sort() : undefined;
 }
 

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -544,12 +544,16 @@ function Read-InstallerSecret {
 }
 
 function Configure-InstallerAuth {
-    param([string]$ProjectRoot, $State)
+    param([string]$ProjectRoot, $State, [string[]]$SelectedCliCommands = @())
 
     $hasClaude = $null -ne (Resolve-ToolCommandWithRetry -Name "claude" -Attempts 6)
     $hasCodex = $null -ne (Resolve-ToolCommandWithRetry -Name "codex" -Attempts 6)
     $hasGemini = $null -ne (Resolve-ToolCommandWithRetry -Name "gemini" -Attempts 6)
     $hasKimi = $null -ne (Resolve-ToolCommandWithRetry -Name "kimi" -Attempts 6)
+    $shouldOfferClaude = $hasClaude -or ($SelectedCliCommands -contains "claude")
+    $shouldOfferCodex = $hasCodex -or ($SelectedCliCommands -contains "codex")
+    $shouldOfferGemini = $hasGemini -or ($SelectedCliCommands -contains "gemini")
+    $shouldOfferKimi = $hasKimi -or ($SelectedCliCommands -contains "kimi")
     $isInteractive = [Environment]::UserInteractive -and -not $env:CI
 
     if (-not $isInteractive) {
@@ -557,7 +561,7 @@ function Configure-InstallerAuth {
         return
     }
 
-    if ($hasClaude) {
+    if ($shouldOfferClaude) {
         Write-Host ""
         Write-Host "  Claude (claude):"
         $globalCatCafe = if ($env:CAT_CAFE_GLOBAL_CONFIG_ROOT) { $env:CAT_CAFE_GLOBAL_CONFIG_ROOT } else { $env:USERPROFILE }
@@ -593,7 +597,7 @@ function Configure-InstallerAuth {
         }
     }
 
-    if ($hasCodex) {
+    if ($shouldOfferCodex) {
         Write-Host ""
         Write-Host "  Codex (codex):"
         $globalCatCafeCodex = if ($env:CAT_CAFE_GLOBAL_CONFIG_ROOT) { $env:CAT_CAFE_GLOBAL_CONFIG_ROOT } else { $env:USERPROFILE }
@@ -630,7 +634,7 @@ function Configure-InstallerAuth {
         }
     }
 
-    if ($hasGemini) {
+    if ($shouldOfferGemini) {
         Write-Host ""
         Write-Host "  Gemini (gemini):"
         $globalCatCafeGemini = if ($env:CAT_CAFE_GLOBAL_CONFIG_ROOT) { $env:CAT_CAFE_GLOBAL_CONFIG_ROOT } else { $env:USERPROFILE }
@@ -666,7 +670,7 @@ function Configure-InstallerAuth {
         }
     }
 
-    if ($hasKimi) {
+    if ($shouldOfferKimi) {
         Write-Host ""
         Write-Host "  Kimi (kimi):"
         $kimiOptions = @(

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -410,6 +410,7 @@ if (-not $SkipCli) {
     $toolsToInstall = if ($missingTools.Count -gt 0 -and [Environment]::UserInteractive -and -not $env:CI) {
         Select-InstallerMultiChoice -Title "Missing agent CLIs" -Prompt "Choose which agent CLIs to install" -Options $missingTools
     } else { $missingTools }
+    $selectedCliCommands = @($toolsToInstall | ForEach-Object { $_.Cmd })
     $npmInstallCommand = Resolve-ToolCommand -Name "npm"
     foreach ($tool in $cliTools) {
         $installed = $null -ne (Resolve-ToolCommand -Name $tool.Cmd)
@@ -448,10 +449,11 @@ if (-not $SkipCli) {
     }
 } else {
     Write-Warn "CLI tools install skipped (-SkipCli)"
+    $selectedCliCommands = @()
 }
 
 Write-Step "Step 8/9 - Auth config"
-Configure-InstallerAuth -ProjectRoot $ProjectRoot -State $authState
+Configure-InstallerAuth -ProjectRoot $ProjectRoot -State $authState -SelectedCliCommands $selectedCliCommands
 
 Apply-InstallerAuthEnv -State $authState -EnvFile $envFile
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -34,6 +34,58 @@ function Refresh-Path {
 
 function Resolve-PnpmCommand { Resolve-ToolCommand -Name "pnpm" }
 function Invoke-Pnpm { param([string[]]$CommandArgs) Invoke-ToolCommand -Name "pnpm" -CommandArgs $CommandArgs }
+function Get-CommandOutputText {
+    param([object[]]$OutputLines)
+    return (@($OutputLines) | ForEach-Object { "$_" }) -join "`n"
+}
+function Test-PuppeteerBrowserDownloadFailure {
+    param([string]$OutputText)
+    return $OutputText -match "puppeteer" -and
+        ($OutputText -match "Failed to set up chrome" -or $OutputText -match "PUPPETEER_SKIP_DOWNLOAD")
+}
+function Write-PuppeteerSkipWarning {
+    Write-Warn "Puppeteer browser download failed - retrying install without bundled Chrome"
+    Write-Warn "Thread export / screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"
+}
+function Invoke-PnpmInstallWithCapturedOutput {
+    param(
+        [string[]]$CommandArgs,
+        [switch]$SkipPuppeteerDownload
+    )
+
+    $capturedOutput = @()
+    $hadPreviousSkip = Test-Path Env:PUPPETEER_SKIP_DOWNLOAD
+    $previousSkipValue = if ($hadPreviousSkip) { $env:PUPPETEER_SKIP_DOWNLOAD } else { $null }
+
+    try {
+        if ($SkipPuppeteerDownload) {
+            $env:PUPPETEER_SKIP_DOWNLOAD = "1"
+        } elseif (-not $hadPreviousSkip) {
+            Remove-Item Env:PUPPETEER_SKIP_DOWNLOAD -ErrorAction SilentlyContinue
+        }
+
+        try {
+            Invoke-Pnpm -CommandArgs $CommandArgs 2>&1 | Tee-Object -Variable capturedOutput
+            return [pscustomobject]@{
+                Ok = $LASTEXITCODE -eq 0
+                ErrorRecord = $null
+                OutputText = Get-CommandOutputText -OutputLines $capturedOutput
+            }
+        } catch {
+            return [pscustomobject]@{
+                Ok = $false
+                ErrorRecord = $_
+                OutputText = Get-CommandOutputText -OutputLines ($capturedOutput + @($_))
+            }
+        }
+    } finally {
+        if ($hadPreviousSkip) {
+            $env:PUPPETEER_SKIP_DOWNLOAD = $previousSkipValue
+        } else {
+            Remove-Item Env:PUPPETEER_SKIP_DOWNLOAD -ErrorAction SilentlyContinue
+        }
+    }
+}
 function Test-InstallerCancellation {
     param($ErrorRecord)
     if (-not $ErrorRecord -or -not $ErrorRecord.Exception) {
@@ -301,19 +353,24 @@ if (Test-Path $envFile) {
 Write-Step "Step 5/9 - Install dependencies and build"
 
 Write-Host "  Running pnpm install..."
-$frozenInstallOk = $false
-$frozenInstallError = $null
-try {
-    Invoke-Pnpm -CommandArgs @("install", "--frozen-lockfile") 2>$null
-    $frozenInstallOk = $LASTEXITCODE -eq 0
-} catch {
-    $frozenInstallError = $_
+$frozenInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install", "--frozen-lockfile")
+if (-not $frozenInstallResult.Ok -and (Test-PuppeteerBrowserDownloadFailure -OutputText $frozenInstallResult.OutputText)) {
+    Write-PuppeteerSkipWarning
+    $frozenInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install", "--frozen-lockfile") -SkipPuppeteerDownload
 }
-if (-not $frozenInstallOk) {
-    Exit-InstallerIfCancelled -ErrorRecord $frozenInstallError -Context "pnpm install"
+if (-not $frozenInstallResult.Ok) {
+    Exit-InstallerIfCancelled -ErrorRecord $frozenInstallResult.ErrorRecord -Context "pnpm install"
     Write-Warn "Frozen lockfile failed, retrying..."
-    Invoke-Pnpm -CommandArgs @("install")
-    if ($LASTEXITCODE -ne 0) { Write-Err "pnpm install failed"; exit 1 }
+    $plainInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install")
+    if (-not $plainInstallResult.Ok -and (Test-PuppeteerBrowserDownloadFailure -OutputText $plainInstallResult.OutputText)) {
+        Write-PuppeteerSkipWarning
+        $plainInstallResult = Invoke-PnpmInstallWithCapturedOutput -CommandArgs @("install") -SkipPuppeteerDownload
+    }
+    if (-not $plainInstallResult.Ok) {
+        Exit-InstallerIfCancelled -ErrorRecord $plainInstallResult.ErrorRecord -Context "pnpm install"
+        Write-Err "pnpm install failed"
+        exit 1
+    }
 }
 Write-Ok "Dependencies installed"
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -44,8 +44,8 @@ function Test-PuppeteerBrowserDownloadFailure {
         ($OutputText -match "Failed to set up chrome" -or $OutputText -match "PUPPETEER_SKIP_DOWNLOAD")
 }
 function Write-PuppeteerSkipWarning {
-    Write-Warn "Puppeteer browser download failed - retrying install without bundled Chrome"
-    Write-Warn "Thread export / screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"
+    Write-Warn "Bundled Chrome download failed - skipped"
+    Write-Warn "Thread export / screenshot may be unavailable. To install later: npx puppeteer browsers install chrome"
 }
 function Invoke-PnpmInstallWithCapturedOutput {
     param(

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -328,9 +328,54 @@ read_env_key() {
     printf '%s\n' "$value"
 }
 pnpm_install_with_fallback() {
-    pnpm install --frozen-lockfile && return 0; [[ -n "$NPM_REGISTRY" ]] && return 1
+    local log_file; log_file="$(mktemp)"
+    if run_pnpm_install_capture "$log_file" pnpm install --frozen-lockfile; then
+        rm -f "$log_file"
+        return 0
+    fi
+    if pnpm_install_needs_puppeteer_skip "$log_file"; then
+        warn_puppeteer_skip_fallback
+        if run_pnpm_install_capture "$log_file" env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile; then
+            rm -f "$log_file"
+            return 0
+        fi
+    fi
+    if [[ -n "$NPM_REGISTRY" ]]; then
+        rm -f "$log_file"
+        return 1
+    fi
     warn "pnpm install failed — retrying with npmmirror"; use_registry "https://registry.npmmirror.com"
-    pnpm install --frozen-lockfile
+    if run_pnpm_install_capture "$log_file" pnpm install --frozen-lockfile; then
+        rm -f "$log_file"
+        return 0
+    fi
+    if pnpm_install_needs_puppeteer_skip "$log_file"; then
+        warn_puppeteer_skip_fallback
+        if run_pnpm_install_capture "$log_file" env PUPPETEER_SKIP_DOWNLOAD=1 pnpm install --frozen-lockfile; then
+            rm -f "$log_file"
+            return 0
+        fi
+    fi
+    rm -f "$log_file"
+    return 1
+}
+run_pnpm_install_capture() {
+    local log_file="$1"; shift
+    local status=0
+    set +e
+    "$@" 2>&1 | tee "$log_file"
+    status=${PIPESTATUS[0]}
+    set -e
+    return "$status"
+}
+pnpm_install_needs_puppeteer_skip() {
+    local log_file="$1"
+    grep -Eqi 'puppeteer' "$log_file" \
+        && grep -Eqi 'Failed to set up chrome|PUPPETEER_SKIP_DOWNLOAD' "$log_file"
+}
+warn_puppeteer_skip_fallback() {
+    warn "Puppeteer browser download failed — retrying install without bundled Chrome"
+    warn "Thread export / screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"
 }
 build_step() { local label="$1"; shift; info "  Building $label..."
     "$@" || { fail "$label build failed in $PROJECT_DIR"; exit 1; }; ok "$label done"; }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -529,16 +529,20 @@ runtime_worktree_initialized() {
     [[ -d "$runtime_dir" ]] || return 1
     [[ -e "$runtime_dir/.git" ]] || return 1
     git -C "$runtime_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
-    local resolved_runtime resolved_toplevel project_toplevel worktree_line resolved_worktree
+    local resolved_runtime resolved_toplevel resolved_project project_toplevel worktree_line resolved_worktree
     resolved_runtime="$(cd "$runtime_dir" && pwd -P)"
     resolved_toplevel="$(git -C "$runtime_dir" rev-parse --show-toplevel 2>/dev/null || true)"
     [[ -n "$resolved_toplevel" ]] || return 1
     resolved_toplevel="$(cd "$resolved_toplevel" && pwd -P)"
     [[ "$resolved_runtime" == "$resolved_toplevel" ]] || return 1
 
+    [[ -d "$PROJECT_DIR" ]] || return 1
+    [[ -e "$PROJECT_DIR/.git" ]] || return 1
+    resolved_project="$(cd "$PROJECT_DIR" && pwd -P)"
     project_toplevel="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
     [[ -n "$project_toplevel" ]] || return 1
     project_toplevel="$(cd "$project_toplevel" && pwd -P)"
+    [[ "$resolved_project" == "$project_toplevel" ]] || return 1
 
     while IFS= read -r worktree_line; do
         [[ "$worktree_line" == worktree\ * ]] || continue

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -529,10 +529,24 @@ runtime_worktree_initialized() {
     [[ -d "$runtime_dir" ]] || return 1
     [[ -e "$runtime_dir/.git" ]] || return 1
     git -C "$runtime_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
-    local resolved_runtime resolved_toplevel
+    local resolved_runtime resolved_toplevel project_toplevel worktree_line resolved_worktree
     resolved_runtime="$(cd "$runtime_dir" && pwd -P)"
     resolved_toplevel="$(git -C "$runtime_dir" rev-parse --show-toplevel 2>/dev/null || true)"
-    [[ -n "$resolved_toplevel" && "$resolved_runtime" == "$resolved_toplevel" ]]
+    [[ -n "$resolved_toplevel" ]] || return 1
+    resolved_toplevel="$(cd "$resolved_toplevel" && pwd -P)"
+    [[ "$resolved_runtime" == "$resolved_toplevel" ]] || return 1
+
+    project_toplevel="$(git -C "$PROJECT_DIR" rev-parse --show-toplevel 2>/dev/null || true)"
+    [[ -n "$project_toplevel" ]] || return 1
+    project_toplevel="$(cd "$project_toplevel" && pwd -P)"
+
+    while IFS= read -r worktree_line; do
+        [[ "$worktree_line" == worktree\ * ]] || continue
+        resolved_worktree="$(cd "${worktree_line#worktree }" 2>/dev/null && pwd -P)" || continue
+        [[ "$resolved_worktree" == "$resolved_runtime" ]] && return 0
+    done < <(git -C "$project_toplevel" worktree list --porcelain 2>/dev/null)
+
+    return 1
 }
 resolve_installer_auth_config_root() {
     if [[ -n "${CAT_CAFE_GLOBAL_CONFIG_ROOT:-}" ]]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -614,6 +614,9 @@ run_install_auth_config() {
     local auth_root
     auth_root="$(resolve_installer_auth_config_root)"
     CAT_CAFE_GLOBAL_CONFIG_ROOT="$auth_root" node scripts/install-auth-config.mjs "$@"
+    if [[ -z "${CAT_CAFE_GLOBAL_CONFIG_ROOT:-}" && "$auth_root" != "$PROJECT_DIR" ]]; then
+        CAT_CAFE_GLOBAL_CONFIG_ROOT="$PROJECT_DIR" node scripts/install-auth-config.mjs "$@"
+    fi
 }
 
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -131,6 +131,21 @@ tty_read_secret() {
 # These provide a TUI-style menu: ↑↓ to move, space to toggle, enter to confirm.
 # Falls back to plain tty_read when HAS_TTY is false.
 
+tty_arrow_delta() {
+    case "$1" in
+        '[A'|'OA') printf '%s' '-1'; return 0 ;;
+        '[B'|'OB') printf '%s' '1'; return 0 ;;
+    esac
+    return 1
+}
+tty_numeric_index() {
+    local key="$1" count="$2"
+    [[ "$key" =~ ^[1-9]$ ]] || return 1
+    local idx=$((10#$key - 1))
+    (( idx >= 0 && idx < count )) || return 1
+    printf '%s' "$idx"
+}
+
 # tty_select: Single-select with arrow keys.
 #   Usage: tty_select RESULT_VAR "prompt" "option1" "option2" ...
 #   Sets RESULT_VAR to the 0-based index of the chosen option (default 0).
@@ -146,14 +161,14 @@ tty_select() {
     # Save terminal state and switch to raw mode
     local saved_tty; saved_tty="$(stty -g </dev/tty 2>/dev/null)"
     printf '\n%s\n' "$prompt" >/dev/tty
-    printf '  Use ↑↓ arrows to move, Enter to select\n\n' >/dev/tty
+    printf '  Use ↑↓ arrows or number keys to move, Enter to select\n\n' >/dev/tty
 
     local i
     for ((i=0; i<count; i++)); do
         if ((i == cur)); then
-            printf '  \033[36m❯ %s\033[0m\n' "${options[$i]}" >/dev/tty
+            printf '  %d. \033[36m❯ %s\033[0m\n' "$((i+1))" "${options[$i]}" >/dev/tty
         else
-            printf '    %s\n' "${options[$i]}" >/dev/tty
+            printf '  %d.   %s\n' "$((i+1))" "${options[$i]}" >/dev/tty
         fi
     done
 
@@ -166,10 +181,16 @@ tty_select() {
         local need_redraw=false
         if [[ "$key" == $'\x1b' ]]; then
             read -rsn2 -t 0.1 key </dev/tty 2>/dev/null || true
-            case "$key" in
-                '[A') ((cur > 0)) && ((cur--)) || true; need_redraw=true ;;
-                '[B') ((cur < count-1)) && ((cur++)) || true; need_redraw=true ;;
-            esac
+            local delta
+            if delta="$(tty_arrow_delta "$key")"; then
+                if ((delta < 0)); then ((cur > 0)) && ((cur--)) || true
+                elif ((delta > 0)); then ((cur < count-1)) && ((cur++)) || true
+                fi
+                need_redraw=true
+            fi
+        elif tty_numeric_index "$key" "$count" >/dev/null; then
+            cur="$(tty_numeric_index "$key" "$count")"
+            need_redraw=true
         elif [[ "$key" == '' ]]; then
             break
         fi
@@ -178,9 +199,9 @@ tty_select() {
         for ((i=0; i<count; i++)); do
             printf '\r\033[K' >/dev/tty
             if ((i == cur)); then
-                printf '  \033[36m❯ %s\033[0m\n' "${options[$i]}" >/dev/tty
+                printf '  %d. \033[36m❯ %s\033[0m\n' "$((i+1))" "${options[$i]}" >/dev/tty
             else
-                printf '    %s\n' "${options[$i]}" >/dev/tty
+                printf '  %d.   %s\n' "$((i+1))" "${options[$i]}" >/dev/tty
             fi
         done
     done
@@ -214,14 +235,14 @@ tty_multiselect() {
 
     local saved_tty; saved_tty="$(stty -g </dev/tty 2>/dev/null)"
     printf '\n%s\n' "$prompt" >/dev/tty
-    printf '  Use ↑↓ to move, Space to toggle, Enter to confirm\n\n' >/dev/tty
+    printf '  Use ↑↓ to move, number keys to jump, Space to toggle, Enter to confirm\n\n' >/dev/tty
 
     for ((i=0; i<count; i++)); do
         local marker="◉"; [[ "${selected[$i]}" != "1" ]] && marker="○"
         if ((i == cur)); then
-            printf '  \033[36m❯ %s %s\033[0m\n' "$marker" "${options[$i]}" >/dev/tty
+            printf '  %d. \033[36m❯ %s %s\033[0m\n' "$((i+1))" "$marker" "${options[$i]}" >/dev/tty
         else
-            printf '    %s %s\n' "$marker" "${options[$i]}" >/dev/tty
+            printf '  %d.   %s %s\n' "$((i+1))" "$marker" "${options[$i]}" >/dev/tty
         fi
     done
 
@@ -234,10 +255,16 @@ tty_multiselect() {
         local need_redraw=false
         if [[ "$key" == $'\x1b' ]]; then
             read -rsn2 -t 0.1 key </dev/tty 2>/dev/null || true
-            case "$key" in
-                '[A') ((cur > 0)) && ((cur--)) || true; need_redraw=true ;;
-                '[B') ((cur < count-1)) && ((cur++)) || true; need_redraw=true ;;
-            esac
+            local delta
+            if delta="$(tty_arrow_delta "$key")"; then
+                if ((delta < 0)); then ((cur > 0)) && ((cur--)) || true
+                elif ((delta > 0)); then ((cur < count-1)) && ((cur++)) || true
+                fi
+                need_redraw=true
+            fi
+        elif tty_numeric_index "$key" "$count" >/dev/null; then
+            cur="$(tty_numeric_index "$key" "$count")"
+            need_redraw=true
         elif [[ "$key" == ' ' ]]; then
             if [[ "${selected[$cur]}" == "1" ]]; then selected[$cur]="0"; else selected[$cur]="1"; fi
             need_redraw=true
@@ -250,9 +277,9 @@ tty_multiselect() {
             local marker="◉"; [[ "${selected[$i]}" != "1" ]] && marker="○"
             printf '\r\033[K' >/dev/tty
             if ((i == cur)); then
-                printf '  \033[36m❯ %s %s\033[0m\n' "$marker" "${options[$i]}" >/dev/tty
+                printf '  %d. \033[36m❯ %s %s\033[0m\n' "$((i+1))" "$marker" "${options[$i]}" >/dev/tty
             else
-                printf '    %s %s\n' "$marker" "${options[$i]}" >/dev/tty
+                printf '  %d.   %s %s\n' "$((i+1))" "$marker" "${options[$i]}" >/dev/tty
             fi
         done
     done
@@ -931,6 +958,7 @@ fi
 step "[7/9] Authentication setup / 认证配置..."
 configure_agent_auth() {
     local name="$1" cmd="$2"
+    local allow_skip="${3:-false}"
     command -v "$cmd" &>/dev/null || return 0
 
     # Gemini CLI doesn't support custom API endpoints — always use OAuth
@@ -944,9 +972,17 @@ configure_agent_auth() {
     fi
 
     local auth_sel
-    tty_select auth_sel "  $name ($cmd) — auth mode:" \
+    local -a auth_options=(
         "OAuth / Subscription (recommended / 推荐)" \
         "API Key"
+    )
+    [[ "$allow_skip" == true ]] && auth_options+=("Skip auth setup (configure later / 稍后配置)")
+    tty_select auth_sel "  $name ($cmd) — auth mode:" "${auth_options[@]}"
+    local skip_index=2
+    if [[ "$allow_skip" == true && "$auth_sel" == "$skip_index" ]]; then
+        warn "$name: auth setup skipped"
+        return 0
+    fi
     if [[ "$auth_sel" != "1" ]]; then
         # Do not auto-delete installer API-key profiles here: accounts are global
         # and we cannot prove other projects are not still bound to installer refs.
@@ -989,7 +1025,7 @@ configure_agent_auth() {
 if [[ "$HAS_TTY" == true ]]; then
     info "  Configure each agent / 逐个配置每只猫的认证方式："
     configure_agent_auth "Claude (布偶猫)" "claude"; configure_agent_auth "Codex (缅因猫)" "codex"
-    configure_agent_auth "Gemini (暹罗猫)" "gemini"; configure_agent_auth "Kimi (月之暗面)" "kimi"
+    configure_agent_auth "Gemini (暹罗猫)" "gemini"; configure_agent_auth "Kimi (月之暗面)" "kimi" true
 else
     info "  Non-interactive — skipping auth. Run each CLI to log in: claude / codex / gemini / kimi"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -524,6 +524,16 @@ default_runtime_dir() {
     parent="$(cd "$PROJECT_DIR/.." && pwd)"
     printf '%s/cat-cafe-runtime\n' "$parent"
 }
+runtime_worktree_initialized() {
+    local runtime_dir="$1"
+    [[ -d "$runtime_dir" ]] || return 1
+    [[ -e "$runtime_dir/.git" ]] || return 1
+    git -C "$runtime_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+    local resolved_runtime resolved_toplevel
+    resolved_runtime="$(cd "$runtime_dir" && pwd -P)"
+    resolved_toplevel="$(git -C "$runtime_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+    [[ -n "$resolved_toplevel" && "$resolved_runtime" == "$resolved_toplevel" ]]
+}
 resolve_installer_auth_config_root() {
     if [[ -n "${CAT_CAFE_GLOBAL_CONFIG_ROOT:-}" ]]; then
         printf '%s\n' "$CAT_CAFE_GLOBAL_CONFIG_ROOT"
@@ -531,7 +541,7 @@ resolve_installer_auth_config_root() {
     fi
     local runtime_dir="${CAT_CAFE_RUNTIME_DIR:-}"
     [[ -n "$runtime_dir" ]] || runtime_dir="$(default_runtime_dir)"
-    if [[ -d "$runtime_dir" ]]; then
+    if runtime_worktree_initialized "$runtime_dir"; then
         (cd "$runtime_dir" && pwd)
         return 0
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,9 +153,14 @@ tty_select() {
     local result_var="$1" prompt="$2"; shift 2
     local -a options=("$@")
     local count=${#options[@]} cur=0
+    local default_index="${TTY_SELECT_DEFAULT_INDEX:-0}"
+    if [[ "$default_index" =~ ^[0-9]+$ ]]; then
+        local parsed_default=$((10#$default_index))
+        (( parsed_default >= 0 && parsed_default < count )) && cur="$parsed_default"
+    fi
 
     if [[ "$HAS_TTY" != true || $count -eq 0 ]]; then
-        printf -v "$result_var" '%s' '0'; return
+        printf -v "$result_var" '%s' "$cur"; return
     fi
 
     # Save terminal state and switch to raw mode
@@ -976,9 +981,11 @@ configure_agent_auth() {
         "OAuth / Subscription (recommended / 推荐)" \
         "API Key"
     )
-    [[ "$allow_skip" == true ]] && auth_options+=("Skip auth setup (configure later / 稍后配置)")
-    tty_select auth_sel "  $name ($cmd) — auth mode:" "${auth_options[@]}"
+    [[ "$allow_skip" == true ]] && auth_options+=("Skip auth setup (default / configure later / 稍后配置)")
     local skip_index=2
+    local default_auth_sel=0
+    [[ "$allow_skip" == true ]] && default_auth_sel="$skip_index"
+    TTY_SELECT_DEFAULT_INDEX="$default_auth_sel" tty_select auth_sel "  $name ($cmd) — auth mode:" "${auth_options[@]}"
     if [[ "$allow_skip" == true && "$auth_sel" == "$skip_index" ]]; then
         warn "$name: auth setup skipped"
         return 0

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -519,6 +519,29 @@ collect_env() { ENV_KEYS+=("$1"); ENV_VALUES+=("$2"); }
 clear_env() { ENV_DELETE_KEYS+=("$1"); }
 # #340 P6: Dead .env auth wrappers removed — all auth now uses
 # install-auth-config.mjs client-auth set → accounts.json + credentials.json
+default_runtime_dir() {
+    local parent
+    parent="$(cd "$PROJECT_DIR/.." && pwd)"
+    printf '%s/cat-cafe-runtime\n' "$parent"
+}
+resolve_installer_auth_config_root() {
+    if [[ -n "${CAT_CAFE_GLOBAL_CONFIG_ROOT:-}" ]]; then
+        printf '%s\n' "$CAT_CAFE_GLOBAL_CONFIG_ROOT"
+        return 0
+    fi
+    local runtime_dir="${CAT_CAFE_RUNTIME_DIR:-}"
+    [[ -n "$runtime_dir" ]] || runtime_dir="$(default_runtime_dir)"
+    if [[ -d "$runtime_dir" ]]; then
+        (cd "$runtime_dir" && pwd)
+        return 0
+    fi
+    printf '%s\n' "$PROJECT_DIR"
+}
+run_install_auth_config() {
+    local auth_root
+    auth_root="$(resolve_installer_auth_config_root)"
+    CAT_CAFE_GLOBAL_CONFIG_ROOT="$auth_root" node scripts/install-auth-config.mjs "$@"
+}
 
 
 PLATFORM="$(uname -s)"
@@ -968,7 +991,7 @@ configure_agent_auth() {
 
     # Gemini CLI doesn't support custom API endpoints — always use OAuth
     if [[ "$cmd" == "gemini" ]]; then
-        node scripts/install-auth-config.mjs client-auth set \
+        run_install_auth_config client-auth set \
             --project-dir "$PROJECT_DIR" \
             --client "$cmd" \
             --mode oauth
@@ -993,7 +1016,7 @@ configure_agent_auth() {
     if [[ "$auth_sel" != "1" ]]; then
         # Do not auto-delete installer API-key profiles here: accounts are global
         # and we cannot prove other projects are not still bound to installer refs.
-        node scripts/install-auth-config.mjs client-auth set \
+        run_install_auth_config client-auth set \
             --project-dir "$PROJECT_DIR" \
             --client "$cmd" \
             --mode oauth
@@ -1008,7 +1031,7 @@ configure_agent_auth() {
     if [[ -n "$key" ]]; then
         # All clients use the same install-auth-config.mjs to create provider profiles
         local install_args=(
-            node scripts/install-auth-config.mjs client-auth set
+            run_install_auth_config client-auth set
             --project-dir "$PROJECT_DIR"
             --client "$cmd"
             --mode api_key
@@ -1021,7 +1044,7 @@ configure_agent_auth() {
         # No key provided — set OAuth mode via unified path
         # Do not auto-delete installer API-key profiles here: accounts are global
         # and we cannot prove other projects are not still bound to installer refs.
-        node scripts/install-auth-config.mjs client-auth set \
+        run_install_auth_config client-auth set \
             --project-dir "$PROJECT_DIR" \
             --client "$cmd" \
             --mode oauth

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -374,8 +374,8 @@ pnpm_install_needs_puppeteer_skip() {
         && grep -Eqi 'Failed to set up chrome|PUPPETEER_SKIP_DOWNLOAD' "$log_file"
 }
 warn_puppeteer_skip_fallback() {
-    warn "Puppeteer browser download failed — retrying install without bundled Chrome"
-    warn "Thread export / screenshot features will stay unavailable until you run: npx puppeteer browsers install chrome"
+    warn "Bundled Chrome download failed — skipped"
+    warn "Thread export / screenshot may be unavailable. To install later: npx puppeteer browsers install chrome"
 }
 build_step() { local label="$1"; shift; info "  Building $label..."
     "$@" || { fail "$label build failed in $PROJECT_DIR"; exit 1; }; ok "$label done"; }

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -432,12 +432,14 @@ start_runtime_worktree() {
     if is_api_running && [ "$FORCE" != "true" ]; then
       info "API port is active; skip pre-start sync to avoid in-place hot swap."
       info "Run 'pnpm runtime:sync' after stop if you need latest origin/main."
+      seed_runtime_config_from_project
     else
       sync_runtime_worktree
     fi
+  else
+    seed_runtime_config_from_project
   fi
 
-  seed_runtime_config_from_project
   ensure_runtime_start_prereqs
 
   info "starting production stack from runtime worktree: $RUNTIME_DIR"

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -194,6 +194,26 @@ install_runtime_dependencies() {
   pnpm -C "$RUNTIME_DIR" install --frozen-lockfile
 }
 
+seed_runtime_config_from_project() {
+  local source_config="$PROJECT_DIR/.cat-cafe"
+  local target_config="$RUNTIME_DIR/.cat-cafe"
+  local file
+
+  [ "$RUNTIME_DIR" != "$PROJECT_DIR" ] || return 0
+  [ -d "$source_config" ] || return 0
+
+  for file in cat-catalog.json accounts.json credentials.json; do
+    [ -f "$source_config/$file" ] || continue
+    [ ! -e "$target_config/$file" ] || continue
+    mkdir -p "$target_config"
+    cp "$source_config/$file" "$target_config/$file"
+    if [ "$file" = "credentials.json" ]; then
+      chmod 600 "$target_config/$file" || true
+    fi
+    info "seeded runtime config: .cat-cafe/$file"
+  done
+}
+
 ensure_runtime_dependencies() {
   local missing=()
 
@@ -314,6 +334,8 @@ init_runtime_worktree() {
     pnpm -C "$RUNTIME_DIR" install
   fi
 
+  seed_runtime_config_from_project
+
   info "runtime worktree ready at $RUNTIME_DIR"
 }
 
@@ -355,6 +377,8 @@ sync_runtime_worktree() {
       git -C "$RUNTIME_DIR" stash push -m "lock-drift-auto-stash" -- pnpm-lock.yaml
     fi
   fi
+
+  seed_runtime_config_from_project
 
   info "sync complete"
 }
@@ -413,6 +437,7 @@ start_runtime_worktree() {
     fi
   fi
 
+  seed_runtime_config_from_project
   ensure_runtime_start_prereqs
 
   info "starting production stack from runtime worktree: $RUNTIME_DIR"

--- a/scripts/windows-installer-ui.ps1
+++ b/scripts/windows-installer-ui.ps1
@@ -202,12 +202,18 @@ function Resolve-InstallerRedisPlan {
     if ($mode -eq "keep_local") {
         return [pscustomobject]@{ Mode = "keep_local"; RedisUrl = $anyRedisUrl }
     }
-    $redisUrl = if ($mode -eq "external") {
-        if (Test-InstallerConsoleUi) { Read-Host "  External Redis URL" } else { $defaultRedisUrl }
-    } else { "" }
-    if ($mode -eq "external" -and -not $redisUrl) {
-        Write-Warn "External Redis URL empty - using local Redis setup"
-        $mode = "portable"
+    $redisUrl = ""
+    if ($mode -eq "external") {
+        if (Test-InstallerConsoleUi) {
+            while (-not $redisUrl) {
+                $redisUrl = (Read-Host "  External Redis URL").Trim()
+                if (-not $redisUrl) {
+                    Write-Warn "External Redis URL is required when you choose external Redis."
+                }
+            }
+        } else {
+            $redisUrl = $defaultRedisUrl
+        }
     }
     return [pscustomobject]@{ Mode = $mode; RedisUrl = $redisUrl }
 }


### PR DESCRIPTION
Fixes #519

## Summary
- default optional Kimi auth to skip so first-run install does not block on broken TTY arrow-key selection
- write installer auth output into the runtime config root and seed runtime worktree auth/config files on first start
- stop synthesizing unconfigured builtin accounts in the Hub so runtime only shows real configured auth state

## Problem
Fresh install had a few coupled first-run failures:
- Kimi selection could trap the installer on terminals where arrow-key navigation does not work reliably
- auth config could be written to the project root while runtime reads from the runtime root
- Hub could show derived builtin entries instead of the runtime's actual configured accounts

## Verification
- `node --test packages/api/test/install-script.test.js packages/api/test/install-auth-config-script.test.js packages/api/test/runtime-worktree-script.test.js`
- `pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/cat-cafe-hub-accounts-tab.test.ts`
- `bash -n scripts/install.sh`
- `bash -n scripts/runtime-worktree.sh`
- `node --check scripts/install-auth-config.mjs`
- `git diff --check`
- `pnpm check`
