### PR TITLE
fix(api): dedupe queue replay by idempotency key

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -148,8 +148,7 @@ export class InvocationQueue {
     if (input.idempotencyKey) {
       const existing = q.find(
         (entry) =>
-          entry.idempotencyKey === input.idempotencyKey &&
-          (entry.status === 'queued' || entry.status === 'processing'),
+          entry.idempotencyKey === input.idempotencyKey && (entry.status === 'queued' || entry.status === 'processing'),
       );
       if (existing) {
         const position = q.findIndex((entry) => entry.id === existing.id);

--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -17,6 +17,8 @@ export interface QueueEntry {
   id: string;
   threadId: string;
   userId: string;
+  /** Optional request-level idempotency key for API replay dedup. */
+  idempotencyKey?: string;
   content: string;
   messageId: string | null;
   mergedMessageIds: string[];
@@ -49,6 +51,8 @@ export interface EnqueueResult {
   outcome: 'enqueued' | 'full';
   entry?: QueueEntry;
   queuePosition?: number;
+  /** True when enqueue returned an existing active entry by idempotency key. */
+  deduped?: boolean;
 }
 
 const MAX_QUEUE_DEPTH = 5;
@@ -139,6 +143,25 @@ export class InvocationQueue {
     const key = this.scopeKey(input.threadId, input.userId);
     const q = this.getOrCreate(key);
 
+    // Request replay dedupe: if an active entry already exists for this key in this scope,
+    // return it instead of creating a second queue row.
+    if (input.idempotencyKey) {
+      const existing = q.find(
+        (entry) =>
+          entry.idempotencyKey === input.idempotencyKey &&
+          (entry.status === 'queued' || entry.status === 'processing'),
+      );
+      if (existing) {
+        const position = q.findIndex((entry) => entry.id === existing.id);
+        return {
+          outcome: 'enqueued',
+          entry: { ...existing },
+          queuePosition: position >= 0 ? position + 1 : undefined,
+          deduped: true,
+        };
+      }
+    }
+
     // F175: capacity check — only user messages are depth-limited
     if (input.source === 'user') {
       const userQueuedCount = q.filter((e) => e.status === 'queued' && e.source === 'user').length;
@@ -151,6 +174,7 @@ export class InvocationQueue {
       id: randomUUID(),
       threadId: input.threadId,
       userId: input.userId,
+      idempotencyKey: input.idempotencyKey,
       content: input.content,
       messageId: null,
       mergedMessageIds: [],

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -465,6 +465,7 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
       const enqueueResult = opts.invocationQueue.enqueue({
         threadId: resolvedThreadId,
         userId,
+        idempotencyKey: resolvedIdempotencyKey,
         content,
         source: 'user',
         targetCats,
@@ -487,35 +488,39 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
         };
       }
 
-      let storedUserMessageId: string | null = null;
+      let storedUserMessageId: string | null = enqueueResult.entry?.messageId ?? null;
 
       // ② Write user message (F117: mark as queued — invisible until dequeue)
-      try {
-        const userMessage = await opts.messageStore.append({
-          userId,
-          catId: null,
-          content,
-          mentions: targetCats,
-          timestamp: Date.now(),
-          threadId: resolvedThreadId,
-          deliveryStatus: 'queued', // F117: not visible in history/context/mentions until delivered
-          ...(contentBlocks ? { contentBlocks } : {}),
-          ...(whisperVisibility && whisperRecipients
-            ? { visibility: whisperVisibility, whisperTo: whisperRecipients }
-            : {}),
-        });
-        storedUserMessageId = userMessage.id;
+      // If enqueue returned a deduped active entry, reuse existing messageId and skip append.
+      if (!enqueueResult.deduped) {
+        try {
+          const userMessage = await opts.messageStore.append({
+            userId,
+            catId: null,
+            content,
+            mentions: targetCats,
+            timestamp: Date.now(),
+            threadId: resolvedThreadId,
+            idempotencyKey: resolvedIdempotencyKey,
+            deliveryStatus: 'queued', // F117: not visible in history/context/mentions until delivered
+            ...(contentBlocks ? { contentBlocks } : {}),
+            ...(whisperVisibility && whisperRecipients
+              ? { visibility: whisperVisibility, whisperTo: whisperRecipients }
+              : {}),
+          });
+          storedUserMessageId = userMessage.id;
 
-        const queueEntryId = enqueueResult.entry?.id;
-        if (queueEntryId) {
-          opts.invocationQueue.backfillMessageId(resolvedThreadId, userId, queueEntryId, userMessage.id);
+          const queueEntryId = enqueueResult.entry?.id;
+          if (queueEntryId) {
+            opts.invocationQueue.backfillMessageId(resolvedThreadId, userId, queueEntryId, userMessage.id);
+          }
+        } catch (err) {
+          const queueEntryId = enqueueResult.entry?.id;
+          if (queueEntryId) {
+            opts.invocationQueue.rollbackEnqueue(resolvedThreadId, userId, queueEntryId);
+          }
+          throw err;
         }
-      } catch (err) {
-        const queueEntryId = enqueueResult.entry?.id;
-        if (queueEntryId) {
-          opts.invocationQueue.rollbackEnqueue(resolvedThreadId, userId, queueEntryId);
-        }
-        throw err;
       }
 
       // Emit queue update to this user only (privacy: scopeKey isolation)
@@ -576,6 +581,7 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
             const enqueueResult = opts.invocationQueue.enqueue({
               threadId: resolvedThreadId,
               userId,
+              idempotencyKey: resolvedIdempotencyKey,
               content,
               source: 'user',
               targetCats,
@@ -593,31 +599,40 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
             }
             // F122 R1-gpt52 P1-1: Wrap append+backfill in try/catch with rollback,
             // matching original queue path (lines 340-374) to prevent ghost queue entries.
-            let toctouUserMessage: { id: string };
-            try {
-              toctouUserMessage = await opts.messageStore.append({
-                userId,
-                catId: null,
-                content,
-                mentions: targetCats,
-                timestamp: Date.now(),
-                threadId: resolvedThreadId,
-                deliveryStatus: 'queued',
-                ...(contentBlocks ? { contentBlocks } : {}),
-                ...(whisperVisibility && whisperRecipients
-                  ? { visibility: whisperVisibility, whisperTo: whisperRecipients }
-                  : {}),
-              });
-              const queueEntryId = enqueueResult.entry?.id;
-              if (queueEntryId) {
-                opts.invocationQueue.backfillMessageId(resolvedThreadId, userId, queueEntryId, toctouUserMessage.id);
+            let toctouUserMessageId: string | null = enqueueResult.entry?.messageId ?? null;
+            if (!enqueueResult.deduped) {
+              try {
+                const toctouUserMessage = await opts.messageStore.append({
+                  userId,
+                  catId: null,
+                  content,
+                  mentions: targetCats,
+                  timestamp: Date.now(),
+                  threadId: resolvedThreadId,
+                  idempotencyKey: resolvedIdempotencyKey,
+                  deliveryStatus: 'queued',
+                  ...(contentBlocks ? { contentBlocks } : {}),
+                  ...(whisperVisibility && whisperRecipients
+                    ? { visibility: whisperVisibility, whisperTo: whisperRecipients }
+                    : {}),
+                });
+                toctouUserMessageId = toctouUserMessage.id;
+                const queueEntryId = enqueueResult.entry?.id;
+                if (queueEntryId) {
+                  opts.invocationQueue.backfillMessageId(
+                    resolvedThreadId,
+                    userId,
+                    queueEntryId,
+                    toctouUserMessage.id,
+                  );
+                }
+              } catch (err) {
+                const queueEntryId = enqueueResult.entry?.id;
+                if (queueEntryId) {
+                  opts.invocationQueue.rollbackEnqueue(resolvedThreadId, userId, queueEntryId);
+                }
+                throw err;
               }
-            } catch (err) {
-              const queueEntryId = enqueueResult.entry?.id;
-              if (queueEntryId) {
-                opts.invocationQueue.rollbackEnqueue(resolvedThreadId, userId, queueEntryId);
-              }
-              throw err;
             }
             opts.socketManager.emitToUser(userId, 'queue_updated', {
               threadId: resolvedThreadId,
@@ -631,7 +646,7 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
               queuePosition: enqueueResult.queuePosition,
               entryId: enqueueResult.entry?.id,
               merged: false,
-              userMessageId: toctouUserMessage.id,
+              ...(toctouUserMessageId ? { userMessageId: toctouUserMessageId } : {}),
             };
           }
           // No queue available — thread is busy but we can't queue. Reject.

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -619,12 +619,7 @@ export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (
                 toctouUserMessageId = toctouUserMessage.id;
                 const queueEntryId = enqueueResult.entry?.id;
                 if (queueEntryId) {
-                  opts.invocationQueue.backfillMessageId(
-                    resolvedThreadId,
-                    userId,
-                    queueEntryId,
-                    toctouUserMessage.id,
-                  );
+                  opts.invocationQueue.backfillMessageId(resolvedThreadId, userId, queueEntryId, toctouUserMessage.id);
                 }
               } catch (err) {
                 const queueEntryId = enqueueResult.entry?.id;

--- a/packages/api/test/invocation-queue.test.js
+++ b/packages/api/test/invocation-queue.test.js
@@ -81,6 +81,19 @@ describe('InvocationQueue', () => {
     assert.equal(queue.size('t1', 'u1'), 1); // only 'b' counts
   });
 
+  it('same idempotencyKey replays are deduped to one active entry', () => {
+    const first = queue.enqueue(entry({ content: 'first', idempotencyKey: 'idem-1' }));
+    assert.equal(first.outcome, 'enqueued');
+    assert.equal(first.deduped, undefined);
+
+    const replay = queue.enqueue(entry({ content: 'replay', idempotencyKey: 'idem-1' }));
+    assert.equal(replay.outcome, 'enqueued');
+    assert.equal(replay.deduped, true);
+    assert.equal(replay.entry.id, first.entry.id);
+    assert.equal(queue.size('t1', 'u1'), 1);
+    assert.equal(queue.list('t1', 'u1')[0].content, 'first');
+  });
+
   // ── F175: no merge — every entry is independent ──
 
   it('same-source same-target entries are independent (F175 no merge)', () => {

--- a/packages/api/test/messages-delivery-mode.test.js
+++ b/packages/api/test/messages-delivery-mode.test.js
@@ -129,6 +129,43 @@ describe('POST /api/messages deliveryMode', () => {
     assert.equal(queueUpdate.arguments[2].action, 'enqueued');
   });
 
+  it('queue mode replay with same idempotencyKey does not append duplicate message', async () => {
+    deps.invocationTracker.has.mock.mockImplementation(() => true);
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      headers: { 'x-cat-cafe-user': 'user-1', 'content-type': 'application/json' },
+      payload: {
+        content: '会重放',
+        threadId: 'thread-1',
+        deliveryMode: 'queue',
+        idempotencyKey: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+    assert.equal(first.statusCode, 202);
+    const firstBody = JSON.parse(first.body);
+
+    const replay = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      headers: { 'x-cat-cafe-user': 'user-1', 'content-type': 'application/json' },
+      payload: {
+        content: '会重放',
+        threadId: 'thread-1',
+        deliveryMode: 'queue',
+        idempotencyKey: '11111111-1111-4111-8111-111111111111',
+      },
+    });
+    assert.equal(replay.statusCode, 202);
+    const replayBody = JSON.parse(replay.body);
+
+    assert.equal(deps.messageStore.append.mock.calls.length, 1, 'replay should not append again');
+    assert.equal(deps.invocationQueue.list('thread-1', 'user-1').length, 1, 'replay should not add a new queue row');
+    assert.equal(replayBody.entryId, firstBody.entryId, 'replay should point to existing queue entry');
+    assert.equal(replayBody.userMessageId, firstBody.userMessageId, 'replay should reuse original user message');
+  });
+
   it('queue mode → same-user consecutive messages are independent entries (F175: no merge)', async () => {
     deps.invocationTracker.has.mock.mockImplementation(() => true);
 
@@ -289,6 +326,44 @@ describe('POST /api/messages deliveryMode', () => {
     assert.equal(body.status, 'processing');
     assert.ok(deps.invocationRecordStore.create.mock.calls.length > 0);
     assert.equal(deps.invocationQueue.list('thread-1', 'user-1').length, 1, 'leftover queue must not grow');
+  });
+
+  it('TOCTOU degrade-to-queue replay with same idempotencyKey does not append duplicate message', async () => {
+    deps.invocationTracker.has.mock.mockImplementation(() => false);
+    deps.invocationTracker.tryStartThreadAll.mock.mockImplementation(() => null);
+
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      headers: { 'x-cat-cafe-user': 'user-1', 'content-type': 'application/json' },
+      payload: {
+        content: 'TOCTOU replay',
+        threadId: 'thread-1',
+        deliveryMode: 'immediate',
+        idempotencyKey: '22222222-2222-4222-8222-222222222222',
+      },
+    });
+    assert.equal(first.statusCode, 202);
+    const firstBody = JSON.parse(first.body);
+
+    const replay = await app.inject({
+      method: 'POST',
+      url: '/api/messages',
+      headers: { 'x-cat-cafe-user': 'user-1', 'content-type': 'application/json' },
+      payload: {
+        content: 'TOCTOU replay',
+        threadId: 'thread-1',
+        deliveryMode: 'immediate',
+        idempotencyKey: '22222222-2222-4222-8222-222222222222',
+      },
+    });
+    assert.equal(replay.statusCode, 202);
+    const replayBody = JSON.parse(replay.body);
+
+    assert.equal(deps.messageStore.append.mock.calls.length, 1, 'replay should not append again');
+    assert.equal(deps.invocationQueue.list('thread-1', 'user-1').length, 1, 'replay should not add a new queue row');
+    assert.equal(replayBody.entryId, firstBody.entryId, 'replay should point to existing queue entry');
+    assert.equal(replayBody.userMessageId, firstBody.userMessageId, 'replay should reuse original user message');
   });
 
   it('aborted invocation does not emit spawn_started after stop wins the race', async () => {


### PR DESCRIPTION
## Summary

Fix queue-path replay idempotency so the same logical user request does not enqueue/append twice.

### What changed

- Added optional `idempotencyKey` to `InvocationQueue` entries.
- Added active-entry dedupe in `InvocationQueue.enqueue(...)`:
  - if same `(threadId, userId, idempotencyKey)` already exists in `queued`/`processing`, return existing entry instead of creating a new row.
- In `POST /api/messages` queue flow, passed `resolvedIdempotencyKey` into:
  - `invocationQueue.enqueue(...)`
  - queued `messageStore.append(...)`
- Applied the same change to the TOCTOU degrade-to-queue path.
- When enqueue is deduped, skip message append/backfill and reuse existing `messageId`.

## Scope / boundary notes

- Dedup window is intentionally **active queue entry lifetime** (`queued`/`processing`), not global forever dedup.
  - After an entry fully completes and is removed, a later request with the same key is treated as a new request by design.
- This PR covers **user-message queue replay** paths in `POST /api/messages`.
  - Connector-source replay/idempotency behavior is out of scope for this patch and should be validated separately.

## Why

Replay/retry of the same logical message in queue mode could produce duplicate queue rows and duplicate user messages, which can cause duplicated execution and extra token usage.

## Tests

Added/updated tests:

- `packages/api/test/invocation-queue.test.js`
  - `same idempotencyKey replays are deduped to one active entry`
- `packages/api/test/messages-delivery-mode.test.js`
  - `queue mode replay with same idempotencyKey does not append duplicate message`
  - `TOCTOU degrade-to-queue replay with same idempotencyKey does not append duplicate message`

Validation run:

```bash
pnpm --dir packages/api build
CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import $(pwd)/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/invocation-queue.test.js test/messages-delivery-mode.test.js
```

Closes #630
