### PR TITLE
fix(telegram): eliminate streaming duplicate messages and align completion state UI

### DIFF
--- a/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
+++ b/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
@@ -111,7 +111,10 @@ export class StreamingOutboundHook {
       const adapter = this.opts.adapters.get(session.connectorId);
       if (!adapter?.editMessage || !session.platformMessageId) continue;
       try {
-        await adapter.editMessage(session.externalChatId, session.platformMessageId, `${accumulatedText} ▌`);
+        const chunkPrefix = session.connectorId === 'telegram'
+          ? `【${session.catDisplayName || '猫猫'}🐱 思考中...】\n`
+          : '';
+        await adapter.editMessage(session.externalChatId, session.platformMessageId, `${chunkPrefix}${accumulatedText} ▌`);
         session.lastUpdateAt = now;
         session.lastContentLength = accumulatedText.length;
         session.lastAccumulatedText = accumulatedText;
@@ -139,9 +142,14 @@ export class StreamingOutboundHook {
         // If deleteMessage exists, defer cleanup (delete placeholder after edit).
         const resolvedFinalText =
           finalText.trim().length > 0 ? finalText : session.lastAccumulatedText || '⚠️ 回复中断，请重试';
+        // Completion state: replace "思考中..." prefix with "✅" to signal done
+        const finalPrefix = session.connectorId === 'telegram'
+          ? `【${session.catDisplayName || '猫猫'}🐱 ✅】\n`
+          : '';
+        const finalMessage = `${finalPrefix}${resolvedFinalText}`;
         let editSucceeded = false;
         try {
-          await adapter.editMessage(session.externalChatId, session.platformMessageId, resolvedFinalText);
+          await adapter.editMessage(session.externalChatId, session.platformMessageId, finalMessage);
           editSucceeded = true;
         } catch (err) {
           this.opts.log.warn({ err }, '[StreamingOutbound] onStreamEnd editMessage failed — removing from skip list for fallback delivery');

--- a/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
+++ b/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
@@ -12,9 +12,12 @@ interface StreamingSession {
   readonly externalChatId: string;
   /** Display name of the cat that owns this streaming session (for finalizeStreamCard). */
   readonly catDisplayName: string;
+  /** Connector edits the placeholder into the final content instead of sending a new message. */
+  readonly ownsFinalDelivery: boolean;
   platformMessageId: string;
   lastUpdateAt: number;
   lastContentLength: number;
+  lastAccumulatedText: string;
 }
 
 export interface StreamingOutboundHookOptions {
@@ -28,6 +31,7 @@ export interface StreamingOutboundHookOptions {
 export class StreamingOutboundHook {
   private readonly sessions = new Map<string, StreamingSession[]>();
   private readonly pendingCleanup = new Map<string, StreamingSession[]>();
+  private readonly deliverySkipConnectors = new Map<string, string[]>();
   private readonly updateIntervalMs: number;
   private readonly minDeltaChars: number;
 
@@ -64,13 +68,16 @@ export class StreamingOutboundHook {
           binding.connectorId === 'feishu' ? `${prefix}${pickReceiptLine(catId)}` : `${prefix}🤔 思考中...`;
         const msgId = await adapter.sendPlaceholder(binding.externalChatId, placeholderText);
         if (msgId) {
+          const ownsFinalDelivery = adapter.ownsFinalDelivery === true;
           sessions.push({
             connectorId: binding.connectorId,
             externalChatId: binding.externalChatId,
             catDisplayName: displayName,
+            ownsFinalDelivery,
             platformMessageId: msgId,
             lastUpdateAt: Date.now(),
             lastContentLength: 0,
+            lastAccumulatedText: '',
           });
         }
       } catch (err) {
@@ -81,6 +88,12 @@ export class StreamingOutboundHook {
     if (sessions.length > 0) {
       const key = this.scopeKey(threadId, invocationId);
       this.sessions.set(key, sessions);
+      const skipConnectorIds = [...new Set(sessions.filter((s) => s.ownsFinalDelivery).map((s) => s.connectorId))];
+      if (skipConnectorIds.length > 0) {
+        this.deliverySkipConnectors.set(key, skipConnectorIds);
+      } else {
+        this.deliverySkipConnectors.delete(key);
+      }
     }
   }
 
@@ -101,6 +114,7 @@ export class StreamingOutboundHook {
         await adapter.editMessage(session.externalChatId, session.platformMessageId, `${accumulatedText} ▌`);
         session.lastUpdateAt = now;
         session.lastContentLength = accumulatedText.length;
+        session.lastAccumulatedText = accumulatedText;
       } catch (err) {
         this.opts.log.warn({ err }, '[StreamingOutbound] editMessage chunk failed');
       }
@@ -117,12 +131,43 @@ export class StreamingOutboundHook {
     for (const session of sessions) {
       const adapter = this.opts.adapters.get(session.connectorId);
       if (!session.platformMessageId) continue;
-      if (adapter?.deleteMessage || adapter?.finalizeStreamCard) {
-        // Defer cleanup — keep placeholder as fallback until outbound delivery succeeds
+      if (adapter?.finalizeStreamCard) {
+        // Feishu-style: edit to "✅ 已回复" completion state, final content delivered separately
+        deferred.push(session);
+      } else if (session.ownsFinalDelivery && adapter?.editMessage) {
+        // Telegram-style: adapter owns final delivery, write final content inline now.
+        // If deleteMessage exists, defer cleanup (delete placeholder after edit).
+        const resolvedFinalText =
+          finalText.trim().length > 0 ? finalText : session.lastAccumulatedText || '⚠️ 回复中断，请重试';
+        let editSucceeded = false;
+        try {
+          await adapter.editMessage(session.externalChatId, session.platformMessageId, resolvedFinalText);
+          editSucceeded = true;
+        } catch (err) {
+          this.opts.log.warn({ err }, '[StreamingOutbound] onStreamEnd editMessage failed — removing from skip list for fallback delivery');
+          // Remove from skip list so OutboundDeliveryHook can deliver as fallback
+          const key = this.scopeKey(threadId, invocationId);
+          const skipList = this.deliverySkipConnectors.get(key);
+          if (skipList) {
+            const updated = skipList.filter((id) => id !== session.connectorId);
+            if (updated.length > 0) {
+              this.deliverySkipConnectors.set(key, updated);
+            } else {
+              this.deliverySkipConnectors.delete(key);
+            }
+          }
+        }
+        if (editSucceeded && adapter?.deleteMessage) {
+          deferred.push(session);
+        }
+      } else if (adapter?.deleteMessage) {
+        // Has deleteMessage but not ownsFinalDelivery — defer cleanup only
         deferred.push(session);
       } else if (adapter?.editMessage) {
         try {
-          await adapter.editMessage(session.externalChatId, session.platformMessageId, finalText);
+          const resolvedFinalText =
+            finalText.trim().length > 0 ? finalText : session.lastAccumulatedText || '⚠️ 回复中断，请重试';
+          await adapter.editMessage(session.externalChatId, session.platformMessageId, resolvedFinalText);
         } catch (err) {
           this.opts.log.warn({ err }, '[StreamingOutbound] onStreamEnd editMessage failed');
         }
@@ -137,9 +182,12 @@ export class StreamingOutboundHook {
    * Clean up streaming placeholders after outbound delivery succeeds.
    * F157: Prefer finalizeStreamCard (edit to "✅ 已回复") over deleteMessage
    * to avoid Feishu's "recalled a message" notification.
+   * Inline-final adapters may not have a pending cleanup entry here; this still
+   * clears any delivery-skip bookkeeping created during onStreamStart.
    */
   async cleanupPlaceholders(threadId: string, invocationId?: string): Promise<void> {
     const key = this.scopeKey(threadId, invocationId);
+    this.deliverySkipConnectors.delete(key);
     const sessions = this.pendingCleanup.get(key);
     if (!sessions) return;
     this.pendingCleanup.delete(key);
@@ -158,6 +206,11 @@ export class StreamingOutboundHook {
         this.opts.log.warn({ err }, '[StreamingOutbound] cleanupPlaceholders failed');
       }
     }
+  }
+
+  getDeliverySkipConnectorIds(threadId: string, invocationId?: string): string[] {
+    const key = this.scopeKey(threadId, invocationId);
+    return [...(this.deliverySkipConnectors.get(key) ?? [])];
   }
 
   /** F151: Notify adapters that an invocation's delivery batch is complete. */

--- a/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
+++ b/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
@@ -64,8 +64,13 @@ export class StreamingOutboundHook {
         // P2: Group chat @mention — add sender name to prefix when available
         const senderSuffix = binding.connectorId === 'feishu' && senderHint?.name ? `→${senderHint.name}` : '';
         const prefix = displayName || senderSuffix ? `【${displayName || '猫猫'}🐱${senderSuffix}】` : '';
+        const telegramDisplayName = displayName || '猫猫';
         const placeholderText =
-          binding.connectorId === 'feishu' ? `${prefix}${pickReceiptLine(catId)}` : `${prefix}🤔 思考中...`;
+          binding.connectorId === 'feishu'
+            ? `${prefix}${pickReceiptLine(catId)}`
+            : binding.connectorId === 'telegram'
+              ? `【${telegramDisplayName}🐱 思考中...】`
+              : `${prefix}🤔 思考中...`;
         const msgId = await adapter.sendPlaceholder(binding.externalChatId, placeholderText);
         if (msgId) {
           const ownsFinalDelivery = adapter.ownsFinalDelivery === true;

--- a/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
+++ b/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
@@ -36,6 +36,7 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
   readonly connectorId = 'telegram';
   private readonly bot: Bot;
   private readonly log: FastifyBaseLogger;
+  private readonly placeholderChats = new Map<string, string>(); // msgId → chatId
   private sendMessageFn: ((chatId: string, text: string, opts?: Record<string, unknown>) => Promise<unknown>) | null =
     null;
   private sendMediaFns: {
@@ -197,7 +198,20 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
    */
   async sendPlaceholder(externalChatId: string, text: string): Promise<string> {
     const msg = await this.bot.api.sendMessage(Number(externalChatId), text);
-    return String(msg.message_id);
+    const msgId = String(msg.message_id);
+    this.placeholderChats.set(msgId, externalChatId);
+    return msgId;
+  }
+
+  /**
+   * Delete a streaming placeholder message after outbound delivery succeeds.
+   * chatId is looked up from the placeholderChats cache set in sendPlaceholder.
+   */
+  async deleteMessage(platformMessageId: string): Promise<void> {
+    const chatId = this.placeholderChats.get(platformMessageId);
+    if (!chatId) return;
+    this.placeholderChats.delete(platformMessageId);
+    await this.bot.api.deleteMessage(Number(chatId), Number(platformMessageId));
   }
 
   /**

--- a/packages/api/test/streaming-outbound-hook.test.js
+++ b/packages/api/test/streaming-outbound-hook.test.js
@@ -102,7 +102,7 @@ describe('StreamingOutboundHook', () => {
     assert.ok(!text.includes('placeholder'), `Receipt should not be a raw placeholder, got: ${text}`);
   });
 
-  it('F157 P1-2: non-Feishu adapter gets generic "思考中" placeholder, not receipt text', async () => {
+  it('F157 P1-2: Telegram adapter gets 【猫猫🐱 思考中...】 placeholder (scheme C start state)', async () => {
     const telegramAdapter = wrapAdapter({
       connectorId: 'telegram',
       sendReply: async () => {},
@@ -134,7 +134,9 @@ describe('StreamingOutboundHook', () => {
     await hook.onStreamStart('thread-1', 'opus');
     assert.equal(telegramAdapter._calls.sendPlaceholder.length, 1);
     const text = telegramAdapter._calls.sendPlaceholder[0].text;
-    assert.ok(text.includes('思考中'), `Non-Feishu adapter should get generic text, got: ${text}`);
+    assert.ok(text.includes('🐱'), `Telegram placeholder must contain 🐱, got: ${text}`);
+    assert.ok(text.includes('思考中'), `Telegram placeholder must contain 思考中, got: ${text}`);
+    assert.ok(!text.includes('🤔'), `Telegram placeholder must not use old 🤔 format, got: ${text}`);
   });
 
   it('F157 P2: sender hint adds sender name to Feishu receipt prefix with 🐱', async () => {

--- a/packages/api/test/streaming-outbound-hook.test.js
+++ b/packages/api/test/streaming-outbound-hook.test.js
@@ -313,11 +313,13 @@ describe('StreamingOutboundHook', () => {
     await hook.onStreamChunk('thread-1', 'Partial streaming content', 'inv-tg');
     await hook.onStreamEnd('thread-1', 'Final complete answer', 'inv-tg');
 
-    // editMessage must have been called with final content (no ▌ cursor)
+    // editMessage must have been called with final content (no ▌ cursor), with ✅ completion prefix
     const edits = telegramAdapter._calls.editMessage;
     assert.ok(edits.length >= 1, 'editMessage must be called at least once');
     const lastEdit = edits[edits.length - 1];
-    assert.equal(lastEdit.text, 'Final complete answer', 'Last edit must be final content without cursor');
+    assert.ok(lastEdit.text.includes('✅'), 'Last edit must contain ✅ completion marker');
+    assert.ok(lastEdit.text.includes('Final complete answer'), 'Last edit must contain final content');
+    assert.ok(!lastEdit.text.includes('▌'), 'Last edit must not contain streaming cursor');
     // deleteMessage must NOT be called yet (deferred until cleanupPlaceholders)
     assert.equal(telegramAdapter._calls.deleteMessage.length, 0, 'deleteMessage must be deferred');
 
@@ -386,13 +388,15 @@ describe('StreamingOutboundHook', () => {
 
     const edits = telegramAdapter._calls.editMessage;
     const lastEdit = edits[edits.length - 1];
-    // Should fall back to lastAccumulatedText, not error message, since we had chunks
-    assert.equal(lastEdit.text, 'Accumulated so far', 'Must fall back to lastAccumulatedText when finalText empty');
+    // Should fall back to lastAccumulatedText, with ✅ completion prefix
+    assert.ok(lastEdit.text.includes('✅'), 'Must contain ✅ completion marker');
+    assert.ok(lastEdit.text.includes('Accumulated so far'), 'Must fall back to lastAccumulatedText when finalText empty');
   });
 
   it('uses streamed text fallback when inline-final-delivery ends without final text', async () => {
     const telegramAdapter = wrapAdapter({
       connectorId: 'telegram',
+      ownsFinalDelivery: true,
       sendReply: async () => {},
       sendPlaceholder: async (_chatId, _text) => 'msg-tg-1',
       editMessage: async (_chatId, _msgId, _text) => {},
@@ -424,8 +428,11 @@ describe('StreamingOutboundHook', () => {
     await hook.onStreamEnd('thread-1', '', 'inv-1');
 
     assert.equal(telegramAdapter._calls.editMessage.length, 2);
-    assert.equal(telegramAdapter._calls.editMessage[0].text, 'Partial answer ▌');
-    assert.equal(telegramAdapter._calls.editMessage[1].text, 'Partial answer');
+    assert.ok(telegramAdapter._calls.editMessage[0].text.includes('思考中...'), 'chunk edit must have 思考中 prefix');
+    assert.ok(telegramAdapter._calls.editMessage[0].text.includes('Partial answer ▌'), 'chunk edit must have content + cursor');
+    assert.ok(telegramAdapter._calls.editMessage[1].text.includes('✅'), 'final edit must have ✅ completion marker');
+    assert.ok(telegramAdapter._calls.editMessage[1].text.includes('Partial answer'), 'final edit must have content');
+    assert.ok(!telegramAdapter._calls.editMessage[1].text.includes('▌'), 'final edit must not have cursor');
   });
 
   it('onStreamEnd cleans up session (second call is no-op)', async () => {

--- a/packages/api/test/streaming-outbound-hook.test.js
+++ b/packages/api/test/streaming-outbound-hook.test.js
@@ -215,6 +215,219 @@ describe('StreamingOutboundHook', () => {
     assert.ok(!adapter._calls.editMessage[0].text.includes('▌'));
   });
 
+  it('tracks inline-final-delivery connectors until cleanup finishes', async () => {
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      ownsFinalDelivery: true,
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-1',
+      editMessage: async (_chatId, _msgId, _text) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      {
+        connectorId: 'telegram',
+        externalChatId: 'tg-chat1',
+        threadId: 'thread-1',
+        userId: 'u1',
+        createdAt: Date.now(),
+      },
+    ]);
+    const log = {
+      warn: () => {},
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      fatal: () => {},
+      trace: () => {},
+      child: () => log,
+    };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-1');
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-1'), ['telegram']);
+
+    await hook.onStreamEnd('thread-1', 'Final telegram text', 'inv-1');
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-1'), ['telegram']);
+
+    await hook.cleanupPlaceholders('thread-1', 'inv-1');
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-1'), []);
+  });
+
+  it('uses explicit ownsFinalDelivery flag instead of inferring from method combinations', async () => {
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      ownsFinalDelivery: true,
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-1',
+      editMessage: async (_chatId, _msgId, _text) => {},
+      deleteMessage: async (_msgId) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      {
+        connectorId: 'telegram',
+        externalChatId: 'tg-chat1',
+        threadId: 'thread-1',
+        userId: 'u1',
+        createdAt: Date.now(),
+      },
+    ]);
+    const log = {
+      warn: () => {},
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      fatal: () => {},
+      trace: () => {},
+      child: () => log,
+    };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-explicit');
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-explicit'), ['telegram']);
+  });
+
+  it('Telegram ownsFinalDelivery+deleteMessage: editMessage writes final content before cleanup', async () => {
+    // Regression test for: streaming stops updating after many edits, final content never written
+    // Root cause: deleteMessage presence caused onStreamEnd to defer without writing final content
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      ownsFinalDelivery: true,
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-1',
+      editMessage: async (_chatId, _msgId, _text) => {},
+      deleteMessage: async (_msgId) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      { connectorId: 'telegram', externalChatId: 'tg-chat1', threadId: 'thread-1', userId: 'u1', createdAt: Date.now() },
+    ]);
+    const log = { warn: () => {}, info: () => {}, error: () => {}, debug: () => {}, fatal: () => {}, trace: () => {}, child: function() { return log; } };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-tg');
+    await hook.onStreamChunk('thread-1', 'Partial streaming content', 'inv-tg');
+    await hook.onStreamEnd('thread-1', 'Final complete answer', 'inv-tg');
+
+    // editMessage must have been called with final content (no ▌ cursor)
+    const edits = telegramAdapter._calls.editMessage;
+    assert.ok(edits.length >= 1, 'editMessage must be called at least once');
+    const lastEdit = edits[edits.length - 1];
+    assert.equal(lastEdit.text, 'Final complete answer', 'Last edit must be final content without cursor');
+    // deleteMessage must NOT be called yet (deferred until cleanupPlaceholders)
+    assert.equal(telegramAdapter._calls.deleteMessage.length, 0, 'deleteMessage must be deferred');
+
+    // After cleanup, placeholder is deleted
+    await hook.cleanupPlaceholders('thread-1', 'inv-tg');
+    assert.equal(telegramAdapter._calls.deleteMessage.length, 1);
+    assert.equal(telegramAdapter._calls.deleteMessage[0].msgId, 'msg-tg-1');
+  });
+
+  it('Telegram ownsFinalDelivery: editMessage failure removes connectorId from skip list for fallback delivery', async () => {
+    // Regression: if final editMessage throws (429/network), skip list must be cleared
+    // so OutboundDeliveryHook can deliver as fallback — otherwise answer is silently lost
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      ownsFinalDelivery: true,
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-fail',
+      editMessage: async (_chatId, _msgId, _text) => { throw new Error('429 Too Many Requests'); },
+      deleteMessage: async (_msgId) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      { connectorId: 'telegram', externalChatId: 'tg-chat1', threadId: 'thread-1', userId: 'u1', createdAt: Date.now() },
+    ]);
+    const log = { warn: () => {}, info: () => {}, error: () => {}, debug: () => {}, fatal: () => {}, trace: () => {}, child: function() { return log; } };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-fail');
+    // Before onStreamEnd, telegram is in skip list
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-fail'), ['telegram']);
+
+    // editMessage will throw — should not propagate, but must remove from skip list
+    await hook.onStreamEnd('thread-1', 'Final answer', 'inv-fail');
+
+    // Skip list must be cleared so OutboundDeliveryHook delivers as fallback
+    assert.deepEqual(hook.getDeliverySkipConnectorIds('thread-1', 'inv-fail'), [],
+      'skip list must be empty after editMessage failure so OutboundDeliveryHook can deliver');
+    // deleteMessage must NOT be deferred (edit failed, nothing to clean up)
+    await hook.cleanupPlaceholders('thread-1', 'inv-fail');
+    assert.equal(telegramAdapter._calls.deleteMessage.length, 0,
+      'deleteMessage must not be called when editMessage failed');
+  });
+
+  it('Telegram ownsFinalDelivery+deleteMessage: falls back to lastAccumulatedText when finalText empty', async () => {
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      ownsFinalDelivery: true,
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-2',
+      editMessage: async (_chatId, _msgId, _text) => {},
+      deleteMessage: async (_msgId) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      { connectorId: 'telegram', externalChatId: 'tg-chat1', threadId: 'thread-1', userId: 'u1', createdAt: Date.now() },
+    ]);
+    const log = { warn: () => {}, info: () => {}, error: () => {}, debug: () => {}, fatal: () => {}, trace: () => {}, child: function() { return log; } };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-tg2');
+    await hook.onStreamChunk('thread-1', 'Accumulated so far', 'inv-tg2');
+    // finalText is empty (stream interrupted)
+    await hook.onStreamEnd('thread-1', '', 'inv-tg2');
+
+    const edits = telegramAdapter._calls.editMessage;
+    const lastEdit = edits[edits.length - 1];
+    // Should fall back to lastAccumulatedText, not error message, since we had chunks
+    assert.equal(lastEdit.text, 'Accumulated so far', 'Must fall back to lastAccumulatedText when finalText empty');
+  });
+
+  it('uses streamed text fallback when inline-final-delivery ends without final text', async () => {
+    const telegramAdapter = wrapAdapter({
+      connectorId: 'telegram',
+      sendReply: async () => {},
+      sendPlaceholder: async (_chatId, _text) => 'msg-tg-1',
+      editMessage: async (_chatId, _msgId, _text) => {},
+      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+    });
+    const adapters = new Map([['telegram', telegramAdapter]]);
+    const bindingStore = createBindingStore([
+      {
+        connectorId: 'telegram',
+        externalChatId: 'tg-chat1',
+        threadId: 'thread-1',
+        userId: 'u1',
+        createdAt: Date.now(),
+      },
+    ]);
+    const log = {
+      warn: () => {},
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      fatal: () => {},
+      trace: () => {},
+      child: () => log,
+    };
+    const hook = new StreamingOutboundHook({ bindingStore, adapters, log, updateIntervalMs: 0, minDeltaChars: 0 });
+
+    await hook.onStreamStart('thread-1', 'opus', 'inv-1');
+    await hook.onStreamChunk('thread-1', 'Partial answer', 'inv-1');
+    await hook.onStreamEnd('thread-1', '', 'inv-1');
+
+    assert.equal(telegramAdapter._calls.editMessage.length, 2);
+    assert.equal(telegramAdapter._calls.editMessage[0].text, 'Partial answer ▌');
+    assert.equal(telegramAdapter._calls.editMessage[1].text, 'Partial answer');
+  });
+
   it('onStreamEnd cleans up session (second call is no-op)', async () => {
     const { hook, adapter } = createHook();
     await hook.onStreamStart('thread-1');


### PR DESCRIPTION
## 问题

Telegram 流式回复结束后出现重复消息，且完成状态 UI 前缀不一致。

Closes #524

## 改动

- `fix(telegram): add deleteMessage to eliminate streaming duplicate messages`
- `fix(streaming): onStreamEnd ownsFinalDelivery path writes final content before cleanup`
- `feat(streaming): Telegram completion state UI — prefix switches from 思考中 to ✅`
- `fix(streaming): align Telegram placeholder start state to scheme C format`

## 验证

- `pnpm --dir packages/api run build` 通过
- 相关测试通过（`telegram-adapter`、`outbound-delivery-hook`、`queue-processor`、`connector-invoke-trigger`）