### PR TITLE
fix(web): per-slot cancel and correct active cat display

### DIFF
--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -65,6 +65,7 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
   const {
     messages,
     hasActiveInvocation,
+    activeInvocations,
     intentMode,
     targetCats,
     catStatuses,
@@ -768,6 +769,8 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
             targetCats={targetCats}
             catStatuses={catStatuses}
             catInvocations={catInvocations}
+            activeInvocations={activeInvocations}
+            hasActiveInvocation={hasActiveInvocation}
             threadId={threadId}
             messageSummary={messageSummary}
             width={statusPanelWidth}
@@ -787,6 +790,8 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
         targetCats={targetCats}
         catStatuses={catStatuses}
         catInvocations={catInvocations}
+        activeInvocations={activeInvocations}
+        hasActiveInvocation={hasActiveInvocation}
         threadId={threadId}
         messageSummary={messageSummary}
       />

--- a/packages/web/src/components/MobileStatusSheet.tsx
+++ b/packages/web/src/components/MobileStatusSheet.tsx
@@ -2,7 +2,6 @@
 
 import { useMemo } from 'react';
 import { formatCatName, useCatData } from '@/hooks/useCatData';
-import { useChatStore } from '@/stores/chatStore';
 import { CatTokenUsage } from './CatTokenUsage';
 import type { RightStatusPanelProps } from './RightStatusPanel';
 import {
@@ -36,7 +35,6 @@ export function MobileStatusSheet({
   messageSummary,
 }: MobileStatusSheetProps) {
   const { getCatById } = useCatData();
-  const activeInvocations = useChatStore((s) => s.activeInvocations);
 
   const activeCats = useMemo(() => {
     const snapshotCats = collectSnapshotActiveCats(catInvocations);

--- a/packages/web/src/components/MobileStatusSheet.tsx
+++ b/packages/web/src/components/MobileStatusSheet.tsx
@@ -4,9 +4,15 @@ import { useMemo } from 'react';
 import { formatCatName, useCatData } from '@/hooks/useCatData';
 import { useChatStore } from '@/stores/chatStore';
 import { CatTokenUsage } from './CatTokenUsage';
-import { deriveActiveCats } from './parallel-status-helpers';
 import type { RightStatusPanelProps } from './RightStatusPanel';
-import { modeLabel, statusLabel, statusTone, truncateId } from './status-helpers';
+import {
+  collectSnapshotActiveCats,
+  deriveActiveCats,
+  modeLabel,
+  statusLabel,
+  statusTone,
+  truncateId,
+} from './status-helpers';
 
 interface MobileStatusSheetProps extends RightStatusPanelProps {
   open: boolean;
@@ -24,6 +30,8 @@ export function MobileStatusSheet({
   targetCats,
   catStatuses,
   catInvocations,
+  activeInvocations,
+  hasActiveInvocation,
   threadId,
   messageSummary,
 }: MobileStatusSheetProps) {
@@ -31,16 +39,9 @@ export function MobileStatusSheet({
   const activeInvocations = useChatStore((s) => s.activeInvocations);
 
   const activeCats = useMemo(() => {
-    const snapshotCats = Object.entries(catInvocations)
-      .filter(([, inv]) => {
-        const taskProgress = inv.taskProgress;
-        if (!taskProgress || taskProgress.tasks.length === 0) return false;
-        return taskProgress.snapshotStatus !== 'completed';
-      })
-      .map(([catId]) => catId);
-    const slotCats = deriveActiveCats(targetCats, activeInvocations);
-    return Array.from(new Set([...slotCats, ...snapshotCats]));
-  }, [targetCats, catInvocations, activeInvocations]);
+    const snapshotCats = collectSnapshotActiveCats(catInvocations);
+    return deriveActiveCats({ targetCats, snapshotCats, activeInvocations, hasActiveInvocation });
+  }, [targetCats, catInvocations, activeInvocations, hasActiveInvocation]);
 
   const allParticipants = useMemo(() => {
     return [...new Set([...activeCats, ...Object.keys(catInvocations)])];

--- a/packages/web/src/components/ParallelStatusBar.tsx
+++ b/packages/web/src/components/ParallelStatusBar.tsx
@@ -6,8 +6,7 @@ import { hexToRgba } from '@/lib/color-utils';
 import type { TokenUsage } from '@/stores/chat-types';
 import type { CatInvocationInfo } from '@/stores/chatStore';
 import { useChatStore } from '@/stores/chatStore';
-import { deriveActiveCats } from './parallel-status-helpers';
-import { formatCost, formatDuration, formatTokenCount } from './status-helpers';
+import { deriveActiveCats, formatCost, formatDuration, formatTokenCount } from './status-helpers';
 
 function StatusDot({ status }: { status: string }) {
   switch (status) {
@@ -98,19 +97,22 @@ export function aggregateUsage(
 }
 
 export function ParallelStatusBar({ onStop }: { onStop?: () => void }) {
-  const { targetCats, activeInvocations, catStatuses, catInvocations } = useChatStore();
+  const { targetCats, catStatuses, catInvocations, activeInvocations, hasActiveInvocation } = useChatStore();
+  const activeCats = deriveActiveCats({
+    targetCats,
+    activeInvocations,
+    hasActiveInvocation,
+  });
 
-  const displayCats = deriveActiveCats(targetCats, activeInvocations);
+  if (activeCats.length === 0) return null;
 
-  if (displayCats.length === 0) return null;
-
-  const agg = aggregateUsage(catInvocations, displayCats);
+  const agg = aggregateUsage(catInvocations, activeCats);
 
   return (
     <div className="px-5 py-2.5 bg-gradient-to-r from-opus-bg via-codex-bg to-gemini-bg border-b border-cafe">
       <div className="flex items-center gap-4">
         <span className="text-sm font-medium text-cafe-secondary">独立观点采样中</span>
-        {displayCats.map((catId) => (
+        {activeCats.map((catId) => (
           <CatStatusCard
             key={catId}
             catId={catId}

--- a/packages/web/src/components/RightStatusPanel.tsx
+++ b/packages/web/src/components/RightStatusPanel.tsx
@@ -8,9 +8,17 @@ import { apiFetch } from '@/utils/api-client';
 import { AuditExplorerPanel } from './audit/AuditExplorerPanel';
 import { CatTokenUsage } from './CatTokenUsage';
 import { PlanBoardPanel } from './PlanBoardPanel';
-import { deriveActiveCats } from './parallel-status-helpers';
 import { SessionChainPanel } from './SessionChainPanel';
-import { type CatStatus, type IntentMode, modeLabel, statusLabel, statusTone, truncateId } from './status-helpers';
+import {
+  type CatStatus,
+  collectSnapshotActiveCats,
+  deriveActiveCats,
+  type IntentMode,
+  modeLabel,
+  statusLabel,
+  statusTone,
+  truncateId,
+} from './status-helpers';
 import { CatInvocationTime, CollapsibleIds } from './status-panel-parts';
 
 export interface RightStatusPanelProps {
@@ -18,6 +26,8 @@ export interface RightStatusPanelProps {
   targetCats: string[];
   catStatuses: Record<string, CatStatus>;
   catInvocations: Record<string, CatInvocationInfo>;
+  activeInvocations?: Record<string, { catId: string; mode: string; startedAt?: number }>;
+  hasActiveInvocation?: boolean;
   threadId: string;
   messageSummary: {
     total: number;
@@ -320,6 +330,8 @@ export function RightStatusPanel({
   targetCats,
   catStatuses,
   catInvocations,
+  activeInvocations,
+  hasActiveInvocation,
   threadId,
   messageSummary,
   width,
@@ -327,19 +339,12 @@ export function RightStatusPanel({
   const activeInvocations = useChatStore((s) => s.activeInvocations);
   // F26: Split into active (working now) vs history (appeared before)
   const { activeCats, historyCats } = useMemo(() => {
-    const snapshotCats = Object.entries(catInvocations)
-      .filter(([, inv]) => {
-        const taskProgress = inv.taskProgress;
-        if (!taskProgress || taskProgress.tasks.length === 0) return false;
-        return taskProgress.snapshotStatus !== 'completed';
-      })
-      .map(([catId]) => catId);
-    const slotCats = deriveActiveCats(targetCats, activeInvocations);
-    const active = Array.from(new Set([...slotCats, ...snapshotCats]));
+    const snapshotCats = collectSnapshotActiveCats(catInvocations);
+    const active = deriveActiveCats({ targetCats, snapshotCats, activeInvocations, hasActiveInvocation });
     const allParticipants = new Set([...active, ...Object.keys(catInvocations)]);
     const history = [...allParticipants].filter((c) => !active.includes(c));
     return { activeCats: active, historyCats: history };
-  }, [targetCats, catInvocations, activeInvocations]);
+  }, [targetCats, catInvocations, activeInvocations, hasActiveInvocation]);
 
   const { getCatById } = useCatData();
   const [historyOpen, setHistoryOpen] = useState(false);

--- a/packages/web/src/components/RightStatusPanel.tsx
+++ b/packages/web/src/components/RightStatusPanel.tsx
@@ -336,7 +336,6 @@ export function RightStatusPanel({
   messageSummary,
   width,
 }: RightStatusPanelProps) {
-  const activeInvocations = useChatStore((s) => s.activeInvocations);
   // F26: Split into active (working now) vs history (appeared before)
   const { activeCats, historyCats } = useMemo(() => {
     const snapshotCats = collectSnapshotActiveCats(catInvocations);

--- a/packages/web/src/components/ThinkingIndicator.tsx
+++ b/packages/web/src/components/ThinkingIndicator.tsx
@@ -70,7 +70,7 @@ function SquareIcon({ className }: { className?: string }) {
 }
 
 interface ThinkingIndicatorProps {
-  onCancel?: (threadId: string) => void;
+  onCancel?: (threadId: string, catId?: string) => void;
 }
 
 /**
@@ -82,11 +82,18 @@ export function ThinkingIndicator({ onCancel }: ThinkingIndicatorProps = {}) {
   const targetCats = useChatStore((s) => s.targetCats);
   const catStatuses = useChatStore((s) => s.catStatuses);
   const catInvocations = useChatStore((s) => s.catInvocations);
+  const activeInvocations = useChatStore((s) => s.activeInvocations);
   const currentThreadId = useChatStore((s) => s.currentThreadId);
   const { getCatById } = useCatData();
 
   if (targetCats.length !== 1) return null;
-  const catId = targetCats[0];
+  // Derive display+cancel target from the same truth source (activeInvocations)
+  // to avoid "显示 A、取消 B" when targetCats is stale.
+  const catId = (() => {
+    const slots = Object.values(activeInvocations ?? {});
+    if (slots.length === 1) return slots[0]?.catId ?? targetCats[0];
+    return targetCats[0];
+  })();
   const status: CatStatusType = catStatuses[catId] ?? 'pending';
   if (status === 'done') return null;
 
@@ -160,7 +167,7 @@ export function ThinkingIndicator({ onCancel }: ThinkingIndicatorProps = {}) {
           {onCancel && currentThreadId && (
             <button
               data-testid="cancel-btn"
-              onClick={() => onCancel(currentThreadId)}
+              onClick={() => onCancel(currentThreadId, catId)}
               className="flex items-center gap-1.5 px-4 py-2 rounded-[10px] text-[13px] font-semibold text-white flex-shrink-0 transition-opacity hover:opacity-90"
               style={{ backgroundColor: '#D08068' }}
             >

--- a/packages/web/src/components/ThinkingIndicator.tsx
+++ b/packages/web/src/components/ThinkingIndicator.tsx
@@ -86,14 +86,11 @@ export function ThinkingIndicator({ onCancel }: ThinkingIndicatorProps = {}) {
   const currentThreadId = useChatStore((s) => s.currentThreadId);
   const { getCatById } = useCatData();
 
-  if (targetCats.length !== 1) return null;
   // Derive display+cancel target from the same truth source (activeInvocations)
   // to avoid "显示 A、取消 B" when targetCats is stale.
-  const catId = (() => {
-    const slots = Object.values(activeInvocations ?? {});
-    if (slots.length === 1) return slots[0]?.catId ?? targetCats[0];
-    return targetCats[0];
-  })();
+  const slots = Object.values(activeInvocations ?? {});
+  const catId = slots.length === 1 ? slots[0]?.catId : targetCats.length === 1 ? targetCats[0] : undefined;
+  if (!catId) return null;
   const status: CatStatusType = catStatuses[catId] ?? 'pending';
   if (status === 'done') return null;
 
@@ -166,6 +163,7 @@ export function ThinkingIndicator({ onCancel }: ThinkingIndicatorProps = {}) {
           </div>
           {onCancel && currentThreadId && (
             <button
+              type="button"
               data-testid="cancel-btn"
               onClick={() => onCancel(currentThreadId, catId)}
               className="flex items-center gap-1.5 px-4 py-2 rounded-[10px] text-[13px] font-semibold text-white flex-shrink-0 transition-opacity hover:opacity-90"

--- a/packages/web/src/components/__tests__/ThinkingIndicator-liveness.test.ts
+++ b/packages/web/src/components/__tests__/ThinkingIndicator-liveness.test.ts
@@ -13,6 +13,7 @@ vi.mock('@/hooks/useCatData', () => ({
 
 const storeState: Record<string, unknown> = {
   targetCats: ['codex'],
+  activeInvocations: {} as Record<string, { catId: string; mode: string }>,
   catStatuses: {} as Record<string, string>,
   catInvocations: {} as Record<string, unknown>,
   currentThreadId: 'thread-1',
@@ -44,6 +45,11 @@ describe('F118 ThinkingIndicator liveness states', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     mockCancelInvocation.mockClear();
+    storeState.targetCats = ['codex'];
+    storeState.activeInvocations = {};
+    storeState.catStatuses = {};
+    storeState.catInvocations = {};
+    storeState.currentThreadId = 'thread-1';
   });
 
   afterEach(() => {
@@ -98,7 +104,7 @@ describe('F118 ThinkingIndicator liveness states', () => {
     const { ThinkingIndicator } = await import('../ThinkingIndicator');
     act(() => {
       root.render(
-        React.createElement(ThinkingIndicator as React.FC<{ onCancel?: (threadId: string) => void }>, {
+        React.createElement(ThinkingIndicator as React.FC<{ onCancel?: (threadId: string, catId?: string) => void }>, {
           onCancel: mockCancelInvocation,
         }),
       );
@@ -130,7 +136,7 @@ describe('F118 ThinkingIndicator liveness states', () => {
     const { ThinkingIndicator } = await import('../ThinkingIndicator');
     act(() => {
       root.render(
-        React.createElement(ThinkingIndicator as React.FC<{ onCancel?: (threadId: string) => void }>, {
+        React.createElement(ThinkingIndicator as React.FC<{ onCancel?: (threadId: string, catId?: string) => void }>, {
           onCancel: mockCancelInvocation,
         }),
       );
@@ -141,7 +147,58 @@ describe('F118 ThinkingIndicator liveness states', () => {
       cancelBtn.click();
     });
 
-    expect(mockCancelInvocation).toHaveBeenCalledWith('thread-1');
+    expect(mockCancelInvocation).toHaveBeenCalledWith('thread-1', 'codex');
+  });
+
+  it('renders from a single active slot even when targetCats is stale or empty', async () => {
+    storeState.targetCats = [];
+    storeState.activeInvocations = {
+      'inv-opus': { catId: 'opus', mode: 'execute' },
+    };
+    storeState.catStatuses = { opus: 'streaming' };
+
+    const { ThinkingIndicator } = await import('../ThinkingIndicator');
+    act(() => {
+      root.render(React.createElement(ThinkingIndicator));
+    });
+
+    expect(container.textContent).toContain('opus');
+    expect(container.textContent).toContain('回复中');
+  });
+
+  it('uses single active slot as cancel target when targetCats contains multiple stale cats', async () => {
+    storeState.targetCats = ['codex', 'opus'];
+    storeState.activeInvocations = {
+      'inv-codex': { catId: 'codex', mode: 'execute' },
+    };
+    storeState.catStatuses = { codex: 'suspected_stall' };
+    storeState.catInvocations = {
+      codex: {
+        livenessWarning: {
+          level: 'suspected_stall',
+          state: 'idle-silent',
+          silenceDurationMs: 312000,
+          processAlive: true,
+          receivedAt: Date.now(),
+        },
+      },
+    };
+
+    const { ThinkingIndicator } = await import('../ThinkingIndicator');
+    act(() => {
+      root.render(
+        React.createElement(ThinkingIndicator as React.FC<{ onCancel?: (threadId: string, catId?: string) => void }>, {
+          onCancel: mockCancelInvocation,
+        }),
+      );
+    });
+
+    const cancelBtn = container.querySelector('[data-testid="cancel-btn"]') as HTMLButtonElement;
+    act(() => {
+      cancelBtn.click();
+    });
+
+    expect(mockCancelInvocation).toHaveBeenCalledWith('thread-1', 'codex');
   });
 
   it('normal thinking state renders paw emoji (KD-9: Apple emoji preferred over Lucide SVG)', async () => {

--- a/packages/web/src/components/__tests__/mobile-status-sheet.test.ts
+++ b/packages/web/src/components/__tests__/mobile-status-sheet.test.ts
@@ -84,6 +84,26 @@ describe('MobileStatusSheet', () => {
     expect(container.textContent).toContain('缅因猫');
   });
 
+  it('prefers activeInvocations over stale targetCats when provided', () => {
+    const props = {
+      ...baseProps,
+      open: true,
+      targetCats: ['codex'],
+      catStatuses: { codex: 'pending' as CatStatus, dare: 'streaming' as CatStatus },
+      activeInvocations: {
+        'inv-dare-1': { catId: 'dare', mode: 'execute' },
+      },
+      hasActiveInvocation: true,
+    };
+
+    act(() => {
+      root.render(React.createElement(MobileStatusSheet, props));
+    });
+
+    expect(container.textContent).toContain('dare');
+    expect(container.textContent).not.toContain('缅因猫');
+  });
+
   it('shows close button that calls onClose', () => {
     let closed = false;
     const props = {

--- a/packages/web/src/components/__tests__/right-status-panel.test.ts
+++ b/packages/web/src/components/__tests__/right-status-panel.test.ts
@@ -37,6 +37,30 @@ describe('RightStatusPanel', () => {
     expect(html).toContain('12');
   });
 
+  it('prefers activeInvocations over stale targetCats when provided by ChatContainer', () => {
+    const html = render({
+      intentMode: 'execute',
+      targetCats: ['codex'],
+      catStatuses: { codex: 'pending', dare: 'streaming' },
+      catInvocations: {},
+      activeInvocations: {
+        'inv-dare-1': { catId: 'dare', mode: 'execute' },
+      },
+      hasActiveInvocation: true,
+      threadId: 'thread-slot-priority',
+      messageSummary: {
+        total: 2,
+        assistant: 1,
+        system: 1,
+        evidence: 0,
+        followup: 0,
+      },
+    });
+
+    expect(html).toContain('dare');
+    expect(html).not.toContain('缅因猫');
+  });
+
   it('shows "空闲" when no target cats', () => {
     const html = render({
       intentMode: null,

--- a/packages/web/src/components/__tests__/status-helpers-liveness.test.ts
+++ b/packages/web/src/components/__tests__/status-helpers-liveness.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { statusLabel, statusTone } from '../status-helpers';
+import { deriveActiveCats, statusLabel, statusTone } from '../status-helpers';
 
 describe('statusLabel — liveness states (F118 AC-C1)', () => {
   it('returns 静默等待 for alive_but_silent', () => {
@@ -18,5 +18,46 @@ describe('statusTone — liveness states (F118 AC-C1)', () => {
 
   it('returns orange for suspected_stall', () => {
     expect(statusTone('suspected_stall')).toBe('text-orange-600');
+  });
+});
+
+describe('deriveActiveCats — slot-first truth source', () => {
+  it('keeps legacy targetCats behavior when slot metadata is absent', () => {
+    expect(deriveActiveCats({ targetCats: ['opus'], snapshotCats: ['codex'] })).toEqual(['opus', 'codex']);
+  });
+
+  it('prefers invocation slots over stale targetCats', () => {
+    const active = deriveActiveCats({
+      targetCats: ['codex'],
+      snapshotCats: [],
+      hasActiveInvocation: true,
+      activeInvocations: {
+        'inv-1': { catId: 'dare', mode: 'execute' },
+      },
+    });
+
+    expect(active).toEqual(['dare']);
+  });
+
+  it('drops targetCats after invocation ends when no slots remain', () => {
+    const active = deriveActiveCats({
+      targetCats: ['codex'],
+      snapshotCats: [],
+      hasActiveInvocation: false,
+      activeInvocations: {},
+    });
+
+    expect(active).toEqual([]);
+  });
+
+  it('keeps targetCats as degraded fallback while invocation is still active but slots are not ready', () => {
+    const active = deriveActiveCats({
+      targetCats: ['opus'],
+      snapshotCats: [],
+      hasActiveInvocation: true,
+      activeInvocations: {},
+    });
+
+    expect(active).toEqual(['opus']);
   });
 });

--- a/packages/web/src/components/status-helpers.ts
+++ b/packages/web/src/components/status-helpers.ts
@@ -3,7 +3,14 @@
  */
 
 export type IntentMode = 'execute' | 'ideate' | null;
-export type CatStatus = 'spawning' | 'pending' | 'streaming' | 'done' | 'error' | 'alive_but_silent' | 'suspected_stall';
+export type CatStatus =
+  | 'spawning'
+  | 'pending'
+  | 'streaming'
+  | 'done'
+  | 'error'
+  | 'alive_but_silent'
+  | 'suspected_stall';
 export type ActiveInvocationSlot = { catId: string; mode?: string; startedAt?: number };
 export type TaskProgressSnapshot = {
   tasks?: unknown[];

--- a/packages/web/src/components/status-helpers.ts
+++ b/packages/web/src/components/status-helpers.ts
@@ -3,14 +3,64 @@
  */
 
 export type IntentMode = 'execute' | 'ideate' | null;
-export type CatStatus =
-  | 'spawning'
-  | 'pending'
-  | 'streaming'
-  | 'done'
-  | 'error'
-  | 'alive_but_silent'
-  | 'suspected_stall';
+export type CatStatus = 'spawning' | 'pending' | 'streaming' | 'done' | 'error' | 'alive_but_silent' | 'suspected_stall';
+export type ActiveInvocationSlot = { catId: string; mode?: string; startedAt?: number };
+export type TaskProgressSnapshot = {
+  tasks?: unknown[];
+  snapshotStatus?: 'running' | 'interrupted' | 'completed' | string;
+};
+
+/**
+ * Extract cats that still have a non-completed task-progress snapshot.
+ * These snapshots should remain visible even when an invocation temporarily drops.
+ */
+export function collectSnapshotActiveCats(
+  catInvocations: Record<string, { taskProgress?: TaskProgressSnapshot }>,
+): string[] {
+  return Object.entries(catInvocations)
+    .filter(([, inv]) => {
+      const taskProgress = inv.taskProgress;
+      if (!taskProgress || (taskProgress.tasks?.length ?? 0) === 0) return false;
+      return taskProgress.snapshotStatus !== 'completed';
+    })
+    .map(([catId]) => catId);
+}
+
+/**
+ * Derive cats currently considered active in UI components.
+ * Priority:
+ * 1) invocation slots (authoritative runtime truth)
+ * 2) targetCats only while invocation is still active but slots not ready (degraded)
+ * 3) snapshot-only when invocation has ended
+ * Legacy compatibility: when slot data is not provided, keep previous targetCats behavior.
+ */
+export function deriveActiveCats({
+  targetCats,
+  snapshotCats = [],
+  activeInvocations,
+  hasActiveInvocation,
+}: {
+  targetCats: string[];
+  snapshotCats?: string[];
+  activeInvocations?: Record<string, ActiveInvocationSlot>;
+  hasActiveInvocation?: boolean;
+}): string[] {
+  if (activeInvocations == null && hasActiveInvocation == null) {
+    return Array.from(new Set([...targetCats, ...snapshotCats]));
+  }
+
+  const slotCats = Array.from(
+    new Set(
+      Object.values(activeInvocations ?? {})
+        .map((slot) => slot?.catId)
+        .filter((catId): catId is string => typeof catId === 'string' && catId.length > 0),
+    ),
+  );
+
+  if (slotCats.length > 0) return Array.from(new Set([...slotCats, ...snapshotCats]));
+  if (hasActiveInvocation) return Array.from(new Set([...targetCats, ...snapshotCats]));
+  return Array.from(new Set(snapshotCats));
+}
 
 export function modeLabel(mode: IntentMode): string {
   if (mode === 'ideate') return '独立观点采样';

--- a/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
@@ -34,6 +34,7 @@ const mockGetThreadState: ReturnType<
         isStreaming?: boolean;
         timestamp: number;
       }>;
+      activeInvocations?: Record<string, { catId: string; mode: string }>;
     }
   >
 > = vi.fn(() => ({
@@ -75,6 +76,7 @@ const storeState = {
   resetThreadInvocationState: mockResetThreadInvocationState,
   setThreadMessageStreaming: mockSetThreadMessageStreaming,
   getThreadState: mockGetThreadState,
+  activeInvocations: {} as Record<string, { catId: string; mode: string }>,
   currentThreadId: 'thread-1',
 };
 
@@ -131,6 +133,7 @@ describe('useAgentMessages loading lifecycle', () => {
     mockSetThreadMessageStreaming.mockClear();
     mockGetThreadState.mockClear();
     mockGetThreadState.mockImplementation(() => ({ messages: [] }));
+    storeState.activeInvocations = {};
     storeState.currentThreadId = 'thread-1';
   });
 
@@ -317,7 +320,7 @@ describe('useAgentMessages loading lifecycle', () => {
       captured?.handleStop(cancelInvocation, 'thread-2');
     });
 
-    expect(cancelInvocation).toHaveBeenCalledWith('thread-2');
+    expect(cancelInvocation).toHaveBeenCalledWith('thread-2', undefined);
     expect(mockResetThreadInvocationState).toHaveBeenCalledWith('thread-2');
     expect(mockSetThreadMessageStreaming).toHaveBeenCalledWith('thread-2', 'bg-stream-1', false);
 
@@ -327,6 +330,41 @@ describe('useAgentMessages loading lifecycle', () => {
     expect(mockSetIntentMode).not.toHaveBeenCalledWith(null);
     expect(mockClearCatStatuses).not.toHaveBeenCalled();
     expect(mockSetStreaming).not.toHaveBeenCalled();
+  });
+
+  it('stopping a background thread derives catId from the TARGET thread slots', () => {
+    const cancelInvocation = vi.fn();
+    storeState.activeInvocations = {
+      'inv-active': { catId: 'codex', mode: 'execute' },
+    };
+
+    mockGetThreadState.mockImplementation(((tid?: string) => {
+      if (tid === 'thread-2') {
+        return {
+          messages: [] as Array<{ id: string; type: string; catId?: string; content: string; isStreaming?: boolean; timestamp: number }>,
+          activeInvocations: {
+            'inv-bg': { catId: 'dare', mode: 'execute' },
+          },
+        };
+      }
+      return {
+        messages: [] as Array<{ id: string; type: string; catId?: string; content: string; isStreaming?: boolean; timestamp: number }>,
+        activeInvocations: {
+          'inv-active': { catId: 'codex', mode: 'execute' },
+        },
+      };
+    }) as unknown as typeof mockGetThreadState);
+
+    act(() => {
+      root.render(React.createElement(Harness));
+    });
+
+    act(() => {
+      captured?.handleStop(cancelInvocation, 'thread-2');
+    });
+
+    expect(cancelInvocation).toHaveBeenCalledWith('thread-2', 'dare');
+    expect(mockResetThreadInvocationState).toHaveBeenCalledWith('thread-2');
   });
 
   it('stopping a background thread clears its pending timeout guard', () => {

--- a/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-loading.test.ts
@@ -341,14 +341,28 @@ describe('useAgentMessages loading lifecycle', () => {
     mockGetThreadState.mockImplementation(((tid?: string) => {
       if (tid === 'thread-2') {
         return {
-          messages: [] as Array<{ id: string; type: string; catId?: string; content: string; isStreaming?: boolean; timestamp: number }>,
+          messages: [] as Array<{
+            id: string;
+            type: string;
+            catId?: string;
+            content: string;
+            isStreaming?: boolean;
+            timestamp: number;
+          }>,
           activeInvocations: {
             'inv-bg': { catId: 'dare', mode: 'execute' },
           },
         };
       }
       return {
-        messages: [] as Array<{ id: string; type: string; catId?: string; content: string; isStreaming?: boolean; timestamp: number }>,
+        messages: [] as Array<{
+          id: string;
+          type: string;
+          catId?: string;
+          content: string;
+          isStreaming?: boolean;
+          timestamp: number;
+        }>,
         activeInvocations: {
           'inv-active': { catId: 'codex', mode: 'execute' },
         },

--- a/packages/web/src/hooks/__tests__/useSocket-background.test.ts
+++ b/packages/web/src/hooks/__tests__/useSocket-background.test.ts
@@ -1742,4 +1742,106 @@ describe('background thread socket handling', () => {
       expect(ts.hasActiveInvocation).toBe(true); // codex still active
     });
   });
+
+  describe('regression: background completion clears stale targetCats', () => {
+    it('codex completion clears targetCats so subsequent dare start is clean', () => {
+      const store = useChatStore.getState();
+      // codex is running with a tracked invocation slot
+      store.addThreadActiveInvocation('thread-bg', 'inv-codex-1', 'codex', 'execute');
+      store.replaceThreadTargetCats('thread-bg', ['codex']);
+      store.updateThreadCatStatus('thread-bg', 'codex', 'streaming');
+
+      // codex finishes — done(isFinal) with invocationId
+      simulateBackgroundMessage({
+        type: 'done',
+        catId: 'codex',
+        threadId: 'thread-bg',
+        invocationId: 'inv-codex-1',
+        isFinal: true,
+        timestamp: Date.now(),
+      });
+
+      // targetCats must be empty — no stale codex lingering
+      const ts = useChatStore.getState().getThreadState('thread-bg');
+      expect(ts.targetCats).toEqual([]);
+      expect(ts.catStatuses).toEqual({});
+
+      // Now dare starts via queue auto-dequeue (uses setThreadTargetCats merge)
+      store.setThreadTargetCats('thread-bg', ['dare']);
+      const ts2 = useChatStore.getState().getThreadState('thread-bg');
+      // Must be ['dare'] only, not ['codex', 'dare']
+      expect(ts2.targetCats).toEqual(['dare']);
+    });
+
+    it('multi-cat: catA done does NOT clear targetCats while catB still active', () => {
+      const store = useChatStore.getState();
+      store.addThreadActiveInvocation('thread-bg', 'inv-opus-1', 'opus', 'execute');
+      store.addThreadActiveInvocation('thread-bg', 'inv-codex-1', 'codex', 'execute');
+      store.replaceThreadTargetCats('thread-bg', ['opus', 'codex']);
+
+      // opus finishes — one slot remains
+      simulateBackgroundMessage({
+        type: 'done',
+        catId: 'opus',
+        threadId: 'thread-bg',
+        invocationId: 'inv-opus-1',
+        isFinal: true,
+        timestamp: Date.now(),
+      });
+
+      const ts = useChatStore.getState().getThreadState('thread-bg');
+      // codex slot still active — targetCats must NOT be cleared
+      expect(Object.keys(ts.activeInvocations)).toHaveLength(1);
+      expect(ts.targetCats).toEqual(['opus', 'codex']);
+    });
+
+    it('last cat done clears targetCats in multi-cat scenario', () => {
+      const store = useChatStore.getState();
+      store.addThreadActiveInvocation('thread-bg', 'inv-opus-1', 'opus', 'execute');
+      store.addThreadActiveInvocation('thread-bg', 'inv-codex-1', 'codex', 'execute');
+      store.replaceThreadTargetCats('thread-bg', ['opus', 'codex']);
+
+      // opus finishes first
+      simulateBackgroundMessage({
+        type: 'done',
+        catId: 'opus',
+        threadId: 'thread-bg',
+        invocationId: 'inv-opus-1',
+        isFinal: true,
+        timestamp: Date.now(),
+      });
+
+      // codex finishes — last slot removed
+      simulateBackgroundMessage({
+        type: 'done',
+        catId: 'codex',
+        threadId: 'thread-bg',
+        invocationId: 'inv-codex-1',
+        isFinal: true,
+        timestamp: Date.now(),
+      });
+
+      const ts = useChatStore.getState().getThreadState('thread-bg');
+      expect(ts.targetCats).toEqual([]);
+      expect(ts.catStatuses).toEqual({});
+    });
+
+    it('legacy path without activeInvocations does not clear targetCats', () => {
+      // Simulate legacy done where no activeInvocations were ever set
+      useChatStore.getState().updateThreadCatStatus('thread-bg', 'opus', 'streaming');
+
+      simulateBackgroundMessage({
+        type: 'text',
+        catId: 'opus',
+        threadId: 'thread-bg',
+        content: 'final',
+        isFinal: true,
+        timestamp: Date.now(),
+      });
+
+      // catStatus should still be 'done' — not wiped
+      const ts = useChatStore.getState().getThreadState('thread-bg');
+      expect(ts.catStatuses.opus).toBe('done');
+    });
+  });
 });

--- a/packages/web/src/hooks/useAgentMessages.ts
+++ b/packages/web/src/hooks/useAgentMessages.ts
@@ -1087,9 +1087,13 @@ export function useAgentMessages() {
   );
 
   const handleStop = useCallback(
-    (cancelFn: (threadId: string) => void, threadId: string) => {
-      cancelFn(threadId);
+    (cancelFn: (threadId: string, catId?: string) => void, threadId: string) => {
       const store = useChatStore.getState();
+      // When exactly one cat is active, cancel only that cat to avoid
+      // thread-level cancelAll accidentally killing other cats.
+      const activeSlots = Object.values(store.getThreadState(threadId).activeInvocations ?? {});
+      const singleCatId = activeSlots.length === 1 ? activeSlots[0]?.catId : undefined;
+      cancelFn(threadId, singleCatId);
       const isActiveThreadStop = threadId === store.currentThreadId;
 
       if (!isActiveThreadStop) {

--- a/packages/web/src/hooks/useSocket-background.ts
+++ b/packages/web/src/hooks/useSocket-background.ts
@@ -287,14 +287,18 @@ function markThreadInvocationActive(msg: BackgroundAgentMessage, options: Handle
 function markThreadInvocationComplete(msg: BackgroundAgentMessage, options: HandleBackgroundMessageOptions): void {
   options.store.setThreadLoading(msg.threadId, false);
   options.store.setThreadCatInvocation(msg.threadId, msg.catId, { invocationId: undefined });
+
+  // Snapshot slot count before removal to detect actual transition to zero.
+  const stateBefore = options.store.getThreadState(msg.threadId);
+  const slotsBefore = Object.keys(stateBefore.activeInvocations ?? {}).length;
+
   // F108: slot-aware — remove specific invocation if ID available.
   // Cancel fallback: find and remove only this cat's latest active slot to avoid
   // clearing other cats' slots during multi-cat concurrent dispatch.
   if (msg.invocationId) {
     // F869: Multi-cat slot-aware cleanup. Only remove the slot that belongs to
     // THIS cat (primary key or synthetic key), not another cat's slot.
-    const threadState = options.store.getThreadState(msg.threadId);
-    const primarySlot = threadState.activeInvocations[msg.invocationId];
+    const primarySlot = stateBefore.activeInvocations[msg.invocationId];
     if (primarySlot?.catId === msg.catId) {
       options.store.removeThreadActiveInvocation(msg.threadId, msg.invocationId);
     }
@@ -308,12 +312,23 @@ function markThreadInvocationComplete(msg: BackgroundAgentMessage, options: Hand
       options.store.removeThreadActiveInvocation(msg.threadId, orphan);
     }
   } else {
-    const threadState = options.store.getThreadState(msg.threadId);
-    const catSlot = findLatestActiveInvocationIdForCat(threadState.activeInvocations, msg.catId);
+    const catSlot = findLatestActiveInvocationIdForCat(stateBefore.activeInvocations, msg.catId);
     if (catSlot) {
       options.store.removeThreadActiveInvocation(msg.threadId, catSlot);
     } else {
       options.store.setThreadHasActiveInvocation(msg.threadId, false);
+    }
+  }
+
+  // Fix: clear targetCats/catStatuses when the last tracked invocation ends.
+  // Only fire when we actually transitioned from >0 to 0 slots — not when
+  // there were never any tracked slots (e.g. legacy paths without activeInvocations).
+  // Without this, stale cats accumulate via merge semantics in setThreadTargetCats,
+  // causing the status panel to display the wrong cat after thread switch.
+  if (slotsBefore > 0) {
+    const slotsAfter = Object.keys(options.store.getThreadState(msg.threadId).activeInvocations ?? {}).length;
+    if (slotsAfter === 0) {
+      options.store.replaceThreadTargetCats(msg.threadId, []);
     }
   }
 }

--- a/packages/web/src/hooks/useSocket-background.types.ts
+++ b/packages/web/src/hooks/useSocket-background.types.ts
@@ -83,6 +83,7 @@ export interface BackgroundStoreLike {
   }) => void;
   clearThreadActiveInvocation: (threadId: string) => void;
   getThreadState: (threadId: string) => ThreadState;
+  replaceThreadTargetCats: (threadId: string, cats: string[]) => void;
   replaceThreadMessageId: (threadId: string, fromId: string, toId: string) => void;
   patchThreadMessage: (threadId: string, messageId: string, patch: ChatMessagePatch) => void;
 }

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -878,8 +878,8 @@ export function useSocket(callbacks: SocketCallbacks, threadId?: string) {
     });
   }, [threadId, storeThreadId]);
 
-  const cancelInvocation = useCallback((tid: string) => {
-    socketRef.current?.emit('cancel_invocation', { threadId: tid });
+  const cancelInvocation = useCallback((tid: string, catId?: string) => {
+    socketRef.current?.emit('cancel_invocation', catId ? { threadId: tid, catId } : { threadId: tid });
   }, []);
 
   return { socketRef, joinRoom, leaveRoom, syncRooms, cancelInvocation };


### PR DESCRIPTION
## Summary

- **P1 — targetCats 状态污染**：background thread 最后一个 invocation 完成后，`markThreadInvocationComplete` 不清理 `targetCats`，导致旧猫残留、前端显示错猫。修复：`slotsAfter === 0` 时调用 `replaceThreadTargetCats(threadId, [])`
- **P1 — Stop 全线程 cancelAll**：`cancelInvocation` 不带 `catId`，服务端走 `cancelAll(threadId)` 打断所有猫。修复：接受可选 `catId`，单猫时 emit 带 catId；`handleStop` 从目标线程 slots 推导 catId（`getThreadState(threadId)`）
- **P1 — ThinkingIndicator 显示/取消不同源**：优先从 `activeInvocations` 单 slot 推导 catId，fallback `targetCats[0]`，确保 cancel 按钮和显示猫同源
- **P2 — RightStatusPanel/ParallelStatusBar/MobileStatusSheet**：active cat 显示改为 slot-first（`deriveActiveCats` 新函数），`status-helpers` 新增 `collectSnapshotActiveCats`

## Root cause

前端把 route intent（`targetCats`）当 active state 用 + 通用 Stop 是 cancelAll。两个源头独立修复后，串台/误打断问题关闭。

## Test plan

- [x] `useSocket-background.test.ts` 58 pass — background completion 清理、多猫最后一只清理、单猫 partial 不清理
- [x] `status-helpers-liveness.test.ts` 8 pass — slot-first 推导、legacy fallback
- [x] `useAgentMessages-loading.test.ts` — 有 `act()` env 失败（pre-existing，main 也失败）；新增 background stop catId 路由测试逻辑已验证通过
- [x] 无新增 Biome error，无新增 TS error

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Issue Closure

- Closes #534
