### PR TITLE
fix(startup): opensource profile TTL 86400→0

### DIFF
--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -90,7 +90,7 @@ describe('start-dev strict profile isolation', () => {
       assert.match(result.stdout, /TTS=0/);
       assert.match(result.stdout, /LLM=0/);
       assert.match(result.stdout, /EMBED=/);
-      assert.match(result.stdout, /TTL=86400/);
+      assert.match(result.stdout, /TTL=0/);
       assert.match(result.stdout, /REDIS_PROFILE=opensource/);
     } finally {
       rmSync(sandboxDir, { recursive: true, force: true });

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -17,14 +17,14 @@
 #   ./scripts/start-dev.sh --status   — 查看 daemon 状态
 #   ./scripts/start-dev.sh --profile=dev          — 家里开发默认值 (proxy ON, sidecar ON)
 #   ./scripts/start-dev.sh --profile=production   — 日常生产 (proxy OFF, sidecar OFF, TTL=永久)
-#   ./scripts/start-dev.sh --profile=opensource   — 开源演示 (proxy OFF, sidecar OFF, TTL=1天)
+#   ./scripts/start-dev.sh --profile=opensource   — 开源演示 (proxy OFF, sidecar OFF, TTL=永久)
 #   ./scripts/start-dev.sh -- --npm-registry=URL --pip-index-url=URL --hf-endpoint=URL
 #                                               — 显式指定安装/模型下载镜像（仅手动 override）
 #
 # Profile 说明:
 #   dev        — proxy ON, ASR/TTS/LLM ON, TTL=永久, redis-dev
 #   production — proxy OFF, ASR/TTS/LLM OFF, TTL=永久, redis-opensource (日常生产)
-#   opensource — proxy OFF, ASR/TTS/LLM OFF, TTL=86400s, redis-opensource (开源演示)
+#   opensource — proxy OFF, ASR/TTS/LLM OFF, TTL=永久, redis-opensource (开源演示)
 #   (无)       — 保持原有行为（各项 ENABLED 默认 0）
 #
 # .env 中的显式值覆盖 profile 默认值。启动摘要标注每个值的来源。
@@ -225,10 +225,10 @@ apply_profile_defaults() {
             _PROF_ASR_ENABLED=0
             _PROF_TTS_ENABLED=0
             _PROF_LLM_POSTPROCESS_ENABLED=0
-            _PROF_MESSAGE_TTL_SECONDS=86400
-            _PROF_THREAD_TTL_SECONDS=86400
-            _PROF_TASK_TTL_SECONDS=86400
-            _PROF_SUMMARY_TTL_SECONDS=86400
+            _PROF_MESSAGE_TTL_SECONDS=0
+            _PROF_THREAD_TTL_SECONDS=0
+            _PROF_TASK_TTL_SECONDS=0
+            _PROF_SUMMARY_TTL_SECONDS=0
             _PROF_REDIS_PROFILE=opensource
             ;;
         "")

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -94,8 +94,8 @@ switch ($Profile_) {
         $profileDefaults = @{
             ANTHROPIC_PROXY_ENABLED = '0'; ASR_ENABLED = '0'
             TTS_ENABLED = '0'; LLM_POSTPROCESS_ENABLED = '0'
-            MESSAGE_TTL_SECONDS = '86400'; THREAD_TTL_SECONDS = '86400'
-            TASK_TTL_SECONDS = '86400'; SUMMARY_TTL_SECONDS = '86400'
+            MESSAGE_TTL_SECONDS = '0'; THREAD_TTL_SECONDS = '0'
+            TASK_TTL_SECONDS = '0'; SUMMARY_TTL_SECONDS = '0'
             REDIS_PROFILE = 'opensource'
         }
     }


### PR DESCRIPTION
## What

Change opensource profile TTL from 86400 (1 day) to 0 (persistent) in:
- `scripts/start-dev.sh`
- `scripts/start-windows.ps1`
- `scripts/start-dev-profile-isolation.test.mjs`

## Why

The opensource profile overrides code-level DEFAULT_TTL=0 with 86400 seconds.
Community users running any version via `pnpm start` / `pnpm start:direct` hit
1-day data expiry — threads and messages silently vanish after 24 hours.

This is a companion fix to cat-cafe source commit `9b27f7aae`.

## Issue Closure

- Related: LL-048 (user data must not silently expire)

## Sync Note

This PR mirrors the same change already committed to cat-cafe source (`9b27f7aae`).
Please register this PR in the sync ledger to avoid future sync conflicts.

## Test Evidence

`bash scripts/test-start-dev.sh` — all passed (cat-cafe source)

---

布偶猫/宪宪 (opus)