### PR TITLE
fix(startup): route env-prefixed API launch through env

### DIFF
--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -646,7 +646,22 @@ printf '%s' "$(api_launch_command)"
 `,
   );
 
-  assert.equal(output, 'cd packages/api && exec NODE_ENV=production pnpm run start');
+  assert.equal(output, 'cd packages/api && exec env NODE_ENV=production pnpm run start');
+});
+
+test('api_launch_command routes multiple env assignments through env before pnpm', () => {
+  const scriptPath = resolve(process.cwd(), '../../scripts/start-dev.sh');
+  const output = runSourceOnlySnippet(
+    scriptPath,
+    `
+CAT_CAFE_DIRECT_NO_WATCH=1
+PROD_WEB=true
+DEBUG_MODE=true
+printf '%s' "$(api_launch_command)"
+`,
+  );
+
+  assert.equal(output, 'cd packages/api && exec env NODE_ENV=production LOG_LEVEL=debug pnpm run start');
 });
 
 test('frontend_launch_command uses exec in production mode so wait tracks next start', () => {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -680,9 +680,9 @@ api_launch_command() {
         env_prefix="${env_prefix}LOG_LEVEL=debug "
     fi
     if [ "${CAT_CAFE_DIRECT_NO_WATCH:-0}" = "1" ]; then
-        printf '%s' "cd packages/api && exec ${env_prefix}pnpm run start"
+        printf '%s' "cd packages/api && exec env ${env_prefix}pnpm run start"
     else
-        printf '%s' "cd packages/api && exec ${env_prefix}pnpm run dev"
+        printf '%s' "cd packages/api && exec env ${env_prefix}pnpm run dev"
     fi
 }
 


### PR DESCRIPTION
Fixes #526

## Summary
- route `api_launch_command()` through `exec env ... pnpm` so bash no longer treats `NODE_ENV=...` as an executable name
- apply the same fix to both `start` and `dev` launch paths
- update the existing start-dev script assertion to the correct command form
- add a regression test covering multiple env assignments (`NODE_ENV` + `LOG_LEVEL`) before `pnpm`

## Verification
- `node --test test/start-dev-script.test.js` (run from `packages/api/`)
