### PR TITLE
fix(desktop): env var override for pnpm deploy bin-links EPERM

### DIFF
--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -77,27 +77,52 @@ if (-not $SkipBundleDeps) {
     if (Test-Path $deployRoot) { Remove-Item $deployRoot -Recurse -Force }
     New-Item -ItemType Directory -Path $deployRoot -Force | Out-Null
 
-    # Exclude the deploy target from Windows Defender real-time scanning.
-    # Without this, Defender locks freshly-written files in .bin/ causing
-    # EPERM even when bin-links are disabled via CLI flag.
-    try { Add-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
-
     # Force disable bin-link creation via env var. The CLI flag
     # --config.bin-links=false is not propagated by pnpm deploy's internal
     # install step; the env var is the only reliable override.
     $prevBinLinks = $env:npm_config_bin_links
-    $env:npm_config_bin_links = "false"
+    $defenderExclusionAdded = $false
+    $deployFailed = $false
 
-    Push-Location $ProjectRoot
-    foreach ($pkg in @('api', 'web', 'mcp-server')) {
-        Write-Host "  Deploying @cat-cafe/$pkg ..." -ForegroundColor Gray
-        $out = Join-Path $deployRoot $pkg
-        pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted deploy $out
-        if ($LASTEXITCODE -ne 0) { Write-Err "pnpm deploy @cat-cafe/$pkg failed"; Pop-Location; exit 1 }
+    # Temporarily exclude the deploy target from Defender scanning. Defender can
+    # lock freshly-written files in .bin/ during pnpm deploy; remove the
+    # exclusion before continuing so the host is not left with a broad bypass.
+    try {
+        Add-MpPreference -ExclusionPath $deployRoot -ErrorAction Stop
+        $defenderExclusionAdded = $true
+    } catch {
+        Write-Host "  Defender exclusion skipped: $($_.Exception.Message)" -ForegroundColor Yellow
     }
-    Pop-Location
 
-    $env:npm_config_bin_links = $prevBinLinks
+    try {
+        $env:npm_config_bin_links = "false"
+
+        Push-Location $ProjectRoot
+        try {
+            foreach ($pkg in @('api', 'web', 'mcp-server')) {
+                Write-Host "  Deploying @cat-cafe/$pkg ..." -ForegroundColor Gray
+                $out = Join-Path $deployRoot $pkg
+                pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted deploy $out
+                if ($LASTEXITCODE -ne 0) { throw "pnpm deploy @cat-cafe/$pkg failed" }
+            }
+        } finally {
+            Pop-Location
+        }
+    } catch {
+        Write-Err $_.Exception.Message
+        $deployFailed = $true
+    } finally {
+        if ($null -eq $prevBinLinks) {
+            Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue
+        } else {
+            $env:npm_config_bin_links = $prevBinLinks
+        }
+        if ($defenderExclusionAdded) {
+            try { Remove-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
+        }
+    }
+
+    if ($deployFailed) { exit 1 }
 
     # Web's pre-built .next artifact is not copied by `pnpm deploy` (it's outside
     # the package `files` field), so inject it explicitly.

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -80,7 +80,7 @@ if (-not $SkipBundleDeps) {
     # Exclude the deploy target from Windows Defender real-time scanning.
     # Without this, Defender locks freshly-written files in .bin/ causing
     # EPERM even when bin-links are disabled via CLI flag.
-    try { Add-MpExclusion -Path $deployRoot -ErrorAction SilentlyContinue } catch {}
+    try { Add-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
 
     # Force disable bin-link creation via env var. The CLI flag
     # --config.bin-links=false is not propagated by pnpm deploy's internal

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -77,17 +77,27 @@ if (-not $SkipBundleDeps) {
     if (Test-Path $deployRoot) { Remove-Item $deployRoot -Recurse -Force }
     New-Item -ItemType Directory -Path $deployRoot -Force | Out-Null
 
+    # Exclude the deploy target from Windows Defender real-time scanning.
+    # Without this, Defender locks freshly-written files in .bin/ causing
+    # EPERM even when bin-links are disabled via CLI flag.
+    try { Add-MpExclusion -Path $deployRoot -ErrorAction SilentlyContinue } catch {}
+
+    # Force disable bin-link creation via env var. The CLI flag
+    # --config.bin-links=false is not propagated by pnpm deploy's internal
+    # install step; the env var is the only reliable override.
+    $prevBinLinks = $env:npm_config_bin_links
+    $env:npm_config_bin_links = "false"
+
     Push-Location $ProjectRoot
     foreach ($pkg in @('api', 'web', 'mcp-server')) {
         Write-Host "  Deploying @cat-cafe/$pkg ..." -ForegroundColor Gray
         $out = Join-Path $deployRoot $pkg
-        # Runtime services launch package entrypoints directly; they do not use
-        # node_modules/.bin shims. Disabling bin links avoids a pnpm 9 hoisted
-        # deploy failure on windows-2025 runners while keeping real-file deps.
-        pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted --config.bin-links=false deploy $out
+        pnpm --filter "@cat-cafe/$pkg" --prod --config.node-linker=hoisted deploy $out
         if ($LASTEXITCODE -ne 0) { Write-Err "pnpm deploy @cat-cafe/$pkg failed"; Pop-Location; exit 1 }
     }
     Pop-Location
+
+    $env:npm_config_bin_links = $prevBinLinks
 
     # Web's pre-built .next artifact is not copied by `pnpm deploy` (it's outside
     # the package `files` field), so inject it explicitly.

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import test from 'node:test';
 
 const packageJsonPath = path.resolve(import.meta.dirname, '../package.json');
+const desktopBuildScriptPath = path.resolve(import.meta.dirname, '../../../desktop/scripts/build-desktop.ps1');
 
 test('api build script avoids unix-only file copy commands', async () => {
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'));
@@ -13,4 +14,21 @@ test('api build script avoids unix-only file copy commands', async () => {
   assert.match(buildScript, /node \.\/scripts\/copy-marketplace-catalog-data\.mjs/);
   assert.doesNotMatch(buildScript, /\bmkdir -p\b/);
   assert.doesNotMatch(buildScript, /\bcp\s+src\/marketplace\/catalog-data/);
+});
+
+test('windows desktop build script cleans up temporary Defender exclusions', async () => {
+  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
+
+  assert.match(buildScript, /Add-MpPreference -ExclusionPath \$deployRoot/);
+  assert.match(buildScript, /Remove-MpPreference -ExclusionPath \$deployRoot/);
+  assert.match(buildScript, /finally\s*\{[\s\S]*Remove-MpPreference -ExclusionPath \$deployRoot[\s\S]*\}/);
+});
+
+test('windows desktop build script restores npm_config_bin_links after deploy', async () => {
+  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
+
+  assert.match(buildScript, /\$prevBinLinks = \$env:npm_config_bin_links/);
+  assert.match(buildScript, /\$env:npm_config_bin_links = "false"/);
+  assert.match(buildScript, /if \(\$null -eq \$prevBinLinks\)\s*\{\s*Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue/s);
+  assert.match(buildScript, /else\s*\{\s*\$env:npm_config_bin_links = \$prevBinLinks/s);
 });

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -29,6 +29,9 @@ test('windows desktop build script restores npm_config_bin_links after deploy', 
 
   assert.match(buildScript, /\$prevBinLinks = \$env:npm_config_bin_links/);
   assert.match(buildScript, /\$env:npm_config_bin_links = "false"/);
-  assert.match(buildScript, /if \(\$null -eq \$prevBinLinks\)\s*\{\s*Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue/s);
+  assert.match(
+    buildScript,
+    /if \(\$null -eq \$prevBinLinks\)\s*\{\s*Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue/s,
+  );
   assert.match(buildScript, /else\s*\{\s*\$env:npm_config_bin_links = \$prevBinLinks/s);
 });


### PR DESCRIPTION
## Summary
- `--config.bin-links=false` CLI flag is not propagated by pnpm deploy's internal install step
- Switch to `npm_config_bin_links=false` env var which pnpm always respects
- Add Windows Defender `Add-MpExclusion` as defense-in-depth

## Evidence
Three consecutive EPERM failures on different bin shims (tsc, web-push) prove the CLI flag has no effect.

## Test plan
- [ ] CI passes (especially Windows Smoke)
- [ ] After merge, re-dispatch `release-desktop.yml` dry-run and verify Windows job passes

🐾 [宪宪/Opus-46]