### PR TITLE
fix: harden Windows workspace path compatibility

### DIFF
--- a/packages/api/src/domains/workspace/workspace-security.ts
+++ b/packages/api/src/domains/workspace/workspace-security.ts
@@ -96,7 +96,7 @@ export async function resolveWorkspacePath(root: string, userPath: string): Prom
  * Returns true if the path should be blocked.
  */
 export function isDenylisted(relPath: string): boolean {
-  const segments = relPath.split(sep);
+  const segments = relPath.split(/[\\/]/);
   for (const seg of segments) {
     if (DENYLIST_DIRS.has(seg)) return true;
     for (const pat of DENYLIST_PATTERNS) {

--- a/packages/api/src/routes/workspace.ts
+++ b/packages/api/src/routes/workspace.ts
@@ -21,6 +21,7 @@ import { createReadStream } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { dirname, extname, isAbsolute, join, relative, resolve, sep } from 'node:path';
 import { promisify } from 'node:util';
+import { isAbsoluteFilesystemPath, normalizeWorkspaceRelativePath } from '@cat-cafe/shared/utils';
 import type { FastifyPluginAsync } from 'fastify';
 import {
   addLinkedRoot,
@@ -206,7 +207,7 @@ async function searchWorkspaceContent(
       break;
     }
 
-    const relPath = relative(root, fullPath);
+    const relPath = normalizeWorkspaceRelativePath(relative(root, fullPath));
     if (isDenylisted(relPath) || !isContentSearchable(relPath)) continue;
 
     const fileStat = await stat(fullPath).catch(() => null);
@@ -253,7 +254,7 @@ async function buildTree(root: string, dirPath: string, depth: number, maxDepth:
     if (SKIP_DIRS.has(entry.name)) continue;
 
     const fullPath = join(dirPath, entry.name);
-    const relPath = relative(root, fullPath);
+    const relPath = normalizeWorkspaceRelativePath(relative(root, fullPath));
 
     if (entry.isDirectory()) {
       if (depth + 1 >= maxDepth) {
@@ -280,7 +281,7 @@ export const workspaceRoutes: FastifyPluginAsync<WorkspaceRouteOpts> = async (ap
   app.get<{ Querystring: { repoRoot?: string } }>('/api/workspace/worktrees', async (request, reply) => {
     const { repoRoot } = request.query;
     if (repoRoot) {
-      if (!repoRoot.startsWith('/')) {
+      if (!isAbsoluteFilesystemPath(repoRoot)) {
         reply.status(400);
         return { error: 'repoRoot must be an absolute path' };
       }
@@ -320,7 +321,7 @@ export const workspaceRoutes: FastifyPluginAsync<WorkspaceRouteOpts> = async (ap
       const root = await getWorktreeRoot(worktreeId);
       const resolved = subpath ? await resolveWorkspacePath(root, subpath) : root;
       const tree = await buildTree(root, resolved, 0, depth);
-      return { root: subpath || '.', worktreeId, tree };
+      return { root: subpath ? normalizeWorkspaceRelativePath(subpath) : '.', worktreeId, tree };
     } catch (e) {
       if (e instanceof WorkspaceSecurityError) {
         reply.status(e.code === 'NOT_FOUND' ? 404 : 403);
@@ -467,7 +468,7 @@ export const workspaceRoutes: FastifyPluginAsync<WorkspaceRouteOpts> = async (ap
         const files = await listWorkspaceFiles(root);
         const lowerQuery = query.toLowerCase();
         const results = files
-          .map((fullPath) => relative(root, fullPath))
+          .map((fullPath) => normalizeWorkspaceRelativePath(relative(root, fullPath)))
           .filter((relPath) => !isDenylisted(relPath) && relPath.toLowerCase().includes(lowerQuery))
           .slice(0, limit)
           .map((relPath) => ({

--- a/packages/api/test/workspace-path-compat.test.js
+++ b/packages/api/test/workspace-path-compat.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { isAbsoluteFilesystemPath, normalizeWorkspaceRelativePath } from '../../shared/src/utils/workspace-paths.ts';
+import { isDenylisted } from '../src/domains/workspace/workspace-security.ts';
+
+describe('workspace path compatibility helpers', () => {
+  it('accepts Windows drive-letter absolute paths', () => {
+    assert.equal(isAbsoluteFilesystemPath('D:\\code\\clowder-ai'), true);
+  });
+
+  it('rejects relative Windows-looking paths', () => {
+    assert.equal(isAbsoluteFilesystemPath('code\\clowder-ai'), false);
+  });
+
+  it('normalizes Windows separators to POSIX separators', () => {
+    assert.equal(normalizeWorkspaceRelativePath('packages\\web\\src\\App.tsx'), 'packages/web/src/App.tsx');
+  });
+
+  it('preserves POSIX relative paths', () => {
+    assert.equal(normalizeWorkspaceRelativePath('packages/web/src/App.tsx'), 'packages/web/src/App.tsx');
+  });
+
+  it('leaves dot paths untouched', () => {
+    assert.equal(normalizeWorkspaceRelativePath('.'), '.');
+  });
+
+  it('keeps denylist checks working for normalized POSIX workspace paths', () => {
+    assert.equal(isDenylisted('secrets/nested/token.txt'), true);
+    assert.equal(isDenylisted('.git/hooks/pre-commit'), true);
+    assert.equal(isDenylisted('packages/api/src/routes/workspace.ts'), false);
+  });
+});

--- a/packages/api/test/workspace-path-compat.test.js
+++ b/packages/api/test/workspace-path-compat.test.js
@@ -1,32 +1,38 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
-import { isAbsoluteFilesystemPath, normalizeWorkspaceRelativePath } from '../../shared/src/utils/workspace-paths.ts';
-import { isDenylisted } from '../src/domains/workspace/workspace-security.ts';
+import { before, describe, it } from 'node:test';
+
+let sharedMod;
+let workspaceSecurityMod;
+
+before(async () => {
+  sharedMod = await import('../../shared/dist/utils/workspace-paths.js');
+  workspaceSecurityMod = await import('../dist/domains/workspace/workspace-security.js');
+});
 
 describe('workspace path compatibility helpers', () => {
   it('accepts Windows drive-letter absolute paths', () => {
-    assert.equal(isAbsoluteFilesystemPath('D:\\code\\clowder-ai'), true);
+    assert.equal(sharedMod.isAbsoluteFilesystemPath('D:\\code\\clowder-ai'), true);
   });
 
   it('rejects relative Windows-looking paths', () => {
-    assert.equal(isAbsoluteFilesystemPath('code\\clowder-ai'), false);
+    assert.equal(sharedMod.isAbsoluteFilesystemPath('code\\clowder-ai'), false);
   });
 
   it('normalizes Windows separators to POSIX separators', () => {
-    assert.equal(normalizeWorkspaceRelativePath('packages\\web\\src\\App.tsx'), 'packages/web/src/App.tsx');
+    assert.equal(sharedMod.normalizeWorkspaceRelativePath('packages\\web\\src\\App.tsx'), 'packages/web/src/App.tsx');
   });
 
   it('preserves POSIX relative paths', () => {
-    assert.equal(normalizeWorkspaceRelativePath('packages/web/src/App.tsx'), 'packages/web/src/App.tsx');
+    assert.equal(sharedMod.normalizeWorkspaceRelativePath('packages/web/src/App.tsx'), 'packages/web/src/App.tsx');
   });
 
   it('leaves dot paths untouched', () => {
-    assert.equal(normalizeWorkspaceRelativePath('.'), '.');
+    assert.equal(sharedMod.normalizeWorkspaceRelativePath('.'), '.');
   });
 
   it('keeps denylist checks working for normalized POSIX workspace paths', () => {
-    assert.equal(isDenylisted('secrets/nested/token.txt'), true);
-    assert.equal(isDenylisted('.git/hooks/pre-commit'), true);
-    assert.equal(isDenylisted('packages/api/src/routes/workspace.ts'), false);
+    assert.equal(workspaceSecurityMod.isDenylisted('secrets/nested/token.txt'), true);
+    assert.equal(workspaceSecurityMod.isDenylisted('.git/hooks/pre-commit'), true);
+    assert.equal(workspaceSecurityMod.isDenylisted('packages/api/src/routes/workspace.ts'), false);
   });
 });

--- a/packages/api/test/workspace-security.test.js
+++ b/packages/api/test/workspace-security.test.js
@@ -140,6 +140,11 @@ describe('workspace-security', () => {
     assert.ok(mod.isDenylisted('.git/HEAD'));
   });
 
+  it('isDenylisted blocks normalized POSIX paths on every host platform', () => {
+    assert.ok(mod.isDenylisted('secrets/nested/token.txt'));
+    assert.ok(mod.isDenylisted('.git/hooks/pre-commit'));
+  });
+
   it('isDenylisted allows safe paths', () => {
     assert.ok(!mod.isDenylisted('src/index.ts'));
     assert.ok(!mod.isDenylisted('packages/api/src/routes/workspace.ts'));

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -3,3 +3,4 @@
  */
 
 export * from './redis.js';
+export * from './workspace-paths.js';

--- a/packages/shared/src/utils/workspace-paths.ts
+++ b/packages/shared/src/utils/workspace-paths.ts
@@ -1,0 +1,17 @@
+import { isAbsolute, win32 } from 'node:path';
+
+/**
+ * Accept both host-platform absolute paths and Windows drive/UNC paths.
+ * This keeps validation deterministic in tests even when they run on macOS/Linux.
+ */
+export function isAbsoluteFilesystemPath(input: string): boolean {
+  return isAbsolute(input) || win32.isAbsolute(input);
+}
+
+/**
+ * Workspace APIs use POSIX-style relative paths as their wire format so the
+ * frontend can reason about ancestry and basenames consistently on every OS.
+ */
+export function normalizeWorkspaceRelativePath(input: string): string {
+  return input.replaceAll('\\', '/');
+}


### PR DESCRIPTION
## What

- accept Windows drive-letter and UNC absolute workspace roots
- normalize Workspace API relative paths to POSIX separators
- keep denylist path splitting robust for normalized workspace paths
- add regression tests for Windows path compatibility

## Why

Fixes #563

Windows workspaces could render an empty file tree because:
- `repoRoot.startsWith('/')` rejected valid `D:\\...` roots
- API responses returned backslash-separated relative paths while the UI expects POSIX-style path segments

## Test Evidence

- Community Windows validation: ✅ passed
- Targeted regression evidence on the matching patch:

```bash
pnpm exec tsx --test packages/api/test/workspace-path-compat.test.js
pnpm exec tsx --eval "import('./packages/api/src/routes/workspace.ts').then(() => console.log('workspace-route-import-ok'))"
```

Both commands passed on the patch branch before upstream handoff.

## Tradeoff

- keeps scope to the confirmed Windows path-compatibility bug
- does not replace the separate Windows-incompatible `find` search path in this PR
