### PR TITLE
feat(F153): TELEMETRY_DEBUG — unredacted console exporter with guardrails

### DIFF
--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1269,6 +1269,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '生产环境强制启用 TELEMETRY_DEBUG 的安全覆写开关。仅限紧急排障',
     category: 'telemetry',
     sensitive: false,
+    hubVisible: false,
+    runtimeEditable: false,
   },
   {
     name: 'TELEMETRY_HMAC_SALT',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1256,6 +1256,14 @@ export const ENV_VARS: EnvDefinition[] = [
 
   // --- telemetry (F153) ---
   {
+    name: 'TELEMETRY_DEBUG',
+    defaultValue: '(未设置 → 关闭)',
+    description:
+      '设为 true 启用 ConsoleSpanExporter（UNREDACTED）。生产环境默认忽略，需额外设 TELEMETRY_DEBUG_FORCE=true',
+    category: 'telemetry',
+    sensitive: false,
+  },
+  {
     name: 'TELEMETRY_HMAC_SALT',
     defaultValue: '(dev/test 自动 fallback)',
     description: 'HMAC salt — 遥测系统 ID 伪名化用。生产环境必设，缺失则禁用 OTel',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1259,9 +1259,11 @@ export const ENV_VARS: EnvDefinition[] = [
     name: 'TELEMETRY_DEBUG',
     defaultValue: '(未设置 → 关闭)',
     description:
-      '设为 true 启用 ConsoleSpanExporter（UNREDACTED）。生产环境默认忽略，需额外设 TELEMETRY_DEBUG_FORCE=true',
+      '设为 true 启用 ConsoleSpanExporter（UNREDACTED）。仅 NODE_ENV=development/test 生效，其他环境需额外设 TELEMETRY_DEBUG_FORCE=true',
     category: 'telemetry',
     sensitive: false,
+    hubVisible: false,
+    runtimeEditable: false,
   },
   {
     name: 'TELEMETRY_DEBUG_FORCE',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1264,6 +1264,13 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
+    name: 'TELEMETRY_DEBUG_FORCE',
+    defaultValue: '(未设置 → 关闭)',
+    description: '生产环境强制启用 TELEMETRY_DEBUG 的安全覆写开关。仅限紧急排障',
+    category: 'telemetry',
+    sensitive: false,
+  },
+  {
     name: 'TELEMETRY_HMAC_SALT',
     defaultValue: '(dev/test 自动 fallback)',
     description: 'HMAC salt — 遥测系统 ID 伪名化用。生产环境必设，缺失则禁用 OTel',

--- a/packages/api/src/infrastructure/telemetry/init.ts
+++ b/packages/api/src/infrastructure/telemetry/init.ts
@@ -73,6 +73,16 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
 
   const cfg = { ...DEFAULT_CONFIG, ...config };
 
+  // Enforce production guardrail on debugMode regardless of source (env or config param).
+  // Without this, initTelemetry({ debugMode: true }) could bypass resolveDebugMode().
+  if (cfg.debugMode) {
+    const isProd = process.env.NODE_ENV === 'production';
+    if (isProd && process.env.TELEMETRY_DEBUG_FORCE !== 'true') {
+      log.warn('debugMode blocked in production (set TELEMETRY_DEBUG_FORCE=true to override)');
+      cfg.debugMode = false;
+    }
+  }
+
   // P2 fix: validate HMAC salt at startup, not on first redaction call.
   // If salt is missing in non-dev environments, disable OTel gracefully
   // rather than crashing the server — telemetry should never be a crash source.
@@ -89,13 +99,17 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
   });
 
   // --- Traces: build span processor pipeline ---
+  // ORDERING MATTERS: debug exporter must come BEFORE RedactingSpanProcessor.
+  // RedactingSpanProcessor.onEnd() mutates shared span.attributes in-place;
+  // SimpleSpanProcessor.onEnd() calls export() synchronously, so the debug
+  // exporter captures unredacted values before the redactor runs.
   const spanProcessors: import('@opentelemetry/sdk-trace-node').SpanProcessor[] = [];
-  if (cfg.otlpEnabled) {
-    spanProcessors.push(new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter())));
-  }
   if (cfg.debugMode) {
     log.warn('TELEMETRY_DEBUG enabled — spans exported UNREDACTED to console. Do NOT use in production.');
     spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+  }
+  if (cfg.otlpEnabled) {
+    spanProcessors.push(new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter())));
   }
 
   // --- Metrics: Prometheus scrape + optional OTLP push ---

--- a/packages/api/src/infrastructure/telemetry/init.ts
+++ b/packages/api/src/infrastructure/telemetry/init.ts
@@ -17,7 +17,7 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
 import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node';
+import { BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
 import { ATTR_SERVICE_NAME, ATTR_SERVICE_VERSION } from '@opentelemetry/semantic-conventions';
 import { createModuleLogger } from '../logger.js';
 import { validateSalt } from './hmac.js';
@@ -33,6 +33,22 @@ export interface TelemetryConfig {
   prometheusPort?: number;
   /** Set true to also export via OTLP (requires OTEL_EXPORTER_OTLP_ENDPOINT). */
   otlpEnabled?: boolean;
+  /**
+   * TELEMETRY_DEBUG: emit UNREDACTED spans to console via ConsoleSpanExporter.
+   * Blocked in production unless TELEMETRY_DEBUG_FORCE=true.
+   */
+  debugMode?: boolean;
+}
+
+/** True when TELEMETRY_DEBUG=true AND env is non-production (or force-override set). */
+function resolveDebugMode(): boolean {
+  if (process.env.TELEMETRY_DEBUG !== 'true') return false;
+  const isProd = process.env.NODE_ENV === 'production';
+  if (isProd && process.env.TELEMETRY_DEBUG_FORCE !== 'true') {
+    log.warn('TELEMETRY_DEBUG ignored in production (set TELEMETRY_DEBUG_FORCE=true to override)');
+    return false;
+  }
+  return true;
 }
 
 const DEFAULT_CONFIG: Required<TelemetryConfig> = {
@@ -40,6 +56,7 @@ const DEFAULT_CONFIG: Required<TelemetryConfig> = {
   serviceVersion: '0.1.0',
   prometheusPort: process.env.PROMETHEUS_PORT ? Number(process.env.PROMETHEUS_PORT) : 9464,
   otlpEnabled: !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
+  debugMode: resolveDebugMode(),
 };
 
 let sdk: NodeSDK | null = null;
@@ -71,10 +88,15 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
     [ATTR_SERVICE_VERSION]: cfg.serviceVersion,
   });
 
-  // --- Traces: Redacting processor wraps OTLP exporter ---
-  const spanProcessor = cfg.otlpEnabled
-    ? new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter()))
-    : undefined;
+  // --- Traces: build span processor pipeline ---
+  const spanProcessors: import('@opentelemetry/sdk-trace-node').SpanProcessor[] = [];
+  if (cfg.otlpEnabled) {
+    spanProcessors.push(new RedactingSpanProcessor(new BatchSpanProcessor(new OTLPTraceExporter())));
+  }
+  if (cfg.debugMode) {
+    log.warn('TELEMETRY_DEBUG enabled — spans exported UNREDACTED to console. Do NOT use in production.');
+    spanProcessors.push(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+  }
 
   // --- Metrics: Prometheus scrape + optional OTLP push ---
   const prometheusExporter = new PrometheusExporter({
@@ -102,7 +124,7 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
 
   sdk = new NodeSDK({
     resource,
-    spanProcessors: spanProcessor ? [spanProcessor] : [],
+    spanProcessors,
     metricReaders,
     logRecordProcessors: logProcessor ? [logProcessor] : [],
     views,
@@ -113,6 +135,7 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
     {
       prometheus: cfg.prometheusPort,
       otlp: cfg.otlpEnabled,
+      debug: cfg.debugMode,
     },
     'OTel SDK initialized',
   );

--- a/packages/api/src/infrastructure/telemetry/init.ts
+++ b/packages/api/src/infrastructure/telemetry/init.ts
@@ -35,20 +35,29 @@ export interface TelemetryConfig {
   otlpEnabled?: boolean;
   /**
    * TELEMETRY_DEBUG: emit UNREDACTED spans to console via ConsoleSpanExporter.
-   * Blocked in production unless TELEMETRY_DEBUG_FORCE=true.
+   * Default-deny: only allowed in NODE_ENV=development|test.
+   * All other environments (including unset NODE_ENV from profile-driven
+   * startup) require TELEMETRY_DEBUG_FORCE=true.
    */
   debugMode?: boolean;
 }
 
-/** True when TELEMETRY_DEBUG=true AND env is non-production (or force-override set). */
-function resolveDebugMode(): boolean {
-  if (process.env.TELEMETRY_DEBUG !== 'true') return false;
-  const isProd = process.env.NODE_ENV === 'production';
-  if (isProd && process.env.TELEMETRY_DEBUG_FORCE !== 'true') {
-    log.warn('TELEMETRY_DEBUG ignored in production (set TELEMETRY_DEBUG_FORCE=true to override)');
-    return false;
-  }
-  return true;
+/**
+ * Default-deny guardrail for TELEMETRY_DEBUG.
+ *
+ * Returns true only when debug is requested AND the environment is safe:
+ * - NODE_ENV=development or NODE_ENV=test → allowed
+ * - Any other NODE_ENV (including unset, which is the normal state for
+ *   profile-driven startup via start-dev.sh --profile=production/opensource)
+ *   → blocked unless TELEMETRY_DEBUG_FORCE=true
+ *
+ * Exported for direct testing of guardrail logic.
+ */
+export function shouldEnableDebugMode(requested: boolean): boolean {
+  if (!requested) return false;
+  const env = process.env.NODE_ENV;
+  if (env === 'development' || env === 'test') return true;
+  return process.env.TELEMETRY_DEBUG_FORCE === 'true';
 }
 
 const DEFAULT_CONFIG: Required<TelemetryConfig> = {
@@ -56,7 +65,7 @@ const DEFAULT_CONFIG: Required<TelemetryConfig> = {
   serviceVersion: '0.1.0',
   prometheusPort: process.env.PROMETHEUS_PORT ? Number(process.env.PROMETHEUS_PORT) : 9464,
   otlpEnabled: !!process.env.OTEL_EXPORTER_OTLP_ENDPOINT,
-  debugMode: resolveDebugMode(),
+  debugMode: process.env.TELEMETRY_DEBUG === 'true',
 };
 
 let sdk: NodeSDK | null = null;
@@ -73,14 +82,11 @@ export function initTelemetry(config?: TelemetryConfig): () => Promise<void> {
 
   const cfg = { ...DEFAULT_CONFIG, ...config };
 
-  // Enforce production guardrail on debugMode regardless of source (env or config param).
-  // Without this, initTelemetry({ debugMode: true }) could bypass resolveDebugMode().
-  if (cfg.debugMode) {
-    const isProd = process.env.NODE_ENV === 'production';
-    if (isProd && process.env.TELEMETRY_DEBUG_FORCE !== 'true') {
-      log.warn('debugMode blocked in production (set TELEMETRY_DEBUG_FORCE=true to override)');
-      cfg.debugMode = false;
-    }
+  // Apply default-deny guardrail to debugMode regardless of source (env or config param).
+  const debugRequested = cfg.debugMode;
+  cfg.debugMode = shouldEnableDebugMode(cfg.debugMode ?? false);
+  if (debugRequested && !cfg.debugMode) {
+    log.warn('TELEMETRY_DEBUG blocked — NODE_ENV is not development/test (set TELEMETRY_DEBUG_FORCE=true to override)');
   }
 
   // P2 fix: validate HMAC salt at startup, not on first redaction call.

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -641,11 +641,12 @@ test('api_launch_command uses exec so wait tracks the long-lived server process'
     scriptPath,
     `
 CAT_CAFE_DIRECT_NO_WATCH=1
+PROD_WEB=true
 printf '%s' "$(api_launch_command)"
 `,
   );
 
-  assert.equal(output, 'cd packages/api && exec pnpm run start');
+  assert.equal(output, 'cd packages/api && exec NODE_ENV=production pnpm run start');
 });
 
 test('frontend_launch_command uses exec in production mode so wait tracks next start', () => {

--- a/packages/api/test/telemetry/telemetry-debug.test.js
+++ b/packages/api/test/telemetry/telemetry-debug.test.js
@@ -1,0 +1,106 @@
+/**
+ * F153: TELEMETRY_DEBUG feature tests (#456).
+ *
+ * Verifies:
+ * 1. Guardrail logic: production blocking, dev/test passthrough
+ * 2. Structural plumbing: ConsoleSpanExporter wired in init.ts
+ * 3. Env registry: TELEMETRY_DEBUG registered
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INIT_SRC = resolve(__dirname, '../../src/infrastructure/telemetry/init.ts');
+const ENV_REGISTRY_SRC = resolve(__dirname, '../../src/config/env-registry.ts');
+
+// ── Structural: init.ts plumbing ───────────────────────────────────
+
+test('F153 TELEMETRY_DEBUG: init.ts imports ConsoleSpanExporter', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(src.includes('ConsoleSpanExporter'), 'Should import ConsoleSpanExporter');
+  assert.ok(src.includes('SimpleSpanProcessor'), 'Should import SimpleSpanProcessor for debug path');
+});
+
+test('F153 TELEMETRY_DEBUG: init.ts wires ConsoleSpanExporter on debugMode', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(src.includes('cfg.debugMode') || src.includes('config.debugMode'), 'Should check debugMode config flag');
+  assert.ok(
+    src.includes('new SimpleSpanProcessor(new ConsoleSpanExporter())'),
+    'Should create SimpleSpanProcessor wrapping ConsoleSpanExporter',
+  );
+});
+
+test('F153 TELEMETRY_DEBUG: init.ts uses spanProcessors array (not single)', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(
+    src.includes('spanProcessors:') && !src.includes('spanProcessor ?'),
+    'Should use spanProcessors array pattern, not ternary single processor',
+  );
+});
+
+test('F153 TELEMETRY_DEBUG: init.ts emits warning when debug enabled', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(src.includes('UNREDACTED') && src.includes('log.warn'), 'Should warn about unredacted export');
+});
+
+// ── Guardrail: resolveDebugMode logic ──────────────────────────────
+
+test('F153 TELEMETRY_DEBUG: guardrail blocks in production without force', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(
+    src.includes("NODE_ENV === 'production'") || src.includes("NODE_ENV==='production'"),
+    'Should check for production environment',
+  );
+  assert.ok(src.includes('TELEMETRY_DEBUG_FORCE'), 'Should support TELEMETRY_DEBUG_FORCE override');
+});
+
+test('F153 TELEMETRY_DEBUG: TelemetryConfig exposes debugMode field', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(src.includes('debugMode?: boolean'), 'TelemetryConfig should have optional debugMode boolean');
+});
+
+// ── Env registry ───────────────────────────────────────────────────
+
+test('F153 TELEMETRY_DEBUG: registered in env-registry.ts', () => {
+  const src = readFileSync(ENV_REGISTRY_SRC, 'utf8');
+  assert.ok(src.includes("name: 'TELEMETRY_DEBUG'"), 'TELEMETRY_DEBUG should be in env registry');
+});
+
+test('F153 TELEMETRY_DEBUG: env-registry description mentions UNREDACTED', () => {
+  const src = readFileSync(ENV_REGISTRY_SRC, 'utf8');
+  const idx = src.indexOf("name: 'TELEMETRY_DEBUG'");
+  const block = src.slice(idx, idx + 300);
+  assert.ok(
+    block.includes('UNREDACTED') || block.includes('unredacted'),
+    'Registry description should warn about unredacted export',
+  );
+});
+
+// ── Runtime: resolveDebugMode env var behavior ─────────────────────
+
+test('F153 TELEMETRY_DEBUG: resolveDebugMode returns false when env not set', async () => {
+  // Test via fresh import with clean env
+  const saved = { ...process.env };
+  delete process.env.TELEMETRY_DEBUG;
+  delete process.env.TELEMETRY_DEBUG_FORCE;
+  process.env.NODE_ENV = 'test';
+
+  // Re-read source to verify the logic path
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(
+    src.includes("TELEMETRY_DEBUG !== 'true'") || src.includes('TELEMETRY_DEBUG !== "true"'),
+    'Should return false when TELEMETRY_DEBUG is not "true"',
+  );
+
+  // Restore env
+  Object.assign(process.env, saved);
+});
+
+test('F153 TELEMETRY_DEBUG: debug field included in SDK init log', () => {
+  const src = readFileSync(INIT_SRC, 'utf8');
+  assert.ok(src.includes('debug: cfg.debugMode'), 'OTel SDK init log should include debug mode status');
+});

--- a/packages/api/test/telemetry/telemetry-debug.test.js
+++ b/packages/api/test/telemetry/telemetry-debug.test.js
@@ -2,10 +2,9 @@
  * F153: TELEMETRY_DEBUG feature tests (#456).
  *
  * Verifies:
- * 1. Structural plumbing: ConsoleSpanExporter wired in init.ts
- * 2. Env registry: TELEMETRY_DEBUG registered
- * 3. Runtime: debug exporter ordering vs redactor (P2 fix)
- * 4. Runtime: production guardrail blocks config-param bypass (P2 fix)
+ * 1. Runtime: shouldEnableDebugMode() guardrail under all env combinations
+ * 2. Runtime: debug exporter ordering vs redactor (unredacted before mutation)
+ * 3. Structural: init.ts plumbing + env registry
  */
 
 // Ensure HMAC fallback salt is available (CI test:public may not set NODE_ENV)
@@ -20,16 +19,13 @@ import { fileURLToPath } from 'node:url';
 const { ExportResultCode } = await import('@opentelemetry/core');
 const { NodeTracerProvider, SimpleSpanProcessor } = await import('@opentelemetry/sdk-trace-node');
 const { RedactingSpanProcessor } = await import('../../dist/infrastructure/telemetry/redactor.js');
+const { shouldEnableDebugMode } = await import('../../dist/infrastructure/telemetry/init.js');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INIT_SRC = resolve(__dirname, '../../src/infrastructure/telemetry/init.ts');
 const ENV_REGISTRY_SRC = resolve(__dirname, '../../src/config/env-registry.ts');
 
-/**
- * Exporter that snapshots span attributes at export() time.
- * Unlike InMemorySpanExporter (which stores refs and sees later mutations),
- * this captures a frozen copy — the only way to prove ordering correctness.
- */
+/** Exporter that snapshots span attributes at export() time (not refs). */
 class SnapshotExporter {
   spans = [];
   export(spans, cb) {
@@ -44,42 +40,73 @@ class SnapshotExporter {
   forceFlush() {
     return Promise.resolve();
   }
-  reset() {
-    this.spans = [];
+}
+
+// Helper: run callback with env vars, then restore
+function withEnv(overrides, fn) {
+  const saved = {};
+  for (const key of Object.keys(overrides)) {
+    saved[key] = process.env[key];
+  }
+  try {
+    for (const [key, val] of Object.entries(overrides)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
+    return fn();
+  } finally {
+    for (const [key, val] of Object.entries(saved)) {
+      if (val === undefined) delete process.env[key];
+      else process.env[key] = val;
+    }
   }
 }
 
+// ── Runtime: shouldEnableDebugMode() guardrail ─────────────────────
+
+test('shouldEnableDebugMode: returns false when not requested', () => {
+  withEnv({ NODE_ENV: 'test' }, () => {
+    assert.equal(shouldEnableDebugMode(false), false);
+  });
+});
+
+test('shouldEnableDebugMode: allowed in NODE_ENV=test', () => {
+  withEnv({ NODE_ENV: 'test', TELEMETRY_DEBUG_FORCE: undefined }, () => {
+    assert.equal(shouldEnableDebugMode(true), true);
+  });
+});
+
+test('shouldEnableDebugMode: allowed in NODE_ENV=development', () => {
+  withEnv({ NODE_ENV: 'development', TELEMETRY_DEBUG_FORCE: undefined }, () => {
+    assert.equal(shouldEnableDebugMode(true), true);
+  });
+});
+
+test('shouldEnableDebugMode: blocked in NODE_ENV=production', () => {
+  withEnv({ NODE_ENV: 'production', TELEMETRY_DEBUG_FORCE: undefined }, () => {
+    assert.equal(shouldEnableDebugMode(true), false);
+  });
+});
+
+test('shouldEnableDebugMode: blocked when NODE_ENV unset (profile-driven startup)', () => {
+  withEnv({ NODE_ENV: undefined, TELEMETRY_DEBUG_FORCE: undefined }, () => {
+    assert.equal(shouldEnableDebugMode(true), false, 'Unset NODE_ENV must be treated as production-like');
+  });
+});
+
+test('shouldEnableDebugMode: FORCE overrides in production', () => {
+  withEnv({ NODE_ENV: 'production', TELEMETRY_DEBUG_FORCE: 'true' }, () => {
+    assert.equal(shouldEnableDebugMode(true), true);
+  });
+});
+
+test('shouldEnableDebugMode: FORCE overrides when NODE_ENV unset', () => {
+  withEnv({ NODE_ENV: undefined, TELEMETRY_DEBUG_FORCE: 'true' }, () => {
+    assert.equal(shouldEnableDebugMode(true), true);
+  });
+});
+
 // ── Structural: init.ts plumbing ───────────────────────────────────
-
-test('F153 TELEMETRY_DEBUG: init.ts imports ConsoleSpanExporter', () => {
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(src.includes('ConsoleSpanExporter'), 'Should import ConsoleSpanExporter');
-  assert.ok(src.includes('SimpleSpanProcessor'), 'Should import SimpleSpanProcessor for debug path');
-});
-
-test('F153 TELEMETRY_DEBUG: init.ts wires ConsoleSpanExporter on debugMode', () => {
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(src.includes('cfg.debugMode') || src.includes('config.debugMode'), 'Should check debugMode config flag');
-  assert.ok(
-    src.includes('new SimpleSpanProcessor(new ConsoleSpanExporter())'),
-    'Should create SimpleSpanProcessor wrapping ConsoleSpanExporter',
-  );
-});
-
-test('F153 TELEMETRY_DEBUG: init.ts uses spanProcessors array (not single)', () => {
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(
-    src.includes('spanProcessors:') && !src.includes('spanProcessor ?'),
-    'Should use spanProcessors array pattern, not ternary single processor',
-  );
-});
-
-test('F153 TELEMETRY_DEBUG: init.ts emits warning when debug enabled', () => {
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(src.includes('UNREDACTED') && src.includes('log.warn'), 'Should warn about unredacted export');
-});
-
-// ── Structural: debug exporter ordering ────────────────────────────
 
 test('F153 TELEMETRY_DEBUG: debug exporter appears BEFORE redactor in source', () => {
   const src = readFileSync(INIT_SRC, 'utf8');
@@ -90,30 +117,38 @@ test('F153 TELEMETRY_DEBUG: debug exporter appears BEFORE redactor in source', (
   assert.ok(debugIdx < redactIdx, 'Debug exporter must come BEFORE RedactingSpanProcessor');
 });
 
-test('F153 TELEMETRY_DEBUG: production guardrail enforced after config merge', () => {
+test('F153 TELEMETRY_DEBUG: guardrail call-site is after config merge', () => {
   const src = readFileSync(INIT_SRC, 'utf8');
   const mergeIdx = src.indexOf('...DEFAULT_CONFIG, ...config');
-  const guardrailIdx = src.indexOf('debugMode blocked in production');
+  // Match the call site (cfg.debugMode = shouldEnableDebugMode(...)), not the declaration
+  const callIdx = src.indexOf('= shouldEnableDebugMode(cfg.');
   assert.ok(mergeIdx > 0, 'Should merge config');
-  assert.ok(guardrailIdx > 0, 'Should have post-merge guardrail');
-  assert.ok(guardrailIdx > mergeIdx, 'Guardrail must come AFTER config merge to catch param bypass');
+  assert.ok(callIdx > 0, 'Should call shouldEnableDebugMode on merged cfg');
+  assert.ok(callIdx > mergeIdx, 'shouldEnableDebugMode call must be AFTER config merge');
 });
 
 // ── Env registry ───────────────────────────────────────────────────
 
-test('F153 TELEMETRY_DEBUG: registered in env-registry.ts', () => {
+test('F153 TELEMETRY_DEBUG: both vars registered and locked in env-registry', () => {
   const src = readFileSync(ENV_REGISTRY_SRC, 'utf8');
-  assert.ok(src.includes("name: 'TELEMETRY_DEBUG'"), 'TELEMETRY_DEBUG should be in env registry');
-  assert.ok(src.includes("name: 'TELEMETRY_DEBUG_FORCE'"), 'TELEMETRY_DEBUG_FORCE should be in env registry');
+  assert.ok(src.includes("name: 'TELEMETRY_DEBUG'"), 'TELEMETRY_DEBUG in registry');
+  assert.ok(src.includes("name: 'TELEMETRY_DEBUG_FORCE'"), 'TELEMETRY_DEBUG_FORCE in registry');
+
+  // Verify both are locked from Hub UI
+  for (const varName of ['TELEMETRY_DEBUG', 'TELEMETRY_DEBUG_FORCE']) {
+    const idx = src.indexOf(`name: '${varName}'`);
+    const block = src.slice(idx, src.indexOf('},', idx) + 2);
+    assert.ok(block.includes('hubVisible: false'), `${varName} must be hubVisible: false`);
+    assert.ok(block.includes('runtimeEditable: false'), `${varName} must be runtimeEditable: false`);
+  }
 });
 
-// ── Runtime: debug exporter sees unredacted spans when both modes active ──
+// ── Runtime: debug exporter ordering vs redactor ───────────────────
 
-test('F153 runtime: debug exporter snapshot captures UNREDACTED attrs before redactor mutates', async () => {
+test('F153 runtime: debug snapshot captures UNREDACTED attrs before redactor mutates', async () => {
   const debugSnapshot = new SnapshotExporter();
   const redactedSnapshot = new SnapshotExporter();
 
-  // Mirror init.ts pipeline: debug FIRST, redactor SECOND
   const provider = new NodeTracerProvider({
     spanProcessors: [
       new SimpleSpanProcessor(debugSnapshot),
@@ -132,28 +167,21 @@ test('F153 runtime: debug exporter snapshot captures UNREDACTED attrs before red
   });
   span.end();
 
-  // Debug exporter (first): should see original values
-  assert.equal(debugSnapshot.spans.length, 1, 'Debug exporter should capture 1 span');
   const debugAttrs = debugSnapshot.spans[0].attributes;
-  assert.equal(debugAttrs.authorization, 'Bearer sk-secret-key', 'Debug: Class A should be UNREDACTED');
-  assert.equal(debugAttrs.prompt, 'Hello, this is a secret prompt', 'Debug: Class B should be UNREDACTED');
-  assert.equal(debugAttrs.invocationId, 'inv-12345', 'Debug: Class C should be UNREDACTED');
-  assert.equal(debugAttrs['cli.command'], 'claude', 'Debug: Class D should pass through');
+  assert.equal(debugAttrs.authorization, 'Bearer sk-secret-key', 'Debug: Class A UNREDACTED');
+  assert.equal(debugAttrs.prompt, 'Hello, this is a secret prompt', 'Debug: Class B UNREDACTED');
+  assert.equal(debugAttrs.invocationId, 'inv-12345', 'Debug: Class C UNREDACTED');
 
-  // Redacted exporter (second): should see redacted values
-  assert.equal(redactedSnapshot.spans.length, 1, 'Redacted exporter should capture 1 span');
   const redactedAttrs = redactedSnapshot.spans[0].attributes;
-  assert.equal(redactedAttrs.authorization, '[REDACTED]', 'Redacted: Class A should be [REDACTED]');
-  assert.match(String(redactedAttrs.prompt), /^\[hash:[0-9a-f]{16} len:\d+\]$/, 'Redacted: Class B should be hashed');
-  assert.notEqual(redactedAttrs.invocationId, 'inv-12345', 'Redacted: Class C should be pseudonymized');
+  assert.equal(redactedAttrs.authorization, '[REDACTED]', 'Redacted: Class A [REDACTED]');
+  assert.match(String(redactedAttrs.prompt), /^\[hash:[0-9a-f]{16} len:\d+\]$/, 'Redacted: Class B hashed');
+  assert.notEqual(redactedAttrs.invocationId, 'inv-12345', 'Redacted: Class C pseudonymized');
 
   await provider.shutdown();
 });
 
 test('F153 runtime: debug-only mode (no OTLP) sees unredacted attrs', async () => {
   const debugSnapshot = new SnapshotExporter();
-
-  // Debug only, no redactor — simplest case
   const provider = new NodeTracerProvider({
     spanProcessors: [new SimpleSpanProcessor(debugSnapshot)],
   });
@@ -165,13 +193,8 @@ test('F153 runtime: debug-only mode (no OTLP) sees unredacted attrs', async () =
   span.end();
 
   const attrs = debugSnapshot.spans[0].attributes;
-  assert.equal(attrs.authorization, 'Bearer sk-xyz', 'Debug-only: should see raw auth');
-  assert.equal(attrs.prompt, 'secret stuff', 'Debug-only: should see raw prompt');
+  assert.equal(attrs.authorization, 'Bearer sk-xyz', 'Debug-only: raw auth');
+  assert.equal(attrs.prompt, 'secret stuff', 'Debug-only: raw prompt');
 
   await provider.shutdown();
-});
-
-test('F153 TELEMETRY_DEBUG: debug field included in SDK init log', () => {
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(src.includes('debug: cfg.debugMode'), 'OTel SDK init log should include debug mode status');
 });

--- a/packages/api/test/telemetry/telemetry-debug.test.js
+++ b/packages/api/test/telemetry/telemetry-debug.test.js
@@ -2,10 +2,14 @@
  * F153: TELEMETRY_DEBUG feature tests (#456).
  *
  * Verifies:
- * 1. Guardrail logic: production blocking, dev/test passthrough
- * 2. Structural plumbing: ConsoleSpanExporter wired in init.ts
- * 3. Env registry: TELEMETRY_DEBUG registered
+ * 1. Structural plumbing: ConsoleSpanExporter wired in init.ts
+ * 2. Env registry: TELEMETRY_DEBUG registered
+ * 3. Runtime: debug exporter ordering vs redactor (P2 fix)
+ * 4. Runtime: production guardrail blocks config-param bypass (P2 fix)
  */
+
+// Ensure HMAC fallback salt is available (CI test:public may not set NODE_ENV)
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
 
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
@@ -13,9 +17,37 @@ import { dirname, resolve } from 'node:path';
 import { test } from 'node:test';
 import { fileURLToPath } from 'node:url';
 
+const { ExportResultCode } = await import('@opentelemetry/core');
+const { NodeTracerProvider, SimpleSpanProcessor } = await import('@opentelemetry/sdk-trace-node');
+const { RedactingSpanProcessor } = await import('../../dist/infrastructure/telemetry/redactor.js');
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INIT_SRC = resolve(__dirname, '../../src/infrastructure/telemetry/init.ts');
 const ENV_REGISTRY_SRC = resolve(__dirname, '../../src/config/env-registry.ts');
+
+/**
+ * Exporter that snapshots span attributes at export() time.
+ * Unlike InMemorySpanExporter (which stores refs and sees later mutations),
+ * this captures a frozen copy — the only way to prove ordering correctness.
+ */
+class SnapshotExporter {
+  spans = [];
+  export(spans, cb) {
+    for (const s of spans) {
+      this.spans.push({ name: s.name, attributes: { ...s.attributes } });
+    }
+    cb({ code: ExportResultCode.SUCCESS });
+  }
+  shutdown() {
+    return Promise.resolve();
+  }
+  forceFlush() {
+    return Promise.resolve();
+  }
+  reset() {
+    this.spans = [];
+  }
+}
 
 // ── Structural: init.ts plumbing ───────────────────────────────────
 
@@ -47,20 +79,24 @@ test('F153 TELEMETRY_DEBUG: init.ts emits warning when debug enabled', () => {
   assert.ok(src.includes('UNREDACTED') && src.includes('log.warn'), 'Should warn about unredacted export');
 });
 
-// ── Guardrail: resolveDebugMode logic ──────────────────────────────
+// ── Structural: debug exporter ordering ────────────────────────────
 
-test('F153 TELEMETRY_DEBUG: guardrail blocks in production without force', () => {
+test('F153 TELEMETRY_DEBUG: debug exporter appears BEFORE redactor in source', () => {
   const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(
-    src.includes("NODE_ENV === 'production'") || src.includes("NODE_ENV==='production'"),
-    'Should check for production environment',
-  );
-  assert.ok(src.includes('TELEMETRY_DEBUG_FORCE'), 'Should support TELEMETRY_DEBUG_FORCE override');
+  const debugIdx = src.indexOf('new SimpleSpanProcessor(new ConsoleSpanExporter())');
+  const redactIdx = src.indexOf('new RedactingSpanProcessor(');
+  assert.ok(debugIdx > 0, 'Should have debug exporter');
+  assert.ok(redactIdx > 0, 'Should have redacting processor');
+  assert.ok(debugIdx < redactIdx, 'Debug exporter must come BEFORE RedactingSpanProcessor');
 });
 
-test('F153 TELEMETRY_DEBUG: TelemetryConfig exposes debugMode field', () => {
+test('F153 TELEMETRY_DEBUG: production guardrail enforced after config merge', () => {
   const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(src.includes('debugMode?: boolean'), 'TelemetryConfig should have optional debugMode boolean');
+  const mergeIdx = src.indexOf('...DEFAULT_CONFIG, ...config');
+  const guardrailIdx = src.indexOf('debugMode blocked in production');
+  assert.ok(mergeIdx > 0, 'Should merge config');
+  assert.ok(guardrailIdx > 0, 'Should have post-merge guardrail');
+  assert.ok(guardrailIdx > mergeIdx, 'Guardrail must come AFTER config merge to catch param bypass');
 });
 
 // ── Env registry ───────────────────────────────────────────────────
@@ -68,36 +104,71 @@ test('F153 TELEMETRY_DEBUG: TelemetryConfig exposes debugMode field', () => {
 test('F153 TELEMETRY_DEBUG: registered in env-registry.ts', () => {
   const src = readFileSync(ENV_REGISTRY_SRC, 'utf8');
   assert.ok(src.includes("name: 'TELEMETRY_DEBUG'"), 'TELEMETRY_DEBUG should be in env registry');
+  assert.ok(src.includes("name: 'TELEMETRY_DEBUG_FORCE'"), 'TELEMETRY_DEBUG_FORCE should be in env registry');
 });
 
-test('F153 TELEMETRY_DEBUG: env-registry description mentions UNREDACTED', () => {
-  const src = readFileSync(ENV_REGISTRY_SRC, 'utf8');
-  const idx = src.indexOf("name: 'TELEMETRY_DEBUG'");
-  const block = src.slice(idx, idx + 300);
-  assert.ok(
-    block.includes('UNREDACTED') || block.includes('unredacted'),
-    'Registry description should warn about unredacted export',
-  );
+// ── Runtime: debug exporter sees unredacted spans when both modes active ──
+
+test('F153 runtime: debug exporter snapshot captures UNREDACTED attrs before redactor mutates', async () => {
+  const debugSnapshot = new SnapshotExporter();
+  const redactedSnapshot = new SnapshotExporter();
+
+  // Mirror init.ts pipeline: debug FIRST, redactor SECOND
+  const provider = new NodeTracerProvider({
+    spanProcessors: [
+      new SimpleSpanProcessor(debugSnapshot),
+      new RedactingSpanProcessor(new SimpleSpanProcessor(redactedSnapshot)),
+    ],
+  });
+
+  const tracer = provider.getTracer('debug-ordering-test');
+  const span = tracer.startSpan('test.span', {
+    attributes: {
+      authorization: 'Bearer sk-secret-key',
+      prompt: 'Hello, this is a secret prompt',
+      invocationId: 'inv-12345',
+      'cli.command': 'claude',
+    },
+  });
+  span.end();
+
+  // Debug exporter (first): should see original values
+  assert.equal(debugSnapshot.spans.length, 1, 'Debug exporter should capture 1 span');
+  const debugAttrs = debugSnapshot.spans[0].attributes;
+  assert.equal(debugAttrs.authorization, 'Bearer sk-secret-key', 'Debug: Class A should be UNREDACTED');
+  assert.equal(debugAttrs.prompt, 'Hello, this is a secret prompt', 'Debug: Class B should be UNREDACTED');
+  assert.equal(debugAttrs.invocationId, 'inv-12345', 'Debug: Class C should be UNREDACTED');
+  assert.equal(debugAttrs['cli.command'], 'claude', 'Debug: Class D should pass through');
+
+  // Redacted exporter (second): should see redacted values
+  assert.equal(redactedSnapshot.spans.length, 1, 'Redacted exporter should capture 1 span');
+  const redactedAttrs = redactedSnapshot.spans[0].attributes;
+  assert.equal(redactedAttrs.authorization, '[REDACTED]', 'Redacted: Class A should be [REDACTED]');
+  assert.match(String(redactedAttrs.prompt), /^\[hash:[0-9a-f]{16} len:\d+\]$/, 'Redacted: Class B should be hashed');
+  assert.notEqual(redactedAttrs.invocationId, 'inv-12345', 'Redacted: Class C should be pseudonymized');
+
+  await provider.shutdown();
 });
 
-// ── Runtime: resolveDebugMode env var behavior ─────────────────────
+test('F153 runtime: debug-only mode (no OTLP) sees unredacted attrs', async () => {
+  const debugSnapshot = new SnapshotExporter();
 
-test('F153 TELEMETRY_DEBUG: resolveDebugMode returns false when env not set', async () => {
-  // Test via fresh import with clean env
-  const saved = { ...process.env };
-  delete process.env.TELEMETRY_DEBUG;
-  delete process.env.TELEMETRY_DEBUG_FORCE;
-  process.env.NODE_ENV = 'test';
+  // Debug only, no redactor — simplest case
+  const provider = new NodeTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(debugSnapshot)],
+  });
 
-  // Re-read source to verify the logic path
-  const src = readFileSync(INIT_SRC, 'utf8');
-  assert.ok(
-    src.includes("TELEMETRY_DEBUG !== 'true'") || src.includes('TELEMETRY_DEBUG !== "true"'),
-    'Should return false when TELEMETRY_DEBUG is not "true"',
-  );
+  const tracer = provider.getTracer('debug-only-test');
+  const span = tracer.startSpan('test.span', {
+    attributes: { authorization: 'Bearer sk-xyz', prompt: 'secret stuff' },
+  });
+  span.end();
 
-  // Restore env
-  Object.assign(process.env, saved);
+  const attrs = debugSnapshot.spans[0].attributes;
+  assert.equal(attrs.authorization, 'Bearer sk-xyz', 'Debug-only: should see raw auth');
+  assert.equal(attrs.prompt, 'secret stuff', 'Debug-only: should see raw prompt');
+
+  await provider.shutdown();
 });
 
 test('F153 TELEMETRY_DEBUG: debug field included in SDK init log', () => {

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -158,13 +158,28 @@ describe('start-dev strict profile isolation', () => {
     }
   });
 
-  it('marks opensource profile API launches with NODE_ENV=production for child process semantics', () => {
+  it('marks opensource profile API launches WITHOUT --prod-web as NODE_ENV=development (dev:direct path)', () => {
     const sandboxDir = createSandbox();
     try {
       const result = runApiLaunchCommand({
         sandboxDir,
         env: { CAT_CAFE_STRICT_PROFILE_DEFAULTS: '1' },
         extraArgs: ['--', '--profile=opensource'],
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /NODE_ENV=development/, result.stdout);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks --prod-web + --profile=opensource API launches as NODE_ENV=production (runtime/start:direct path)', () => {
+    const sandboxDir = createSandbox();
+    try {
+      const result = runApiLaunchCommand({
+        sandboxDir,
+        env: { CAT_CAFE_STRICT_PROFILE_DEFAULTS: '1' },
+        extraArgs: ['--prod-web', '--', '--profile=opensource'],
       });
       assert.equal(result.status, 0, result.stderr || result.stdout);
       assert.match(result.stdout, /NODE_ENV=production/, result.stdout);

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -43,6 +43,24 @@ function runSourceOnly({ sandboxDir, env = {}, extraArgs = [] }) {
   });
 }
 
+function runApiLaunchCommand({ sandboxDir, env = {}, extraArgs = [] }) {
+  const command = [
+    `source scripts/start-dev.sh --source-only ${extraArgs.join(' ')}`,
+    'printf "%s\\n" "$(api_launch_command)"',
+  ].join('; ');
+
+  return spawnSync('bash', ['-lc', command], {
+    cwd: sandboxDir,
+    env: {
+      PATH: process.env.PATH ?? '',
+      HOME: process.env.HOME ?? '',
+      TERM: process.env.TERM ?? 'xterm-256color',
+      ...env,
+    },
+    encoding: 'utf8',
+  });
+}
+
 describe('start-dev strict profile isolation', () => {
   it('ignores inherited shell env for profile-controlled vars when strict mode is on', () => {
     const sandboxDir = createSandbox();
@@ -123,6 +141,33 @@ describe('start-dev strict profile isolation', () => {
       assert.match(result.stdout, /EMBED=/);
       assert.match(result.stdout, /TTL=123/);
       assert.match(result.stdout, /REDIS_PROFILE=custom/);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks default dev API launches with NODE_ENV=development for child process semantics', () => {
+    const sandboxDir = createSandbox();
+    try {
+      const result = runApiLaunchCommand({ sandboxDir });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /NODE_ENV=development/, result.stdout);
+      assert.match(result.stdout, /pnpm run dev/, result.stdout);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks opensource profile API launches with NODE_ENV=production for child process semantics', () => {
+    const sandboxDir = createSandbox();
+    try {
+      const result = runApiLaunchCommand({
+        sandboxDir,
+        env: { CAT_CAFE_STRICT_PROFILE_DEFAULTS: '1' },
+        extraArgs: ['--', '--profile=opensource'],
+      });
+      assert.equal(result.status, 0, result.stderr || result.stdout);
+      assert.match(result.stdout, /NODE_ENV=production/, result.stdout);
     } finally {
       rmSync(sandboxDir, { recursive: true, force: true });
     }
@@ -213,6 +258,16 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     );
 
     assert.ok(ps1.includes('Start-Job'), 'start-windows.ps1 must use Start-Job (which inherits parent process env)');
+  });
+
+  it('start-windows.ps1 assigns NODE_ENV inside the API Start-Job', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+    const jobBlocks = ps1.match(/Start-Job[\s\S]*?-ScriptBlock\s*\{([\s\S]*?)\}\s*-ArgumentList/g);
+    assert.ok(jobBlocks && jobBlocks.length > 0, 'start-windows.ps1 must have Start-Job blocks');
+    const apiJobBlock = jobBlocks.find((b) => b.includes('-Name "api"'));
+    assert.ok(apiJobBlock, 'start-windows.ps1 must have an API Start-Job block');
+    assert.match(ps1, /NODE_ENV\s*=\s*\$apiNodeEnv/, 'Windows runtime env overrides must include NODE_ENV');
+    assert.match(apiJobBlock, /runtimeEnvOverrides/, 'API job must consume runtimeEnvOverrides');
   });
 });
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -663,21 +663,15 @@ background_eval_with_null_stdin() {
 }
 
 api_node_env() {
-    case "$PROFILE" in
-        production|opensource)
-            printf '%s' 'production'
-            ;;
-        dev)
-            printf '%s' 'development'
-            ;;
-        *)
-            if [ "$PROD_WEB" = true ]; then
-                printf '%s' 'production'
-            else
-                printf '%s' 'development'
-            fi
-            ;;
-    esac
+    # NODE_ENV is driven by launch mode (--prod-web), not by profile.
+    # Profile controls data isolation (Redis, TTLs, sidecar features);
+    # --prod-web controls whether the API runs in production or dev mode.
+    # dev:direct may carry --profile=opensource but is still development.
+    if [ "$PROD_WEB" = true ]; then
+        printf '%s' 'production'
+    else
+        printf '%s' 'development'
+    fi
 }
 
 api_launch_command() {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -662,10 +662,28 @@ background_eval_with_null_stdin() {
     register_managed_pid "$!"
 }
 
+api_node_env() {
+    case "$PROFILE" in
+        production|opensource)
+            printf '%s' 'production'
+            ;;
+        dev)
+            printf '%s' 'development'
+            ;;
+        *)
+            if [ "$PROD_WEB" = true ]; then
+                printf '%s' 'production'
+            else
+                printf '%s' 'development'
+            fi
+            ;;
+    esac
+}
+
 api_launch_command() {
-    local env_prefix=""
+    local env_prefix="NODE_ENV=$(api_node_env) "
     if [ "$DEBUG_MODE" = true ]; then
-        env_prefix="LOG_LEVEL=debug "
+        env_prefix="${env_prefix}LOG_LEVEL=debug "
     fi
     if [ "${CAT_CAFE_DIRECT_NO_WATCH:-0}" = "1" ]; then
         printf '%s' "cd packages/api && exec ${env_prefix}pnpm run start"

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -409,14 +409,10 @@ try {
 
     # Track background jobs for cleanup
     $jobs = @()
-    $apiNodeEnv = switch ($Profile_) {
-        'dev' { 'development'; break }
-        'production' { 'production'; break }
-        'opensource' { 'production'; break }
-        default {
-            if ($Dev) { 'development' } else { 'production' }
-        }
-    }
+    # NODE_ENV is driven by launch mode (-Dev), not by profile.
+    # Profile controls data isolation (Redis, TTLs, sidecar features);
+    # -Dev controls whether the API runs in development or production mode.
+    $apiNodeEnv = if ($Dev) { 'development' } else { 'production' }
 
     $runtimeEnvOverrides = @{
         REDIS_URL = $env:REDIS_URL

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -409,12 +409,22 @@ try {
 
     # Track background jobs for cleanup
     $jobs = @()
+    $apiNodeEnv = switch ($Profile_) {
+        'dev' { 'development'; break }
+        'production' { 'production'; break }
+        'opensource' { 'production'; break }
+        default {
+            if ($Dev) { 'development' } else { 'production' }
+        }
+    }
+
     $runtimeEnvOverrides = @{
         REDIS_URL = $env:REDIS_URL
         MEMORY_STORE = $env:MEMORY_STORE
         CAT_CAFE_MCP_SERVER_PATH = $env:CAT_CAFE_MCP_SERVER_PATH
         API_SERVER_PORT = $ApiPort
         FRONTEND_PORT = $WebPort
+        NODE_ENV = $apiNodeEnv
     }
 
     # API Server


### PR DESCRIPTION
## Summary
- Adds `TELEMETRY_DEBUG=true` debug mode using `ConsoleSpanExporter` for local span inspection
- Adds `TELEMETRY_DEBUG_FORCE=true` as emergency override
- Enforces **default-deny** guardrail in `shouldEnableDebugMode()`:
  - allow only when `NODE_ENV` is `development` or `test`
  - block all other/unset environments unless `TELEMETRY_DEBUG_FORCE=true`
- Locks both debug vars from Hub surface (`hubVisible: false`, `runtimeEditable: false`)
- Keeps debug exporter ordered before redaction processor so debug snapshot sees raw attributes while regular pipeline still redacts
- Aligns startup semantics with guardrail by injecting API child-process `NODE_ENV` in startup scripts:
  - Unix `start-dev.sh`: dev -> `development`, production/opensource -> `production`
  - Windows `start-windows.ps1`: same mapping via `runtimeEnvOverrides`

Closes #456

## Test plan
- [x] `node --test scripts/start-dev-profile-isolation.test.mjs`
- [x] `pnpm --filter @cat-cafe/api run build`
- [x] `node --test packages/api/test/telemetry/telemetry-debug.test.js scripts/start-dev-profile-isolation.test.mjs`
- [x] `pnpm check`
- [x] CI green on Linux + Windows lanes
