### PR TITLE
fix(rescue): accept empty-signature thinking blocks

### DIFF
--- a/packages/api/src/domains/cats/services/session/ClaudeThinkingRescue.ts
+++ b/packages/api/src/domains/cats/services/session/ClaudeThinkingRescue.ts
@@ -68,7 +68,6 @@ export function hasShortThinkingSignature(entry: unknown): boolean {
       item.type === 'thinking' &&
       'signature' in item &&
       typeof item.signature === 'string' &&
-      item.signature.length > 0 &&
       item.signature.length < MIN_VALID_SIGNATURE_LENGTH,
   );
 }
@@ -107,8 +106,7 @@ export function isPureThinkingAssistantTurn(entry: unknown): boolean {
         'type' in item &&
         item.type === 'thinking' &&
         'signature' in item &&
-        typeof item.signature === 'string' &&
-        item.signature.length > 0,
+        typeof item.signature === 'string',
     )
   );
 }

--- a/packages/api/test/claude-thinking-rescue.test.js
+++ b/packages/api/test/claude-thinking-rescue.test.js
@@ -76,6 +76,29 @@ describe('ClaudeThinkingRescue', () => {
     });
   });
 
+  it('findBrokenClaudeThinkingSessions detects empty thinking signatures without an API error entry', async () => {
+    const { findBrokenClaudeThinkingSessions } = await import(
+      '../dist/domains/cats/services/session/ClaudeThinkingRescue.js'
+    );
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-thinking-rescue-api-'));
+    const projectsRoot = path.join(tmp, 'projects');
+    await fs.mkdir(projectsRoot, { recursive: true });
+
+    const brokenFile = path.join(projectsRoot, 'empty-signature.jsonl');
+    await fs.writeFile(brokenFile, `${buildPureThinkingAssistantTurn('empty-signature', '')}\n`, 'utf8');
+
+    const result = await findBrokenClaudeThinkingSessions({ rootDir: projectsRoot });
+
+    assert.equal(result.sessions.length, 1);
+    assert.deepEqual(result.sessions[0], {
+      sessionId: 'empty-signature',
+      transcriptPath: brokenFile,
+      removableThinkingTurns: 1,
+      detectedBy: 'short_signature',
+    });
+  });
+
   it('rescueClaudeThinkingSessions repairs selected sessions and reports structured results', async () => {
     const { rescueClaudeThinkingSessions } = await import(
       '../dist/domains/cats/services/session/ClaudeThinkingRescue.js'
@@ -115,6 +138,41 @@ describe('ClaudeThinkingRescue', () => {
     const repaired = await fs.readFile(brokenFile, 'utf8');
     assert.ok(repaired.includes('survivor'));
     assert.ok(!repaired.includes('"type":"thinking"'));
+  });
+
+  it('rescueClaudeThinkingSessions strips pure thinking turns with empty signatures', async () => {
+    const { rescueClaudeThinkingSessions } = await import(
+      '../dist/domains/cats/services/session/ClaudeThinkingRescue.js'
+    );
+
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-thinking-rescue-api-'));
+    const projectsRoot = path.join(tmp, 'projects');
+    const backupDir = path.join(tmp, 'backups');
+    await fs.mkdir(projectsRoot, { recursive: true });
+
+    const brokenFile = path.join(projectsRoot, 'empty-signature.jsonl');
+    await fs.writeFile(
+      brokenFile,
+      [
+        buildPureThinkingAssistantTurn('empty-signature', ''),
+        buildHealthyAssistantTurn('empty-signature', 'survivor'),
+      ].join('\n'),
+      'utf8',
+    );
+
+    const result = await rescueClaudeThinkingSessions({
+      targets: [{ sessionId: 'empty-signature', transcriptPath: brokenFile }],
+      backupDir,
+      now: 1_772_947_520_000,
+    });
+
+    assert.equal(result.status, 'ok');
+    assert.equal(result.results[0].status, 'repaired');
+    assert.equal(result.results[0].removedTurns, 1);
+
+    const repaired = await fs.readFile(brokenFile, 'utf8');
+    assert.ok(repaired.includes('survivor'));
+    assert.ok(!repaired.includes('"signature":""'));
   });
 
   it('rescueClaudeThinkingSessions returns partial when repaired and skipped results coexist', async () => {

--- a/scripts/rescue-claude-thinking-signature.mjs
+++ b/scripts/rescue-claude-thinking-signature.mjs
@@ -56,11 +56,7 @@ export function isPureThinkingAssistantTurn(entry) {
   return (
     entry.message.content.length > 0 &&
     entry.message.content.every(
-      (item) =>
-        item &&
-        typeof item === 'object' &&
-        item.type === 'thinking' &&
-        typeof item.signature === 'string',
+      (item) => item && typeof item === 'object' && item.type === 'thinking' && typeof item.signature === 'string',
     )
   );
 }

--- a/scripts/rescue-claude-thinking-signature.mjs
+++ b/scripts/rescue-claude-thinking-signature.mjs
@@ -35,23 +35,32 @@ function readRequiredValue(argv, index, flagName) {
   return value;
 }
 
+const MIN_VALID_SIGNATURE_LENGTH = 300;
+
+export function hasShortThinkingSignature(entry) {
+  if (!entry || typeof entry !== 'object' || entry.type !== 'assistant') return false;
+  if (!entry.message || entry.message.role !== 'assistant' || !Array.isArray(entry.message.content)) return false;
+  return entry.message.content.some(
+    (item) =>
+      item &&
+      typeof item === 'object' &&
+      item.type === 'thinking' &&
+      typeof item.signature === 'string' &&
+      item.signature.length < MIN_VALID_SIGNATURE_LENGTH,
+  );
+}
+
 export function isPureThinkingAssistantTurn(entry) {
-  if (!entry || typeof entry !== 'object') return false;
-  if (entry.type !== 'assistant') return false;
-  const message = entry.message;
-  if (!message || typeof message !== 'object') return false;
-  if (message.role !== 'assistant') return false;
-  const content = message.content;
+  if (!entry || typeof entry !== 'object' || entry.type !== 'assistant') return false;
+  if (!entry.message || entry.message.role !== 'assistant' || !Array.isArray(entry.message.content)) return false;
   return (
-    Array.isArray(content) &&
-    content.length > 0 &&
-    content.every(
+    entry.message.content.length > 0 &&
+    entry.message.content.every(
       (item) =>
         item &&
         typeof item === 'object' &&
         item.type === 'thinking' &&
-        typeof item.signature === 'string' &&
-        item.signature.length > 0,
+        typeof item.signature === 'string',
     )
   );
 }
@@ -86,6 +95,21 @@ export function stripPureThinkingAssistantTurns(rawContent) {
   };
 }
 
+function hasBrokenThinkingSignature(rawContent) {
+  if (INVALID_THINKING_SIGNATURE_RE.test(rawContent)) return true;
+
+  for (const line of rawContent.split('\n')) {
+    if (line.trim().length === 0) continue;
+    try {
+      if (hasShortThinkingSignature(JSON.parse(line))) return true;
+    } catch {
+      // Ignore malformed lines while scanning; they are not rescue targets.
+    }
+  }
+
+  return false;
+}
+
 async function walkJsonlFiles(rootDir) {
   const results = [];
   const stack = [rootDir];
@@ -117,7 +141,7 @@ export async function findBrokenSessionFiles(rootDir = defaultProjectsRoot()) {
   for (const filePath of files) {
     try {
       const content = await fs.readFile(filePath, 'utf8');
-      if (INVALID_THINKING_SIGNATURE_RE.test(content)) broken.push(filePath);
+      if (hasBrokenThinkingSignature(content)) broken.push(filePath);
     } catch {
       // Ignore unreadable files and keep scanning the rest.
     }

--- a/scripts/rescue-claude-thinking-signature.test.mjs
+++ b/scripts/rescue-claude-thinking-signature.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  findBrokenSessionFiles,
+  hasShortThinkingSignature,
+  stripPureThinkingAssistantTurns,
+} from './rescue-claude-thinking-signature.mjs';
+
+function buildThinkingLine(sessionId, signature = 'sig-123') {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'thinking', thinking: 'ponder', signature }],
+    },
+  });
+}
+
+function buildTextLine(sessionId, text = 'hello') {
+  return JSON.stringify({
+    type: 'assistant',
+    sessionId,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text }],
+    },
+  });
+}
+
+test('hasShortThinkingSignature treats an empty thinking signature as invalid', () => {
+  assert.equal(JSON.parse(buildThinkingLine('empty', '')).message.content[0].signature, '');
+  assert.equal(hasShortThinkingSignature(JSON.parse(buildThinkingLine('empty', ''))), true);
+});
+
+test('stripPureThinkingAssistantTurns removes pure thinking turns with empty signatures', () => {
+  const input = [
+    buildThinkingLine('sess-1', ''),
+    buildTextLine('sess-1', 'keep me'),
+    JSON.stringify({ type: 'user', sessionId: 'sess-1', message: { role: 'user', content: 'hi' } }),
+    '',
+  ].join('\n');
+
+  const result = stripPureThinkingAssistantTurns(input);
+
+  assert.equal(result.removedCount, 1);
+  assert.ok(!result.content.includes('"signature":""'));
+  assert.ok(result.content.includes('keep me'));
+  assert.ok(result.content.includes('"role":"user"'));
+});
+
+test('findBrokenSessionFiles finds empty-signature thinking turns without an API error entry', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-thinking-broken-'));
+  const okDir = path.join(tmp, 'ok');
+  const badDir = path.join(tmp, 'bad');
+  await fs.mkdir(okDir, { recursive: true });
+  await fs.mkdir(badDir, { recursive: true });
+  await fs.writeFile(path.join(okDir, 'ok.jsonl'), `${buildTextLine('ok')}\n`, 'utf8');
+  await fs.writeFile(path.join(badDir, 'bad.jsonl'), `${buildThinkingLine('bad', '')}\n`, 'utf8');
+
+  const files = await findBrokenSessionFiles(tmp);
+
+  assert.deepEqual(
+    files.map((file) => path.basename(file)),
+    ['bad.jsonl'],
+  );
+});


### PR DESCRIPTION
## Summary
- Fix hasShortThinkingSignature and isPureThinkingAssistantTurn to accept empty-signature thinking blocks
- Applied to both TS source and standalone .mjs rescue script

## Problem
Third-party gateways produce thinking blocks with empty signatures. Existing checks required signature.length > 0, causing these blocks to be skipped — broken sessions unrescuable.

## Files Changed
- packages/api/src/domains/cats/services/session/ClaudeThinkingRescue.ts
- scripts/rescue-claude-thinking-signature.mjs

## Tested
sonnet session f0718c1b: 204 previously-skipped thinking turns now detected and removable.

Fixes #609
