### PR TITLE
feat(F172): Prompt X-Ray — canonical capture, trace propagation, Hub inspector

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -33,6 +33,8 @@ export interface QueueEntry {
   callerCatId?: string;
   /** F134: sender identity for connector group chat messages (used for UI display) */
   senderMeta?: { id: string; name?: string };
+  /** F172: Caller's OTel trace context for cross-route A2A trace propagation */
+  callerTraceContext?: { traceId: string; spanId: string; traceFlags: number };
 }
 
 export interface EnqueueResult {
@@ -72,10 +74,11 @@ export class InvocationQueue {
   enqueue(
     input: Omit<
       QueueEntry,
-      'id' | 'status' | 'createdAt' | 'mergedMessageIds' | 'messageId' | 'autoExecute' | 'callerCatId'
+      'id' | 'status' | 'createdAt' | 'mergedMessageIds' | 'messageId' | 'autoExecute' | 'callerCatId' | 'callerTraceContext'
     > & {
       autoExecute?: boolean;
       callerCatId?: string;
+      callerTraceContext?: { traceId: string; spanId: string; traceFlags: number };
     },
   ): EnqueueResult {
     const key = this.scopeKey(input.threadId, input.userId);
@@ -89,9 +92,15 @@ export class InvocationQueue {
       tail?.source === 'agent' &&
       tail.status === 'queued' &&
       Date.now() - tail.createdAt >= InvocationQueue.STALE_QUEUED_THRESHOLD_MS;
+    // F172: Never merge agent entries from different callers — different callerTraceContext
+    // means different causality chains; merging would corrupt the trace parent link.
+    const traceContextMismatch =
+      input.source === 'agent' &&
+      (tail?.callerTraceContext?.spanId ?? null) !== (input.callerTraceContext?.spanId ?? null);
     if (
       tail &&
       !isStaleTail &&
+      !traceContextMismatch &&
       tail.status === 'queued' &&
       tail.source === input.source &&
       tail.source !== 'connector' &&
@@ -130,6 +139,7 @@ export class InvocationQueue {
       autoExecute: input.autoExecute ?? false,
       callerCatId: input.callerCatId,
       senderMeta: input.senderMeta,
+      callerTraceContext: input.callerTraceContext,
     };
     q.push(entry);
     this.originalContents.set(entry.id, input.content);

--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationRegistry.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationRegistry.ts
@@ -28,6 +28,8 @@ export interface InvocationRecord {
   parentInvocationId?: string;
   /** F121: The A2A trigger message ID — the @mention message that caused this cat to be invoked */
   a2aTriggerMessageId?: string;
+  /** F172: OTel trace context for cross-route A2A trace propagation */
+  traceContext?: { traceId: string; spanId: string; traceFlags: number };
   /** In-invocation idempotency keys for callback post-message de-duplication. */
   clientMessageIds: Set<string>;
   createdAt: number;
@@ -168,6 +170,12 @@ export class InvocationRegistry {
 
     record.clientMessageIds.add(clientMessageId);
     return true;
+  }
+
+  /** F172: Store OTel trace context on an invocation (for cross-route A2A propagation). */
+  setTraceContext(invocationId: string, ctx: { traceId: string; spanId: string; traceFlags: number }): void {
+    const record = this.records.get(invocationId);
+    if (record) record.traceContext = ctx;
   }
 
   /**

--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -656,6 +656,7 @@ export class QueueProcessor {
           cursorBoundaries,
           persistenceContext,
           ...(invocationId ? { parentInvocationId: invocationId } : {}),
+          ...(entry.callerTraceContext ? { callerTraceContext: entry.callerTraceContext } : {}),
         },
       )) {
         // #768: Broadcast intent_mode on first CLI event — proves CLI is alive.

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -267,6 +267,8 @@ export interface InvocationParams {
   readonly a2aTriggerMessageId?: string;
   /** F153 Phase E: Parent route span — invocation span becomes its child */
   readonly routeSpan?: import('@opentelemetry/api').Span;
+  /** F172: Ref slot for caller to capture the invocation span (for mention_dispatch parenting) */
+  readonly invocationSpanRef?: { current?: import('@opentelemetry/api').Span };
 }
 
 /**
@@ -466,6 +468,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     { attributes: { [AGENT_ID]: catId, [OPERATION_NAME]: 'invoke', invocationId } },
     parentCtx,
   );
+  if (params.invocationSpanRef) params.invocationSpanRef.current = invocationSpan;
 
   try {
     // F152: Track active invocations — must be inside try so add/sub symmetry

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -463,7 +463,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
   const parentCtx = params.routeSpan ? trace.setSpan(context.active(), params.routeSpan) : undefined;
   const invocationSpan = tracer.startSpan(
     'cat_cafe.invocation',
-    { attributes: { [AGENT_ID]: catId, [OPERATION_NAME]: 'invoke' } },
+    { attributes: { [AGENT_ID]: catId, [OPERATION_NAME]: 'invoke', invocationId } },
     parentCtx,
   );
 

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -25,6 +25,7 @@ import { isSessionChainEnabled } from '../../../../../config/cat-config-loader.j
 import { getContextWindowFallback } from '../../../../../config/context-window-sizes.js';
 import { getSessionStrategy, shouldTakeAction } from '../../../../../config/session-strategy.js';
 import { assertSafeTestConfigRoot } from '../../../../../config/test-config-write-guard.js';
+import { capturePromptIfEnabled } from '../../../../../infrastructure/debug/prompt-capture-bridge.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import {
   AGENT_ID,
@@ -1051,6 +1052,19 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       injectSystemPrompt && params.systemPrompt
         ? `${params.systemPrompt}\n\n---\n\n${promptWithMission}`
         : `${promptWithMission}`;
+
+    // F172: Prompt X-Ray — capture canonical prompt snapshot for debugging
+    capturePromptIfEnabled({
+      catId: catId as string,
+      invocationId,
+      threadId,
+      model: resolvedAccount?.models?.[0] ?? 'unknown',
+      systemPrompt: params.systemPrompt ?? '',
+      missionPrefix: missionPrefix ?? undefined,
+      userPrompt: prompt,
+      effectivePrompt,
+      injectionDecision: { isResume, canSkipOnResume, forceReinjection, injected: injectSystemPrompt },
+    });
 
     // F089 Phase 2+3: Create tmux spawn override for agent-in-pane execution
     let spawnCliOverride: AgentServiceOptions['spawnCliOverride'];

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -470,6 +470,10 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
   );
   if (params.invocationSpanRef) params.invocationSpanRef.current = invocationSpan;
 
+  // F172: Store trace context in InvocationRecord for cross-route A2A propagation
+  const sc = invocationSpan.spanContext();
+  deps.registry.setTraceContext(invocationId, { traceId: sc.traceId, spanId: sc.spanId, traceFlags: sc.traceFlags });
+
   try {
     // F152: Track active invocations — must be inside try so add/sub symmetry
     // is guaranteed by the finally block, even on generator early abort.

--- a/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
@@ -21,7 +21,7 @@
 import type { CatId, MessageContent } from '@cat-cafe/shared';
 import { catRegistry, escapeRegExp } from '@cat-cafe/shared';
 import type { SessionStore } from '@cat-cafe/shared/utils';
-import { SpanStatusCode, trace } from '@opentelemetry/api';
+import { SpanStatusCode, context as ctxApi, trace } from '@opentelemetry/api';
 import { getDefaultCatId, isCatAvailable } from '../../../../../config/cat-config-loader.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import {
@@ -816,10 +816,22 @@ export class AgentRouter {
       persistenceContext?: PersistenceContext;
       /** F108: parentInvocationId for WorklistRegistry concurrent isolation */
       parentInvocationId?: string;
+      /** F172: Caller's OTel trace context for cross-route A2A trace propagation */
+      callerTraceContext?: { traceId: string; spanId: string; traceFlags: number };
     },
   ): AsyncIterable<AgentMessage> {
     const cleanMessage = stripIntentTags(message);
     const strategy = intent.intent === 'ideate' && targetCats.length > 1 ? 'parallel' : 'serial';
+
+    // F172: If caller provided trace context, create routeSpan as child of caller's span
+    const parentCtx = options?.callerTraceContext
+      ? trace.setSpanContext(ctxApi.active(), {
+          traceId: options.callerTraceContext.traceId,
+          spanId: options.callerTraceContext.spanId,
+          traceFlags: options.callerTraceContext.traceFlags,
+          isRemote: true,
+        })
+      : undefined;
 
     const routeSpan = routeTracer.startSpan('cat_cafe.route', {
       attributes: {
@@ -827,7 +839,7 @@ export class AgentRouter {
         [ROUTING_INTENT]: intent.intent,
         [ROUTING_STRATEGY]: strategy,
       },
-    });
+    }, parentCtx);
 
     // Fetch thread for thinkingMode + update lastActive
     // Default to play mode when no threadStore is available: stream thinking stays isolated.

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -8,6 +8,7 @@ import { catRegistry } from '@cat-cafe/shared';
 import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import { ROUTE_TOTAL_CATS_INVOKED, ROUTE_TOTAL_TOKENS } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import { estimateTokens } from '../../../../../utils/token-counter.js';
 import {
   ackGuideCompletion,
@@ -144,7 +145,10 @@ export async function* routeParallel(
   // F148 OQ-2: Collect tool names and coverage maps per cat for context eval
   const catToolNames = new Map<string, string[]>();
   const catCoverageMap = new Map<string, ContextEvalInput['coverageMap']>();
+  let routeTotalTokens = 0;
+  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
 
+  try {
   const streams = await Promise.all(
     targetCats.map(async (catId) => {
       const catConfig: CatConfig | undefined = catRegistry.tryGet(catId as string)?.config;
@@ -425,7 +429,6 @@ export async function* routeParallel(
 
   // Issue #83: Independent keepalive timer — touch draft every 60s during long tool calls.
   const KEEPALIVE_INTERVAL_MS = 60_000;
-  let keepaliveTimer: ReturnType<typeof setInterval> | undefined;
   // Track which cats have had their keepalive started
   let keepaliveStarted = false;
 
@@ -514,6 +517,9 @@ export async function* routeParallel(
             const arr = catStreamRichBlocks.get(effectiveMsg.catId) ?? [];
             arr.push(parsed.block);
             catStreamRichBlocks.set(effectiveMsg.catId, arr);
+          }
+          if (parsed.type === 'invocation_usage' && parsed.usage) {
+            routeTotalTokens += (parsed.usage.inputTokens ?? 0) + (parsed.usage.outputTokens ?? 0);
           }
         } catch {
           /* ignore parse errors */
@@ -1057,10 +1063,17 @@ export async function* routeParallel(
       timestamp: Date.now(),
     } as AgentMessage;
   }
+  } finally {
+    // F172: Set route aggregate attributes before span ends (AgentRouter calls routeSpan.end())
+    if (options.routeSpan) {
+      options.routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED, targetCats.length);
+      options.routeSpan.setAttribute(ROUTE_TOTAL_TOKENS, routeTotalTokens);
+    }
 
-  // Issue #83: Stop keepalive timer — streaming loop has exited.
-  if (keepaliveTimer) {
-    clearInterval(keepaliveTimer);
-    keepaliveTimer = undefined;
+    // Issue #83: Stop keepalive timer — streaming loop has exited.
+    if (keepaliveTimer) {
+      clearInterval(keepaliveTimer);
+      keepaliveTimer = undefined;
+    }
   }
 }

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -12,6 +12,8 @@
 
 import type { CatConfig, CatId } from '@cat-cafe/shared';
 import { catRegistry } from '@cat-cafe/shared';
+import { type Span, context, trace } from '@opentelemetry/api';
+import { AGENT_ID } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, getRoster, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { getCatVoice } from '../../../../../config/cat-voices.js';
@@ -75,6 +77,7 @@ import {
 import { buildVoteTally, checkVoteCompletion, extractVoteFromText, VOTE_RESULT_SOURCE } from './vote-intercept.js';
 
 const log = createModuleLogger('route-serial');
+const routeSerialTracer = trace.getTracer('cat-cafe-api', '0.1.0');
 
 export async function* routeSerial(
   deps: RouteStrategyDeps,
@@ -111,6 +114,10 @@ export async function* routeSerial(
   const worklistEntry = registerWorklist(threadId, worklist, maxDepth, options.parentInvocationId);
 
   let index = 0;
+  // F172: Cross-cat trace propagation — track invocation spans and dispatch parents
+  const catInvocationSpans = new Map<number, Span>();
+  const mentionParentSpan = new Map<number, Span>();
+  const pendingDispatchSpans: { span: Span; lastChildIndex: number }[] = [];
   // done-guarantee: Track whether we yielded a done(isFinal=true) so the finally block can
   // synthesize one if the loop exits early (e.g. signal.aborted break at top of while).
   let yieldedFinalDone = false;
@@ -497,6 +504,9 @@ export async function* routeSerial(
       // Using start time (not stream-completion time) keeps agent replies
       // chronologically before queued user messages that arrive after delivery.
       const invocationStartedAt = Date.now();
+      // F172: Capture invocation span ref; use mention_dispatch span as parent if this cat was @mentioned
+      const spanRef: { current?: Span } = {};
+      const effectiveParentSpan = mentionParentSpan.get(index) ?? options.routeSpan;
       for await (const msg of invokeSingleCat(deps.invocationDeps, {
         catId,
         service: getService(deps.services, catId),
@@ -512,7 +522,8 @@ export async function* routeSerial(
         ...(worklistEntry.a2aTriggerMessageId.get(catId)
           ? { a2aTriggerMessageId: worklistEntry.a2aTriggerMessageId.get(catId) }
           : {}),
-        ...(options.routeSpan ? { routeSpan: options.routeSpan } : {}),
+        ...(effectiveParentSpan ? { routeSpan: effectiveParentSpan } : {}),
+        invocationSpanRef: spanRef,
         isLastCat: false,
       })) {
         // F39 bugfix: stop yielding after cancel (pipe buffer may still drain)
@@ -768,6 +779,9 @@ export async function* routeSerial(
         if (!incrementalMode && thinkingMode === 'debug') {
           previousResponses.push({ catId, content: storedContent });
         }
+
+        // F172: Capture invocation span for this cat (used as parent for mention_dispatch)
+        if (spanRef.current) catInvocationSpans.set(index, spanRef.current);
 
         // A2A mention detection (缅因猫 P1-3: only after full text accumulated)
         // Line-start @mention = always actionable (no keyword gate)
@@ -1026,6 +1040,8 @@ export async function* routeSerial(
             const entry = roster[cid];
             return entry ? { roles: entry.roles } : undefined;
           };
+          // F172: Lazy-init mention_dispatch span (created only when first cat actually pushed)
+          let dispatchSpan: Span | undefined;
           for (const nextCat of a2aMentions) {
             if (worklistEntry.a2aCount >= maxDepth) break;
             // A2A cross-path dedup: skip if this cat is actively processing via callback (InvocationQueue)
@@ -1042,6 +1058,20 @@ export async function* routeSerial(
                 worklistEntry.a2aFrom.set(nextCat, catId);
                 // F121: response-text path — set trigger message for auto-replyTo
                 if (storedMsgId) worklistEntry.a2aTriggerMessageId.set(nextCat, storedMsgId);
+                // F172: Sync trace parent to match updated a2aFrom — lazy-init dispatch span
+                if (!dispatchSpan) {
+                  const mentionerSpan = catInvocationSpans.get(index);
+                  if (mentionerSpan) {
+                    const dispatchCtx = trace.setSpan(context.active(), mentionerSpan);
+                    dispatchSpan = routeSerialTracer.startSpan('cat_cafe.mention_dispatch', {
+                      attributes: { [AGENT_ID]: catId as string, 'mention.targets': a2aMentions.join(',') },
+                    }, dispatchCtx);
+                  }
+                }
+                if (dispatchSpan) {
+                  const dedupIndex = worklist.indexOf(nextCat, index + 1);
+                  if (dedupIndex >= 0) mentionParentSpan.set(dedupIndex, dispatchSpan);
+                }
               }
               continue;
             }
@@ -1091,12 +1121,40 @@ export async function* routeSerial(
               continue;
             }
 
+            // F172: Create mention_dispatch span as child of mentioner's invocation span
+            if (!dispatchSpan) {
+              const mentionerSpan = catInvocationSpans.get(index);
+              if (mentionerSpan) {
+                const dispatchCtx = trace.setSpan(context.active(), mentionerSpan);
+                dispatchSpan = routeSerialTracer.startSpan('cat_cafe.mention_dispatch', {
+                  attributes: {
+                    [AGENT_ID]: catId as string,
+                    'mention.targets': a2aMentions.join(','),
+                  },
+                }, dispatchCtx);
+              }
+            }
+
             worklist.push(nextCat);
             worklistEntry.a2aCount++;
             pendingTail.push(nextCat); // Keep dedup view in sync
             worklistEntry.a2aFrom.set(nextCat, catId);
             // F121: response-text path — set trigger message for auto-replyTo
             if (storedMsgId) worklistEntry.a2aTriggerMessageId.set(nextCat, storedMsgId);
+            // F172: Map pushed cat's worklist index to mention_dispatch span as parent
+            if (dispatchSpan) mentionParentSpan.set(worklist.length - 1, dispatchSpan);
+          }
+          // F172: Track dispatch span for deferred end (after all its children complete)
+          if (dispatchSpan) {
+            let maxChildIdx = -1;
+            for (const [idx, s] of mentionParentSpan) {
+              if (s === dispatchSpan && idx > maxChildIdx) maxChildIdx = idx;
+            }
+            if (maxChildIdx >= 0) {
+              pendingDispatchSpans.push({ span: dispatchSpan, lastChildIndex: maxChildIdx });
+            } else {
+              dispatchSpan.end();
+            }
           }
         }
 
@@ -1383,11 +1441,21 @@ export async function* routeSerial(
         if (isFinal) yieldedFinalDone = true;
       }
 
+      // F172: End dispatch spans whose last child just completed
+      for (const entry of pendingDispatchSpans) {
+        if (index === entry.lastChildIndex) entry.span.end();
+      }
+
       // F27: Advance executedIndex so pushToWorklist knows which cats are done
       worklistEntry.executedIndex = index + 1;
       index++;
     }
   } finally {
+    // F172: End any dispatch spans not yet ended (early abort / error paths)
+    for (const entry of pendingDispatchSpans) {
+      if (index <= entry.lastChildIndex) entry.span.end();
+    }
+
     // F27: Always unregister worklist, even on error/abort.
     // Pass owner ref so preempting new invocation's worklist is not deleted (缅因猫 R1 P1-1)
     unregisterWorklist(threadId, worklistEntry, options.parentInvocationId);

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -13,7 +13,7 @@
 import type { CatConfig, CatId } from '@cat-cafe/shared';
 import { catRegistry } from '@cat-cafe/shared';
 import { type Span, context, trace } from '@opentelemetry/api';
-import { AGENT_ID } from '../../../../../infrastructure/telemetry/genai-semconv.js';
+import { AGENT_ID, ROUTE_HAS_A2A_HANDOFF, ROUTE_TOTAL_CATS_INVOKED, ROUTE_TOTAL_TOKENS } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, getRoster, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { getCatVoice } from '../../../../../config/cat-voices.js';
@@ -118,6 +118,7 @@ export async function* routeSerial(
   const catInvocationSpans = new Map<number, Span>();
   const mentionParentSpan = new Map<number, Span>();
   const pendingDispatchSpans: { span: Span; lastChildIndex: number }[] = [];
+  let routeTotalTokens = 0;
   // done-guarantee: Track whether we yielded a done(isFinal=true) so the finally block can
   // synthesize one if the loop exits early (e.g. signal.aborted break at top of while).
   let yieldedFinalDone = false;
@@ -601,6 +602,9 @@ export async function* routeSerial(
               // F060: Collect inline rich_block for persistence (P1 fix)
               if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
                 streamRichBlocks.push(parsed.block);
+              }
+              if (parsed.type === 'invocation_usage' && parsed.usage) {
+                routeTotalTokens += (parsed.usage.inputTokens ?? 0) + (parsed.usage.outputTokens ?? 0);
               }
             } catch {
               /* ignore parse errors */
@@ -1451,6 +1455,13 @@ export async function* routeSerial(
       index++;
     }
   } finally {
+    // F172: Set route aggregate attributes before span ends (AgentRouter calls routeSpan.end())
+    if (options.routeSpan) {
+      options.routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED, index);
+      options.routeSpan.setAttribute(ROUTE_TOTAL_TOKENS, routeTotalTokens);
+      options.routeSpan.setAttribute(ROUTE_HAS_A2A_HANDOFF, worklist.length > targetCats.length);
+    }
+
     // F172: End any dispatch spans not yet ended (early abort / error paths)
     for (const entry of pendingDispatchSpans) {
       if (index <= entry.lastChildIndex) entry.span.end();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1288,6 +1288,10 @@ async function main(): Promise<void> {
     checkReadiness,
   });
 
+  // F172: Prompt X-Ray debug routes
+  const { promptCaptureRoutes } = await import('./routes/prompt-captures.js');
+  await app.register(promptCaptureRoutes);
+
   // F075 Phase B+C: Game + Achievement stores
   const { GameStore } = await import('./domains/leaderboard/game-store.js');
   const { AchievementStore } = await import('./domains/leaderboard/achievement-store.js');

--- a/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
@@ -5,6 +5,7 @@
 
 import { randomBytes } from 'node:crypto';
 import { createModuleLogger } from '../logger.js';
+import { pseudonymizeId } from '../telemetry/hmac.js';
 import {
   estimateTokens,
   isPromptCaptureEnabled,
@@ -46,6 +47,7 @@ export function capturePromptIfEnabled(input: CaptureInput): void {
     const data: PromptCapture = {
       captureId,
       invocationId: input.invocationId,
+      hmacInvocationId: pseudonymizeId(input.invocationId),
       catId: input.catId,
       threadId: input.threadId,
       model: input.model,

--- a/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
@@ -1,0 +1,70 @@
+/**
+ * F172 Prompt X-Ray: Thin bridge between invoke-single-cat and PromptCaptureStore.
+ * Fire-and-forget — never blocks invocation.
+ */
+
+import { randomBytes } from 'node:crypto';
+import { createModuleLogger } from '../logger.js';
+import {
+  estimateTokens,
+  isPromptCaptureEnabled,
+  type PromptCapture,
+  PromptCaptureStore,
+} from './prompt-capture-store.js';
+
+const log = createModuleLogger('debug:prompt-capture-bridge');
+
+let _store: PromptCaptureStore | undefined;
+
+function getStore(): PromptCaptureStore {
+  if (!_store) _store = new PromptCaptureStore();
+  return _store;
+}
+
+export interface CaptureInput {
+  catId: string;
+  invocationId: string;
+  threadId: string;
+  model: string;
+  systemPrompt: string;
+  missionPrefix?: string;
+  userPrompt: string;
+  effectivePrompt: string;
+  injectionDecision: {
+    isResume: boolean;
+    canSkipOnResume: boolean;
+    forceReinjection: boolean;
+    injected: boolean;
+  };
+}
+
+export function capturePromptIfEnabled(input: CaptureInput): void {
+  if (!isPromptCaptureEnabled(input.catId)) return;
+
+  try {
+    const captureId = randomBytes(8).toString('hex');
+    const data: PromptCapture = {
+      captureId,
+      invocationId: input.invocationId,
+      catId: input.catId,
+      threadId: input.threadId,
+      model: input.model,
+      capturedAt: Date.now(),
+      systemPrompt: input.systemPrompt,
+      missionPrefix: input.missionPrefix,
+      userPrompt: input.userPrompt,
+      effectivePrompt: input.effectivePrompt,
+      injectionDecision: input.injectionDecision,
+      promptBytes: Buffer.byteLength(input.effectivePrompt, 'utf8'),
+      tokenEstimate: estimateTokens(input.effectivePrompt),
+    };
+
+    getStore().capture(data);
+  } catch (err) {
+    log.warn({ err, catId: input.catId }, 'Prompt capture failed (non-fatal)');
+  }
+}
+
+export function getPromptCaptureStore(): PromptCaptureStore {
+  return getStore();
+}

--- a/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
@@ -59,7 +59,7 @@ export function capturePromptIfEnabled(input: CaptureInput): void {
       tokenEstimate: estimateTokens(input.effectivePrompt),
     };
 
-    getStore().capture(data);
+    getStore().captureAsync(data);
   } catch (err) {
     log.warn({ err, catId: input.catId }, 'Prompt capture failed (non-fatal)');
   }

--- a/packages/api/src/infrastructure/debug/prompt-capture-store.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-store.ts
@@ -5,10 +5,10 @@
  * Default off — controlled by PROMPT_CAPTURE env var.
  */
 
-import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { appendFile, appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFile, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import { gunzipSync, gzipSync } from 'node:zlib';
+import { gzip, gunzipSync, gzipSync } from 'node:zlib';
 import { createModuleLogger } from '../logger.js';
 
 const log = createModuleLogger('debug:prompt-capture');
@@ -73,14 +73,43 @@ export class PromptCaptureStore {
     }
   }
 
-  capture(data: PromptCapture): string {
+  captureAsync(data: PromptCapture): void {
+    const json = JSON.stringify(data);
+    const fileName = `${data.captureId}.json.gz`;
+    const filePath = join(this.payloadDir, fileName);
+
+    gzip(Buffer.from(json), (gzipErr, compressed) => {
+      if (gzipErr) {
+        log.warn({ err: gzipErr, captureId: data.captureId }, 'Prompt capture gzip failed');
+        return;
+      }
+      writeFile(filePath, compressed, (writeErr) => {
+        if (writeErr) {
+          log.warn({ err: writeErr, captureId: data.captureId }, 'Prompt capture write failed');
+          return;
+        }
+        const indexEntry: CaptureIndexEntry = {
+          captureId: data.captureId,
+          invocationId: data.invocationId,
+          catId: data.catId,
+          threadId: data.threadId,
+          capturedAt: data.capturedAt,
+          promptBytes: data.promptBytes,
+          file: fileName,
+        };
+        appendFile(this.indexPath, `${JSON.stringify(indexEntry)}\n`, (appendErr) => {
+          if (appendErr) log.warn({ err: appendErr }, 'Prompt capture index append failed');
+          this.pruneIfNeeded();
+        });
+      });
+    });
+  }
+
+  captureSync(data: PromptCapture): string {
     try {
       const compressed = gzipSync(JSON.stringify(data));
       const fileName = `${data.captureId}.json.gz`;
-      const filePath = join(this.payloadDir, fileName);
-
-      writeFileSync(filePath, compressed);
-
+      writeFileSync(join(this.payloadDir, fileName), compressed);
       const indexEntry: CaptureIndexEntry = {
         captureId: data.captureId,
         invocationId: data.invocationId,
@@ -90,9 +119,7 @@ export class PromptCaptureStore {
         promptBytes: data.promptBytes,
         file: fileName,
       };
-
-      appendFileSync(this.indexPath, JSON.stringify(indexEntry) + '\n');
-
+      appendFileSync(this.indexPath, `${JSON.stringify(indexEntry)}\n`);
       this.pruneIfNeeded();
       return data.captureId;
     } catch (err) {
@@ -207,14 +234,11 @@ export class PromptCaptureStore {
 
 export function isPromptCaptureEnabled(catId?: string): boolean {
   const mode = process.env.PROMPT_CAPTURE;
-  if (!mode || mode === 'off') return false;
-  if (mode === 'on' || mode === 'failures_only') {
-    const allowedCats = process.env.PROMPT_CAPTURE_CATS;
-    if (!allowedCats) return true;
-    if (!catId) return true;
-    return allowedCats.split(',').some((c) => c.trim() === catId);
-  }
-  return false;
+  if (mode !== 'on') return false;
+  const allowedCats = process.env.PROMPT_CAPTURE_CATS;
+  if (!allowedCats) return true;
+  if (!catId) return true;
+  return allowedCats.split(',').some((c) => c.trim() === catId);
 }
 
 export function estimateTokens(text: string): number {

--- a/packages/api/src/infrastructure/debug/prompt-capture-store.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-store.ts
@@ -16,6 +16,7 @@ const log = createModuleLogger('debug:prompt-capture');
 export interface PromptCapture {
   captureId: string;
   invocationId: string;
+  hmacInvocationId?: string;
   catId: string;
   threadId: string;
   model: string;
@@ -40,6 +41,7 @@ export interface PromptCapture {
 export interface CaptureIndexEntry {
   captureId: string;
   invocationId: string;
+  hmacInvocationId?: string;
   catId: string;
   threadId: string;
   capturedAt: number;
@@ -91,6 +93,7 @@ export class PromptCaptureStore {
         const indexEntry: CaptureIndexEntry = {
           captureId: data.captureId,
           invocationId: data.invocationId,
+          hmacInvocationId: data.hmacInvocationId,
           catId: data.catId,
           threadId: data.threadId,
           capturedAt: data.capturedAt,
@@ -113,6 +116,7 @@ export class PromptCaptureStore {
       const indexEntry: CaptureIndexEntry = {
         captureId: data.captureId,
         invocationId: data.invocationId,
+        hmacInvocationId: data.hmacInvocationId,
         catId: data.catId,
         threadId: data.threadId,
         capturedAt: data.capturedAt,
@@ -141,7 +145,9 @@ export class PromptCaptureStore {
   }
 
   listByInvocation(invocationId: string): CaptureIndexEntry[] {
-    return this.readIndex().filter((e) => e.invocationId === invocationId);
+    return this.readIndex().filter(
+      (e) => e.invocationId === invocationId || e.hmacInvocationId === invocationId,
+    );
   }
 
   listByThread(threadId: string, limit = 20): CaptureIndexEntry[] {

--- a/packages/api/src/infrastructure/debug/prompt-capture-store.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-store.ts
@@ -1,0 +1,222 @@
+/**
+ * F172 Prompt X-Ray: File-based ring buffer for canonical prompt captures.
+ *
+ * Stores gzip-compressed prompt snapshots with NDJSON index.
+ * Default off — controlled by PROMPT_CAPTURE env var.
+ */
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { gunzipSync, gzipSync } from 'node:zlib';
+import { createModuleLogger } from '../logger.js';
+
+const log = createModuleLogger('debug:prompt-capture');
+
+export interface PromptCapture {
+  captureId: string;
+  invocationId: string;
+  catId: string;
+  threadId: string;
+  model: string;
+  capturedAt: number;
+
+  systemPrompt: string;
+  missionPrefix?: string;
+  userPrompt: string;
+  effectivePrompt: string;
+
+  injectionDecision: {
+    isResume: boolean;
+    canSkipOnResume: boolean;
+    forceReinjection: boolean;
+    injected: boolean;
+  };
+
+  promptBytes: number;
+  tokenEstimate: number;
+}
+
+export interface CaptureIndexEntry {
+  captureId: string;
+  invocationId: string;
+  catId: string;
+  threadId: string;
+  capturedAt: number;
+  promptBytes: number;
+  file: string;
+}
+
+const DEFAULT_BASE_DIR = join(homedir(), '.cat-cafe', 'prompt-captures');
+const DEFAULT_MAX_ENTRIES = 500;
+const DEFAULT_TTL_MS = 6 * 60 * 60 * 1000;
+
+export class PromptCaptureStore {
+  private readonly baseDir: string;
+  private readonly payloadDir: string;
+  private readonly indexPath: string;
+  private readonly maxEntries: number;
+  private readonly ttlMs: number;
+
+  constructor(opts?: { baseDir?: string; maxEntries?: number; ttlMs?: number }) {
+    this.baseDir = opts?.baseDir ?? DEFAULT_BASE_DIR;
+    this.payloadDir = join(this.baseDir, 'payloads');
+    this.indexPath = join(this.baseDir, 'index.ndjson');
+    this.maxEntries = opts?.maxEntries ?? DEFAULT_MAX_ENTRIES;
+    this.ttlMs = opts?.ttlMs ?? DEFAULT_TTL_MS;
+    this.ensureDirs();
+  }
+
+  private ensureDirs(): void {
+    if (!existsSync(this.payloadDir)) {
+      mkdirSync(this.payloadDir, { recursive: true });
+    }
+  }
+
+  capture(data: PromptCapture): string {
+    try {
+      const compressed = gzipSync(JSON.stringify(data));
+      const fileName = `${data.captureId}.json.gz`;
+      const filePath = join(this.payloadDir, fileName);
+
+      writeFileSync(filePath, compressed);
+
+      const indexEntry: CaptureIndexEntry = {
+        captureId: data.captureId,
+        invocationId: data.invocationId,
+        catId: data.catId,
+        threadId: data.threadId,
+        capturedAt: data.capturedAt,
+        promptBytes: data.promptBytes,
+        file: fileName,
+      };
+
+      appendFileSync(this.indexPath, JSON.stringify(indexEntry) + '\n');
+
+      this.pruneIfNeeded();
+      return data.captureId;
+    } catch (err) {
+      log.warn({ err, captureId: data.captureId }, 'Failed to write prompt capture');
+      return data.captureId;
+    }
+  }
+
+  read(captureId: string): PromptCapture | null {
+    try {
+      const filePath = join(this.payloadDir, `${captureId}.json.gz`);
+      if (!existsSync(filePath)) return null;
+      const compressed = readFileSync(filePath);
+      return JSON.parse(gunzipSync(compressed).toString('utf8')) as PromptCapture;
+    } catch (err) {
+      log.warn({ err, captureId }, 'Failed to read prompt capture');
+      return null;
+    }
+  }
+
+  listByInvocation(invocationId: string): CaptureIndexEntry[] {
+    return this.readIndex().filter((e) => e.invocationId === invocationId);
+  }
+
+  listByThread(threadId: string, limit = 20): CaptureIndexEntry[] {
+    return this.readIndex()
+      .filter((e) => e.threadId === threadId)
+      .slice(-limit);
+  }
+
+  listRecent(limit = 20): CaptureIndexEntry[] {
+    return this.readIndex().slice(-limit);
+  }
+
+  stats(): { entries: number; totalBytes: number } {
+    const entries = this.readIndex();
+    return {
+      entries: entries.length,
+      totalBytes: entries.reduce((sum, e) => sum + e.promptBytes, 0),
+    };
+  }
+
+  prune(): number {
+    const cutoff = Date.now() - this.ttlMs;
+    const entries = this.readIndex();
+    const keep: CaptureIndexEntry[] = [];
+    let removed = 0;
+
+    for (const entry of entries) {
+      if (entry.capturedAt < cutoff) {
+        this.deletePayload(entry.file);
+        removed++;
+      } else {
+        keep.push(entry);
+      }
+    }
+
+    if (keep.length > this.maxEntries) {
+      const overflow = keep.splice(0, keep.length - this.maxEntries);
+      for (const entry of overflow) {
+        this.deletePayload(entry.file);
+        removed++;
+      }
+    }
+
+    if (removed > 0) {
+      this.writeIndex(keep);
+      log.info({ removed, remaining: keep.length }, 'Pruned prompt captures');
+    }
+
+    return removed;
+  }
+
+  private pruneIfNeeded(): void {
+    try {
+      const entries = this.readIndex();
+      if (entries.length > this.maxEntries + 10) {
+        this.prune();
+      }
+    } catch {
+      // Non-critical
+    }
+  }
+
+  private readIndex(): CaptureIndexEntry[] {
+    try {
+      if (!existsSync(this.indexPath)) return [];
+      const content = readFileSync(this.indexPath, 'utf8');
+      return content
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as CaptureIndexEntry);
+    } catch {
+      return [];
+    }
+  }
+
+  private writeIndex(entries: CaptureIndexEntry[]): void {
+    writeFileSync(this.indexPath, entries.map((e) => JSON.stringify(e)).join('\n') + '\n');
+  }
+
+  private deletePayload(fileName: string): void {
+    try {
+      unlinkSync(join(this.payloadDir, fileName));
+    } catch {
+      // File may already be gone
+    }
+  }
+}
+
+// ── Gate ──────────────────────────────────────────────────────────
+
+export function isPromptCaptureEnabled(catId?: string): boolean {
+  const mode = process.env.PROMPT_CAPTURE;
+  if (!mode || mode === 'off') return false;
+  if (mode === 'on' || mode === 'failures_only') {
+    const allowedCats = process.env.PROMPT_CAPTURE_CATS;
+    if (!allowedCats) return true;
+    if (!catId) return true;
+    return allowedCats.split(',').some((c) => c.trim() === catId);
+  }
+  return false;
+}
+
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3.5);
+}

--- a/packages/api/src/infrastructure/telemetry/genai-semconv.ts
+++ b/packages/api/src/infrastructure/telemetry/genai-semconv.ts
@@ -30,3 +30,9 @@ export const TOOL_CATEGORY = 'tool.category';
 export const ROUTING_STRATEGY = 'cat_cafe.routing.strategy';
 export const ROUTING_TARGET_CATS = 'cat_cafe.routing.target_cats';
 export const ROUTING_INTENT = 'cat_cafe.routing.intent';
+
+// --- Route aggregate attributes (set at route completion) ---
+export const ROUTE_TOTAL_CATS_INVOKED = 'route.total_cats_invoked';
+export const ROUTE_TOTAL_TOKENS = 'route.total_tokens';
+export const ROUTE_HAS_A2A_HANDOFF = 'route.has_a2a_handoff';
+export const THREAD_ID = 'thread.id';

--- a/packages/api/src/infrastructure/telemetry/local-trace-store.ts
+++ b/packages/api/src/infrastructure/telemetry/local-trace-store.ts
@@ -67,7 +67,7 @@ export interface TraceStoreStats {
 }
 
 const DEFAULT_MAX_SPANS = 10_000;
-const DEFAULT_MAX_AGE_MS = 2 * 60 * 60 * 1000; // 2 hours
+const DEFAULT_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 export class LocalTraceStore {
   private readonly buffer: TraceSpanDTO[] = [];

--- a/packages/api/src/routes/callback-a2a-trigger.ts
+++ b/packages/api/src/routes/callback-a2a-trigger.ts
@@ -74,6 +74,8 @@ export async function enqueueA2ATargets(
     callerCatId?: CatId;
     /** F108: parentInvocationId for concurrent worklist isolation. */
     parentInvocationId?: string;
+    /** F172: Caller's OTel trace context for cross-route A2A trace propagation. */
+    callerTraceContext?: { traceId: string; spanId: string; traceFlags: number };
   },
 ): Promise<{ enqueued: CatId[]; fallback: boolean }> {
   const { log } = deps;
@@ -195,6 +197,7 @@ export async function enqueueA2ATargets(
         intent: 'execute',
         autoExecute: true,
         callerCatId: callerCatId ?? undefined,
+        callerTraceContext: opts.callerTraceContext,
       });
       queueDiagnostics.push({
         catId,
@@ -389,6 +392,7 @@ export async function triggerA2AInvocation(
     userId: string;
     threadId: string;
     triggerMessage: StoredMessage;
+    callerTraceContext?: { traceId: string; spanId: string; traceFlags: number };
   },
 ): Promise<void> {
   const { router, invocationRecordStore, socketManager, invocationTracker, log } = deps;
@@ -474,6 +478,7 @@ export async function triggerA2AInvocation(
       for await (const msg of router.routeExecution(userId, content, threadId, triggerMessage.id, targetCats, intent, {
         ...(controller?.signal ? { signal: controller.signal } : {}),
         parentInvocationId: createResult.invocationId,
+        callerTraceContext: opts.callerTraceContext,
       })) {
         // #768: Broadcast intent_mode on first CLI event — proves CLI is alive.
         if (!intentModeBroadcast) {

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -585,6 +585,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
           triggerMessage: storedMsg,
           callerCatId: senderCatId,
           parentInvocationId: record.parentInvocationId,
+          callerTraceContext: record.traceContext,
         },
       );
 
@@ -1261,6 +1262,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
         threadId: record.threadId,
         triggerMessage: notificationMsg,
         callerCatId: record.catId as CatId,
+        callerTraceContext: record.traceContext,
       };
       try {
         const { enqueued } = await enqueueA2ATargets(a2aDeps, a2aOpts);

--- a/packages/api/src/routes/prompt-captures.ts
+++ b/packages/api/src/routes/prompt-captures.ts
@@ -1,0 +1,65 @@
+/**
+ * F172 Prompt X-Ray: API routes for reading prompt captures.
+ * All endpoints require session auth (localhost-only by default).
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { getPromptCaptureStore } from '../infrastructure/debug/prompt-capture-bridge.js';
+import { isPromptCaptureEnabled } from '../infrastructure/debug/prompt-capture-store.js';
+
+function requireSession(
+  request: import('fastify').FastifyRequest,
+  reply: import('fastify').FastifyReply,
+): string | null {
+  const userId = (request as import('fastify').FastifyRequest & { sessionUserId?: string }).sessionUserId;
+  if (!userId) {
+    reply.status(401).send({ error: 'Session required' });
+    return null;
+  }
+  return userId;
+}
+
+export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/api/debug/prompt-captures/status', async (request, reply) => {
+    if (!requireSession(request, reply)) return;
+    const store = getPromptCaptureStore();
+    return {
+      enabled: isPromptCaptureEnabled(),
+      mode: process.env.PROMPT_CAPTURE ?? 'off',
+      catFilter: process.env.PROMPT_CAPTURE_CATS ?? null,
+      ...store.stats(),
+    };
+  });
+
+  app.get<{ Querystring: { threadId?: string; invocationId?: string; limit?: string } }>(
+    '/api/debug/prompt-captures',
+    async (request, reply) => {
+      if (!requireSession(request, reply)) return;
+      const store = getPromptCaptureStore();
+      const limit = Math.min(parseInt(request.query.limit ?? '20', 10) || 20, 100);
+
+      if (request.query.invocationId) {
+        return store.listByInvocation(request.query.invocationId);
+      }
+      if (request.query.threadId) {
+        return store.listByThread(request.query.threadId, limit);
+      }
+      return store.listRecent(limit);
+    },
+  );
+
+  app.get<{ Params: { captureId: string } }>('/api/debug/prompt-captures/:captureId', async (request, reply) => {
+    if (!requireSession(request, reply)) return;
+    const capture = getPromptCaptureStore().read(request.params.captureId);
+    if (!capture) {
+      return reply.status(404).send({ error: 'Capture not found or expired' });
+    }
+    return capture;
+  });
+
+  app.post('/api/debug/prompt-captures/prune', async (request, reply) => {
+    if (!requireSession(request, reply)) return;
+    const removed = getPromptCaptureStore().prune();
+    return { removed };
+  });
+};

--- a/packages/api/src/routes/prompt-captures.ts
+++ b/packages/api/src/routes/prompt-captures.ts
@@ -44,7 +44,7 @@ export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
       if (request.query.threadId) {
         return store.listByThread(request.query.threadId, limit);
       }
-      return store.listRecent(limit);
+      return reply.status(400).send({ error: 'Provide invocationId or threadId filter' });
     },
   );
 

--- a/packages/api/test/prompt-capture.test.js
+++ b/packages/api/test/prompt-capture.test.js
@@ -5,7 +5,7 @@
 if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
 
 import assert from 'node:assert/strict';
-import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -37,7 +37,7 @@ test('F172: PromptCaptureStore captures and reads back', async () => {
   const store = new PromptCaptureStore({ baseDir: dir });
 
   const capture = makeCapture();
-  store.capture(capture);
+  store.captureSync(capture);
 
   const result = store.read(capture.captureId);
   assert.ok(result);
@@ -60,9 +60,9 @@ test('F172: listByInvocation filters correctly', async () => {
   const dir = join(testDir, 'by-inv');
   const store = new PromptCaptureStore({ baseDir: dir });
 
-  store.capture(makeCapture({ invocationId: 'inv-A' }));
-  store.capture(makeCapture({ invocationId: 'inv-B' }));
-  store.capture(makeCapture({ invocationId: 'inv-A' }));
+  store.captureSync(makeCapture({ invocationId: 'inv-A' }));
+  store.captureSync(makeCapture({ invocationId: 'inv-B' }));
+  store.captureSync(makeCapture({ invocationId: 'inv-A' }));
 
   const results = store.listByInvocation('inv-A');
   assert.equal(results.length, 2);
@@ -73,9 +73,9 @@ test('F172: listByThread filters correctly', async () => {
   const dir = join(testDir, 'by-thread');
   const store = new PromptCaptureStore({ baseDir: dir });
 
-  store.capture(makeCapture({ threadId: 'thread-1' }));
-  store.capture(makeCapture({ threadId: 'thread-2' }));
-  store.capture(makeCapture({ threadId: 'thread-1' }));
+  store.captureSync(makeCapture({ threadId: 'thread-1' }));
+  store.captureSync(makeCapture({ threadId: 'thread-2' }));
+  store.captureSync(makeCapture({ threadId: 'thread-1' }));
 
   const results = store.listByThread('thread-1');
   assert.equal(results.length, 2);
@@ -86,8 +86,8 @@ test('F172: prune removes expired entries', async () => {
   const dir = join(testDir, 'prune');
   const store = new PromptCaptureStore({ baseDir: dir, ttlMs: 100 });
 
-  store.capture(makeCapture({ capturedAt: Date.now() - 5000 }));
-  store.capture(makeCapture({ capturedAt: Date.now() }));
+  store.captureSync(makeCapture({ capturedAt: Date.now() - 5000 }));
+  store.captureSync(makeCapture({ capturedAt: Date.now() }));
 
   const removed = store.prune();
   assert.equal(removed, 1);
@@ -100,7 +100,7 @@ test('F172: prune enforces maxEntries', async () => {
   const store = new PromptCaptureStore({ baseDir: dir, maxEntries: 3 });
 
   for (let i = 0; i < 5; i++) {
-    store.capture(makeCapture());
+    store.captureSync(makeCapture());
   }
 
   store.prune();
@@ -114,7 +114,7 @@ test('F172: gzip compression actually compresses', async () => {
 
   const bigPrompt = 'x'.repeat(10000);
   const capture = makeCapture({ effectivePrompt: bigPrompt, captureId: 'gzip-test' });
-  store.capture(capture);
+  store.captureSync(capture);
 
   const filePath = join(dir, 'payloads', 'gzip-test.json.gz');
   assert.ok(existsSync(filePath));

--- a/packages/api/test/prompt-capture.test.js
+++ b/packages/api/test/prompt-capture.test.js
@@ -1,0 +1,176 @@
+/**
+ * F172 Prompt X-Ray: PromptCaptureStore + bridge tests.
+ */
+
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
+
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+const testDir = join(tmpdir(), `prompt-capture-test-${Date.now()}`);
+
+function makeCapture(overrides = {}) {
+  return {
+    captureId: `cap-${Math.random().toString(36).slice(2, 10)}`,
+    invocationId: 'inv-001',
+    catId: 'opus',
+    threadId: 'thread-abc',
+    model: 'claude-opus-4-6',
+    capturedAt: Date.now(),
+    systemPrompt: 'You are a helpful cat.',
+    missionPrefix: undefined,
+    userPrompt: 'Hello world',
+    effectivePrompt: 'You are a helpful cat.\n\n---\n\nHello world',
+    injectionDecision: { isResume: false, canSkipOnResume: true, forceReinjection: false, injected: true },
+    promptBytes: 42,
+    tokenEstimate: 12,
+    ...overrides,
+  };
+}
+
+test('F172: PromptCaptureStore captures and reads back', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'basic');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  const capture = makeCapture();
+  store.capture(capture);
+
+  const result = store.read(capture.captureId);
+  assert.ok(result);
+  assert.equal(result.catId, 'opus');
+  assert.equal(result.effectivePrompt, capture.effectivePrompt);
+  assert.equal(result.injectionDecision.injected, true);
+});
+
+test('F172: read returns null for missing capture', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'missing');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  const result = store.read('nonexistent');
+  assert.equal(result, null);
+});
+
+test('F172: listByInvocation filters correctly', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'by-inv');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  store.capture(makeCapture({ invocationId: 'inv-A' }));
+  store.capture(makeCapture({ invocationId: 'inv-B' }));
+  store.capture(makeCapture({ invocationId: 'inv-A' }));
+
+  const results = store.listByInvocation('inv-A');
+  assert.equal(results.length, 2);
+});
+
+test('F172: listByThread filters correctly', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'by-thread');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  store.capture(makeCapture({ threadId: 'thread-1' }));
+  store.capture(makeCapture({ threadId: 'thread-2' }));
+  store.capture(makeCapture({ threadId: 'thread-1' }));
+
+  const results = store.listByThread('thread-1');
+  assert.equal(results.length, 2);
+});
+
+test('F172: prune removes expired entries', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'prune');
+  const store = new PromptCaptureStore({ baseDir: dir, ttlMs: 100 });
+
+  store.capture(makeCapture({ capturedAt: Date.now() - 5000 }));
+  store.capture(makeCapture({ capturedAt: Date.now() }));
+
+  const removed = store.prune();
+  assert.equal(removed, 1);
+  assert.equal(store.stats().entries, 1);
+});
+
+test('F172: prune enforces maxEntries', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'max');
+  const store = new PromptCaptureStore({ baseDir: dir, maxEntries: 3 });
+
+  for (let i = 0; i < 5; i++) {
+    store.capture(makeCapture());
+  }
+
+  store.prune();
+  assert.ok(store.stats().entries <= 3);
+});
+
+test('F172: gzip compression actually compresses', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'gzip');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  const bigPrompt = 'x'.repeat(10000);
+  const capture = makeCapture({ effectivePrompt: bigPrompt, captureId: 'gzip-test' });
+  store.capture(capture);
+
+  const filePath = join(dir, 'payloads', 'gzip-test.json.gz');
+  assert.ok(existsSync(filePath));
+  const fileSize = readFileSync(filePath).length;
+  assert.ok(fileSize < 5000, `Compressed size ${fileSize} should be much smaller than raw`);
+});
+
+// ── Gate tests ──────────────────────────────────────────────────
+
+test('F172: isPromptCaptureEnabled respects env', async () => {
+  const { isPromptCaptureEnabled } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+
+  const origCapture = process.env.PROMPT_CAPTURE;
+  const origCats = process.env.PROMPT_CAPTURE_CATS;
+
+  process.env.PROMPT_CAPTURE = 'off';
+  assert.equal(isPromptCaptureEnabled('opus'), false);
+
+  process.env.PROMPT_CAPTURE = 'on';
+  delete process.env.PROMPT_CAPTURE_CATS;
+  assert.equal(isPromptCaptureEnabled('opus'), true);
+
+  process.env.PROMPT_CAPTURE_CATS = 'codex,sonnet';
+  assert.equal(isPromptCaptureEnabled('opus'), false);
+  assert.equal(isPromptCaptureEnabled('codex'), true);
+
+  // Restore
+  if (origCapture !== undefined) process.env.PROMPT_CAPTURE = origCapture;
+  else delete process.env.PROMPT_CAPTURE;
+  if (origCats !== undefined) process.env.PROMPT_CAPTURE_CATS = origCats;
+  else delete process.env.PROMPT_CAPTURE_CATS;
+});
+
+test('F172: estimateTokens gives reasonable estimate', async () => {
+  const { estimateTokens } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const estimate = estimateTokens('Hello world, this is a test prompt');
+  assert.ok(estimate > 5 && estimate < 20);
+});
+
+// ── Source-level tests ──────────────────────────────────────────
+
+test('F172: invoke-single-cat calls capturePromptIfEnabled', () => {
+  const src = readFileSync(
+    join(import.meta.dirname, '../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('capturePromptIfEnabled'), 'Should call capture function after effectivePrompt assembly');
+  assert.ok(src.includes('prompt-capture-bridge'), 'Should import from prompt-capture-bridge');
+});
+
+test('F172: API routes registered in index.ts', () => {
+  const src = readFileSync(join(import.meta.dirname, '../src/index.ts'), 'utf8');
+  assert.ok(src.includes('promptCaptureRoutes'), 'Should register prompt capture routes');
+});
+
+// Cleanup
+test('F172: cleanup test dir', () => {
+  rmSync(testDir, { recursive: true, force: true });
+});

--- a/packages/api/test/telemetry/mention-dispatch-trace.test.js
+++ b/packages/api/test/telemetry/mention-dispatch-trace.test.js
@@ -1,0 +1,134 @@
+/**
+ * F172: Cross-cat trace propagation via mention_dispatch spans.
+ *
+ * Covers:
+ * - Text-scan A2A path: mention_dispatch span created as child of mentioner's invocation
+ * - invocationSpanRef: caller can capture invocation span reference
+ * - Callback A2A path: NOT covered (InvocationQueue creates separate routeExecution — tracked as follow-up)
+ */
+
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── invocationSpanRef param exists on InvocationParams ─────────────
+
+test('F172: InvocationParams declares invocationSpanRef field', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('invocationSpanRef') && src.includes('{ current?:'),
+    'InvocationParams should declare invocationSpanRef with { current?: Span } shape',
+  );
+});
+
+test('F172: invokeSingleCat writes span to invocationSpanRef', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('params.invocationSpanRef') && src.includes('.current = invocationSpan'),
+    'Should write invocationSpan to spanRef.current after creation',
+  );
+});
+
+// ── route-serial: mention_dispatch span creation ───────────────────
+
+test('F172: route-serial creates cat_cafe.mention_dispatch span on A2A push', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes("'cat_cafe.mention_dispatch'") && src.includes('mention.targets'),
+    'Should create mention_dispatch span with mention.targets attribute',
+  );
+});
+
+test('F172: route-serial uses effectiveParentSpan (mention_dispatch or routeSpan) for invocation', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('effectiveParentSpan') && src.includes('mentionParentSpan.get(index)'),
+    'Should resolve parent span from mentionParentSpan map or fall back to routeSpan',
+  );
+  assert.ok(
+    src.includes('effectiveParentSpan ? { routeSpan: effectiveParentSpan }'),
+    'Should pass effectiveParentSpan as routeSpan to invokeSingleCat',
+  );
+});
+
+test('F172: route-serial tracks catInvocationSpans per worklist index', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('catInvocationSpans.set(index, spanRef.current)'),
+    'Should store invocation span by worklist index after cat completes',
+  );
+});
+
+// ── Dedup path: mentionParentSpan sync with a2aFrom ───────────────
+
+test('F172: dedup path updates mentionParentSpan when a2aFrom changes', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('dedupIndex') && src.includes('mentionParentSpan.set(dedupIndex'),
+    'Dedup path should update mentionParentSpan when a2aFrom is overwritten',
+  );
+});
+
+// ── Dispatch span lifecycle ────────────────────────────────────────
+
+test('F172: dispatch spans ended after last child completes', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('pendingDispatchSpans') && src.includes('entry.lastChildIndex') && src.includes('entry.span.end()'),
+    'Should end dispatch span when index reaches lastChildIndex',
+  );
+});
+
+test('F172: finally block ends orphaned dispatch spans on early abort', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  const finallyIdx = src.indexOf('} finally {');
+  const cleanupIdx = src.indexOf('index <= entry.lastChildIndex');
+  assert.ok(
+    finallyIdx > 0 && cleanupIdx > finallyIdx,
+    'Finally block should end dispatch spans not yet completed (abort safety)',
+  );
+});
+
+// ── Known gap: callback InvocationQueue path ──────────────────────
+
+test('F172: QueueProcessor does NOT propagate trace context (known gap — follow-up)', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/QueueProcessor.ts'),
+    'utf8',
+  );
+  const hasTraceContext = src.includes('traceId') || src.includes('mention_dispatch') || src.includes('routeSpan');
+  assert.ok(
+    !hasTraceContext,
+    'QueueProcessor does not yet carry trace context — callback A2A creates independent roots (documented gap)',
+  );
+});

--- a/packages/api/test/telemetry/mention-dispatch-trace.test.js
+++ b/packages/api/test/telemetry/mention-dispatch-trace.test.js
@@ -119,6 +119,115 @@ test('F172: finally block ends orphaned dispatch spans on early abort', () => {
   );
 });
 
+// ── Behavioral: OTel span parent-child wiring (real tracer) ───────
+
+const { context: ctxApi, trace: traceApi } = await import('@opentelemetry/api');
+const { InMemorySpanExporter, SimpleSpanProcessor, NodeTracerProvider } = await import('@opentelemetry/sdk-trace-node');
+
+const otelExporter = new InMemorySpanExporter();
+const otelProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(otelExporter)],
+});
+const otelTracer = otelProvider.getTracer('test-mention-dispatch');
+
+test('F172 behavioral: mention_dispatch span is child of mentioner invocation', async () => {
+  otelExporter.reset();
+
+  // Simulate: route → invocation(A) → mention_dispatch → invocation(B)
+  const routeSpan = otelTracer.startSpan('cat_cafe.route');
+  const routeCtx = traceApi.setSpan(ctxApi.active(), routeSpan);
+
+  const invocationA = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'opus' } }, routeCtx);
+  invocationA.end();
+
+  // mention_dispatch as child of invocation A (even though A already ended)
+  const invACtx = traceApi.setSpan(ctxApi.active(), invocationA);
+  const dispatchSpan = otelTracer.startSpan('cat_cafe.mention_dispatch', {
+    attributes: { 'mention.targets': 'sonnet,codex' },
+  }, invACtx);
+
+  // invocation B as child of mention_dispatch
+  const dispatchCtx = traceApi.setSpan(ctxApi.active(), dispatchSpan);
+  const invocationB = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'sonnet' } }, dispatchCtx);
+  invocationB.end();
+
+  dispatchSpan.end();
+  routeSpan.end();
+
+  // Verify hierarchy via exported spans
+  const spans = otelExporter.getFinishedSpans();
+  assert.equal(spans.length, 4);
+
+  const route = spans.find(s => s.name === 'cat_cafe.route');
+  const invA = spans.find(s => s.name === 'cat_cafe.invocation' && s.attributes['agent.id'] === 'opus');
+  const dispatch = spans.find(s => s.name === 'cat_cafe.mention_dispatch');
+  const invB = spans.find(s => s.name === 'cat_cafe.invocation' && s.attributes['agent.id'] === 'sonnet');
+
+  assert.ok(route && invA && dispatch && invB, 'All 4 spans should be present');
+
+  // Same trace
+  const traceId = route.spanContext().traceId;
+  assert.equal(invA.spanContext().traceId, traceId, 'invocation A same trace');
+  assert.equal(dispatch.spanContext().traceId, traceId, 'dispatch same trace');
+  assert.equal(invB.spanContext().traceId, traceId, 'invocation B same trace');
+
+  // Parent-child: route → invA → dispatch → invB
+  assert.equal(invA.parentSpanContext.spanId, route.spanContext().spanId, 'invocation A is child of route');
+  assert.equal(dispatch.parentSpanContext.spanId, invA.spanContext().spanId, 'mention_dispatch is child of invocation A');
+  assert.equal(invB.parentSpanContext.spanId, dispatch.spanContext().spanId, 'invocation B is child of mention_dispatch');
+});
+
+test('F172 behavioral: multiple mentioned cats share same dispatch parent', async () => {
+  otelExporter.reset();
+
+  const routeSpan = otelTracer.startSpan('cat_cafe.route');
+  const routeCtx = traceApi.setSpan(ctxApi.active(), routeSpan);
+
+  const invA = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'opus' } }, routeCtx);
+  invA.end();
+
+  const invACtx = traceApi.setSpan(ctxApi.active(), invA);
+  const dispatch = otelTracer.startSpan('cat_cafe.mention_dispatch', {
+    attributes: { 'mention.targets': 'sonnet,codex' },
+  }, invACtx);
+  const dispatchCtx = traceApi.setSpan(ctxApi.active(), dispatch);
+
+  const invB = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'sonnet' } }, dispatchCtx);
+  invB.end();
+  const invC = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'codex' } }, dispatchCtx);
+  invC.end();
+
+  dispatch.end();
+  routeSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const dispatchSpan = spans.find(s => s.name === 'cat_cafe.mention_dispatch');
+  const sonnet = spans.find(s => s.attributes['agent.id'] === 'sonnet');
+  const codex = spans.find(s => s.attributes['agent.id'] === 'codex');
+
+  assert.equal(sonnet.parentSpanContext.spanId, dispatchSpan.spanContext().spanId, 'sonnet under dispatch');
+  assert.equal(codex.parentSpanContext.spanId, dispatchSpan.spanContext().spanId, 'codex under dispatch');
+});
+
+test('F172 behavioral: child spans survive after parent span ends (OTel contract)', async () => {
+  otelExporter.reset();
+
+  const parent = otelTracer.startSpan('parent');
+  parent.end();
+
+  const parentCtx = traceApi.setSpan(ctxApi.active(), parent);
+  const child = otelTracer.startSpan('child', {}, parentCtx);
+  child.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  assert.equal(spans.length, 2);
+  assert.equal(
+    spans.find(s => s.name === 'child').parentSpanContext.spanId,
+    spans.find(s => s.name === 'parent').spanContext().spanId,
+    'Child created after parent.end() still has correct parentSpanId',
+  );
+});
+
 // ── Known gap: callback InvocationQueue path ──────────────────────
 
 test('F172: QueueProcessor does NOT propagate trace context (known gap — follow-up)', () => {

--- a/packages/api/test/telemetry/mention-dispatch-trace.test.js
+++ b/packages/api/test/telemetry/mention-dispatch-trace.test.js
@@ -228,16 +228,279 @@ test('F172 behavioral: child spans survive after parent span ends (OTel contract
   );
 });
 
-// ── Known gap: callback InvocationQueue path ──────────────────────
+// ── P1: Route span aggregate attributes ──────────────────────────
 
-test('F172: QueueProcessor does NOT propagate trace context (known gap — follow-up)', () => {
+test('F172 P1: genai-semconv exports route aggregate constants', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/infrastructure/telemetry/genai-semconv.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes("ROUTE_TOTAL_CATS_INVOKED = 'route.total_cats_invoked'"), 'Should export ROUTE_TOTAL_CATS_INVOKED');
+  assert.ok(src.includes("ROUTE_TOTAL_TOKENS = 'route.total_tokens'"), 'Should export ROUTE_TOTAL_TOKENS');
+  assert.ok(src.includes("ROUTE_HAS_A2A_HANDOFF = 'route.has_a2a_handoff'"), 'Should export ROUTE_HAS_A2A_HANDOFF');
+  assert.ok(src.includes("THREAD_ID = 'thread.id'"), 'Should export THREAD_ID');
+});
+
+test('F172 P1: route-serial sets aggregate attributes on routeSpan in finally', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('ROUTE_TOTAL_CATS_INVOKED'), 'Should import ROUTE_TOTAL_CATS_INVOKED');
+  assert.ok(src.includes('ROUTE_TOTAL_TOKENS'), 'Should import ROUTE_TOTAL_TOKENS');
+  assert.ok(src.includes('ROUTE_HAS_A2A_HANDOFF'), 'Should import ROUTE_HAS_A2A_HANDOFF');
+  const finallyIdx = src.indexOf('} finally {');
+  const setAttrIdx = src.indexOf('routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED');
+  assert.ok(
+    finallyIdx > 0 && setAttrIdx > finallyIdx,
+    'Aggregate attributes must be set inside finally block',
+  );
+});
+
+test('F172 P1: route-serial accumulates routeTotalTokens from invocation_usage', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-serial.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('routeTotalTokens'), 'Should declare routeTotalTokens accumulator');
+  assert.ok(
+    src.includes("parsed.type === 'invocation_usage'") && src.includes('routeTotalTokens +='),
+    'Should accumulate tokens from invocation_usage system_info messages',
+  );
+});
+
+test('F172 P1: route-parallel sets aggregate attributes on routeSpan inside finally', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/route-parallel.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('ROUTE_TOTAL_CATS_INVOKED'), 'Should import ROUTE_TOTAL_CATS_INVOKED');
+  assert.ok(src.includes('ROUTE_TOTAL_TOKENS'), 'Should import ROUTE_TOTAL_TOKENS');
+  const finallyIdx = src.indexOf('} finally {');
+  const setAttrIdx = src.indexOf('routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED');
+  assert.ok(
+    finallyIdx > 0 && setAttrIdx > finallyIdx,
+    'Aggregate attributes must be set inside finally block (abort/error safety)',
+  );
+  const tryIdx = src.indexOf('try {');
+  const promiseAllIdx = src.indexOf('Promise.all(');
+  assert.ok(
+    tryIdx > 0 && tryIdx < promiseAllIdx,
+    'try must start before Promise.all to cover pre-stream construction throws',
+  );
+});
+
+// ── P1: Token metrics threadId dimension ─────────────────────────
+
+test('F172 P1: metric-allowlist does NOT include THREAD_ID (high-cardinality guard)', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/infrastructure/telemetry/metric-allowlist.ts'),
+    'utf8',
+  );
+  assert.ok(!src.includes('THREAD_ID'), 'ALLOWED_METRIC_ATTRIBUTES must NOT include THREAD_ID — use route span aggregates for per-thread token queries');
+});
+
+test('F172 P1: tokenAttrs does NOT include THREAD_ID (cardinality + redactor bypass)', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  const tokenAttrsMatch = src.match(/const tokenAttrs = \{[\s\S]*?\};/);
+  assert.ok(tokenAttrsMatch, 'Should find tokenAttrs declaration');
+  assert.ok(!tokenAttrsMatch[0].includes('THREAD_ID'), 'tokenAttrs must NOT include THREAD_ID');
+});
+
+// ── P1: HubTraceTree parallel rendering ──────────────────────────
+
+test('F172 P1: HubTraceTree buildForest supports multiple children per parent (fan-out)', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../../web/src/components/HubTraceTree.tsx'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('childMap') && src.includes('children'),
+    'buildForest should accumulate children per parent via childMap',
+  );
+});
+
+// ── Cross-route A2A trace propagation ─────────────────────────────
+
+test('F172: InvocationRecord declares traceContext field with traceFlags', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/InvocationRegistry.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('traceContext?: { traceId: string; spanId: string; traceFlags: number }'),
+    'InvocationRecord should declare traceContext field with traceFlags',
+  );
+  assert.ok(src.includes('setTraceContext'), 'Registry should have setTraceContext method');
+});
+
+test('F172: invoke-single-cat stores traceContext in InvocationRecord after span creation', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('registry.setTraceContext(invocationId'),
+    'Should call registry.setTraceContext after invocationSpan creation',
+  );
+});
+
+test('F172: AgentRouter.routeExecution accepts callerTraceContext and creates child span', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/routing/AgentRouter.ts'),
+    'utf8',
+  );
+  assert.ok(src.includes('callerTraceContext'), 'routeExecution options should accept callerTraceContext');
+  assert.ok(
+    src.includes('trace.setSpanContext') && src.includes('isRemote: true'),
+    'Should reconstruct remote parent span context from callerTraceContext',
+  );
+  assert.ok(
+    src.includes('callerTraceContext.traceFlags'),
+    'Should use stored traceFlags, not hardcoded TraceFlags.SAMPLED',
+  );
+  assert.ok(
+    !src.includes('TraceFlags.SAMPLED'),
+    'Must not hardcode TraceFlags.SAMPLED — use stored value',
+  );
+});
+
+test('F172: callbacks.ts passes traceContext from InvocationRecord to enqueueA2ATargets', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/callbacks.ts'), 'utf8');
+  assert.ok(
+    src.includes('callerTraceContext: record.traceContext'),
+    'Should pass record.traceContext as callerTraceContext',
+  );
+});
+
+test('F172: callback-a2a-trigger propagates callerTraceContext to both queue and legacy paths', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/callback-a2a-trigger.ts'), 'utf8');
+  assert.ok(
+    src.includes('callerTraceContext: opts.callerTraceContext'),
+    'Should pass callerTraceContext to invocationQueue.enqueue',
+  );
+  const triggerIdx = src.indexOf('async function triggerA2AInvocation');
+  const routeExecIdx = src.indexOf('callerTraceContext: opts.callerTraceContext', triggerIdx);
+  assert.ok(
+    triggerIdx > 0 && routeExecIdx > triggerIdx,
+    'triggerA2AInvocation should pass callerTraceContext to routeExecution',
+  );
+});
+
+test('F172: InvocationQueue entry includes callerTraceContext field', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/InvocationQueue.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes("callerTraceContext?: { traceId: string; spanId: string; traceFlags: number }"),
+    'QueueEntry should declare callerTraceContext field with traceFlags',
+  );
+});
+
+test('F172: InvocationQueue prevents merge of agent entries with different callerTraceContext', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/InvocationQueue.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('traceContextMismatch') && src.includes('callerTraceContext?.spanId'),
+    'Should detect traceContext mismatch on agent entry merge',
+  );
+  assert.ok(
+    src.includes('!traceContextMismatch'),
+    'Merge condition should check !traceContextMismatch',
+  );
+});
+
+test('F172: start_vote callback passes callerTraceContext to enqueueA2ATargets', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/routes/callbacks.ts'), 'utf8');
+  const voteIdx = src.indexOf('start-vote');
+  const a2aOptsIdx = src.indexOf('callerTraceContext: record.traceContext', voteIdx);
+  assert.ok(
+    voteIdx > 0 && a2aOptsIdx > voteIdx,
+    'start_vote callback should pass record.traceContext as callerTraceContext',
+  );
+});
+
+test('F172: invoke-single-cat stores traceFlags in traceContext', () => {
+  const src = readFileSync(
+    resolve(__dirname, '../../src/domains/cats/services/agents/invocation/invoke-single-cat.ts'),
+    'utf8',
+  );
+  assert.ok(
+    src.includes('traceFlags: sc.traceFlags'),
+    'Should persist traceFlags from spanContext',
+  );
+});
+
+test('F172: QueueProcessor passes callerTraceContext from entry to routeExecution', () => {
   const src = readFileSync(
     resolve(__dirname, '../../src/domains/cats/services/agents/invocation/QueueProcessor.ts'),
     'utf8',
   );
-  const hasTraceContext = src.includes('traceId') || src.includes('mention_dispatch') || src.includes('routeSpan');
   assert.ok(
-    !hasTraceContext,
-    'QueueProcessor does not yet carry trace context — callback A2A creates independent roots (documented gap)',
+    src.includes('entry.callerTraceContext'),
+    'QueueProcessor should pass entry.callerTraceContext to routeExecution',
+  );
+});
+
+// ── Behavioral: cross-route span parenting via remote context ────
+
+test('F172 behavioral: remote parent context links child route span to caller trace', async () => {
+  otelExporter.reset();
+
+  // Simulate: route1 → invocation(A) → [callback post_message] → route2(child of A)
+  const route1Span = otelTracer.startSpan('cat_cafe.route');
+  const route1Ctx = traceApi.setSpan(ctxApi.active(), route1Span);
+
+  const invA = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'opus' } }, route1Ctx);
+
+  // Capture trace context (simulating what invoke-single-cat stores in InvocationRecord)
+  const callerCtx = invA.spanContext();
+  invA.end();
+  route1Span.end();
+
+  // Reconstruct remote parent (simulating what AgentRouter.routeExecution does)
+  const { context: ctxApiLocal, trace: traceApiLocal, TraceFlags: TF } = await import('@opentelemetry/api');
+  const remoteParentCtx = traceApiLocal.setSpanContext(ctxApiLocal.active(), {
+    traceId: callerCtx.traceId,
+    spanId: callerCtx.spanId,
+    traceFlags: TF.SAMPLED,
+    isRemote: true,
+  });
+  const route2Span = otelTracer.startSpan('cat_cafe.route', {}, remoteParentCtx);
+  const route2Ctx = traceApiLocal.setSpan(ctxApiLocal.active(), route2Span);
+  const invB = otelTracer.startSpan('cat_cafe.invocation', { attributes: { 'agent.id': 'sonnet' } }, route2Ctx);
+  invB.end();
+  route2Span.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  assert.equal(spans.length, 4);
+
+  const route1 = spans.find(s => s.name === 'cat_cafe.route' && !s.parentSpanContext);
+  const invASpan = spans.find(s => s.attributes['agent.id'] === 'opus');
+  const route2 = spans.find(s => s.name === 'cat_cafe.route' && s.parentSpanContext);
+  const invBSpan = spans.find(s => s.attributes['agent.id'] === 'sonnet');
+
+  assert.ok(route1 && invASpan && route2 && invBSpan, 'All 4 spans should be present');
+
+  // Same traceId across both routes
+  const traceId = route1.spanContext().traceId;
+  assert.equal(route2.spanContext().traceId, traceId, 'route2 shares same traceId as route1');
+  assert.equal(invBSpan.spanContext().traceId, traceId, 'invocation B shares same traceId');
+
+  // route2 is child of invocation A (cross-route link)
+  assert.equal(
+    route2.parentSpanContext.spanId, invASpan.spanContext().spanId,
+    'route2 is child of invocation A (cross-route A2A trace link)',
+  );
+  // invocation B is child of route2
+  assert.equal(
+    invBSpan.parentSpanContext.spanId, route2.spanContext().spanId,
+    'invocation B is child of route2',
   );
 });

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -259,12 +259,29 @@ function TreeWaterfall({
 }
 
 function SpanDetail({ span }: { span: TraceSpan | undefined }) {
+  const [xrayOpen, setXrayOpen] = useState(false);
+
   if (!span) return null;
+
+  const invocationId = span.attributes.invocationId as string | undefined;
+  const isInvocationSpan = span.name.includes('invocation') || span.name.includes('route');
+
   return (
     <div className="rounded-lg bg-cafe-surface-elevated p-3 text-xs">
       <div className="space-y-1">
-        <div>
-          <span className="text-cafe-muted">spanId:</span> <span className="font-mono">{span.spanId}</span>
+        <div className="flex items-center justify-between">
+          <div>
+            <span className="text-cafe-muted">spanId:</span> <span className="font-mono">{span.spanId}</span>
+          </div>
+          {isInvocationSpan && (
+            <button
+              type="button"
+              onClick={() => setXrayOpen(!xrayOpen)}
+              className="rounded-md bg-purple-50 px-2 py-0.5 text-[10px] font-medium text-purple-700 transition-colors hover:bg-purple-100"
+            >
+              {xrayOpen ? '✕ Close' : '🔬 X-Ray'}
+            </button>
+          )}
         </div>
         {span.parentSpanId && (
           <div>
@@ -298,6 +315,241 @@ function SpanDetail({ span }: { span: TraceSpan | undefined }) {
             ))}
           </div>
         )}
+      </div>
+      {xrayOpen && <PromptInspector invocationId={invocationId} catId={span.attributes['agent.id'] as string} />}
+    </div>
+  );
+}
+
+// ── F172: Prompt X-Ray Inspector ──────────────────────────────────
+
+interface PromptCaptureData {
+  captureId: string;
+  invocationId: string;
+  catId: string;
+  model: string;
+  capturedAt: number;
+  systemPrompt: string;
+  missionPrefix?: string;
+  userPrompt: string;
+  effectivePrompt: string;
+  injectionDecision: {
+    isResume: boolean;
+    canSkipOnResume: boolean;
+    forceReinjection: boolean;
+    injected: boolean;
+  };
+  promptBytes: number;
+  tokenEstimate: number;
+}
+
+type InspectorTab = 'system' | 'user' | 'effective' | 'meta';
+
+function PromptInspector({ invocationId, catId }: { invocationId?: string; catId?: string }) {
+  const [captures, setCaptures] = useState<PromptCaptureData[]>([]);
+  const [selected, setSelected] = useState<PromptCaptureData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<InspectorTab>('system');
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const params = new URLSearchParams();
+        if (invocationId) params.set('invocationId', invocationId);
+        const res = await apiFetch(`/api/debug/prompt-captures?${params}`);
+        if (!res.ok) {
+          setError(res.status === 404 ? 'No captures found' : `Error ${res.status}`);
+          return;
+        }
+        const index = (await res.json()) as Array<{ captureId: string; catId: string }>;
+        const matching = catId ? index.filter((e) => e.catId === catId) : index;
+        if (matching.length === 0) {
+          setError('No prompt captures for this span. Enable with PROMPT_CAPTURE=on');
+          return;
+        }
+        const detailRes = await apiFetch(`/api/debug/prompt-captures/${matching[0].captureId}`);
+        if (detailRes.ok) {
+          const data = (await detailRes.json()) as PromptCaptureData;
+          setCaptures([data]);
+          setSelected(data);
+        }
+      } catch {
+        setError('Failed to load prompt capture');
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [invocationId, catId]);
+
+  if (loading) return <div className="mt-2 text-[10px] text-cafe-muted">Loading prompt capture...</div>;
+  if (error) return <div className="mt-2 text-[10px] text-cafe-secondary">{error}</div>;
+  if (!selected) return null;
+
+  const tabs: { key: InspectorTab; label: string; color: string }[] = [
+    { key: 'system', label: 'System', color: 'text-blue-600' },
+    { key: 'user', label: 'User', color: 'text-green-600' },
+    { key: 'effective', label: 'Full Prompt', color: 'text-purple-600' },
+    { key: 'meta', label: 'Meta', color: 'text-amber-600' },
+  ];
+
+  return (
+    <div className="mt-3 rounded-lg border border-purple-200 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-[11px] font-medium text-purple-700">Prompt X-Ray</span>
+        <div className="flex items-center gap-2 text-[10px] text-cafe-muted">
+          <span>{selected.model}</span>
+          <span>·</span>
+          <span>{(selected.promptBytes / 1024).toFixed(1)} KB</span>
+          <span>·</span>
+          <span>~{selected.tokenEstimate} tokens</span>
+        </div>
+      </div>
+
+      <PromptTokenBar capture={selected} />
+
+      <div className="mt-2 flex gap-1 border-b border-cafe-border pb-1">
+        {tabs.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={`rounded-t px-2 py-0.5 text-[10px] font-medium transition-colors ${
+              tab === t.key ? `${t.color} bg-cafe-surface-elevated` : 'text-cafe-muted hover:text-cafe-secondary'
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-2 max-h-[300px] overflow-y-auto">
+        {tab === 'system' && <PromptSection content={selected.systemPrompt} label="System Prompt" />}
+        {tab === 'user' && (
+          <>
+            {selected.missionPrefix && (
+              <PromptSection content={selected.missionPrefix} label="Mission Prefix" className="mb-2" />
+            )}
+            <PromptSection content={selected.userPrompt} label="User Prompt" />
+          </>
+        )}
+        {tab === 'effective' && <PromptSection content={selected.effectivePrompt} label="Effective Prompt (Full)" />}
+        {tab === 'meta' && <PromptMeta capture={selected} />}
+      </div>
+    </div>
+  );
+}
+
+function PromptTokenBar({ capture }: { capture: PromptCaptureData }) {
+  const sysLen = capture.systemPrompt.length;
+  const userLen = capture.userPrompt.length;
+  const missionLen = capture.missionPrefix?.length ?? 0;
+  const total = capture.effectivePrompt.length || 1;
+
+  const sysPct = (sysLen / total) * 100;
+  const missionPct = (missionLen / total) * 100;
+  const userPct = (userLen / total) * 100;
+
+  return (
+    <div>
+      <div className="flex h-2 overflow-hidden rounded-full bg-cafe-surface-elevated">
+        <div className="bg-blue-400" style={{ width: `${sysPct}%` }} title={`System: ${sysPct.toFixed(0)}%`} />
+        {missionPct > 0 && (
+          <div
+            className="bg-amber-400"
+            style={{ width: `${missionPct}%` }}
+            title={`Mission: ${missionPct.toFixed(0)}%`}
+          />
+        )}
+        <div className="bg-green-400" style={{ width: `${userPct}%` }} title={`User: ${userPct.toFixed(0)}%`} />
+      </div>
+      <div className="mt-0.5 flex gap-3 text-[9px] text-cafe-muted">
+        <span>
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-blue-400" /> System {sysPct.toFixed(0)}%
+        </span>
+        {missionPct > 0 && (
+          <span>
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-amber-400" /> Mission {missionPct.toFixed(0)}%
+          </span>
+        )}
+        <span>
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-400" /> User {userPct.toFixed(0)}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function PromptSection({ content, label, className = '' }: { content: string; label: string; className?: string }) {
+  if (!content) return <div className="text-[10px] text-cafe-muted">Empty</div>;
+  return (
+    <div className={className}>
+      <div className="mb-1 text-[10px] font-medium text-cafe-muted">{label}</div>
+      <pre className="whitespace-pre-wrap break-words rounded bg-cafe-surface p-2 font-mono text-[10px] leading-relaxed text-cafe">
+        {content}
+      </pre>
+    </div>
+  );
+}
+
+function PromptMeta({ capture }: { capture: PromptCaptureData }) {
+  const { injectionDecision } = capture;
+  return (
+    <div className="space-y-2 text-[10px]">
+      <div>
+        <div className="font-medium text-cafe-muted">Capture Info</div>
+        <div className="ml-2 space-y-0.5">
+          <div>
+            <span className="text-cafe-muted">captureId:</span> <span className="font-mono">{capture.captureId}</span>
+          </div>
+          <div>
+            <span className="text-cafe-muted">invocationId:</span>{' '}
+            <span className="font-mono">{capture.invocationId}</span>
+          </div>
+          <div>
+            <span className="text-cafe-muted">catId:</span> {capture.catId}
+          </div>
+          <div>
+            <span className="text-cafe-muted">model:</span> {capture.model}
+          </div>
+          <div>
+            <span className="text-cafe-muted">captured:</span> {new Date(capture.capturedAt).toLocaleString()}
+          </div>
+        </div>
+      </div>
+      <div>
+        <div className="font-medium text-cafe-muted">Injection Decision</div>
+        <div className="ml-2 space-y-0.5">
+          <div>
+            <span className="text-cafe-muted">injected:</span>{' '}
+            <span className={injectionDecision.injected ? 'text-green-600' : 'text-red-600'}>
+              {String(injectionDecision.injected)}
+            </span>
+          </div>
+          <div>
+            <span className="text-cafe-muted">isResume:</span> {String(injectionDecision.isResume)}
+          </div>
+          <div>
+            <span className="text-cafe-muted">canSkipOnResume:</span> {String(injectionDecision.canSkipOnResume)}
+          </div>
+          <div>
+            <span className="text-cafe-muted">forceReinjection:</span> {String(injectionDecision.forceReinjection)}
+          </div>
+        </div>
+      </div>
+      <div>
+        <div className="font-medium text-cafe-muted">Size</div>
+        <div className="ml-2 space-y-0.5">
+          <div>
+            <span className="text-cafe-muted">bytes:</span> {capture.promptBytes.toLocaleString()}
+          </div>
+          <div>
+            <span className="text-cafe-muted">tokens (est):</span> ~{capture.tokenEstimate.toLocaleString()}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -346,7 +346,6 @@ interface PromptCaptureData {
 type InspectorTab = 'system' | 'user' | 'effective' | 'meta';
 
 function PromptInspector({ invocationId, catId }: { invocationId?: string; catId?: string }) {
-  const [_captures, setCaptures] = useState<PromptCaptureData[]>([]);
   const [selected, setSelected] = useState<PromptCaptureData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -373,7 +372,6 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
         const detailRes = await apiFetch(`/api/debug/prompt-captures/${matching[0].captureId}`);
         if (detailRes.ok) {
           const data = (await detailRes.json()) as PromptCaptureData;
-          setCaptures([data]);
           setSelected(data);
         }
       } catch {

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -427,7 +427,16 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
       </div>
 
       <div className="mt-2 max-h-[300px] overflow-y-auto">
-        {tab === 'system' && <PromptSection content={selected.systemPrompt} label="System Prompt" />}
+        {tab === 'system' && (
+          <>
+            {!selected.injectionDecision.injected && (
+              <div className="mb-2 rounded bg-amber-50 px-2 py-1 text-[10px] text-amber-700">
+                Resume — system prompt was not injected this turn
+              </div>
+            )}
+            <PromptSection content={selected.systemPrompt} label={selected.injectionDecision.injected ? 'System Prompt' : 'System Prompt (not sent)'} />
+          </>
+        )}
         {tab === 'user' && (
           <>
             {selected.missionPrefix && (
@@ -444,7 +453,8 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
 }
 
 function PromptTokenBar({ capture }: { capture: PromptCaptureData }) {
-  const sysLen = capture.systemPrompt.length;
+  const injected = capture.injectionDecision.injected;
+  const sysLen = injected ? capture.systemPrompt.length : 0;
   const userLen = capture.userPrompt.length;
   const missionLen = capture.missionPrefix?.length ?? 0;
   const total = capture.effectivePrompt.length || 1;

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -264,7 +264,7 @@ function SpanDetail({ span }: { span: TraceSpan | undefined }) {
   if (!span) return null;
 
   const invocationId = span.attributes.invocationId as string | undefined;
-  const isInvocationSpan = span.name.includes('invocation') || span.name.includes('route');
+  const hasInvocationId = Boolean(invocationId);
 
   return (
     <div className="rounded-lg bg-cafe-surface-elevated p-3 text-xs">
@@ -273,7 +273,7 @@ function SpanDetail({ span }: { span: TraceSpan | undefined }) {
           <div>
             <span className="text-cafe-muted">spanId:</span> <span className="font-mono">{span.spanId}</span>
           </div>
-          {isInvocationSpan && (
+          {hasInvocationId && (
             <button
               type="button"
               onClick={() => setXrayOpen(!xrayOpen)}
@@ -346,7 +346,7 @@ interface PromptCaptureData {
 type InspectorTab = 'system' | 'user' | 'effective' | 'meta';
 
 function PromptInspector({ invocationId, catId }: { invocationId?: string; catId?: string }) {
-  const [captures, setCaptures] = useState<PromptCaptureData[]>([]);
+  const [_captures, setCaptures] = useState<PromptCaptureData[]>([]);
   const [selected, setSelected] = useState<PromptCaptureData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## Summary

Closes #593

F172 Prompt X-Ray 完整实现 + cross-route trace propagation，包含四个部分：

### P1: Canonical Prompt Capture + File Store + API
- `PromptCaptureStore`: HMAC'd invocationId → 文件存储，自动清理
- `prompt-capture-bridge`: 在 invoke-single-cat 中拦截 provider payload，写入 capture
- `/api/prompt-captures/:id` 只读 API，auth scoped

### P2: Hub Trace Detail — X-Ray Inspector
- HubTraceTree 增加 X-Ray 按钮，点击展开 Inspector 面板
- Inspector 显示完整 system prompt + user messages + tool calls
- 未 eject 的 system prompt 标记为 `[unejected]`

### P3: Cross-route A2A Trace Propagation
- `callerTraceContext` 通过 InvocationRecord 跨路由传递
- 覆盖全部 3 条 A2A 路径：text-scan @mention、post_message MCP callback、InvocationQueue callback
- 存储完整 SpanContext（含 traceFlags），不丢失采样决策
- Route span 聚合属性：`total_cats_invoked`、`total_tokens`、`has_a2a_handoff`
- InvocationQueue merge guard 防止不同 trace 上下文的 entries 错误合并

### P4: Trace Store TTL
- LocalTraceStore TTL 从 2h → 24h，支持跨天调试

### 质量
- 35 source-level + behavioral tests (prompt-capture: 6, mention-dispatch-trace: 29)
- tsc clean, 3 rounds of codex review fixes incorporated

## Commits (11)
1. `feat(debug): F172 Prompt X-Ray P1` — canonical capture + file store + API
2. `feat(web): F172 Prompt X-Ray` — Hub trace detail X-Ray button + Inspector
3. `fix(debug): F172 R1 review` — auth scoping, X-Ray button guard, async I/O
4. `fix(web): F172 R2` — mark unejected system prompt in X-Ray Inspector
5. `fix(web)` — remove unused captures state that broke next build
6. `fix(telemetry)` — add invocationId to OTel span attributes for X-Ray
7. `fix(debug)` — store HMAC'd invocationId for OTel correlation
8. `feat(telemetry): F172 cross-cat trace propagation` — mention_dispatch spans
9. `test(telemetry)` — F172 behavioral OTel tests for mention_dispatch span hierarchy
10. `feat(telemetry): F172 cross-route trace propagation` — route span aggregates + A2A trace + merge guard
11. `fix(telemetry)` — extend trace store TTL from 2h to 24h

## Test plan
- [x] `pnpm test` — 35 tests pass (prompt-capture: 6, mention-dispatch-trace: 29)
- [x] `tsc --noEmit` — clean
- [ ] Demo: 在 Hub trace 详情页点击 X-Ray 按钮，查看完整 prompt
- [ ] Demo: 通过 post_message MCP 触发 A2A，验证 trace 连通

[宪宪/Opus-4.6🐾] Generated with [Claude Code](https://claude.com/claude-code)