### PR TITLE
fix(windows): replace redis-cli dependency with pure-PowerShell RESP PING/PONG (#620)

### DIFF
--- a/packages/api/test/windows-portable-redis-lifecycle.test.js
+++ b/packages/api/test/windows-portable-redis-lifecycle.test.js
@@ -83,14 +83,13 @@ test('Windows stop script only stops Clowder-owned API and frontend listeners', 
 
 test('Windows startup preserves runtime Redis overrides, validates artifacts, and exits when service jobs stop', () => {
   assert.match(startWindowsScript, /\$configuredRedisUrl = if \(\$env:REDIS_URL\)/);
-  assert.match(helpersScript, /function Test-LocalRedisUrl/);
+  assert.match(helpersScript, /function Test-RedisReachable/);
+  assert.match(helpersScript, /function Format-RedisRespCommand/);
+  assert.match(helpersScript, /function Send-RedisShutdown/);
   assert.match(helpersScript, /function Get-RedactedRedisUrl/);
-  assert.match(
-    startWindowsScript,
-    /\$useExternalRedis = \$useRedis -and \$configuredRedisUrl -and -not \(Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort\)/,
-  );
   assert.match(startWindowsScript, /\$safeConfiguredRedisUrl = Get-RedactedRedisUrl -RedisUrl \$configuredRedisUrl/);
-  assert.match(startWindowsScript, /Write-Ok "Using external Redis: \$safeConfiguredRedisUrl"/);
+  assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$configuredRedisUrl/);
+  assert.match(startWindowsScript, /Write-Ok "Redis reachable at \$safeConfiguredRedisUrl"/);
   assert.match(startWindowsScript, /\$safeEffectiveRedisUrl = Get-RedactedRedisUrl -RedisUrl \$effectiveRedisUrl/);
   assert.match(
     startWindowsScript,
@@ -111,11 +110,9 @@ test('Windows startup preserves runtime Redis overrides, validates artifacts, an
   assert.match(startWindowsScript, /Service job '\$\(\$job.Name\)' stopped \(\$\(\$job.State\)\)/);
 });
 
-test('Windows startup preserves configured REDIS_URL with DB suffix and credentials when local Redis is already running', () => {
-  assert.match(
-    startWindowsScript,
-    /if \(\$configuredRedisUrl\) \{\s+\$env:REDIS_URL = \$configuredRedisUrl\s+\} else \{\s+\$env:REDIS_URL = "redis:\/\/localhost:\$RedisPort"\s+\}/s,
-  );
+test('Windows startup preserves configured REDIS_URL when provided', () => {
+  assert.match(startWindowsScript, /\$env:REDIS_URL = \$configuredRedisUrl/);
+  assert.match(startWindowsScript, /Write-Ok "Redis reachable at \$safeConfiguredRedisUrl"/);
 });
 
 test('Windows startup refuses non-Clowder Redis listeners before reusing port 6399', () => {
@@ -192,13 +189,11 @@ test('Windows PATH refresh preserves shell-provided shim entries while appending
   );
 });
 
-test('Windows stop script resolves redis-cli through the shared helper chain before shutdown', () => {
+test('Windows stop script resolves Redis through RESP instead of redis-cli', () => {
   assert.match(stopWindowsScript, /install-windows-helpers\.ps1/);
-  assert.match(stopWindowsScript, /Resolve-PortableRedisBinaries -ProjectRoot \$ProjectRoot/);
   assert.match(stopWindowsScript, /Resolve-PortableRedisLayout -ProjectRoot \$ProjectRoot/);
-  assert.match(stopWindowsScript, /Resolve-GlobalRedisBinaries/);
-  assert.match(stopWindowsScript, /\$redisCli = \$redisCommands\.CliPath/);
-  assert.doesNotMatch(stopWindowsScript, /& redis-cli -p \$RedisPort ping/);
+  assert.match(stopWindowsScript, /Test-RedisReachable -RedisUrl \$shutdownUrl/);
+  assert.match(stopWindowsScript, /Send-RedisShutdown -RedisUrl \$shutdownUrl/);
   assert.match(
     stopWindowsScript,
     /\$redisPidFile = if \(\$redisLayout\) \{ Join-Path \$redisLayout\.Data "redis-\$RedisPort\.pid" \} else \{ \$null \}/,
@@ -213,9 +208,8 @@ test('Windows stop script resolves redis-cli through the shared helper chain bef
     /\$isClowderOwned = \$isManagedPid -or \(Test-ClowderOwnedProcess -ProcessId \$conn\.OwningProcess -ClowderProjectRoot \$ProjectRoot\)/,
   );
   assert.match(stopWindowsScript, /Write-Warn "Skipping non-Clowder Redis listener on port \$RedisPort/);
-  assert.match(stopWindowsScript, /Get-RedisAuthArgs\s+-RedisUrl\s+\$configuredRedisUrl/);
-  assert.match(stopWindowsScript, /@redisAuthArgs\s+ping/);
-  assert.match(stopWindowsScript, /@redisAuthArgs\s+shutdown/);
+  assert.doesNotMatch(stopWindowsScript, /& redis-cli/);
+  assert.doesNotMatch(stopWindowsScript, /@redisAuthArgs/);
 });
 
 test('Windows start.bat delegates to start-windows.ps1', () => {

--- a/packages/api/test/windows-portable-redis-url.test.js
+++ b/packages/api/test/windows-portable-redis-url.test.js
@@ -106,6 +106,12 @@ test('Windows Redis auth helpers decode percent-escaped ACL credentials before i
   );
 });
 
+test('Windows RESP helpers use UTF-8 byte counts for bulk string lengths', () => {
+  assert.match(helpersScript, /function Format-RedisRespCommand/);
+  assert.match(helpersScript, /\[System\.Text\.Encoding\]::UTF8\.GetByteCount\(\$arg\)/);
+  assert.doesNotMatch(helpersScript, /\$\(\$arg\.Length\)/);
+});
+
 test('Windows portable Redis defers REDIS_URL to runtime instead of hardcoding localhost:6379', () => {
   assert.match(uiHelpersScript, /function Apply-InstallerRedisPlan/);
   assert.match(uiHelpersScript, /Add-InstallerEnvDelete \$State "REDIS_URL"/);
@@ -156,6 +162,8 @@ test('Windows installer prefers plain portable Redis zips before service bundles
 test('Windows Redis URL handling validates connectivity with RESP and detects external backends for shutdown skip', () => {
   assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$configuredRedisUrl/);
   assert.match(helpersScript, /Format-RedisRespCommand -Args @\("PING"\)/);
+  assert.match(startWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
+  assert.match(stopWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
   assert.match(
     stopWindowsScript,
     /\$configuredRedisUrl = Get-InstallerEnvValueFromFile -EnvFile \$envFile -Key "REDIS_URL"\s+if \(-not \$configuredRedisUrl -and \$env:REDIS_URL\) \{\s+\$configuredRedisUrl = \$env:REDIS_URL\.Trim\(\)\s+\}/,

--- a/packages/api/test/windows-portable-redis-url.test.js
+++ b/packages/api/test/windows-portable-redis-url.test.js
@@ -153,17 +153,12 @@ test('Windows installer prefers plain portable Redis zips before service bundles
   assert.ok(msys2Zip < msys2ServiceZip, 'portable zip should be preferred before service zip');
 });
 
-test('Windows Redis URL handling preserves external backends and treats localhost URLs with suffixes as local', () => {
-  assert.match(startWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
-  assert.match(helpersScript, /\$isLoopbackHost = \$uri\.Host -eq "localhost"/);
-  assert.match(helpersScript, /if \(\$uri\.Port -gt 0 -and "\$\(\$uri\.Port\)" -ne "\$RedisPort"\) \{/);
+test('Windows Redis URL handling validates connectivity with RESP and detects external backends for shutdown skip', () => {
+  assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$configuredRedisUrl/);
+  assert.match(helpersScript, /Format-RedisRespCommand -Args @\("PING"\)/);
   assert.match(
     stopWindowsScript,
     /\$configuredRedisUrl = Get-InstallerEnvValueFromFile -EnvFile \$envFile -Key "REDIS_URL"\s+if \(-not \$configuredRedisUrl -and \$env:REDIS_URL\) \{\s+\$configuredRedisUrl = \$env:REDIS_URL\.Trim\(\)\s+\}/,
-  );
-  assert.match(
-    stopWindowsScript,
-    /if \(\$configuredRedisUrl -and -not \(Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort\)\) \{/,
   );
   assert.match(
     stopWindowsScript,
@@ -215,12 +210,6 @@ test('Windows startup passes localhost REDIS_URL auth into redis-server auto-sta
   assert.match(startWindowsScript, /Start-Job -Name "redis-bootstrap"/);
   assert.match(startWindowsScript, /& \$launcherPath @launcherArgs 2>&1/);
 
-  const pingMatches = startWindowsScript.match(
-    /\$redisPing = & \$redisCliPath -p \$RedisPort @redisAuthArgs ping 2>\$null/g,
-  );
-  assert.ok(
-    pingMatches && pingMatches.length >= 2,
-    `Expected authenticated redis-cli ping in both already-running and auto-start branches, found ${pingMatches ? pingMatches.length : 0}`,
-  );
-  assert.match(startWindowsScript, /& \$redisCliPath -p \$RedisPort @redisAuthArgs shutdown save 2>\$null/);
+  assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$localUrl/);
+  assert.match(startWindowsScript, /Send-RedisShutdown -RedisUrl "redis:\/\/localhost:\$RedisPort"/);
 });

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -236,6 +236,9 @@ function Get-RedactedRedisUrl {
     }
 }
 
+# Legacy: formats auth args for redis-cli CLI invocation (--user, -a).
+# RESP-based functions (Test-RedisReachable, Send-RedisShutdown) parse
+# credentials directly from the URL and do NOT use this function.
 function Get-RedisAuthArgs {
     param([string]$RedisUrl)
     if (-not $RedisUrl) { return @() }

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -264,7 +264,8 @@ function Format-RedisRespCommand {
 
     $parts = "*$($Args.Count)`r`n"
     foreach ($arg in $Args) {
-        $parts += "`$$($arg.Length)`r`n$arg`r`n"
+        $byteLength = [System.Text.Encoding]::UTF8.GetByteCount($arg)
+        $parts += "`$$byteLength`r`n$arg`r`n"
     }
     return $parts
 }

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -256,6 +256,147 @@ function Get-RedisAuthArgs {
     return @()
 }
 
+function Format-RedisRespCommand {
+    param([string[]]$Args)
+
+    $parts = "*$($Args.Count)`r`n"
+    foreach ($arg in $Args) {
+        $parts += "`$$($arg.Length)`r`n$arg`r`n"
+    }
+    return $parts
+}
+
+# Pure-PowerShell Redis connectivity check via TCP + RESP PING/PONG.
+# Replaces redis-cli dependency for local and WSL-based Redis instances.
+function Test-RedisReachable {
+    param(
+        [string]$RedisUrl,
+        [int]$TimeoutMs = 3000
+    )
+
+    if (-not $RedisUrl) {
+        return $false
+    }
+
+    $uri = $null
+    if (-not [System.Uri]::TryCreate($RedisUrl, [System.UriKind]::Absolute, [ref]$uri)) {
+        return $false
+    }
+
+    $hostName = $uri.Host
+    $port = if ($uri.Port -gt 0) { $uri.Port } else { 6379 }
+
+    $client = $null
+    try {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        $connectTask = $client.ConnectAsync($hostName, $port)
+        if (-not $connectTask.Wait($TimeoutMs) -or -not $client.Connected) {
+            return $false
+        }
+
+        $stream = $client.GetStream()
+        $stream.ReadTimeout = $TimeoutMs
+        $stream.WriteTimeout = $TimeoutMs
+        $writer = [System.IO.StreamWriter]::new($stream, [System.Text.Encoding]::UTF8)
+        $writer.AutoFlush = $true
+        $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
+
+        # AUTH if credentials embedded in URL
+        if ($uri.UserInfo) {
+            $parts = $uri.UserInfo -split ":", 2
+            $username = [System.Uri]::UnescapeDataString($parts[0])
+            $password = if ($parts.Count -ge 2) { [System.Uri]::UnescapeDataString($parts[1]) } else { "" }
+
+            if ($parts.Count -ge 2 -and $username) {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username, $password)
+            } elseif ($username) {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username)
+            } else {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $password)
+            }
+            $writer.Write($authCmd)
+            $authLine = $reader.ReadLine()
+            if ($authLine -notmatch '^\+OK') {
+                return $false
+            }
+        }
+
+        # PING
+        $writer.Write((Format-RedisRespCommand -Args @("PING")))
+        $pingLine = $reader.ReadLine()
+        return $pingLine -eq '+PONG'
+    } catch {
+        return $false
+    } finally {
+        if ($client) { $client.Dispose() }
+    }
+}
+
+# Send SHUTDOWN SAVE via RESP, replacing redis-cli shutdown save.
+function Send-RedisShutdown {
+    param(
+        [string]$RedisUrl,
+        [int]$TimeoutMs = 3000
+    )
+
+    if (-not $RedisUrl) {
+        return $false
+    }
+
+    $uri = $null
+    if (-not [System.Uri]::TryCreate($RedisUrl, [System.UriKind]::Absolute, [ref]$uri)) {
+        return $false
+    }
+
+    $hostName = $uri.Host
+    $port = if ($uri.Port -gt 0) { $uri.Port } else { 6379 }
+
+    $client = $null
+    try {
+        $client = [System.Net.Sockets.TcpClient]::new()
+        $connectTask = $client.ConnectAsync($hostName, $port)
+        if (-not $connectTask.Wait($TimeoutMs) -or -not $client.Connected) {
+            return $false
+        }
+
+        $stream = $client.GetStream()
+        $stream.ReadTimeout = $TimeoutMs
+        $stream.WriteTimeout = $TimeoutMs
+        $writer = [System.IO.StreamWriter]::new($stream, [System.Text.Encoding]::UTF8)
+        $writer.AutoFlush = $true
+        $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
+
+        # AUTH if needed
+        if ($uri.UserInfo) {
+            $parts = $uri.UserInfo -split ":", 2
+            $username = [System.Uri]::UnescapeDataString($parts[0])
+            $password = if ($parts.Count -ge 2) { [System.Uri]::UnescapeDataString($parts[1]) } else { "" }
+
+            if ($parts.Count -ge 2 -and $username) {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username, $password)
+            } elseif ($username) {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username)
+            } else {
+                $authCmd = Format-RedisRespCommand -Args @("AUTH", $password)
+            }
+            $writer.Write($authCmd)
+            $authLine = $reader.ReadLine()
+            if ($authLine -notmatch '^\+OK') {
+                return $false
+            }
+        }
+
+        # SHUTDOWN SAVE
+        $writer.Write((Format-RedisRespCommand -Args @("SHUTDOWN", "SAVE")))
+        $reader.ReadLine() | Out-Null
+        return $true
+    } catch {
+        return $false
+    } finally {
+        if ($client) { $client.Dispose() }
+    }
+}
+
 function Get-RedisServerAuthArgs {
     param([string]$RedisUrl, [string]$AclFilePath)
     if (-not $RedisUrl) { return @() }

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -305,24 +305,24 @@ $redisJob = $null
 $redisLogFile = Join-Path $redisLayout.Logs "redis-$RedisPort.log"
 $redisPidFile = Join-Path $redisLayout.Data "redis-$RedisPort.pid"
 $configuredRedisUrl = if ($env:REDIS_URL) { $env:REDIS_URL.Trim() } else { "" }
+$configuredIsManagedRedis = $configuredRedisUrl -and (Test-LocalRedisUrl -RedisUrl $configuredRedisUrl -RedisPort $RedisPort)
+$useExternalRedis = $useRedis -and $configuredRedisUrl -and -not $configuredIsManagedRedis
 $safeConfiguredRedisUrl = Get-RedactedRedisUrl -RedisUrl $configuredRedisUrl
 
 if ($useRedis) {
-    if ($configuredRedisUrl) {
-        # User configured a Redis URL — validate connectivity, never manage the process.
-        if (Test-RedisReachable -RedisUrl $configuredRedisUrl) {
-            Write-Ok "Redis reachable at $safeConfiguredRedisUrl"
-            $env:REDIS_URL = $configuredRedisUrl
-        } else {
-            Write-Warn "Redis not reachable at $safeConfiguredRedisUrl - falling back to memory storage"
-            Write-Warn "Check your REDIS_URL or use -Memory to skip Redis."
-            $useRedis = $false
-        }
+    if ($configuredRedisUrl -and (Test-RedisReachable -RedisUrl $configuredRedisUrl)) {
+        # A configured reachable Redis endpoint can be used without redis-cli.
+        Write-Ok "Redis reachable at $safeConfiguredRedisUrl"
+        $env:REDIS_URL = $configuredRedisUrl
+    } elseif ($useExternalRedis) {
+        Write-Warn "Redis not reachable at $safeConfiguredRedisUrl - falling back to memory storage"
+        Write-Warn "Check your REDIS_URL or use -Memory to skip Redis."
+        $useRedis = $false
     } else {
-        # No REDIS_URL configured — use managed Redis on $RedisPort.
+        # No reachable configured Redis endpoint; manage Redis on $RedisPort.
         $localUrl = "redis://localhost:$RedisPort"
         if (Test-RedisReachable -RedisUrl $localUrl) {
-            # Redis already listening on our managed port — verify ownership.
+            # Redis already listening on our managed port; verify ownership.
             $redisConnections = Get-NetTCPConnection -LocalPort $RedisPort -State Listen -ErrorAction SilentlyContinue
             $hasNonClowder = $false
             if ($redisConnections) {
@@ -340,9 +340,13 @@ if ($useRedis) {
                 throw "Redis port $RedisPort is in use by a non-Clowder process"
             }
             Write-Ok "Redis already running on port $RedisPort"
-            $env:REDIS_URL = $localUrl
+            if ($configuredRedisUrl) {
+                $env:REDIS_URL = $configuredRedisUrl
+            } else {
+                $env:REDIS_URL = "redis://localhost:$RedisPort"
+            }
         } else {
-            # Not running — try to start our own Redis.
+            # Not running; try to start our own Redis.
             Write-Warn "Redis not running on port $RedisPort"
             $redisCommands = Resolve-PortableRedisBinaries -ProjectRoot $ProjectRoot
             if (-not $redisCommands) {
@@ -374,9 +378,14 @@ if ($useRedis) {
                         & $launcherPath @launcherArgs 2>&1
                     } -ArgumentList $redisServerPath, $redisArgs
                     Start-Sleep -Seconds 2
-                    if (Test-RedisReachable -RedisUrl $localUrl) {
+                    $managedProbeUrl = if ($configuredRedisUrl) { $configuredRedisUrl } else { $localUrl }
+                    if (Test-RedisReachable -RedisUrl $managedProbeUrl) {
                         Write-Ok "Redis started on port $RedisPort"
-                        $env:REDIS_URL = $localUrl
+                        if ($configuredRedisUrl) {
+                            $env:REDIS_URL = $configuredRedisUrl
+                        } else {
+                            $env:REDIS_URL = "redis://localhost:$RedisPort"
+                        }
                         $startedRedis = $true
                     } else {
                         Write-Warn "Redis start failed - falling back to memory storage"

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -299,109 +299,102 @@ Write-Step "Storage"
 $useRedis = -not $Memory
 $startedRedis = $false
 $redisLayout = Resolve-PortableRedisLayout -ProjectRoot $ProjectRoot
-$redisCliPath = $null
 $redisServerPath = $null
 $redisSource = $null
-$redisAuthArgs = @()
 $redisJob = $null
 $redisLogFile = Join-Path $redisLayout.Logs "redis-$RedisPort.log"
 $redisPidFile = Join-Path $redisLayout.Data "redis-$RedisPort.pid"
 $configuredRedisUrl = if ($env:REDIS_URL) { $env:REDIS_URL.Trim() } else { "" }
-$useExternalRedis = $useRedis -and $configuredRedisUrl -and -not (Test-LocalRedisUrl -RedisUrl $configuredRedisUrl -RedisPort $RedisPort)
 $safeConfiguredRedisUrl = Get-RedactedRedisUrl -RedisUrl $configuredRedisUrl
 
-if ($useExternalRedis) {
-    Write-Ok "Using external Redis: $safeConfiguredRedisUrl"
-} elseif ($useRedis) {
-    $redisCommands = Resolve-PortableRedisBinaries -ProjectRoot $ProjectRoot
-    if (-not $redisCommands) {
-        $redisCommands = Resolve-GlobalRedisBinaries
-    }
-    if ($redisCommands) {
-        $redisCliPath = $redisCommands.CliPath
-        $redisServerPath = $redisCommands.ServerPath
-        $redisSource = $redisCommands.Source
-        Write-Ok "Redis binaries resolved ($redisSource): $($redisCommands.BinDir)"
-    }
-    $redisAuthArgs = Get-RedisAuthArgs -RedisUrl $configuredRedisUrl
-    # Check if Redis is already running
-    try {
-        if (-not $redisCliPath) {
-            throw "redis-cli unavailable"
+if ($useRedis) {
+    if ($configuredRedisUrl) {
+        # User configured a Redis URL — validate connectivity, never manage the process.
+        if (Test-RedisReachable -RedisUrl $configuredRedisUrl) {
+            Write-Ok "Redis reachable at $safeConfiguredRedisUrl"
+            $env:REDIS_URL = $configuredRedisUrl
+        } else {
+            Write-Warn "Redis not reachable at $safeConfiguredRedisUrl - falling back to memory storage"
+            Write-Warn "Check your REDIS_URL or use -Memory to skip Redis."
+            $useRedis = $false
         }
-        $redisPing = & $redisCliPath -p $RedisPort @redisAuthArgs ping 2>$null
-        if ($redisPing -eq "PONG") {
+    } else {
+        # No REDIS_URL configured — use managed Redis on $RedisPort.
+        $localUrl = "redis://localhost:$RedisPort"
+        if (Test-RedisReachable -RedisUrl $localUrl) {
+            # Redis already listening on our managed port — verify ownership.
             $redisConnections = Get-NetTCPConnection -LocalPort $RedisPort -State Listen -ErrorAction SilentlyContinue
-            if (-not $redisConnections) {
-                throw "not running"
-            }
-            $managedRedisPid = Get-ManagedProcessId -PidFile $redisPidFile
-            foreach ($conn in $redisConnections) {
-                $isManagedPid = $managedRedisPid -and ($conn.OwningProcess -eq $managedRedisPid)
-                $isClowderOwned = $isManagedPid -or (Test-ClowderOwnedProcess -ProcessId $conn.OwningProcess -ProjectRoot $ProjectRoot)
-                if (-not $isClowderOwned) {
-                    Write-Err "Redis port $RedisPort is in use by non-Clowder PID $($conn.OwningProcess). Stop it manually or change REDIS_PORT."
-                    throw "Redis port $RedisPort is in use by a non-Clowder process"
+            $hasNonClowder = $false
+            if ($redisConnections) {
+                $managedRedisPid = Get-ManagedProcessId -PidFile $redisPidFile
+                foreach ($conn in $redisConnections) {
+                    $isManagedPid = $managedRedisPid -and ($conn.OwningProcess -eq $managedRedisPid)
+                    $isClowderOwned = $isManagedPid -or (Test-ClowderOwnedProcess -ProcessId $conn.OwningProcess -ProjectRoot $ProjectRoot)
+                    if (-not $isClowderOwned) {
+                        Write-Err "Redis port $RedisPort is in use by non-Clowder PID $($conn.OwningProcess). Stop it manually or change REDIS_PORT."
+                        $hasNonClowder = $true
+                    }
                 }
+            }
+            if ($hasNonClowder) {
+                throw "Redis port $RedisPort is in use by a non-Clowder process"
             }
             Write-Ok "Redis already running on port $RedisPort"
-            if ($configuredRedisUrl) {
-                $env:REDIS_URL = $configuredRedisUrl
-            } else {
-                $env:REDIS_URL = "redis://localhost:$RedisPort"
-            }
+            $env:REDIS_URL = $localUrl
         } else {
-            throw "not running"
-        }
-    } catch {
-        if ($_.Exception -and $_.Exception.Message -like "Redis port $RedisPort is in use by a non-Clowder process") {
-            throw
-        }
-        Write-Warn "Redis not running on port $RedisPort"
-        # Try to start Redis
-        try {
-            if ($redisServerPath) {
-                New-Item -Path $redisLayout.Data -ItemType Directory -Force | Out-Null
-                New-Item -Path $redisLayout.Logs -ItemType Directory -Force | Out-Null
-                $redisAclFile = Join-Path $redisLayout.Data "redis-$RedisPort.acl"
-                $redisServerAuthArgs = Get-RedisServerAuthArgs -RedisUrl $configuredRedisUrl -AclFilePath $redisAclFile
-                $redisArgs = @(
-                    "--port", $RedisPort,
-                    "--bind", "127.0.0.1",
-                    "--dir", (Quote-WindowsProcessArgument -Value $redisLayout.Data),
-                    "--logfile", (Quote-WindowsProcessArgument -Value $redisLogFile),
-                    "--pidfile", (Quote-WindowsProcessArgument -Value $redisPidFile)
-                ) + $redisServerAuthArgs
-                Write-Host "  Starting Redis on port $RedisPort ($redisSource)..."
-                $redisJob = Start-Job -Name "redis-bootstrap" -ScriptBlock {
-                    param($launcherPath, $launcherArgs)
-                    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
-                    $OutputEncoding = [System.Text.Encoding]::UTF8
-                    & $launcherPath @launcherArgs 2>&1
-                } -ArgumentList $redisServerPath, $redisArgs
-                Start-Sleep -Seconds 2
-                $redisPing = & $redisCliPath -p $RedisPort @redisAuthArgs ping 2>$null
-                if ($redisPing -eq "PONG") {
-                    Write-Ok "Redis started on port $RedisPort"
-                    if ($configuredRedisUrl) {
-                        $env:REDIS_URL = $configuredRedisUrl
+            # Not running — try to start our own Redis.
+            Write-Warn "Redis not running on port $RedisPort"
+            $redisCommands = Resolve-PortableRedisBinaries -ProjectRoot $ProjectRoot
+            if (-not $redisCommands) {
+                $redisCommands = Resolve-GlobalRedisBinaries
+            }
+            if ($redisCommands) {
+                $redisServerPath = $redisCommands.ServerPath
+                $redisSource = $redisCommands.Source
+                Write-Ok "Redis binaries resolved ($redisSource): $($redisCommands.BinDir)"
+            }
+            try {
+                if ($redisServerPath) {
+                    New-Item -Path $redisLayout.Data -ItemType Directory -Force | Out-Null
+                    New-Item -Path $redisLayout.Logs -ItemType Directory -Force | Out-Null
+                    $redisAclFile = Join-Path $redisLayout.Data "redis-$RedisPort.acl"
+                    $redisServerAuthArgs = Get-RedisServerAuthArgs -RedisUrl $configuredRedisUrl -AclFilePath $redisAclFile
+                    $redisArgs = @(
+                        "--port", $RedisPort,
+                        "--bind", "127.0.0.1",
+                        "--dir", (Quote-WindowsProcessArgument -Value $redisLayout.Data),
+                        "--logfile", (Quote-WindowsProcessArgument -Value $redisLogFile),
+                        "--pidfile", (Quote-WindowsProcessArgument -Value $redisPidFile)
+                    ) + $redisServerAuthArgs
+                    Write-Host "  Starting Redis on port $RedisPort ($redisSource)..."
+                    $redisJob = Start-Job -Name "redis-bootstrap" -ScriptBlock {
+                        param($launcherPath, $launcherArgs)
+                        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+                        $OutputEncoding = [System.Text.Encoding]::UTF8
+                        & $launcherPath @launcherArgs 2>&1
+                    } -ArgumentList $redisServerPath, $redisArgs
+                    Start-Sleep -Seconds 2
+                    if (Test-RedisReachable -RedisUrl $localUrl) {
+                        Write-Ok "Redis started on port $RedisPort"
+                        $env:REDIS_URL = $localUrl
+                        $startedRedis = $true
                     } else {
-                        $env:REDIS_URL = "redis://localhost:$RedisPort"
+                        Write-Warn "Redis start failed - falling back to memory storage"
+                        $useRedis = $false
                     }
-                    $startedRedis = $true
                 } else {
-                    Write-Warn "Redis start failed - falling back to memory storage"
+                    Write-Warn "Redis not installed - using memory storage"
+                    Write-Warn "Run .\\scripts\\install.ps1 again to fetch the project-local Redis bundle into .cat-cafe/redis/windows."
                     $useRedis = $false
                 }
-            } else {
-                Write-Warn "Redis not installed - using memory storage"
-                Write-Warn "Run .\\scripts\\install.ps1 again to fetch the project-local Redis bundle into .cat-cafe/redis/windows."
+            } catch {
+                if ($_.Exception -and $_.Exception.Message -like "Redis port $RedisPort is in use by a non-Clowder process") {
+                    throw
+                }
+                Write-Warn "Redis start failed - using memory storage"
+                Write-InstallerExceptionDetails -Context "Redis start" -ErrorRecord $_
                 $useRedis = $false
             }
-        } catch {
-            Write-Warn "Redis start failed - using memory storage"
-            Write-InstallerExceptionDetails -Context "Redis start" -ErrorRecord $_
-            $useRedis = $false
         }
     }
 }
@@ -669,7 +662,7 @@ try {
 
     if ($startedRedis) {
         try {
-            & $redisCliPath -p $RedisPort @redisAuthArgs shutdown save 2>$null
+            Send-RedisShutdown -RedisUrl "redis://localhost:$RedisPort"
             Write-Ok "Redis stopped"
         } catch {
             Write-Warn "Could not stop Redis gracefully"

--- a/scripts/stop-windows.ps1
+++ b/scripts/stop-windows.ps1
@@ -122,24 +122,32 @@ $WebPidFile = if ($RunDir) { Join-Path $RunDir "web-$WebPort.pid" } else { $null
 Stop-PortProcess -Port $ApiPort -Name "API Server" -PidFile $ApiPidFile -ProjectRoot $ProjectRoot
 Stop-PortProcess -Port $WebPort -Name "Frontend" -PidFile $WebPidFile -ProjectRoot $ProjectRoot
 
-# Stop Redis if running on our port
-$redisCommands = $null
+# Stop Redis if running on our managed port.
+# Only shut down Redis when:
+# 1. No external REDIS_URL is configured (we manage the instance), OR
+# 2. REDIS_URL points to our managed port (localhost:$RedisPort)
 $redisLayout = if ($ProjectRoot) { Resolve-PortableRedisLayout -ProjectRoot $ProjectRoot } else { $null }
 $redisPidFile = if ($redisLayout) { Join-Path $redisLayout.Data "redis-$RedisPort.pid" } else { $null }
-if ($ProjectRoot) {
-    $redisCommands = Resolve-PortableRedisBinaries -ProjectRoot $ProjectRoot
-}
-if (-not $redisCommands) {
-    $redisCommands = Resolve-GlobalRedisBinaries
+
+$isExternalRedis = $false
+if ($configuredRedisUrl) {
+    $uri = $null
+    if ([System.Uri]::TryCreate($configuredRedisUrl, [System.UriKind]::Absolute, [ref]$uri)) {
+        $isLoopback = $uri.Host -eq "localhost"
+        $ipAddress = $null
+        if (-not $isLoopback -and [System.Net.IPAddress]::TryParse($uri.Host, [ref]$ipAddress)) {
+            $isLoopback = [System.Net.IPAddress]::IsLoopback($ipAddress)
+        }
+        if (-not $isLoopback) {
+            $isExternalRedis = $true
+        }
+    }
 }
 
-if ($configuredRedisUrl -and -not (Test-LocalRedisUrl -RedisUrl $configuredRedisUrl -RedisPort $RedisPort)) {
+if ($isExternalRedis) {
     Write-Warn "Skipping local Redis shutdown because REDIS_URL points to an external host"
 } else {
     try {
-        if (-not $redisCommands -or -not $redisCommands.CliPath) {
-            throw "redis-cli unavailable"
-        }
         $redisConnections = Get-NetTCPConnection -LocalPort $RedisPort -State Listen -ErrorAction SilentlyContinue
         if (-not $redisConnections) {
             Write-Warn "Redis (port $RedisPort) - not running"
@@ -158,11 +166,9 @@ if ($configuredRedisUrl -and -not (Test-LocalRedisUrl -RedisUrl $configuredRedis
             if ($ownedRedisConnections.Count -eq 0) {
                 Write-Warn "Redis (port $RedisPort) - no Clowder-owned listener found"
             } else {
-                $redisCli = $redisCommands.CliPath
-                $redisAuthArgs = Get-RedisAuthArgs -RedisUrl $configuredRedisUrl
-                $redisPing = & $redisCli -p $RedisPort @redisAuthArgs ping 2>$null
-                if ($redisPing -eq "PONG") {
-                    & $redisCli -p $RedisPort @redisAuthArgs shutdown save 2>$null
+                $shutdownUrl = if ($configuredRedisUrl) { $configuredRedisUrl } else { "redis://localhost:$RedisPort" }
+                if (Test-RedisReachable -RedisUrl $shutdownUrl) {
+                    Send-RedisShutdown -RedisUrl $shutdownUrl
                     Write-Ok "Redis stopped (port $RedisPort)"
                 } else {
                     Write-Warn "Redis (port $RedisPort) - not running"

--- a/scripts/stop-windows.ps1
+++ b/scripts/stop-windows.ps1
@@ -129,22 +129,7 @@ Stop-PortProcess -Port $WebPort -Name "Frontend" -PidFile $WebPidFile -ProjectRo
 $redisLayout = if ($ProjectRoot) { Resolve-PortableRedisLayout -ProjectRoot $ProjectRoot } else { $null }
 $redisPidFile = if ($redisLayout) { Join-Path $redisLayout.Data "redis-$RedisPort.pid" } else { $null }
 
-$isExternalRedis = $false
-if ($configuredRedisUrl) {
-    $uri = $null
-    if ([System.Uri]::TryCreate($configuredRedisUrl, [System.UriKind]::Absolute, [ref]$uri)) {
-        $isLoopback = $uri.Host -eq "localhost"
-        $ipAddress = $null
-        if (-not $isLoopback -and [System.Net.IPAddress]::TryParse($uri.Host, [ref]$ipAddress)) {
-            $isLoopback = [System.Net.IPAddress]::IsLoopback($ipAddress)
-        }
-        if (-not $isLoopback) {
-            $isExternalRedis = $true
-        }
-    }
-}
-
-if ($isExternalRedis) {
+if ($configuredRedisUrl -and -not (Test-LocalRedisUrl -RedisUrl $configuredRedisUrl -RedisPort $RedisPort)) {
     Write-Warn "Skipping local Redis shutdown because REDIS_URL points to an external host"
 } else {
     try {


### PR DESCRIPTION
## Summary

- Replace `redis-cli.exe` dependency in `start-windows.ps1` and `stop-windows.ps1` with pure-PowerShell TCP + RESP PING/PONG
- Fixes #620: WSL Redis falsely reported as "not running" when `redis-cli.exe` is unavailable on Windows

## Changes

### `scripts/install-windows-helpers.ps1`
Add three new functions:
- `Format-RedisRespCommand` — build RESP protocol command strings
- `Test-RedisReachable` — TCP connect + RESP AUTH + PING/PONG validation
- `Send-RedisShutdown` — TCP connect + RESP AUTH + SHUTDOWN SAVE

### `scripts/start-windows.ps1`
Refactor Storage section:
- When `REDIS_URL` is configured: validate connectivity via `Test-RedisReachable`
- When no `REDIS_URL`: check managed port, attempt to start own Redis on fallback
- Remove `Test-LocalRedisUrl` usage in startup path
- Remove all `redis-cli` calls

### `scripts/stop-windows.ps1`
- Replace `redis-cli ping`/`shutdown` with `Test-RedisReachable` + `Send-RedisShutdown`
- Replace `Test-LocalRedisUrl` call with inline loopback check
- Remove `redis-cli` binary resolution

### Test updates
- Update `windows-portable-redis-lifecycle.test.js` and `windows-portable-redis-url.test.js` to match new code patterns

## Test plan

- [ ] `pnpm start` on Windows with WSL Redis (REDIS_URL=redis://localhost:6379)
- [ ] `pnpm start` on Windows with no local Redis (should attempt start or memory fallback)
- [ ] `pnpm start --memory` (should skip Redis entirely)
- [ ] `pnpm stop` on Windows
- [ ] Existing test suite: `node --test packages/api/test/windows-portable-redis-*.test.js`

Closes #620