### PR TITLE
fix(web): unify cross-layout navigation to document-level routing

### DIFF
--- a/packages/web/src/app/(chat)/__tests__/thread-route-marker.test.tsx
+++ b/packages/web/src/app/(chat)/__tests__/thread-route-marker.test.tsx
@@ -1,5 +1,6 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
+import { resolveLayoutThreadId } from '../layout';
 import Home from '../page';
 import ThreadPage from '../thread/[threadId]/page';
 
@@ -12,5 +13,12 @@ describe('chat route markers', () => {
   it('renders the active thread id into the page tree', () => {
     const html = renderToStaticMarkup(<ThreadPage params={{ threadId: 'thread-123' }} />);
     expect(html).toContain('data-thread-route="thread-123"');
+  });
+
+  it('uses pathname for first render, then trusts the browser route store after hydration', () => {
+    expect(resolveLayoutThreadId('thread-refresh', null)).toBe('thread-refresh');
+    expect(resolveLayoutThreadId('default', null, 'thread-refresh')).toBe('thread-refresh');
+    expect(resolveLayoutThreadId('thread-stale', 'default')).toBe('default');
+    expect(resolveLayoutThreadId('thread-stale', 'thread-current')).toBe('thread-current');
   });
 });

--- a/packages/web/src/app/(chat)/layout.tsx
+++ b/packages/web/src/app/(chat)/layout.tsx
@@ -1,22 +1,23 @@
 'use client';
 
-import { useSyncExternalStore } from 'react';
+import { usePathname } from 'next/navigation';
+import { useLayoutEffect, useState } from 'react';
 import { ChatContainer } from '@/components/ChatContainer';
 import { CHAT_THREAD_ROUTE_EVENT, getThreadIdFromPathname } from '@/components/ThreadSidebar/thread-navigation';
-
-function subscribeToThreadRoute(onStoreChange: () => void): () => void {
-  if (typeof window === 'undefined') return () => {};
-  window.addEventListener('popstate', onStoreChange);
-  window.addEventListener(CHAT_THREAD_ROUTE_EVENT, onStoreChange);
-  return () => {
-    window.removeEventListener('popstate', onStoreChange);
-    window.removeEventListener(CHAT_THREAD_ROUTE_EVENT, onStoreChange);
-  };
-}
 
 function getThreadRouteSnapshot(): string {
   if (typeof window === 'undefined') return 'default';
   return getThreadIdFromPathname(window.location.pathname);
+}
+
+export function resolveLayoutThreadId(
+  pathnameThreadId: string,
+  browserThreadId: string | null,
+  immediateBrowserThreadId: string | null = null,
+): string {
+  if (browserThreadId !== null) return browserThreadId;
+  if (immediateBrowserThreadId !== null) return immediateBrowserThreadId;
+  return pathnameThreadId;
 }
 
 /**
@@ -27,7 +28,23 @@ function getThreadRouteSnapshot(): string {
  * loss, and socket/state survives navigation.
  */
 export default function ChatLayout({ children }: { children: React.ReactNode }) {
-  const threadId = useSyncExternalStore(subscribeToThreadRoute, getThreadRouteSnapshot, () => 'default');
+  const pathname = usePathname();
+  const pathnameThreadId = getThreadIdFromPathname(pathname ?? '');
+  // Parent layouts can briefly see the default route during hard refresh; the
+  // address bar is the authority before chat history effects are allowed to run.
+  const immediateBrowserThreadId = typeof window !== 'undefined' ? getThreadRouteSnapshot() : null;
+  const [browserThreadId, setBrowserThreadId] = useState<string | null>(null);
+  useLayoutEffect(() => {
+    const syncBrowserRoute = () => setBrowserThreadId(getThreadRouteSnapshot());
+    syncBrowserRoute();
+    window.addEventListener('popstate', syncBrowserRoute);
+    window.addEventListener(CHAT_THREAD_ROUTE_EVENT, syncBrowserRoute);
+    return () => {
+      window.removeEventListener('popstate', syncBrowserRoute);
+      window.removeEventListener(CHAT_THREAD_ROUTE_EVENT, syncBrowserRoute);
+    };
+  }, []);
+  const threadId = resolveLayoutThreadId(pathnameThreadId, browserThreadId, immediateBrowserThreadId);
 
   return (
     <>

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useAgentMessages } from '@/hooks/useAgentMessages';
 import { useAuthorization } from '@/hooks/useAuthorization';
@@ -51,7 +50,7 @@ import { SplitPaneView } from './SplitPaneView';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ThreadExecutionBar } from './ThreadExecutionBar';
 import { ThreadSidebar } from './ThreadSidebar';
-import { pushThreadRouteWithHistory } from './ThreadSidebar/thread-navigation';
+import { assignDocumentRoute, pushThreadRouteWithHistory } from './ThreadSidebar/thread-navigation';
 import { VoteActiveBar } from './VoteActiveBar';
 import { type VoteConfig, VoteConfigModal } from './VoteConfigModal';
 import { WorkspacePanel } from './WorkspacePanel';
@@ -473,8 +472,6 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
     [stopHandler, cancelInvocation, threadId],
   );
 
-  const router = useRouter();
-
   const handleZoomToThread = useCallback(
     (tid: string) => {
       setViewMode('single');
@@ -485,13 +482,13 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
 
   const handleSearchKnowledge = useCallback(() => {
     const fromParam = threadId ? `?from=${encodeURIComponent(threadId)}` : '';
-    router.push(`/memory/search${fromParam}`);
-  }, [router, threadId]);
+    assignDocumentRoute(`/memory/search${fromParam}`, typeof window !== 'undefined' ? window : undefined);
+  }, [threadId]);
 
   const handleGoToMemoryHub = useCallback(() => {
     const fromParam = threadId ? `?from=${encodeURIComponent(threadId)}` : '';
-    router.push(`/memory${fromParam}`);
-  }, [router, threadId]);
+    assignDocumentRoute(`/memory${fromParam}`, typeof window !== 'undefined' ? window : undefined);
+  }, [threadId]);
 
   if (viewMode === 'split') {
     return (

--- a/packages/web/src/components/HubMemoryTab.tsx
+++ b/packages/web/src/components/HubMemoryTab.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { useChatStore } from '@/stores/chatStore';
 import { IndexStatus } from './memory/IndexStatus';
+import { assignDocumentRoute } from './ThreadSidebar/thread-navigation';
 
 /**
  * F102 Phase J (AC-J7): Memory status tab in Hub Group 3 (监控与治理).
@@ -10,12 +10,11 @@ import { IndexStatus } from './memory/IndexStatus';
  * plus a "打开 Memory Hub" jump button.
  */
 export function HubMemoryTab() {
-  const router = useRouter();
   const currentThreadId = useChatStore((s) => s.currentThreadId);
 
   const openMemory = () => {
     const fromParam = currentThreadId ? `?from=${encodeURIComponent(currentThreadId)}` : '';
-    router.push(`/memory${fromParam}`);
+    assignDocumentRoute(`/memory${fromParam}`, typeof window !== 'undefined' ? window : undefined);
   };
 
   return (

--- a/packages/web/src/components/ThreadSidebar/thread-navigation.ts
+++ b/packages/web/src/components/ThreadSidebar/thread-navigation.ts
@@ -10,6 +10,12 @@ export interface ThreadNavigationWindow {
   };
 }
 
+export interface DocumentNavigationWindow {
+  location: {
+    assign: (url: string) => void;
+  };
+}
+
 export function getThreadHref(threadId: string): string {
   return threadId === 'default' ? '/' : `/thread/${threadId}`;
 }
@@ -26,5 +32,12 @@ export function pushThreadRouteWithHistory(threadId: string, windowObj: ThreadNa
   if (windowObj.location.pathname === href) return href;
   windowObj.history.pushState({}, '', href);
   windowObj.dispatchEvent(new Event(CHAT_THREAD_ROUTE_EVENT));
+  return href;
+}
+
+export function assignDocumentRoute(href: string, windowObj: DocumentNavigationWindow | undefined): string {
+  if (windowObj) {
+    windowObj.location.assign(href);
+  }
   return href;
 }

--- a/packages/web/src/components/__tests__/thread-navigation.test.ts
+++ b/packages/web/src/components/__tests__/thread-navigation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
-  CHAT_THREAD_ROUTE_EVENT,
   assignDocumentRoute,
+  CHAT_THREAD_ROUTE_EVENT,
   getThreadHref,
   getThreadIdFromPathname,
   pushThreadRouteWithHistory,

--- a/packages/web/src/components/__tests__/thread-navigation.test.ts
+++ b/packages/web/src/components/__tests__/thread-navigation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CHAT_THREAD_ROUTE_EVENT,
+  assignDocumentRoute,
   getThreadHref,
   getThreadIdFromPathname,
   pushThreadRouteWithHistory,
@@ -53,5 +54,17 @@ describe('thread navigation history bridge', () => {
     expect(href).toBe('/thread/thread-b');
     expect(fakeWindow.location.pathname).toBe('/thread/thread-b');
     expect(fakeWindow.dispatched).toEqual([]);
+  });
+
+  it('assigns document routes for hub navigation outside the chat route store', () => {
+    const assigned: string[] = [];
+    const href = assignDocumentRoute('/memory?from=thread-b', {
+      location: {
+        assign: (url) => assigned.push(url),
+      },
+    });
+
+    expect(href).toBe('/memory?from=thread-b');
+    expect(assigned).toEqual(['/memory?from=thread-b']);
   });
 });

--- a/packages/web/src/components/memory/MemoryNav.tsx
+++ b/packages/web/src/components/memory/MemoryNav.tsx
@@ -62,7 +62,7 @@ export function MemoryNav({ active }: MemoryNavProps) {
 
   return (
     <nav aria-label="Memory navigation" className="flex items-center gap-2">
-      <Link
+      <a
         href={backHref}
         className="inline-flex items-center gap-1.5 rounded-lg border border-[#D8C6AD] bg-[#FCF7EE] px-3 py-1.5 text-xs font-medium text-[#8B6F47] transition-colors hover:bg-[#F7EEDB]"
         data-testid="memory-back-to-chat"
@@ -79,7 +79,7 @@ export function MemoryNav({ active }: MemoryNavProps) {
           <polyline points="15 18 9 12 15 6" />
         </svg>
         返回对话
-      </Link>
+      </a>
       {items.map((item) => {
         const isActive = item.id === active;
         return (

--- a/packages/web/src/components/memory/MemoryNav.tsx
+++ b/packages/web/src/components/memory/MemoryNav.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 
 export type MemoryTab = 'feed' | 'search' | 'status' | 'health';
@@ -45,12 +45,14 @@ export function buildMemoryTabItems(fromSuffix: string): readonly TabConfig[] {
 
 function useReferrerThread(): string | null {
   const storeThreadId = useChatStore((s) => s.currentThreadId);
+  const [fromParam, setFromParam] = useState<string | null>(null);
+  useEffect(() => {
+    setFromParam(new URLSearchParams(window.location.search).get('from'));
+  }, []);
   return useMemo(() => {
-    if (typeof window !== 'undefined') {
-      return resolveReferrerThread(window.location.search, storeThreadId ?? null);
-    }
+    if (fromParam) return fromParam;
     return storeThreadId && storeThreadId !== 'default' ? storeThreadId : null;
-  }, [storeThreadId]);
+  }, [fromParam, storeThreadId]);
 }
 
 export function MemoryNav({ active }: MemoryNavProps) {

--- a/packages/web/src/components/mission-control/MissionControlPage.tsx
+++ b/packages/web/src/components/mission-control/MissionControlPage.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { BacklogItem, CatId, ExternalProject, MissionHubSelfClaimScope, ThreadPhase } from '@cat-cafe/shared';
-import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 import { useExternalProjectStore } from '@/stores/externalProjectStore';
@@ -452,7 +451,7 @@ export function MissionControlPage() {
         {/* Header */}
         <header className="flex items-center justify-between border-b border-[#E7DAC7] bg-[#FFFDF8] px-6 py-3">
           <div className="flex items-center gap-3">
-            <Link
+            <a
               href={referrerThread && referrerThread !== 'default' ? `/thread/${referrerThread}` : '/'}
               className="inline-flex items-center gap-1.5 rounded-lg border border-[#D8C6AD] bg-[#FCF7EE] px-3 py-1.5 text-xs font-medium text-[#8B6F47] transition-colors hover:bg-[#F7EEDB]"
               data-testid="mc-back-to-chat"
@@ -469,7 +468,7 @@ export function MissionControlPage() {
                 <polyline points="15 18 9 12 15 6" />
               </svg>
               返回线程
-            </Link>
+            </a>
             <div className="flex items-center gap-2">
               <svg
                 className="h-5 w-5 text-[#9A866F]"

--- a/packages/web/src/components/mission-control/MissionControlPage.tsx
+++ b/packages/web/src/components/mission-control/MissionControlPage.tsx
@@ -436,14 +436,14 @@ export function MissionControlPage() {
   // AC-H2: Referrer-based back button — remember where we came from
   // Priority: URL ?from= param > store's currentThreadId (last active thread)
   const storeThreadId = useChatStore((s) => s.currentThreadId);
+  const [mcFromParam, setMcFromParam] = useState<string | null>(null);
+  useEffect(() => {
+    setMcFromParam(new URLSearchParams(window.location.search).get('from'));
+  }, []);
   const referrerThread = useMemo(() => {
-    if (typeof window !== 'undefined') {
-      const fromParam = new URLSearchParams(window.location.search).get('from');
-      if (fromParam) return fromParam;
-    }
-    // Fallback: use last active thread from store (survives navigation without ?from=)
+    if (mcFromParam) return mcFromParam;
     return storeThreadId && storeThreadId !== 'default' ? storeThreadId : null;
-  }, [storeThreadId]);
+  }, [mcFromParam, storeThreadId]);
 
   return (
     <div className="flex h-screen bg-[#F4EFE7]">

--- a/packages/web/src/components/signals/SignalNav.tsx
+++ b/packages/web/src/components/signals/SignalNav.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 
 export type SignalNavItem = 'chat' | 'signals' | 'sources';
@@ -21,13 +21,14 @@ interface ItemConfig {
  */
 function useReferrerThread(): string | null {
   const storeThreadId = useChatStore((s) => s.currentThreadId);
+  const [fromParam, setFromParam] = useState<string | null>(null);
+  useEffect(() => {
+    setFromParam(new URLSearchParams(window.location.search).get('from'));
+  }, []);
   return useMemo(() => {
-    if (typeof window !== 'undefined') {
-      const fromParam = new URLSearchParams(window.location.search).get('from');
-      if (fromParam) return fromParam;
-    }
+    if (fromParam) return fromParam;
     return storeThreadId && storeThreadId !== 'default' ? storeThreadId : null;
-  }, [storeThreadId]);
+  }, [fromParam, storeThreadId]);
 }
 
 export function SignalNav({ active }: SignalNavProps) {

--- a/packages/web/src/components/signals/SignalNav.tsx
+++ b/packages/web/src/components/signals/SignalNav.tsx
@@ -46,7 +46,7 @@ export function SignalNav({ active }: SignalNavProps) {
 
   return (
     <nav aria-label="Signal navigation" className="flex items-center gap-2">
-      <Link
+      <a
         href={backHref}
         className="inline-flex items-center gap-1.5 rounded-lg border border-[#D8C6AD] bg-[#FCF7EE] px-3 py-1.5 text-xs font-medium text-[#8B6F47] transition-colors hover:bg-[#F7EEDB]"
         data-testid="signal-back-to-chat"
@@ -63,7 +63,7 @@ export function SignalNav({ active }: SignalNavProps) {
           <polyline points="15 18 9 12 15 6" />
         </svg>
         返回线程
-      </Link>
+      </a>
       {items.map((item) => {
         const isActive = item.id === active;
         return (


### PR DESCRIPTION
## Summary

Fixes #550 — Cross-layout navigation (chat ↔ memory/signals/mission-control) used Next.js `<Link>` and `router.push`, which perform SPA client-side transitions. Since these pages live in different `(chat)` vs root layouts, the chat layout's Zustand store and `useSyncExternalStore` state desync after navigation, causing:

- "前往记忆中心" / "搜索知识" buttons unresponsive after thread switches
- "返回对话" back-links all pointing to lobby (`/`) instead of the originating thread
- F5 refresh showing lobby content instead of current thread

### Changes

- **`layout.tsx`**: Replace `useSyncExternalStore` with `usePathname()` + `useLayoutEffect` three-tier priority chain (`browserThreadId > immediateBrowserThreadId > pathnameThreadId`)
- **`ChatContainer.tsx` / `HubMemoryTab.tsx`**: Switch `router.push` to `window.location.assign` via `assignDocumentRoute` helper for cross-layout routes
- **`MemoryNav.tsx` / `SignalNav.tsx` / `MissionControlPage.tsx`**: Change back-link from `<Link>` to native `<a href>` for full page navigation; read `?from=` param via `useEffect` + `useState` to avoid SSR hydration mismatch
- **`thread-navigation.ts`**: Add `assignDocumentRoute` helper with `DocumentNavigationWindow` interface for testability

### Root cause

Next.js App Router SPA transitions don't remount layout components when navigating between route groups. The chat layout kept stale `threadId` state, and `useSyncExternalStore` with a hardcoded server snapshot `() => 'default'` couldn't recover after a full-page navigation reset the Zustand store.

## Test plan

- [x] Verify `pnpm lint` and `pnpm check` pass
- [x] Run `pnpm test` — new tests for `resolveLayoutThreadId` and `assignDocumentRoute`
- [x] Create a thread → click "前往记忆中心" → verify Memory Hub loads
- [x] Click "返回对话" → verify it returns to the correct thread (not lobby)
- [x] Repeat from Signals and Mission Control pages
- [x] F5 refresh on a thread page → verify it stays on the correct thread
- [x] Switch threads via sidebar → repeat cross-layout navigation → verify no stale routing

🤖 Generated with [Claude Code](https://claude.com/claude-code)