### PR TITLE
docs(F175): sync phase progress after PR #575 merge

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,6 +57,6 @@ created: 2026-02-26
 | F165 | Guided Overfitting — 引导式过拟合 / 养猫路径 | spec | Ragdoll | internal | [F165](features/F165-guided-overfitting.md) |
 | F167 | A2A Chain Quality — 乒乓球熔断 + 虚空传球检测 + 角色护栏 | spec | Ragdoll | internal | [F167](features/F167-a2a-chain-quality.md) |
 | F169 | Agent Memory Reflex — 愿景文档（vision artifact） | vision | 三猫 | internal | [F169](features/F169-agent-memory-reflex.md) |
-| F175 | Unified Message Queue — 优先级排序 + 用户可控编排（urgent bypass 收口）| spec | @mindfn (community) | community [#575](https://github.com/zts212653/clowder-ai/pull/575) | [F175](features/F175-unified-message-queue.md) |
+| F175 | Unified Message Queue — 优先级排序 + 用户可控编排（urgent bypass 收口）| in-progress | @mindfn (community) | community [#575](https://github.com/zts212653/clowder-ai/pull/575) | [F175](features/F175-unified-message-queue.md) |
 | F177 | Harness Update — Close Gate 结构化判据 + 四心智专属护栏 | spec | Ragdoll | internal | [F177](features/F177-harness-update.md) |
 | F178 | Persistent MCP Agent-Key Auth — 跨 invocation 写权限（F061 Bug-H follow-up） | spec | Ragdoll | internal | [F178](features/F178-persistent-mcp-agent-key-auth.md) |

--- a/docs/features/F167-a2a-chain-quality.md
+++ b/docs/features/F167-a2a-chain-quality.md
@@ -547,7 +547,7 @@ team experience："简直了你和Maine Coon是没头脑（Maine Coon听不懂�
 ### Case E2: Runtime 已吃到新护栏 + 6-case replay（2026-04-20）
 
 **Runtime smoke**：
-- `curl http://127.0.0.1:3004/health` 返回 `{"status":"ok"}`，runtime 在线
+- `curl http://127.0.0.1:3004/health` 返回 `{“status”:”ok”}`，runtime 在线
 - 运行中的猫进程 prompt 已包含最新压缩版球权检查：`@co-creator`、死锁禁止、虚假离场防护、review/分析/建议完成后默认必须传球（见 `SystemPromptBuilder.ts:578`）
 
 **6-case replay 对照表**：
@@ -555,11 +555,21 @@ team experience："简直了你和Maine Coon是没头脑（Maine Coon听不懂�
 | Case | 护栏/证据 | 结果 |
 |------|-----------|------|
 | 1. team lead球权盲区 | runtime 注入已明确 `team lead需要动 → 末尾行首 @co-creator`（`SystemPromptBuilder.ts:578`） | ✅ |
-| 2. 球权死锁 | `shared-rules §10` 明确禁止“收了球却说你等着/你别动”（`shared-rules.md:252-253`） | ✅ |
-| 3. 虚假离场 | `shared-rules §10` + runtime prompt 都要求“不 @ 但自己还在干活 → 声明球在我手上，继续 X”（`shared-rules.md:268`, `SystemPromptBuilder.ts:578`） | ✅ |
-| 4. 状态描述代替球权声明 | `shared-rules §10` 核心原则已写死“状态描述 ≠ 球权声明”（`shared-rules.md:246`） | ✅ |
+| 2. 球权死锁 | `shared-rules §10` 明确禁止”收了球却说你等着/你别动”（`shared-rules.md:252-253`） | ✅ |
+| 3. 虚假离场 | `shared-rules §10` + runtime prompt 都要求”不 @ 但自己还在干活 → 声明球在我手上，继续 X”（`shared-rules.md:268`, `SystemPromptBuilder.ts:578`） | ✅ |
+| 4. 状态描述代替球权声明 | `shared-rules §10` 核心原则已写死”状态描述 ≠ 球权声明”（`shared-rules.md:246`） | ✅ |
 | 5. 诊断不解决 | `shared-rules §10` 要求 push back 后必须接/退/升；runtime prompt 同步注入（`shared-rules.md:252`, `SystemPromptBuilder.ts:578`） | ✅ |
 | 6. Codex context overflow | `dynamic contextWindow + autoCompactTokenLimit per variant` 已合入 main，spec 记录 `41/41 codex-agent-service + 31/31 config tests` 全绿（AC-B9/B10） | ✅ |
+
+### Case E3: Playwright 验证被错误跳过（2026-04-27）
+
+| 维度 | 内容 |
+|------|------|
+| 我以为 | F170 多稿 review 中，若 dev server / 后端报错即可把页面验证标记为不可用，继续只做静态 diff 与单元测试 |
+| 实际要求 | CVO 明确要求：当前后端和 MCP 工具服务都可运行，不能用笼统”后端错误用不了”跳过；剩余稿件必须按真实启动 + Playwright 验证流程走，并推动 Opus 也采用该验证 |
+| 偏差根因 | 锚定偏差 + 证据不足：把一次启动/页面失败过早归因为环境不可用，没有继续区分 dev-mode 已知问题、production web 可运行路径、以及真实产品回归 |
+| 纠正轮次 | 1 次纠正后执行：fetch 目标分支、安装依赖、启动 3003/3004 memory/prod 服务、用 Playwright 验证页面并复核测试 |
+| 元心智哪条没执行 | Q2 信息验证不足：没有先穷尽可运行路径并收集服务日志/Playwright 证据，就准备接受”不可验证”前提 |
 
 ## Review Gate
 

--- a/docs/features/F175-unified-message-queue.md
+++ b/docs/features/F175-unified-message-queue.md
@@ -8,7 +8,7 @@ created: 2026-04-24
 
 # F175: 消息队列统一设计 — 优先级排序 + 用户可控编排
 
-> **Status**: spec | **Owner**: Ragdoll | **Priority**: P1
+> **Status**: in-progress | **Owner**: @mindfn (community) | **Priority**: P1
 
 ## Why
 
@@ -120,17 +120,17 @@ QueueProcessor 出队时：
 
 ## Acceptance Criteria
 
-### Phase A（后端统一）
-- [ ] AC-A1: `handleUrgentTrigger()` 和 urgent 分支已删除，active-slot 时所有 connector 消息走 `enqueueWhileActive()`（idle slot 保留 fast path）
-- [ ] AC-A2: QueueEntry 有 `priority` 字段，4 个 urgent 调用方正确透传
-- [ ] AC-A3: 出队逻辑 priority-first — urgent 消息在 normal 前面被处理
-- [ ] AC-A4: 用户手动 position 覆盖 priority 排序（仅显式设置时）
-- [ ] AC-A5: 用户消息不再强制 merge — 每条独立 QueueEntry
-- [ ] AC-A6: 出队时 user-message batching — 连续同 userId + 同 intent + 同 targetCats 的 user entries 汇聚为一次 invocation
-- [ ] AC-A7: connector/agent 消息不受 MAX_QUEUE_DEPTH 限制
-- [ ] AC-A8: reorder API 可用（`PATCH /queue/reorder`）
-- [ ] AC-A9: 回归：urgent connector 不打断 A2A 链（#564 原始场景修复）
-- [ ] AC-A10: 回归：跨优先级自动 dequeue — urgent 处理完后自动继续 normal
+### Phase A（后端统一）✅ PR #575 merged 2026-04-28
+- [x] AC-A1: `handleUrgentTrigger()` 和 urgent 分支已删除，active-slot 时所有 connector 消息走 `enqueueWhileActive()`（idle slot 保留 fast path）
+- [x] AC-A2: QueueEntry 有 `priority` 字段，4 个 urgent 调用方正确透传
+- [x] AC-A3: 出队逻辑 priority-first — urgent 消息在 normal 前面被处理
+- [x] AC-A4: 用户手动 position 覆盖 priority 排序（仅显式设置时）
+- [x] AC-A5: 用户消息不再强制 merge — 每条独立 QueueEntry
+- [x] AC-A6: 出队时 user-message batching — 连续同 userId + 同 intent + 同 targetCats 的 user entries 汇聚为一次 invocation
+- [x] AC-A7: connector/agent 消息不受 MAX_QUEUE_DEPTH 限制
+- [x] AC-A8: reorder API 可用（`PATCH /queue/reorder`）
+- [x] AC-A9: 回归：urgent connector 不打断 A2A 链（#564 原始场景修复）
+- [x] AC-A10: 回归：跨优先级自动 dequeue — urgent 处理完后自动继续 normal
 
 ### Phase B（前端编排）
 - [ ] AC-B1: QueuePanel 支持拖动排序
@@ -138,11 +138,11 @@ QueueProcessor 出队时：
 - [ ] AC-B3: 视觉分组（sourceCategory + urgent 标记）
 - [ ] AC-B4: QueuePanel 收起/折叠
 
-### Phase C（Spec + ADR）
-- [ ] AC-C1: F133 KD-4 修正完成
-- [ ] AC-C2: F122 spec 标 "executor unification: complete"
-- [ ] AC-C3: F047 spec 加 reorder
-- [ ] AC-C4: 新 ADR 创建，含 guard story
+### Phase C（Spec + ADR）✅ PR #575 merged 2026-04-28
+- [x] AC-C1: F133 KD-4 修正完成
+- [x] AC-C2: F122 spec 标 "executor unification: complete"
+- [x] AC-C3: F047 spec 加 reorder
+- [x] AC-C4: 新 ADR 创建，含 guard story
 
 ## Dependencies
 
@@ -180,6 +180,7 @@ QueueProcessor 出队时：
 |------|------|
 | 2026-04-23 | #564 issue 创建，根因分析 + 设计调查 |
 | 2026-04-24 | Maintainer review 完成，设计共识达成，立项 F175 |
+| 2026-04-28 | Phase A + C merged (PR #575) — 后端 priority ordering + batching + connector dedup + spec/ADR 更新 |
 
 ## Review Gate
 


### PR DESCRIPTION
## Summary
- Phase A (backend) + Phase C (spec/ADR) marked done in F175 feature doc
- ROADMAP.md status updated from `spec` to `in-progress`
- F167 doc: resolved rebase conflict (Case E2 → E2 + E3)

Phase B (frontend QueuePanel) remains pending.

Post-merge doc sync per merge-gate Step 7.5.

[宪宪/Opus-46]