### PR TITLE
fix(#499): unmapped oauth accounts get incorrect clientId

### DIFF
--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -48,7 +48,7 @@ function accountToView(id: string, account: AccountConfig, apiKeyPresent: boolea
     kind: isBuiltin ? 'builtin' : ('api_key' as const),
     authType: account.authType,
     builtin: isBuiltin,
-    ...(builtinClient ? { clientId: builtinClient } : {}),
+    ...(isBuiltin && builtinClient ? { clientId: builtinClient } : {}),
     ...(account.baseUrl ? { baseUrl: account.baseUrl } : {}),
     models: account.models ? [...account.models] : [],
     hasApiKey: apiKeyPresent,

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -40,7 +40,7 @@ const BUILTIN_CLIENT_FOR_ID: Record<string, string> = {
 /** Synthesize a ProviderProfileView-compatible object from AccountConfig (backward compat for Hub UI). */
 function accountToView(id: string, account: AccountConfig, apiKeyPresent: boolean) {
   const isBuiltin = account.authType === 'oauth';
-  const builtinClient = BUILTIN_CLIENT_FOR_ID[id] ?? id;
+  const builtinClient = BUILTIN_CLIENT_FOR_ID[id];
   return {
     id,
     name: account.displayName ?? id,
@@ -48,7 +48,7 @@ function accountToView(id: string, account: AccountConfig, apiKeyPresent: boolea
     kind: isBuiltin ? 'builtin' : ('api_key' as const),
     authType: account.authType,
     builtin: isBuiltin,
-    ...(isBuiltin ? { clientId: builtinClient } : {}),
+    ...(builtinClient ? { clientId: builtinClient } : {}),
     ...(account.baseUrl ? { baseUrl: account.baseUrl } : {}),
     models: account.models ? [...account.models] : [],
     hasApiKey: apiKeyPresent,

--- a/packages/api/test/accounts-route.test.js
+++ b/packages/api/test/accounts-route.test.js
@@ -445,7 +445,11 @@ describe('accounts routes', () => {
       assert.equal(claude.clientId, 'anthropic', 'mapped account should have correct clientId');
 
       const claude2 = providers.find((p) => p.id === 'claude-2');
-      assert.equal(claude2.clientId, undefined, 'unmapped oauth account must not have clientId (let frontend heuristic work)');
+      assert.equal(
+        claude2.clientId,
+        undefined,
+        'unmapped oauth account must not have clientId (let frontend heuristic work)',
+      );
       assert.equal(claude2.builtin, true, 'unmapped oauth account should still be builtin');
 
       const glm = providers.find((p) => p.id === 'glm');

--- a/packages/api/test/accounts-route.test.js
+++ b/packages/api/test/accounts-route.test.js
@@ -408,6 +408,56 @@ describe('accounts routes', () => {
     }
   });
 
+  it('#499: unmapped oauth accounts omit clientId so frontend heuristic can categorize them', async () => {
+    const { writeCatalogAccount } = await import('../dist/config/catalog-accounts.js');
+    const Fastify = (await import('fastify')).default;
+    const { accountsRoutes } = await import('../dist/routes/accounts.js');
+    const app = Fastify();
+    await app.register(accountsRoutes);
+    await app.ready();
+
+    const projectDir = await makeTmpDir('unmapped-clientid');
+    setGlobalRoot(projectDir);
+    try {
+      const catCafeDir = join(projectDir, '.cat-cafe');
+      mkdirSync(catCafeDir, { recursive: true });
+      writeFileSync(
+        join(catCafeDir, 'cat-catalog.json'),
+        JSON.stringify({ version: 2, breeds: [], roster: {}, reviewPolicy: {}, accounts: {} }),
+      );
+
+      // 'claude' is in BUILTIN_CLIENT_FOR_ID → should get clientId
+      writeCatalogAccount(projectDir, 'claude', { authType: 'oauth', models: ['m1'] });
+      // 'claude-2' is NOT in the map → should NOT get clientId
+      writeCatalogAccount(projectDir, 'claude-2', { authType: 'oauth', displayName: 'Claude-2', models: ['m2'] });
+      // 'glm' is NOT in the map → should NOT get clientId
+      writeCatalogAccount(projectDir, 'glm', { authType: 'oauth', displayName: 'GLM', models: ['glm-5'] });
+
+      const res = await app.inject({
+        method: 'GET',
+        url: `/api/accounts?projectPath=${encodeURIComponent(projectDir)}`,
+        headers: AUTH_HEADERS,
+      });
+      assert.equal(res.statusCode, 200);
+      const providers = res.json().providers;
+
+      const claude = providers.find((p) => p.id === 'claude');
+      assert.equal(claude.clientId, 'anthropic', 'mapped account should have correct clientId');
+
+      const claude2 = providers.find((p) => p.id === 'claude-2');
+      assert.equal(claude2.clientId, undefined, 'unmapped oauth account must not have clientId (let frontend heuristic work)');
+      assert.equal(claude2.builtin, true, 'unmapped oauth account should still be builtin');
+
+      const glm = providers.find((p) => p.id === 'glm');
+      assert.equal(glm.clientId, undefined, 'unmapped oauth account must not have clientId');
+      assert.equal(glm.builtin, true, 'unmapped oauth account should still be builtin');
+    } finally {
+      restoreGlobalRoot();
+      await rm(projectDir, { recursive: true, force: true });
+      await app.close();
+    }
+  });
+
   // Skip DELETE tests that create arbitrary temp dirs — they fall outside PROJECT_ALLOWED_ROOTS
   const skipRoots = !!process.env.PROJECT_ALLOWED_ROOTS;
 


### PR DESCRIPTION
## What

2-line fix in `packages/api/src/routes/accounts.ts` `accountToView()`:
- Remove `?? id` fallback from `BUILTIN_CLIENT_FOR_ID[id]`
- Change spread condition from `isBuiltin` to `builtinClient`

New test in `packages/api/test/accounts-route.test.js` verifying unmapped oauth accounts omit `clientId`.

## Why

Unmapped oauth accounts (e.g. `claude-2`, `glm`) were assigned `clientId: rawAccountId` (e.g. `'claude-2'`). The frontend's `legacyProfileClient` returned this non-standard clientId immediately, skipping its name-based heuristic fallback. Result: these accounts were invisible in the member editor's auth dropdown for any client type.

## Issue Closure

- Closes #499

## Original Requirements

- **铲屎官原话**: "我在console的成员配置哪里选不到认证信息了"
- 核心痛点: 成员配置中认证信息下拉框看不到部分 oauth 账号

## Plan / ADR

- Bug fix, no ADR needed
- BACKLOG: #499

## Tradeoff

Could have expanded `BUILTIN_CLIENT_FOR_ID` to cover more IDs (e.g. `'claude-2': 'anthropic'`), but that doesn't scale. Removing the fallback lets the frontend's existing name-based heuristic handle all unmapped accounts correctly.

## Test Evidence

14 passed, 0 failed (accounts-route.test.js, rebased on latest origin/main at 53860572)

## Open Questions

None — minimal change with clear TDD evidence.

---

**本地 Review**: [x] CVO 放行
**云端 Review**: [ ] PR 创建后在 comment 中触发

<!-- 猫猫签名（纯文本）: Ragdoll/宪宪 (opus-46) -->