### PR TITLE
[codex] Fix connection status probes behind reverse proxies

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -618,5 +618,6 @@ This opt-in trusts browsers from RFC 1918 private networks (`10.x.x.x`, `172.16-
 
 **Frontend can't connect to API?**
 - For local dev, `NEXT_PUBLIC_API_URL=http://localhost:3004` should be in `.env`
-- Behind a reverse proxy, the frontend auto-detects the API at the same origin — make sure Nginx proxies `/api/` and `/socket.io/` to port 3004
+- Behind a reverse proxy, the frontend auto-detects the API at the same origin — make sure Nginx proxies `/api/` and `/socket.io/` to port 3004. The status probes use `/api/health` and `/api/ready`, so no special root `/health` or `/ready` proxy rule is required.
+- Set `FRONTEND_URL` to the public origin users open in the browser; otherwise Host/Origin checks will reject API and Socket.IO requests.
 - API must be running before frontend loads

--- a/SETUP.zh-CN.md
+++ b/SETUP.zh-CN.md
@@ -618,5 +618,6 @@ CORS_ALLOW_PRIVATE_NETWORK=true
 
 **前端连不上 API？**
 - 本地开发确认 `.env` 里有 `NEXT_PUBLIC_API_URL=http://localhost:3004`
-- 反向代理场景下前端会自动探测同源 API —— 确保 Nginx 把 `/api/` 和 `/socket.io/` 代理到 3004 端口
+- 反向代理场景下前端会自动探测同源 API —— 确保 Nginx 把 `/api/` 和 `/socket.io/` 代理到 3004 端口。状态探针使用 `/api/health` 和 `/api/ready`，不需要额外为根路径 `/health` 或 `/ready` 写代理规则。
+- 把 `FRONTEND_URL` 设置为用户浏览器实际打开的公网 origin；否则 Host/Origin 校验会拒绝 API 和 Socket.IO 请求。
 - API 必须在前端加载前启动

--- a/packages/api/src/domains/health/activity-route-filter.ts
+++ b/packages/api/src/domains/health/activity-route-filter.ts
@@ -1,0 +1,9 @@
+const ACTIVITY_TRACKING_EXEMPT_API_PATHS = new Set(['/api/health', '/api/ready']);
+
+export function shouldTrackApiActivity(requestUrl: string): boolean {
+  const [path] = requestUrl.split('?', 1);
+  if (!path?.startsWith('/api/')) return false;
+  if (path.startsWith('/api/brake/')) return false;
+  if (ACTIVITY_TRACKING_EXEMPT_API_PATHS.has(path)) return false;
+  return true;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -11,7 +11,7 @@ import { createRedisClient, SessionStore } from '@cat-cafe/shared/utils';
 import fastifyCookie from '@fastify/cookie';
 import cors from '@fastify/cors';
 import fastifyWebsocket from '@fastify/websocket';
-import Fastify from 'fastify';
+import Fastify, { type FastifyReply } from 'fastify';
 import { resolveAnthropicRuntimeProfile, resolveForClient } from './config/account-resolver.js';
 import { generateCliConfigs, readCapabilitiesConfig } from './config/capabilities/capability-orchestrator.js';
 import { resolveBoundAccountRefForCat } from './config/cat-account-binding.js';
@@ -261,8 +261,11 @@ async function main(): Promise<void> {
     done();
   });
 
-  // Health check
-  app.get('/health', async () => ({ status: 'ok', timestamp: Date.now() }));
+  // Health check. Keep root paths for direct API access and expose /api/*
+  // aliases for same-origin reverse-proxy deployments.
+  const healthHandler = async () => ({ status: 'ok' as const, timestamp: Date.now() });
+  app.get('/health', healthHandler);
+  app.get('/api/health', healthHandler);
 
   // F152: Readiness check — verifies dependencies are reachable.
   // evidenceStoreRef is set after memoryServices init; handler runs at request time.
@@ -295,11 +298,13 @@ async function main(): Promise<void> {
     const allOk = Object.values(checks).every((c) => c.ok);
     return { status: allOk ? 'ready' : 'degraded', checks };
   }
-  app.get('/ready', async (_request, reply) => {
+  const readyHandler = async (_request: unknown, reply: FastifyReply) => {
     const result = await checkReadiness();
     if (result.status !== 'ready') reply.code(503);
     return { ...result, timestamp: Date.now() };
-  });
+  };
+  app.get('/ready', readyHandler);
+  app.get('/api/ready', readyHandler);
 
   // Create invocation tracker for cancellation support
   const invocationTracker = new InvocationTracker();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -90,6 +90,7 @@ import { startTtsCacheCleaner } from './domains/cats/services/tts/tts-cache-clea
 import { initVoiceBlockSynthesizer } from './domains/cats/services/tts/VoiceBlockSynthesizer.js';
 import type { AgentService } from './domains/cats/services/types.js';
 import { ActivityTracker } from './domains/health/ActivityTracker.js';
+import { shouldTrackApiActivity } from './domains/health/activity-route-filter.js';
 import { PortDiscoveryService } from './domains/preview/port-discovery.js';
 import { collectRuntimePorts } from './domains/preview/port-validator.js';
 import { PreviewGateway } from './domains/preview/preview-gateway.js';
@@ -346,8 +347,8 @@ async function main(): Promise<void> {
   // F085 Phase 4: Platform-level activity tracker (hyperfocus brake)
   const activityTracker = new ActivityTracker();
   app.addHook('onRequest', (request, _reply, done) => {
-    // Skip non-API paths and brake endpoints (avoid trigger-on-checkin loop)
-    if (!request.url.startsWith('/api/') || request.url.startsWith('/api/brake/')) {
+    // Skip non-user API paths and brake endpoints (avoid trigger-on-checkin loop)
+    if (!shouldTrackApiActivity(request.url)) {
       done();
       return;
     }

--- a/packages/api/test/activity-route-filter.test.js
+++ b/packages/api/test/activity-route-filter.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { shouldTrackApiActivity } from '../dist/domains/health/activity-route-filter.js';
+
+describe('shouldTrackApiActivity', () => {
+  it('tracks ordinary API requests', () => {
+    assert.equal(shouldTrackApiActivity('/api/cats'), true);
+    assert.equal(shouldTrackApiActivity('/api/messages?threadId=t1'), true);
+  });
+
+  it('skips reverse-proxy-safe health probes', () => {
+    assert.equal(shouldTrackApiActivity('/api/health'), false);
+    assert.equal(shouldTrackApiActivity('/api/health?cacheBust=1'), false);
+    assert.equal(shouldTrackApiActivity('/api/ready'), false);
+    assert.equal(shouldTrackApiActivity('/api/ready?cacheBust=1'), false);
+  });
+
+  it('keeps existing brake and non-API exclusions', () => {
+    assert.equal(shouldTrackApiActivity('/api/brake/status'), false);
+    assert.equal(shouldTrackApiActivity('/health'), false);
+  });
+});

--- a/packages/api/test/runtime-health-routes.test.js
+++ b/packages/api/test/runtime-health-routes.test.js
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(testDir, '../src/index.ts'), 'utf8');
+
+describe('runtime health routes', () => {
+  it('keeps root probes while exposing /api/* aliases for same-origin reverse proxies', () => {
+    assert.match(src, /app\.get\('\/health',\s*healthHandler\)/);
+    assert.match(src, /app\.get\('\/api\/health',\s*healthHandler\)/);
+    assert.match(src, /app\.get\('\/ready',\s*readyHandler\)/);
+    assert.match(src, /app\.get\('\/api\/ready',\s*readyHandler\)/);
+  });
+});

--- a/packages/web/src/hooks/__tests__/useConnectionStatus-proxy-paths.test.ts
+++ b/packages/web/src/hooks/__tests__/useConnectionStatus-proxy-paths.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/packages/web/src/hooks/__tests__/useConnectionStatus-proxy-paths.test.ts
+++ b/packages/web/src/hooks/__tests__/useConnectionStatus-proxy-paths.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(testDir, '../useConnectionStatus.ts'), 'utf8');
+
+describe('useConnectionStatus reverse-proxy paths', () => {
+  it('probes health endpoints through the same /api/ reverse-proxy boundary', () => {
+    expect(src).toContain("probePublicEndpoint('/api/health')");
+    expect(src).toContain("probePublicEndpoint('/api/ready')");
+    expect(src).not.toContain("probePublicEndpoint('/health')");
+    expect(src).not.toContain("probePublicEndpoint('/ready')");
+  });
+});

--- a/packages/web/src/hooks/useConnectionStatus.ts
+++ b/packages/web/src/hooks/useConnectionStatus.ts
@@ -111,8 +111,8 @@ export function useConnectionStatus(socketConnected?: boolean | null): Connectio
   const runProbe = useCallback(async () => {
     if (!browserOnline || !probesEnabled) return;
     const [apiLevel, readyLevel, catsLevel] = await Promise.all([
-      probePublicEndpoint('/health'),
-      probePublicEndpoint('/ready'),
+      probePublicEndpoint('/api/health'),
+      probePublicEndpoint('/api/ready'),
       probeCatsAvailability(),
     ]);
     if (!mountedRef.current) return;


### PR DESCRIPTION
Fixes #615.

## Summary

This PR makes the connection status probes work through the same reverse-proxy boundary as normal API calls.

- Keeps the existing root `/health` and `/ready` endpoints for direct API access.
- Adds `/api/health` and `/api/ready` aliases with identical behavior.
- Changes `useConnectionStatus` to probe `/api/health` and `/api/ready`.
- Updates setup docs to clarify reverse-proxy routing and `FRONTEND_URL` requirements.

## Root cause

The frontend previously probed root `/health` and `/ready`. In same-origin deployments, Nginx commonly proxies `/api/` and `/socket.io/` to the API while serving all other root paths from the frontend. Root health probes can therefore hit the web app, return 404/HTML, and make the UI report local API/upstream degradation even when the real API is reachable.

## Validation

- `pnpm --filter @cat-cafe/web exec vitest run src/hooks/__tests__/useConnectionStatus-proxy-paths.test.ts`
- `pnpm --filter @cat-cafe/api run build`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --test test/runtime-health-routes.test.js`
