### PR TITLE
fix: unblock Windows desktop deploy

### DIFF
--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -81,7 +81,10 @@ if (-not $SkipBundleDeps) {
     foreach ($pkg in @('api', 'web', 'mcp-server')) {
         Write-Host "  Deploying @cat-cafe/$pkg ..." -ForegroundColor Gray
         $out = Join-Path $deployRoot $pkg
-        pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted deploy $out
+        # Runtime services launch package entrypoints directly; they do not use
+        # node_modules/.bin shims. Disabling bin links avoids a pnpm 9 hoisted
+        # deploy failure on windows-2025 runners while keeping real-file deps.
+        pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted --config.bin-links=false deploy $out
         if ($LASTEXITCODE -ne 0) { Write-Err "pnpm deploy @cat-cafe/$pkg failed"; Pop-Location; exit 1 }
     }
     Pop-Location


### PR DESCRIPTION
## Summary
- Disable pnpm bin-link generation during Windows desktop runtime deploy.
- Runtime services launch package entrypoints directly and do not depend on node_modules/.bin shims.
- This targets the repeated windows-2025 dry-run failure where pnpm deploy could not create .bin shims and failed on .bin/tsc.

## Evidence
- release-desktop.yml dry-run 25207668089: macOS job passed; Windows job failed twice in Build Windows installer.
- Failure signature: pnpm deploy @cat-cafe/api emitted repeated Failed to create bin warnings under bundled/deploy/api/node_modules/.bin, then EPERM opening .bin/tsc.
- Hotfix base: sync/2026-05-01-081148 from cat-cafe ca8e5afd to clowder-ai 183d524.

## Verification
- sync-hotfix.sh --dry-run passed with target drift check clean.
- sync-hotfix.sh pushed this single-file hotfix branch.
- pnpm accepts --config.bin-links=false locally via config get bin-links.

[砚砚/GPT-5.5🐾]