### PR TITLE
fix(windows): support Antigravity discovery and native CLI spawn

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -17,12 +17,7 @@ import { createInterface, type Interface as ReadlineInterface } from 'node:readl
 
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import { resolveCliCommandOrBare } from '../../../../../../utils/cli-resolve.js';
-import {
-  escapeBashArg,
-  escapeCmdArg,
-  findGitBashPath,
-  resolveWindowsShimSpawn,
-} from '../../../../../../utils/cli-spawn-win.js';
+import { resolveWindowsSpawnPlan } from '../../../../../../utils/cli-spawn-win.js';
 import type {
   AcpAgentRequest,
   AcpContentBlock,
@@ -145,24 +140,20 @@ export class AcpClient {
       env: childEnv,
     };
     if (IS_WINDOWS && !this.config.spawnFn) {
-      const shimSpawn = resolveWindowsShimSpawn(command, args);
-      if (shimSpawn) {
-        log.debug({ original: command, resolved: shimSpawn.command }, 'ACP: Windows shim resolved');
-        command = shimSpawn.command;
-        args = shimSpawn.args;
-      } else {
-        const gitBash = findGitBashPath();
-        if (gitBash) {
-          log.debug({ command, shell: gitBash }, 'ACP: Windows fallback to Git Bash');
-          command = escapeBashArg(command);
-          args = args.map(escapeBashArg);
-          spawnOpts.shell = gitBash;
-        } else {
-          log.debug({ command, shell: true }, 'ACP: Windows fallback to cmd.exe');
-          command = escapeCmdArg(command);
-          args = args.map(escapeCmdArg);
-          spawnOpts.shell = true;
-        }
+      const spawnPlan = resolveWindowsSpawnPlan(command, args);
+      log.debug(
+        {
+          original: command,
+          resolved: spawnPlan.command,
+          mode: spawnPlan.mode,
+          shell: spawnPlan.shell,
+        },
+        'ACP: Windows spawn plan resolved',
+      );
+      command = spawnPlan.command;
+      args = spawnPlan.args;
+      if (spawnPlan.shell !== undefined) {
+        spawnOpts.shell = spawnPlan.shell;
       }
     }
 

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/antigravity-ls-discovery.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/antigravity-ls-discovery.ts
@@ -1,12 +1,25 @@
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import http from 'node:http';
 import https from 'node:https';
+import { platform as osPlatform } from 'node:os';
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import type { BridgeConnection } from './AntigravityBridge.js';
 
 const log = createModuleLogger('antigravity-discovery');
 
-function probe(conn: BridgeConnection): Promise<void> {
+export interface LSProcessInfo {
+  pid: string;
+  cmd: string;
+}
+
+export interface DiscoveryDeps {
+  platform?: NodeJS.Platform;
+  listProcesses?: () => LSProcessInfo[];
+  listListenPorts?: (pid: string) => number[];
+  probe?: (conn: BridgeConnection) => Promise<void>;
+}
+
+function defaultProbe(conn: BridgeConnection): Promise<void> {
   const mod = conn.useTls ? https : http;
   const protocol = conn.useTls ? 'https' : 'http';
   const url = `${protocol}://127.0.0.1:${conn.port}/exa.language_server_pb.LanguageServerService/GetUserStatus`;
@@ -45,52 +58,205 @@ function probe(conn: BridgeConnection): Promise<void> {
   });
 }
 
-export async function discoverAntigravityLS(): Promise<BridgeConnection> {
-  const envPort = process.env['ANTIGRAVITY_PORT'];
-  const envCsrf = process.env['ANTIGRAVITY_CSRF_TOKEN'];
-  if (envPort && envCsrf) {
-    const useTls = process.env['ANTIGRAVITY_TLS'] !== 'false';
-    log.info(`using env config: port=${envPort}, tls=${useTls}`);
-    return { port: Number(envPort), csrfToken: envCsrf, useTls };
+export function listProcessesViaPs(): LSProcessInfo[] {
+  let out = '';
+  try {
+    out = execSync('ps -eo pid,args 2>/dev/null | grep language_server | grep csrf_token | grep -v grep', {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+  } catch (err) {
+    log.warn(`ps lookup failed: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  if (!out) return [];
+
+  const result: LSProcessInfo[] = [];
+  for (const line of out.split('\n')) {
+    const m = line.match(/^\s*(\d+)\s+(.*)$/);
+    if (m) result.push({ pid: m[1], cmd: m[2] });
+  }
+  return result;
+}
+
+export function listListenPortsViaLsof(pid: string): number[] {
+  let out = '';
+  try {
+    out = execSync(`lsof -a -iTCP -sTCP:LISTEN -P -n -p ${pid} 2>/dev/null | grep LISTEN`, {
+      encoding: 'utf8',
+      timeout: 5_000,
+    }).trim();
+  } catch (err) {
+    log.warn(`lsof lookup failed for pid=${pid}: ${err instanceof Error ? err.message : String(err)}`);
+    return [];
+  }
+  if (!out) return [];
+
+  const ports: number[] = [];
+  for (const line of out.split('\n')) {
+    const m = line.match(/:(\d+)\s/);
+    if (m) {
+      const port = Number(m[1]);
+      if (Number.isFinite(port)) ports.push(port);
+    }
+  }
+  return ports;
+}
+
+export function parseProcessesJson(raw: string): LSProcessInfo[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  const arr = Array.isArray(parsed) ? parsed : [parsed];
+  const result: LSProcessInfo[] = [];
+  for (const item of arr) {
+    if (!item || typeof item !== 'object') continue;
+    const obj = item as Record<string, unknown>;
+    const pid = obj.pid;
+    const cmd = obj.cmd;
+    if ((typeof pid === 'number' || typeof pid === 'string') && typeof cmd === 'string') {
+      result.push({ pid: String(pid), cmd });
+    }
+  }
+  return result;
+}
+
+function coerceFinitePort(v: unknown): number | null {
+  if (typeof v === 'number' && Number.isFinite(v)) return v;
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+export function parsePortsJson(raw: string): number[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  const candidates = Array.isArray(parsed) ? parsed : [parsed];
+  const result: number[] = [];
+  for (const v of candidates) {
+    const port = coerceFinitePort(v);
+    if (port !== null) result.push(port);
+  }
+  return result;
+}
+
+const PS_LIST_PROCESSES_SCRIPT = [
+  'Get-CimInstance Win32_Process -Filter "Name LIKE \'%language_server%\'"',
+  "Where-Object { $_.CommandLine -and $_.CommandLine -match 'csrf_token' }",
+  "Select-Object @{Name='pid';Expression={$_.ProcessId}},@{Name='cmd';Expression={$_.CommandLine}}",
+  'ConvertTo-Json -Compress',
+].join(' | ');
+
+function runPowerShell(script: string): string | null {
+  // spawnSync with argv array bypasses cmd.exe entirely, avoiding the
+  // quoting hell that broke -Filter "Name LIKE '%x%'" via execSync.
+  const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], {
+    encoding: 'utf8',
+    timeout: 10_000,
+    windowsHide: true,
+  });
+  if (result.error) {
+    log.warn(`PowerShell spawn failed: ${result.error.message}`);
+    return null;
+  }
+  if (result.status !== 0) {
+    const stderr = (result.stderr ?? '').toString().trim();
+    log.warn(`PowerShell exited ${result.status}: ${stderr.slice(0, 200)}`);
+    return null;
+  }
+  return (result.stdout ?? '').toString().trim();
+}
+
+export function listProcessesViaPowerShell(): LSProcessInfo[] {
+  const out = runPowerShell(PS_LIST_PROCESSES_SCRIPT);
+  return out ? parseProcessesJson(out) : [];
+}
+
+export function listListenPortsViaPowerShell(pid: string): number[] {
+  if (!/^\d+$/.test(pid)) {
+    log.warn(`refusing to query ports for non-numeric pid=${pid}`);
+    return [];
+  }
+  const script = `Get-NetTCPConnection -OwningProcess ${pid} -State Listen -ErrorAction SilentlyContinue | Select-Object -ExpandProperty LocalPort | ConvertTo-Json -Compress`;
+  const out = runPowerShell(script);
+  return out ? parsePortsJson(out) : [];
+}
+
+function readEnvShortcut(): BridgeConnection | null {
+  const envPort = process.env.ANTIGRAVITY_PORT;
+  const envCsrf = process.env.ANTIGRAVITY_CSRF_TOKEN;
+  if (!envPort || !envCsrf) return null;
+  const useTls = process.env.ANTIGRAVITY_TLS !== 'false';
+  log.info(`using env config: port=${envPort}, tls=${useTls}`);
+  return { port: Number(envPort), csrfToken: envCsrf, useTls };
+}
+
+async function probeBothTls(
+  port: number,
+  csrfToken: string,
+  probeFn: (conn: BridgeConnection) => Promise<void>,
+): Promise<BridgeConnection | null> {
+  for (const useTls of [true, false] as const) {
+    try {
+      await probeFn({ port, csrfToken, useTls });
+      return { port, csrfToken, useTls };
+    } catch {
+      /* try next */
+    }
+  }
+  return null;
+}
+
+async function tryProcessConnection(
+  proc: LSProcessInfo,
+  listListenPorts: (pid: string) => number[],
+  probeFn: (conn: BridgeConnection) => Promise<void>,
+): Promise<BridgeConnection | null> {
+  const csrfMatch = proc.cmd.match(/--csrf_token\s+(\S+)/);
+  if (!csrfMatch) return null;
+  const csrf = csrfMatch[1];
+  const extPortMatch = proc.cmd.match(/--extension_server_port\s+(\d+)/);
+  const extPort = extPortMatch ? Number(extPortMatch[1]) : 0;
+
+  for (const port of listListenPorts(proc.pid)) {
+    if (port === extPort) continue;
+    const conn = await probeBothTls(port, csrf, probeFn);
+    if (conn) return conn;
+  }
+  return null;
+}
+
+export async function discoverAntigravityLS(deps: DiscoveryDeps = {}): Promise<BridgeConnection> {
+  const envHit = readEnvShortcut();
+  if (envHit) return envHit;
+
+  const platform = deps.platform ?? osPlatform();
+  const isWin = platform === 'win32';
+  const listProcesses = deps.listProcesses ?? (isWin ? listProcessesViaPowerShell : listProcessesViaPs);
+  const listListenPorts = deps.listListenPorts ?? (isWin ? listListenPortsViaPowerShell : listListenPortsViaLsof);
+  const probeFn = deps.probe ?? defaultProbe;
+
+  const procs = listProcesses();
+  if (procs.length === 0) {
+    throw new Error(`No Antigravity Language Server process found (platform=${platform})`);
   }
 
-  const psOutput = execSync('ps -eo pid,args 2>/dev/null | grep language_server | grep csrf_token | grep -v grep', {
-    encoding: 'utf8',
-    timeout: 5000,
-  }).trim();
-
-  if (!psOutput) throw new Error('No Antigravity Language Server process found');
-
-  for (const line of psOutput.split('\n')) {
-    const csrfMatch = line.match(/--csrf_token\s+(\S+)/);
-    const extPortMatch = line.match(/--extension_server_port\s+(\d+)/);
-    const pidMatch = line.match(/^\s*(\d+)/);
-    if (!csrfMatch || !pidMatch) continue;
-
-    const csrf = csrfMatch[1];
-    const pid = pidMatch[1];
-    const extPort = extPortMatch ? Number(extPortMatch[1]) : 0;
-
-    const lsofOutput = execSync(`lsof -a -iTCP -sTCP:LISTEN -P -n -p ${pid} 2>/dev/null | grep LISTEN`, {
-      encoding: 'utf8',
-      timeout: 5000,
-    }).trim();
-
-    for (const lsofLine of lsofOutput.split('\n')) {
-      const portMatch = lsofLine.match(/:(\d+)\s/);
-      if (!portMatch) continue;
-      const port = Number(portMatch[1]);
-      if (port === extPort) continue;
-
-      for (const useTls of [true, false] as const) {
-        try {
-          await probe({ port, csrfToken: csrf, useTls });
-          log.info(`discovered LS: port=${port}, tls=${useTls}, pid=${pid}`);
-          return { port, csrfToken: csrf, useTls };
-        } catch {
-          /* try next */
-        }
-      }
+  for (const proc of procs) {
+    const conn = await tryProcessConnection(proc, listListenPorts, probeFn);
+    if (conn) {
+      log.info(`discovered LS: port=${conn.port}, tls=${conn.useTls}, pid=${proc.pid}, platform=${platform}`);
+      return conn;
     }
   }
   throw new Error('Could not discover Antigravity Language Server ConnectRPC port');

--- a/packages/api/src/utils/cli-spawn-win.ts
+++ b/packages/api/src/utils/cli-spawn-win.ts
@@ -31,6 +31,15 @@ export interface WindowsShimSpawn {
   args: string[];
 }
 
+export type WindowsSpawnMode = 'shim' | 'native-exe' | 'git-bash' | 'cmd';
+
+export interface WindowsSpawnPlan {
+  command: string;
+  args: string[];
+  mode: WindowsSpawnMode;
+  shell?: true | string;
+}
+
 /**
  * Extract the bare command name from a path or command string.
  * e.g. 'C:\Users\Admin\bin\claude.cmd' → 'claude'
@@ -209,6 +218,42 @@ export function shouldDirectSpawnNativeExe(
   if (!/\.exe$/i.test(command)) return false;
   const fileExists = options.exists ?? existsSync;
   return fileExists(command);
+}
+
+export function resolveWindowsSpawnPlan(command: string, args: readonly string[]): WindowsSpawnPlan {
+  const shimSpawn = resolveWindowsShimSpawn(command, args);
+  if (shimSpawn) {
+    return {
+      command: shimSpawn.command,
+      args: shimSpawn.args,
+      mode: 'shim',
+    };
+  }
+
+  if (shouldDirectSpawnNativeExe(command)) {
+    return {
+      command,
+      args: [...args],
+      mode: 'native-exe',
+    };
+  }
+
+  const gitBash = findGitBashPath();
+  if (gitBash) {
+    return {
+      command: escapeBashArg(command),
+      args: args.map(escapeBashArg),
+      mode: 'git-bash',
+      shell: gitBash,
+    };
+  }
+
+  return {
+    command: escapeCmdArg(command),
+    args: args.map(escapeCmdArg),
+    mode: 'cmd',
+    shell: true,
+  };
 }
 
 /**

--- a/packages/api/src/utils/cli-spawn-win.ts
+++ b/packages/api/src/utils/cli-spawn-win.ts
@@ -45,7 +45,7 @@ export function extractBareName(command: string): string {
 /**
  * Try to extract an entry script from a .cmd shim file by parsing its content.
  * Handles both relative (%~dp0, %dp0, %dp0%) and absolute (%APPDATA%, etc.) paths.
- * Prefers .js matches, falls back to extensionless entrypoints.
+ * Prefers .js matches, falls back to extensionless entrypoints, then native .exe entrypoints.
  */
 export function parseShimFile(cmdPath: string): string | null {
   if (!existsSync(cmdPath)) return null;
@@ -85,6 +85,17 @@ export function parseShimFile(cmdPath: string): string | null {
     const tail = scriptPath.split(/[/\\]/).pop() ?? '';
     if (/\.exe$/i.test(tail) && !/^node(\.exe)?$/i.test(tail) && existsSync(scriptPath)) {
       return scriptPath;
+    }
+  }
+
+  // Third pass: native executable entrypoints (e.g. @anthropic-ai/claude-code/bin/claude.exe).
+  // Keep skipping node.exe launchers; those are shim preludes, not the CLI entry.
+  for (const match of matches) {
+    const raw = match[1].replace(/\\/g, '/').replace(/\s+%\*.*$/, '');
+    const basename = raw.split('/').pop() ?? '';
+    if (/\.exe$/i.test(raw) && !/^node\.exe$/i.test(basename)) {
+      const exePath = join(shimDir, raw);
+      if (existsSync(exePath)) return exePath;
     }
   }
 
@@ -173,12 +184,42 @@ export function resolveWindowsShimSpawn(
   const shimScript = shimScriptOverride ?? resolveCmdShimScript(command);
   if (!shimScript) return null;
   if (/\.exe$/i.test(shimScript)) {
-    return { command: shimScript, args: [...args] };
+    return {
+      command: shimScript,
+      args: [...args],
+    };
   }
   return {
     command: process.execPath,
     args: [shimScript, ...args],
   };
+}
+
+/**
+ * Whether to spawn a Windows native .exe directly via argv (no shell).
+ *
+ * Recent Anthropic / Codex CLI releases ship as standalone PE32+ binaries
+ * (e.g. `claude.exe` 250MB+). They have no .cmd shim parseable by
+ * resolveCmdShimScript — bin/claude.exe is the entry, and the npm shim
+ * (when present) just re-launches the same .exe. Falling through to the
+ * Git Bash shell path passes the (potentially huge) prompt as a `-c`
+ * string, where any unbalanced quote in the multi-line content triggers
+ * `bash: -c: line N: unexpected EOF` (exit 2) before claude.exe even
+ * starts.
+ *
+ * Native exe + argv mode skips shell parsing entirely — child_process
+ * passes args via the Win32 CreateProcess argv array, so quoting is the
+ * exe's problem (it is, in fact, well-behaved).
+ */
+export function shouldDirectSpawnNativeExe(
+  command: string,
+  options: { platform?: NodeJS.Platform; exists?: (p: string) => boolean } = {},
+): boolean {
+  const platform = options.platform ?? process.platform;
+  if (platform !== 'win32') return false;
+  if (!/\.exe$/i.test(command)) return false;
+  const fileExists = options.exists ?? existsSync;
+  return fileExists(command);
 }
 
 /**

--- a/packages/api/src/utils/cli-spawn-win.ts
+++ b/packages/api/src/utils/cli-spawn-win.ts
@@ -88,17 +88,6 @@ export function parseShimFile(cmdPath: string): string | null {
     }
   }
 
-  // Third pass: native executable entrypoints (e.g. @anthropic-ai/claude-code/bin/claude.exe).
-  // Keep skipping node.exe launchers; those are shim preludes, not the CLI entry.
-  for (const match of matches) {
-    const raw = match[1].replace(/\\/g, '/').replace(/\s+%\*.*$/, '');
-    const basename = raw.split('/').pop() ?? '';
-    if (/\.exe$/i.test(raw) && !/^node\.exe$/i.test(basename)) {
-      const exePath = join(shimDir, raw);
-      if (existsSync(exePath)) return exePath;
-    }
-  }
-
   return null;
 }
 

--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -11,7 +11,13 @@ import { createModuleLogger } from '../infrastructure/logger.js';
 import { registerLivenessProbe, unregisterLivenessProbe } from '../infrastructure/telemetry/instruments.js';
 import { emitOtelLog } from '../infrastructure/telemetry/otel-logger.js';
 import { invalidateCliCommand } from './cli-resolve.js';
-import { escapeBashArg, escapeCmdArg, findGitBashPath, resolveWindowsShimSpawn } from './cli-spawn-win.js';
+import {
+  escapeBashArg,
+  escapeCmdArg,
+  findGitBashPath,
+  resolveWindowsShimSpawn,
+  shouldDirectSpawnNativeExe,
+} from './cli-spawn-win.js';
 import { resolveCliTimeoutMs } from './cli-timeout.js';
 import type { ChildProcessLike, CliSpawnOptions, SpawnFn } from './cli-types.js';
 import { isParseError, parseNDJSON } from './ndjson-parser.js';
@@ -559,6 +565,18 @@ function defaultSpawn(
         'Windows shim resolved',
       );
       return nodeSpawn(shimSpawn.command, shimSpawn.args, {
+        cwd: options.cwd,
+        env: options.env,
+        stdio: options.stdio,
+      });
+    }
+    // Native PE32+ binaries (e.g. modern claude.exe, codex.exe shipped as
+    // standalone executables) have no parseable .cmd shim. Spawn directly
+    // via argv to skip shell-based quoting (Git Bash `-c "<long-cmd>"`
+    // chokes on unbalanced quotes inside long prompts → exit code 2).
+    if (shouldDirectSpawnNativeExe(command)) {
+      log.debug({ command, argCount: args.length }, 'Windows native .exe direct spawn');
+      return nodeSpawn(command, [...args], {
         cwd: options.cwd,
         env: options.env,
         stdio: options.stdio,

--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -11,13 +11,7 @@ import { createModuleLogger } from '../infrastructure/logger.js';
 import { registerLivenessProbe, unregisterLivenessProbe } from '../infrastructure/telemetry/instruments.js';
 import { emitOtelLog } from '../infrastructure/telemetry/otel-logger.js';
 import { invalidateCliCommand } from './cli-resolve.js';
-import {
-  escapeBashArg,
-  escapeCmdArg,
-  findGitBashPath,
-  resolveWindowsShimSpawn,
-  shouldDirectSpawnNativeExe,
-} from './cli-spawn-win.js';
+import { resolveWindowsSpawnPlan } from './cli-spawn-win.js';
 import { resolveCliTimeoutMs } from './cli-timeout.js';
 import type { ChildProcessLike, CliSpawnOptions, SpawnFn } from './cli-types.js';
 import { isParseError, parseNDJSON } from './ndjson-parser.js';
@@ -558,47 +552,35 @@ function defaultSpawn(
   },
 ): ChildProcessLike {
   if (IS_WINDOWS) {
-    const shimSpawn = resolveWindowsShimSpawn(command, args);
-    if (shimSpawn) {
+    const spawnPlan = resolveWindowsSpawnPlan(command, args);
+    if (spawnPlan.mode === 'shim') {
       log.debug(
-        { original: command, resolved: shimSpawn.command, argCount: shimSpawn.args.length },
+        {
+          original: command,
+          resolved: spawnPlan.command,
+          argCount: spawnPlan.args.length,
+          mode: spawnPlan.mode,
+          shell: spawnPlan.shell,
+        },
         'Windows shim resolved',
       );
-      return nodeSpawn(shimSpawn.command, shimSpawn.args, {
-        cwd: options.cwd,
-        env: options.env,
-        stdio: options.stdio,
-      });
+    } else {
+      log.debug(
+        {
+          original: command,
+          resolved: spawnPlan.command,
+          argCount: spawnPlan.args.length,
+          mode: spawnPlan.mode,
+          shell: spawnPlan.shell,
+        },
+        'Windows spawn plan resolved',
+      );
     }
-    // Native PE32+ binaries (e.g. modern claude.exe, codex.exe shipped as
-    // standalone executables) have no parseable .cmd shim. Spawn directly
-    // via argv to skip shell-based quoting (Git Bash `-c "<long-cmd>"`
-    // chokes on unbalanced quotes inside long prompts → exit code 2).
-    if (shouldDirectSpawnNativeExe(command)) {
-      log.debug({ command, argCount: args.length }, 'Windows native .exe direct spawn');
-      return nodeSpawn(command, [...args], {
-        cwd: options.cwd,
-        env: options.env,
-        stdio: options.stdio,
-      });
-    }
-    // Prefer Git Bash (UTF-8 native) over cmd.exe (GBK codepage corrupts CJK args)
-    const gitBash = findGitBashPath();
-    if (gitBash) {
-      log.debug({ command, shell: gitBash }, 'Windows shim unresolved, falling back to Git Bash');
-      return nodeSpawn(escapeBashArg(command), args.map(escapeBashArg), {
-        cwd: options.cwd,
-        env: options.env,
-        stdio: options.stdio,
-        shell: gitBash,
-      });
-    }
-    log.debug({ command, shell: true }, 'Windows shim unresolved, falling back to cmd.exe');
-    return nodeSpawn(escapeCmdArg(command), args.map(escapeCmdArg), {
+    return nodeSpawn(spawnPlan.command, spawnPlan.args, {
       cwd: options.cwd,
       env: options.env,
       stdio: options.stdio,
-      shell: true,
+      ...(spawnPlan.shell !== undefined ? { shell: spawnPlan.shell } : {}),
     });
   }
 

--- a/packages/api/test/acp/acp-client-windows-spawn.test.js
+++ b/packages/api/test/acp/acp-client-windows-spawn.test.js
@@ -134,4 +134,51 @@ describe('AcpClient Windows default spawn path', () => {
     assert.equal(captured.options?.shell, undefined);
     assert.deepEqual(captured.options?.stdio, ['pipe', 'pipe', 'pipe']);
   });
+
+  it('spawns native .exe commands directly when spawnFn is omitted', async () => {
+    const platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    assert.ok(platformDescriptor, 'expected process.platform descriptor');
+    Object.defineProperty(process, 'platform', { ...platformDescriptor, value: 'win32' });
+    restorePlatform = () => Object.defineProperty(process, 'platform', platformDescriptor);
+
+    const tempRoot = mkdtempSync(join(tmpdir(), 'acp-win-native-exe-'));
+    const exePath = join(tempRoot, 'gemini.exe');
+    writeFileSync(exePath, 'fake exe\n', 'utf8');
+
+    const { child, clientStdin, agentStdout } = createMockChild();
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        if (!line) continue;
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        }
+      }
+    });
+
+    /** @type {{ command?: string; args?: string[]; options?: import('node:child_process').SpawnOptions }} */
+    const captured = {};
+    originalSpawn = childProcess.spawn;
+    childProcess.spawn = (command, args, options) => {
+      captured.command = command;
+      captured.args = args;
+      captured.options = options;
+      return /** @type {any} */ (child);
+    };
+    syncBuiltinESMExports();
+
+    const { AcpClient } = await import(`${ACP_CLIENT_MODULE}?win-native-exe-test=${Date.now()}`);
+    client = new AcpClient({
+      command: exePath,
+      args: ['--acp', '--approval-mode', 'yolo'],
+      cwd: tempRoot,
+    });
+    const result = await client.initialize();
+
+    assert.equal(result.agentInfo.name, 'test');
+    assert.equal(captured.command, exePath);
+    assert.deepEqual(captured.args, ['--acp', '--approval-mode', 'yolo']);
+    assert.equal(captured.options?.shell, undefined);
+    assert.deepEqual(captured.options?.stdio, ['pipe', 'pipe', 'pipe']);
+  });
 });

--- a/packages/api/test/antigravity-ls-discovery.test.js
+++ b/packages/api/test/antigravity-ls-discovery.test.js
@@ -1,0 +1,243 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import {
+  discoverAntigravityLS,
+  parsePortsJson,
+  parseProcessesJson,
+} from '../dist/domains/cats/services/agents/providers/antigravity/antigravity-ls-discovery.js';
+
+describe('antigravity-ls-discovery', () => {
+  const ENV_KEYS = ['ANTIGRAVITY_PORT', 'ANTIGRAVITY_CSRF_TOKEN', 'ANTIGRAVITY_TLS'];
+  const saved = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  describe('parseProcessesJson', () => {
+    test('parses single PowerShell object output', () => {
+      const json = '{"pid":13360,"cmd":"language_server.exe --csrf_token abc"}';
+      assert.deepEqual(parseProcessesJson(json), [{ pid: '13360', cmd: 'language_server.exe --csrf_token abc' }]);
+    });
+
+    test('parses array output', () => {
+      const json = '[{"pid":1,"cmd":"a"},{"pid":2,"cmd":"b"}]';
+      const result = parseProcessesJson(json);
+      assert.equal(result.length, 2);
+      assert.equal(result[0].pid, '1');
+      assert.equal(result[1].cmd, 'b');
+    });
+
+    test('drops items missing pid or cmd', () => {
+      const json = '[{"pid":1,"cmd":"a"},{"pid":2},{"cmd":"orphan"}]';
+      const result = parseProcessesJson(json);
+      assert.equal(result.length, 1);
+      assert.equal(result[0].pid, '1');
+    });
+
+    test('returns [] on invalid JSON', () => {
+      assert.deepEqual(parseProcessesJson('not-json'), []);
+      assert.deepEqual(parseProcessesJson(''), []);
+    });
+
+    test('coerces numeric pid to string', () => {
+      const result = parseProcessesJson('{"pid":42,"cmd":"x"}');
+      assert.equal(typeof result[0].pid, 'string');
+      assert.equal(result[0].pid, '42');
+    });
+  });
+
+  describe('parsePortsJson', () => {
+    test('parses single number', () => {
+      assert.deepEqual(parsePortsJson('50781'), [50781]);
+    });
+
+    test('parses array of numbers', () => {
+      assert.deepEqual(parsePortsJson('[50781,50782]'), [50781, 50782]);
+    });
+
+    test('returns [] on invalid input', () => {
+      assert.deepEqual(parsePortsJson('not-json'), []);
+      assert.deepEqual(parsePortsJson('"text"'), []);
+      assert.deepEqual(parsePortsJson(''), []);
+    });
+
+    test('filters out non-finite values', () => {
+      assert.deepEqual(parsePortsJson('[80,null,"x",443]'), [80, 443]);
+    });
+  });
+
+  describe('discoverAntigravityLS env shortcut', () => {
+    test('returns env config when port + csrf both set', async () => {
+      process.env.ANTIGRAVITY_PORT = '12345';
+      process.env.ANTIGRAVITY_CSRF_TOKEN = 'env-token';
+      process.env.ANTIGRAVITY_TLS = 'false';
+
+      const conn = await discoverAntigravityLS();
+
+      assert.deepEqual(conn, { port: 12345, csrfToken: 'env-token', useTls: false });
+    });
+
+    test('TLS defaults to true when ANTIGRAVITY_TLS missing', async () => {
+      process.env.ANTIGRAVITY_PORT = '12345';
+      process.env.ANTIGRAVITY_CSRF_TOKEN = 'env-token';
+
+      const conn = await discoverAntigravityLS();
+
+      assert.equal(conn.useTls, true);
+    });
+
+    test('falls through to discovery when only one env var set', async () => {
+      process.env.ANTIGRAVITY_PORT = '12345';
+      // ANTIGRAVITY_CSRF_TOKEN missing → must run discovery
+      let calledLister = false;
+      await assert.rejects(
+        discoverAntigravityLS({
+          platform: 'win32',
+          listProcesses: () => {
+            calledLister = true;
+            return [];
+          },
+        }),
+        /No Antigravity Language Server process found/,
+      );
+      assert.equal(calledLister, true);
+    });
+  });
+
+  describe('discoverAntigravityLS with dependency injection', () => {
+    test('selects PowerShell listers on win32 by default (signature)', async () => {
+      let psListProcessesCalled = false;
+      let psListPortsCalled = false;
+
+      await discoverAntigravityLS({
+        platform: 'win32',
+        listProcesses: () => {
+          psListProcessesCalled = true;
+          return [{ pid: '13360', cmd: '--csrf_token tok --extension_server_port 50777' }];
+        },
+        listListenPorts: (pid) => {
+          psListPortsCalled = true;
+          assert.equal(pid, '13360');
+          return [50781];
+        },
+        probe: async () => {
+          /* succeed on first probe */
+        },
+      });
+
+      assert.equal(psListProcessesCalled, true);
+      assert.equal(psListPortsCalled, true);
+    });
+
+    test('parses csrf_token + extension_server_port from cmd line', async () => {
+      const conn = await discoverAntigravityLS({
+        platform: 'win32',
+        listProcesses: () => [
+          {
+            pid: '13360',
+            cmd: 'C:\\language_server_windows_x64.exe --csrf_token b53c1c60-aaa --extension_server_port 50777 --app_data_dir antigravity',
+          },
+        ],
+        listListenPorts: () => [50777, 50781, 50782],
+        probe: async ({ port, useTls }) => {
+          if (port === 50781 && useTls === true) return;
+          throw new Error('skip');
+        },
+      });
+
+      assert.deepEqual(conn, {
+        port: 50781,
+        csrfToken: 'b53c1c60-aaa',
+        useTls: true,
+      });
+    });
+
+    test('skips extension_server_port when probing', async () => {
+      const probedPorts = [];
+
+      await assert.rejects(
+        discoverAntigravityLS({
+          platform: 'linux',
+          listProcesses: () => [{ pid: '1', cmd: '--csrf_token tok --extension_server_port 9999' }],
+          listListenPorts: () => [9999],
+          probe: async ({ port }) => {
+            probedPorts.push(port);
+            throw new Error('nope');
+          },
+        }),
+        /Could not discover/,
+      );
+
+      assert.deepEqual(probedPorts, [], 'extension_server_port must not be probed');
+    });
+
+    test('falls back to non-TLS when TLS probe fails', async () => {
+      const conn = await discoverAntigravityLS({
+        platform: 'linux',
+        listProcesses: () => [{ pid: '1', cmd: '--csrf_token tok' }],
+        listListenPorts: () => [8080],
+        probe: async ({ useTls }) => {
+          if (useTls) throw new Error('TLS handshake fail');
+        },
+      });
+
+      assert.deepEqual(conn, { port: 8080, csrfToken: 'tok', useTls: false });
+    });
+
+    test('throws when no processes found', async () => {
+      await assert.rejects(
+        discoverAntigravityLS({
+          platform: 'win32',
+          listProcesses: () => [],
+        }),
+        /No Antigravity Language Server process found/,
+      );
+    });
+
+    test('skips processes without csrf_token in cmd line', async () => {
+      await assert.rejects(
+        discoverAntigravityLS({
+          platform: 'win32',
+          listProcesses: () => [
+            { pid: '1', cmd: '--no-csrf-here' },
+            { pid: '2', cmd: '--app_data_dir foo' },
+          ],
+          listListenPorts: () => [8080],
+          probe: async () => {
+            /* should never be called */
+            throw new Error('should not probe');
+          },
+        }),
+        /Could not discover/,
+      );
+    });
+
+    test('tries multiple processes in order', async () => {
+      const conn = await discoverAntigravityLS({
+        platform: 'linux',
+        listProcesses: () => [
+          { pid: '1', cmd: '--csrf_token tok-A' },
+          { pid: '2', cmd: '--csrf_token tok-B' },
+        ],
+        listListenPorts: (pid) => (pid === '2' ? [9090] : []),
+        probe: async () => {
+          /* succeed */
+        },
+      });
+
+      assert.equal(conn.csrfToken, 'tok-B');
+      assert.equal(conn.port, 9090);
+    });
+  });
+});

--- a/packages/api/test/cli-spawn-native-exe.test.js
+++ b/packages/api/test/cli-spawn-native-exe.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+const { shouldDirectSpawnNativeExe } = await import('../dist/utils/cli-spawn-win.js');
+
+describe('shouldDirectSpawnNativeExe', () => {
+  const trueExists = () => true;
+  const falseExists = () => false;
+
+  test('true on Windows for existing .exe path', () => {
+    assert.equal(
+      shouldDirectSpawnNativeExe('C:\\Users\\me\\.local\\bin\\claude.exe', {
+        platform: 'win32',
+        exists: trueExists,
+      }),
+      true,
+    );
+  });
+
+  test('case-insensitive .exe match', () => {
+    assert.equal(
+      shouldDirectSpawnNativeExe('C:\\bin\\Tool.EXE', { platform: 'win32', exists: trueExists }),
+      true,
+    );
+  });
+
+  test('false when .exe does not exist on disk', () => {
+    assert.equal(
+      shouldDirectSpawnNativeExe('C:\\does\\not\\exist.exe', {
+        platform: 'win32',
+        exists: falseExists,
+      }),
+      false,
+    );
+  });
+
+  test('false for non-.exe on Windows', () => {
+    assert.equal(
+      shouldDirectSpawnNativeExe('C:\\bin\\claude.cmd', { platform: 'win32', exists: trueExists }),
+      false,
+    );
+    assert.equal(
+      shouldDirectSpawnNativeExe('C:\\bin\\claude.bat', { platform: 'win32', exists: trueExists }),
+      false,
+    );
+    assert.equal(
+      shouldDirectSpawnNativeExe('claude', { platform: 'win32', exists: trueExists }),
+      false,
+    );
+  });
+
+  test('false on non-Windows platforms regardless of extension', () => {
+    assert.equal(
+      shouldDirectSpawnNativeExe('/usr/local/bin/claude.exe', {
+        platform: 'linux',
+        exists: trueExists,
+      }),
+      false,
+    );
+    assert.equal(
+      shouldDirectSpawnNativeExe('/usr/local/bin/claude.exe', {
+        platform: 'darwin',
+        exists: trueExists,
+      }),
+      false,
+    );
+  });
+
+  test('defaults platform to process.platform when omitted', () => {
+    // Just sanity — should not throw, return depends on host.
+    const result = shouldDirectSpawnNativeExe('C:\\nope\\does-not-exist.exe', { exists: falseExists });
+    assert.equal(result, false);
+  });
+});

--- a/packages/api/test/cli-spawn-native-exe.test.js
+++ b/packages/api/test/cli-spawn-native-exe.test.js
@@ -18,10 +18,7 @@ describe('shouldDirectSpawnNativeExe', () => {
   });
 
   test('case-insensitive .exe match', () => {
-    assert.equal(
-      shouldDirectSpawnNativeExe('C:\\bin\\Tool.EXE', { platform: 'win32', exists: trueExists }),
-      true,
-    );
+    assert.equal(shouldDirectSpawnNativeExe('C:\\bin\\Tool.EXE', { platform: 'win32', exists: trueExists }), true);
   });
 
   test('false when .exe does not exist on disk', () => {
@@ -35,18 +32,9 @@ describe('shouldDirectSpawnNativeExe', () => {
   });
 
   test('false for non-.exe on Windows', () => {
-    assert.equal(
-      shouldDirectSpawnNativeExe('C:\\bin\\claude.cmd', { platform: 'win32', exists: trueExists }),
-      false,
-    );
-    assert.equal(
-      shouldDirectSpawnNativeExe('C:\\bin\\claude.bat', { platform: 'win32', exists: trueExists }),
-      false,
-    );
-    assert.equal(
-      shouldDirectSpawnNativeExe('claude', { platform: 'win32', exists: trueExists }),
-      false,
-    );
+    assert.equal(shouldDirectSpawnNativeExe('C:\\bin\\claude.cmd', { platform: 'win32', exists: trueExists }), false);
+    assert.equal(shouldDirectSpawnNativeExe('C:\\bin\\claude.bat', { platform: 'win32', exists: trueExists }), false);
+    assert.equal(shouldDirectSpawnNativeExe('claude', { platform: 'win32', exists: trueExists }), false);
   });
 
   test('false on non-Windows platforms regardless of extension', () => {

--- a/packages/api/test/cli-spawn-win.test.js
+++ b/packages/api/test/cli-spawn-win.test.js
@@ -184,6 +184,17 @@ test('resolveWindowsShimSpawn uses the current Node executable for direct shim l
   });
 });
 
+test('resolveWindowsShimSpawn directly launches native exe shim targets', () => {
+  const shimExe = join(tmpdir(), 'claude.exe');
+
+  const resolved = resolveWindowsShimSpawn('claude', ['--print'], shimExe);
+
+  assert.deepEqual(resolved, {
+    command: shimExe,
+    args: ['--print'],
+  });
+});
+
 test('resolveCmdShimScript skips sibling node.exe and resolves the actual script (#247)', () => {
   // Portable Node installs place node.exe alongside the .cmd shim.
   // The shim references both %~dp0\node.exe (launcher) and %~dp0\node_modules\...\bin\opencode (script).
@@ -384,6 +395,23 @@ test('parseShimFile resolves extensionless entrypoints when no .js match exists'
 
   try {
     assert.equal(parseShimFile(cmdPath), scriptPath);
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('parseShimFile resolves native exe entrypoints when the shim directly launches a CLI binary', () => {
+  const tempRoot = mkdtempSync(join(tmpdir(), 'cli-spawn-win-parse-native-exe-'));
+  mkdirSync(join(tempRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'bin'), { recursive: true });
+
+  const cmdPath = join(tempRoot, 'claude.cmd');
+  const exePath = join(tempRoot, 'node_modules', '@anthropic-ai', 'claude-code', 'bin', 'claude.exe');
+
+  writeFileSync(cmdPath, '"%dp0%\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n', 'utf8');
+  writeFileSync(exePath, 'MZ fake native exe', 'utf8');
+
+  try {
+    assert.equal(parseShimFile(cmdPath), exePath);
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
﻿## Summary
- Fix Antigravity LS discovery on Windows by using PowerShell-based process and port discovery instead of Unix-only `ps`/`lsof` assumptions.
- Fix Windows native CLI executable spawning for both generic CLI and ACP client paths by sharing the same Windows spawn planner.
- Extend `.cmd` shim parsing so npm shims that launch native `.exe` entrypoints resolve directly while still skipping `node.exe` shim preludes.

## Why
Windows hosts can have native CLI executables installed alongside npm shims. The previous fallback path sent long prompts through shell quoting, which can break on prompt content containing unmatched shell quotes or overlong command strings.

## Issue Anchor
Fixes #611

## Test Evidence
```text
pnpm --dir packages/api run build
PASS

pnpm --dir packages/api run lint
PASS

pnpm biome check packages/api/src/utils/cli-spawn-win.ts packages/api/src/utils/cli-spawn.ts packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts packages/api/test/acp/acp-client-windows-spawn.test.js --diagnostic-level=error
PASS

NODE_ENV=test node --test test/telemetry/cli-spawn-redaction.test.js test/acp/acp-client-windows-spawn.test.js test/cli-spawn-win.test.js test/cli-spawn-native-exe.test.js test/antigravity-ls-discovery.test.js
PASS: 68 tests, 63 pass, 5 skipped, 0 fail
```
