### PR TITLE
fix(infra): make start:status work on Windows

### DIFF
--- a/.dir-exceptions.json
+++ b/.dir-exceptions.json
@@ -4,14 +4,14 @@
       "path": "packages/api/src/routes",
       "owner": "opus",
       "reason": "Routes 按功能已分文件，ADR-010 重构 scope 不含 routes，后续评估是否拆子目录",
-      "expiresAt": "2026-05-01",
+      "expiresAt": "2026-06-01",
       "ticket": "F23"
     },
     {
       "path": "packages/api/src/config",
       "owner": "opus",
       "reason": "Config 文件数接近 warn，均为独立配置项（cat-budgets/cat-config/env 等），暂不拆",
-      "expiresAt": "2026-05-01",
+      "expiresAt": "2026-06-01",
       "ticket": "F23"
     },
     {

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,7 @@ data/
 test-audit-logs/
 
 # Temporary files
+.tmp/
 tmp/
 temp/
 

--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,6 @@ data/
 test-audit-logs/
 
 # Temporary files
-.tmp/
 tmp/
 temp/
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "guards:install": "bash ./scripts/install-git-guards.sh",
     "start": "node ./scripts/start-entry.mjs start",
     "stop": "./scripts/start-dev.sh --stop",
-    "start:status": "./scripts/start-dev.sh --status",
+    "start:status": "node ./scripts/start-entry.mjs status",
     "start:direct": "node ./scripts/start-entry.mjs start:direct --profile=opensource",
     "dev:direct": "node ./scripts/start-entry.mjs dev:direct --profile=opensource",
     "review:start": "bash ./scripts/review-start.sh",

--- a/scripts/check-env-port-drift.test.mjs
+++ b/scripts/check-env-port-drift.test.mjs
@@ -335,6 +335,24 @@ describe(`Code-side port defaults are internally consistent (${repoLabel}: API=$
     );
   });
 
+  it(`platform-status.mjs API status fallback is ${expectedApiPort}`, () => {
+    const fallback = readTsFallback('scripts/lib/platform-status.mjs', /DEFAULT_API_PORT = '(\d+)'/);
+    assert.equal(
+      fallback,
+      expectedApiPort,
+      `platform-status API status fallback should be ${expectedApiPort}, got ${fallback}`,
+    );
+  });
+
+  it(`platform-status.mjs Frontend status fallback is ${expectedFrontendPort}`, () => {
+    const fallback = readTsFallback('scripts/lib/platform-status.mjs', /DEFAULT_WEB_PORT = '(\d+)'/);
+    assert.equal(
+      fallback,
+      expectedFrontendPort,
+      `platform-status Frontend status fallback should be ${expectedFrontendPort}, got ${fallback}`,
+    );
+  });
+
   it(`AgentRouter.ts API port fallback is ${expectedApiPort}`, () => {
     const fallback = readTsFallback(
       'packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts',

--- a/scripts/lib/platform-status.mjs
+++ b/scripts/lib/platform-status.mjs
@@ -1,0 +1,99 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+
+const DEFAULT_API_PORT = '3004';
+const DEFAULT_WEB_PORT = '3003';
+
+export function pidIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+export function readDotEnvValues(dotEnvPath) {
+  if (!existsSync(dotEnvPath)) return {};
+
+  const values = {};
+  for (const rawLine of readFileSync(dotEnvPath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+    values[key] = value;
+  }
+  return values;
+}
+
+function getConfigValue(dotEnv, env, key) {
+  return dotEnv[key] || env[key];
+}
+
+export function resolveWindowsStatusPorts({ projectRoot = process.cwd(), env = process.env } = {}) {
+  const dotEnv = readDotEnvValues(resolve(projectRoot, '.env'));
+  return {
+    apiPort: getConfigValue(dotEnv, env, 'API_SERVER_PORT') ?? DEFAULT_API_PORT,
+    webPort: getConfigValue(dotEnv, env, 'FRONTEND_PORT') ?? DEFAULT_WEB_PORT,
+  };
+}
+
+export function buildWindowsStatus({
+  projectRoot = process.cwd(),
+  env = process.env,
+  pidIsRunning: checkPid = pidIsRunning,
+} = {}) {
+  const runDir = resolve(projectRoot, '.cat-cafe', 'run', 'windows');
+  if (!existsSync(runDir)) {
+    return {
+      exitCode: 1,
+      lines: [`Cat Cafe Windows services not running (no run directory: ${runDir})`],
+    };
+  }
+
+  const { apiPort, webPort } = resolveWindowsStatusPorts({ projectRoot, env });
+  const requiredServices = [
+    { pidFile: `api-${apiPort}.pid`, running: false },
+    { pidFile: `web-${webPort}.pid`, running: false },
+  ];
+
+  const lines = ['Cat Cafe Windows status'];
+  for (const service of requiredServices) {
+    const pidPath = resolve(runDir, service.pidFile);
+    const label = basename(service.pidFile, '.pid');
+    if (!existsSync(pidPath)) {
+      lines.push(`  ${label}: not running (missing PID file)`);
+      continue;
+    }
+
+    const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
+    if (Number.isNaN(pid)) {
+      lines.push(`  ${label}: invalid PID file`);
+      continue;
+    }
+
+    service.running = checkPid(pid);
+    lines.push(`  ${label}: ${service.running ? 'running' : 'not running'} (PID: ${pid})`);
+  }
+
+  return {
+    exitCode: requiredServices.every((service) => service.running) ? 0 : 1,
+    lines,
+  };
+}
+
+export function runWindowsStatus(options = {}) {
+  const result = buildWindowsStatus(options);
+  for (const line of result.lines) {
+    console.log(line);
+  }
+  process.exit(result.exitCode);
+}

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -232,6 +232,31 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
     assert.match(pkg.scripts.start, /start-entry\.mjs start\b/, 'pnpm start must route through start-entry.mjs');
   });
+  it('package.json scripts.start:status routes through start-entry.mjs for Windows pnpm shells', () => {
+    const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
+
+    assert.match(
+      pkg.scripts['start:status'],
+      /start-entry\.mjs status\b/,
+      'pnpm start:status must not invoke ./scripts/start-dev.sh directly',
+    );
+  });
+
+  it('start-entry.mjs handles Windows status without shelling through bash', () => {
+    const source = readFileSync(resolve(ROOT, 'scripts/start-entry.mjs'), 'utf8');
+
+    assert.ok(source.includes('runWindowsStatus()'), 'Windows status path must use the native status helper');
+    assert.ok(source.includes("mode === 'status'"), 'start-entry.mjs must accept status mode');
+    assert.match(
+      source,
+      /if \(IS_WINDOWS\) \{\s+runWindowsStatus\(\);\s+\} else \{/,
+      'Windows status path must not rely on runWindowsStatus() exiting before the bash fallback',
+    );
+    assert.ok(
+      source.includes("'start-dev.sh'), '--status'"),
+      'non-Windows status path must preserve start-dev.sh status',
+    );
+  });
 
   it('start-entry.mjs sets CAT_CAFE_PROFILE and CAT_CAFE_STRICT_PROFILE_DEFAULTS for Windows when --profile is present', () => {
     const source = readFileSync(resolve(ROOT, 'scripts/start-entry.mjs'), 'utf8');

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -232,6 +232,7 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
     assert.match(pkg.scripts.start, /start-entry\.mjs start\b/, 'pnpm start must route through start-entry.mjs');
   });
+
   it('package.json scripts.start:status routes through start-entry.mjs for Windows pnpm shells', () => {
     const pkg = JSON.parse(readFileSync(resolve(ROOT, 'package.json'), 'utf8'));
 
@@ -255,6 +256,20 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     assert.ok(
       source.includes("'start-dev.sh'), '--status'"),
       'non-Windows status path must preserve start-dev.sh status',
+    );
+    assert.ok(
+      source.includes("getConfigValue(dotEnv, 'API_SERVER_PORT') ?? '3004'"),
+      'Windows status must derive the active API port from .env/process env',
+    );
+    assert.ok(
+      source.includes("getConfigValue(dotEnv, 'FRONTEND_PORT') ?? '3003'"),
+      'Windows status must derive the active web port from .env/process env',
+    );
+    assert.match(source, /api-\$\{apiPort\}\.pid/, 'Windows status must check the required API PID file');
+    assert.match(source, /web-\$\{webPort\}\.pid/, 'Windows status must check the required web PID file');
+    assert.ok(
+      source.includes('requiredServices.every((service) => service.running)'),
+      'Windows status must only exit 0 when every required service is running',
     );
   });
 

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -4,6 +4,7 @@ import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, write
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { buildWindowsStatus } from './lib/platform-status.mjs';
 
 const ROOT = resolve(process.cwd());
 const SYNC_SCRIPT = resolve(ROOT, 'scripts/sync-to-opensource.sh');
@@ -243,34 +244,81 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     );
   });
 
-  it('start-entry.mjs handles Windows status without shelling through bash', () => {
-    const source = readFileSync(resolve(ROOT, 'scripts/start-entry.mjs'), 'utf8');
+  it('Windows status succeeds only when required API and web PID files are running', () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'cc-windows-status-'));
+    try {
+      const runDir = join(sandboxDir, '.cat-cafe', 'run', 'windows');
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(join(runDir, 'api-3004.pid'), '41\n');
+      writeFileSync(join(runDir, 'web-3003.pid'), '42\n');
+      writeFileSync(join(runDir, 'embed-9878.pid'), '999\n');
 
-    assert.ok(source.includes('runWindowsStatus()'), 'Windows status path must use the native status helper');
-    assert.ok(source.includes("mode === 'status'"), 'start-entry.mjs must accept status mode');
-    assert.match(
-      source,
-      /if \(IS_WINDOWS\) \{\s+runWindowsStatus\(\);\s+\} else \{/,
-      'Windows status path must not rely on runWindowsStatus() exiting before the bash fallback',
-    );
-    assert.ok(
-      source.includes("'start-dev.sh'), '--status'"),
-      'non-Windows status path must preserve start-dev.sh status',
-    );
-    assert.ok(
-      source.includes("getConfigValue(dotEnv, 'API_SERVER_PORT') ?? '3004'"),
-      'Windows status must derive the active API port from .env/process env',
-    );
-    assert.ok(
-      source.includes("getConfigValue(dotEnv, 'FRONTEND_PORT') ?? '3003'"),
-      'Windows status must derive the active web port from .env/process env',
-    );
-    assert.match(source, /api-\$\{apiPort\}\.pid/, 'Windows status must check the required API PID file');
-    assert.match(source, /web-\$\{webPort\}\.pid/, 'Windows status must check the required web PID file');
-    assert.ok(
-      source.includes('requiredServices.every((service) => service.running)'),
-      'Windows status must only exit 0 when every required service is running',
-    );
+      const result = buildWindowsStatus({
+        projectRoot: sandboxDir,
+        env: {},
+        pidIsRunning: (pid) => pid === 41 || pid === 42,
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.deepEqual(result.lines, [
+        'Cat Cafe Windows status',
+        '  api-3004: running (PID: 41)',
+        '  web-3003: running (PID: 42)',
+      ]);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Windows status fails when optional or stale PID files exist but a required service is missing', () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'cc-windows-status-'));
+    try {
+      const runDir = join(sandboxDir, '.cat-cafe', 'run', 'windows');
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(join(runDir, 'api-3004.pid'), '41\n');
+      writeFileSync(join(runDir, 'embed-9878.pid'), '999\n');
+
+      const result = buildWindowsStatus({
+        projectRoot: sandboxDir,
+        env: {},
+        pidIsRunning: (pid) => pid === 41 || pid === 999,
+      });
+
+      assert.equal(result.exitCode, 1);
+      assert.deepEqual(result.lines, [
+        'Cat Cafe Windows status',
+        '  api-3004: running (PID: 41)',
+        '  web-3003: not running (missing PID file)',
+      ]);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
+  });
+
+  it('Windows status reads active ports from .env before falling back to open-source defaults', () => {
+    const sandboxDir = mkdtempSync(join(tmpdir(), 'cc-windows-status-'));
+    try {
+      writeFileSync(join(sandboxDir, '.env'), 'API_SERVER_PORT=3112\nFRONTEND_PORT=3111\n');
+      const runDir = join(sandboxDir, '.cat-cafe', 'run', 'windows');
+      mkdirSync(runDir, { recursive: true });
+      writeFileSync(join(runDir, 'api-3112.pid'), '51\n');
+      writeFileSync(join(runDir, 'web-3111.pid'), '52\n');
+
+      const result = buildWindowsStatus({
+        projectRoot: sandboxDir,
+        env: {},
+        pidIsRunning: (pid) => pid === 51 || pid === 52,
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.deepEqual(result.lines, [
+        'Cat Cafe Windows status',
+        '  api-3112: running (PID: 51)',
+        '  web-3111: running (PID: 52)',
+      ]);
+    } finally {
+      rmSync(sandboxDir, { recursive: true, force: true });
+    }
   });
 
   it('start-entry.mjs sets CAT_CAFE_PROFILE and CAT_CAFE_STRICT_PROFILE_DEFAULTS for Windows when --profile is present', () => {

--- a/scripts/start-entry.mjs
+++ b/scripts/start-entry.mjs
@@ -12,7 +12,7 @@
  *   pnpm dev:direct          → start-entry.mjs dev:direct [--debug] [--quick] [--memory]
  */
 import { spawn } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -34,6 +34,30 @@ function pidIsRunning(pid) {
   }
 }
 
+function readDotEnvValues(dotEnvPath) {
+  if (!existsSync(dotEnvPath)) return {};
+
+  const values = {};
+  for (const rawLine of readFileSync(dotEnvPath, 'utf8').split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+    const separatorIndex = line.indexOf('=');
+    if (separatorIndex <= 0) continue;
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, '');
+    values[key] = value;
+  }
+  return values;
+}
+
+function getConfigValue(dotEnv, key) {
+  return dotEnv[key] || process.env[key];
+}
+
 function runWindowsStatus() {
   const runDir = resolve(projectRoot, '.cat-cafe', 'run', 'windows');
   if (!existsSync(runDir)) {
@@ -41,31 +65,33 @@ function runWindowsStatus() {
     process.exit(1);
   }
 
-  const pidFiles = readdirSync(runDir)
-    .filter((name) => name.endsWith('.pid'))
-    .sort();
+  const dotEnv = readDotEnvValues(resolve(projectRoot, '.env'));
+  const apiPort = getConfigValue(dotEnv, 'API_SERVER_PORT') ?? '3004';
+  const webPort = getConfigValue(dotEnv, 'FRONTEND_PORT') ?? '3003';
+  const requiredServices = [
+    { label: 'api', pidFile: `api-${apiPort}.pid`, running: false },
+    { label: 'web', pidFile: `web-${webPort}.pid`, running: false },
+  ];
 
-  if (pidFiles.length === 0) {
-    console.log(`Cat Cafe Windows services not running (no PID files in ${runDir})`);
-    process.exit(1);
-  }
-
-  let runningCount = 0;
   console.log('Cat Cafe Windows status');
-  for (const pidFile of pidFiles) {
-    const pidPath = resolve(runDir, pidFile);
+  for (const service of requiredServices) {
+    const pidPath = resolve(runDir, service.pidFile);
+    const label = basename(service.pidFile, '.pid');
+    if (!existsSync(pidPath)) {
+      console.log(`  ${label}: not running (missing PID file)`);
+      continue;
+    }
+
     const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
-    const label = basename(pidFile, '.pid');
     if (Number.isNaN(pid)) {
       console.log(`  ${label}: invalid PID file`);
       continue;
     }
-    const running = pidIsRunning(pid);
-    if (running) runningCount += 1;
-    console.log(`  ${label}: ${running ? 'running' : 'not running'} (PID: ${pid})`);
+    service.running = pidIsRunning(pid);
+    console.log(`  ${label}: ${service.running ? 'running' : 'not running'} (PID: ${pid})`);
   }
 
-  process.exit(runningCount > 0 ? 0 : 1);
+  process.exit(requiredServices.every((service) => service.running) ? 0 : 1);
 }
 
 if (mode === 'status') {

--- a/scripts/start-entry.mjs
+++ b/scripts/start-entry.mjs
@@ -12,7 +12,8 @@
  *   pnpm dev:direct          → start-entry.mjs dev:direct [--debug] [--quick] [--memory]
  */
 import { spawn } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -20,10 +21,64 @@ const projectRoot = resolve(__dirname, '..');
 
 const IS_WINDOWS = process.platform === 'win32';
 
-// First positional arg is the mode (start | start:direct | dev:direct)
+// First positional arg is the mode (start | start:direct | dev:direct | status)
 const [mode, ...rest] = process.argv.slice(2);
 
-if (IS_WINDOWS) {
+function pidIsRunning(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (error?.code === 'EPERM') return true;
+    return false;
+  }
+}
+
+function runWindowsStatus() {
+  const runDir = resolve(projectRoot, '.cat-cafe', 'run', 'windows');
+  if (!existsSync(runDir)) {
+    console.log(`Cat Cafe Windows services not running (no run directory: ${runDir})`);
+    process.exit(1);
+  }
+
+  const pidFiles = readdirSync(runDir)
+    .filter((name) => name.endsWith('.pid'))
+    .sort();
+
+  if (pidFiles.length === 0) {
+    console.log(`Cat Cafe Windows services not running (no PID files in ${runDir})`);
+    process.exit(1);
+  }
+
+  let runningCount = 0;
+  console.log('Cat Cafe Windows status');
+  for (const pidFile of pidFiles) {
+    const pidPath = resolve(runDir, pidFile);
+    const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
+    const label = basename(pidFile, '.pid');
+    if (Number.isNaN(pid)) {
+      console.log(`  ${label}: invalid PID file`);
+      continue;
+    }
+    const running = pidIsRunning(pid);
+    if (running) runningCount += 1;
+    console.log(`  ${label}: ${running ? 'running' : 'not running'} (PID: ${pid})`);
+  }
+
+  process.exit(runningCount > 0 ? 0 : 1);
+}
+
+if (mode === 'status') {
+  if (IS_WINDOWS) {
+    runWindowsStatus();
+  } else {
+    const child = spawn('bash', [resolve(__dirname, 'start-dev.sh'), '--status'], {
+      cwd: projectRoot,
+      stdio: 'inherit',
+    });
+    child.on('exit', (code) => process.exit(code ?? 1));
+  }
+} else if (IS_WINDOWS) {
   // Map Unix-style flags to PowerShell switch params
   const flagMap = { '--debug': '-Debug', '--quick': '-Quick', '--memory': '-Memory', '--dev': '-Dev' };
   const psArgs = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', resolve(__dirname, 'start-windows.ps1')];

--- a/scripts/start-entry.mjs
+++ b/scripts/start-entry.mjs
@@ -12,9 +12,9 @@
  *   pnpm dev:direct          → start-entry.mjs dev:direct [--debug] [--quick] [--memory]
  */
 import { spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { basename, dirname, resolve } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { runWindowsStatus } from './lib/platform-status.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, '..');
@@ -24,79 +24,9 @@ const IS_WINDOWS = process.platform === 'win32';
 // First positional arg is the mode (start | start:direct | dev:direct | status)
 const [mode, ...rest] = process.argv.slice(2);
 
-function pidIsRunning(pid) {
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (error) {
-    if (error?.code === 'EPERM') return true;
-    return false;
-  }
-}
-
-function readDotEnvValues(dotEnvPath) {
-  if (!existsSync(dotEnvPath)) return {};
-
-  const values = {};
-  for (const rawLine of readFileSync(dotEnvPath, 'utf8').split(/\r?\n/)) {
-    const line = rawLine.trim();
-    if (!line || line.startsWith('#')) continue;
-    const separatorIndex = line.indexOf('=');
-    if (separatorIndex <= 0) continue;
-
-    const key = line.slice(0, separatorIndex).trim();
-    const value = line
-      .slice(separatorIndex + 1)
-      .trim()
-      .replace(/^['"]|['"]$/g, '');
-    values[key] = value;
-  }
-  return values;
-}
-
-function getConfigValue(dotEnv, key) {
-  return dotEnv[key] || process.env[key];
-}
-
-function runWindowsStatus() {
-  const runDir = resolve(projectRoot, '.cat-cafe', 'run', 'windows');
-  if (!existsSync(runDir)) {
-    console.log(`Cat Cafe Windows services not running (no run directory: ${runDir})`);
-    process.exit(1);
-  }
-
-  const dotEnv = readDotEnvValues(resolve(projectRoot, '.env'));
-  const apiPort = getConfigValue(dotEnv, 'API_SERVER_PORT') ?? '3004';
-  const webPort = getConfigValue(dotEnv, 'FRONTEND_PORT') ?? '3003';
-  const requiredServices = [
-    { label: 'api', pidFile: `api-${apiPort}.pid`, running: false },
-    { label: 'web', pidFile: `web-${webPort}.pid`, running: false },
-  ];
-
-  console.log('Cat Cafe Windows status');
-  for (const service of requiredServices) {
-    const pidPath = resolve(runDir, service.pidFile);
-    const label = basename(service.pidFile, '.pid');
-    if (!existsSync(pidPath)) {
-      console.log(`  ${label}: not running (missing PID file)`);
-      continue;
-    }
-
-    const pid = Number.parseInt(readFileSync(pidPath, 'utf8').trim(), 10);
-    if (Number.isNaN(pid)) {
-      console.log(`  ${label}: invalid PID file`);
-      continue;
-    }
-    service.running = pidIsRunning(pid);
-    console.log(`  ${label}: ${service.running ? 'running' : 'not running'} (PID: ${pid})`);
-  }
-
-  process.exit(requiredServices.every((service) => service.running) ? 0 : 1);
-}
-
 if (mode === 'status') {
   if (IS_WINDOWS) {
-    runWindowsStatus();
+    runWindowsStatus({ projectRoot });
   } else {
     const child = spawn('bash', [resolve(__dirname, 'start-dev.sh'), '--status'], {
       cwd: projectRoot,


### PR DESCRIPTION
## Summary

- route `pnpm start:status` through the cross-platform `scripts/start-entry.mjs` entrypoint
- add a Windows-native, read-only status path that reports managed API/web PID files from `.cat-cafe/run/windows`
- preserve the existing Unix behavior by dispatching status to `start-dev.sh --status`
- ignore local `.tmp/` scratch directories so local temporary exports do not break Biome root config discovery
- add regression coverage for the Windows `start:status` dispatch shape

## Issue

Refs #521. This PR addresses the `pnpm start:status` portion. The `pnpm redis:user:status` part remains separate follow-up scope.

## Root Cause

`package.json` invoked `./scripts/start-dev.sh --status` directly. On Windows PowerShell, pnpm expands that command without a Bash interpreter, so the command fails before any status logic runs.

Trying to force `bash` is not robust on this machine because the available `bash.exe` can be the Windows/WSL shim and then trips over CRLF shell scripts. Routing through the Node entrypoint keeps Windows on the native startup/status path.

## Validation

- `node --check scripts/start-entry.mjs`
- in-process Node assertions for the `start:status` dispatch shape
- `pnpm start:status` on Windows PowerShell prints running `api-3004` and `web-3003` PIDs
- `pnpm biome check .gitignore package.json scripts/start-entry.mjs scripts/start-dev-profile-isolation.test.mjs --diagnostic-level=error`

## Local Gate Notes

- Full `pnpm check` is blocked locally by broad CRLF formatting drift across the working tree, outside this patch scope.
- Full `pnpm lint` is blocked locally by pnpm child process `spawn EPERM` in the sandboxed shell.