### PR TITLE
fix(desktop): force pnpm deploy bin-links via npmrc

### DIFF
--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -136,7 +136,9 @@ if (-not $SkipBundleDeps) {
             if ($npmrcHadOriginal) {
                 Set-Content -Path $npmrcPath -Value $npmrcOriginalContent -NoNewline -Encoding utf8
             } else {
-                Remove-Item $npmrcPath -ErrorAction SilentlyContinue
+                if (Test-Path $npmrcPath) {
+                    Remove-Item $npmrcPath -ErrorAction Stop
+                }
             }
         } catch {
             Write-Err "Failed to restore temporary .npmrc: $($_.Exception.Message)"

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -77,10 +77,14 @@ if (-not $SkipBundleDeps) {
     if (Test-Path $deployRoot) { Remove-Item $deployRoot -Recurse -Force }
     New-Item -ItemType Directory -Path $deployRoot -Force | Out-Null
 
-    # Force disable bin-link creation via env var. The CLI flag
-    # --config.bin-links=false is not propagated by pnpm deploy's internal
-    # install step; the env var is the only reliable override.
+    # Force disable bin-link creation for pnpm deploy's internal install step.
+    # `pnpm deploy` has ignored both the CLI flag and npm_config env override on
+    # Windows release runners, so write a temporary project-level .npmrc and
+    # restore it before leaving this step.
     $prevBinLinks = $env:npm_config_bin_links
+    $npmrcPath = Join-Path $ProjectRoot ".npmrc"
+    $npmrcHadOriginal = Test-Path $npmrcPath
+    $npmrcOriginalContent = if ($npmrcHadOriginal) { Get-Content $npmrcPath -Raw } else { $null }
     $defenderExclusionAdded = $false
     $deployFailed = $false
 
@@ -96,6 +100,16 @@ if (-not $SkipBundleDeps) {
 
     try {
         $env:npm_config_bin_links = "false"
+        $npmrcDeployContent = if ($npmrcHadOriginal) {
+            $npmrcOriginalContent -replace "(?m)^\s*bin-links\s*=.*\r?\n?", ""
+        } else {
+            ""
+        }
+        if ($npmrcDeployContent.Length -gt 0 -and -not $npmrcDeployContent.EndsWith("`n")) {
+            $npmrcDeployContent += "`n"
+        }
+        $npmrcDeployContent += "bin-links=false`n"
+        Set-Content -Path $npmrcPath -Value $npmrcDeployContent -NoNewline -Encoding utf8
 
         Push-Location $ProjectRoot
         try {
@@ -116,6 +130,11 @@ if (-not $SkipBundleDeps) {
             Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue
         } else {
             $env:npm_config_bin_links = $prevBinLinks
+        }
+        if ($npmrcHadOriginal) {
+            Set-Content -Path $npmrcPath -Value $npmrcOriginalContent -NoNewline -Encoding utf8
+        } else {
+            Remove-Item $npmrcPath -ErrorAction SilentlyContinue
         }
         if ($defenderExclusionAdded) {
             try { Remove-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -87,6 +87,7 @@ if (-not $SkipBundleDeps) {
     $npmrcOriginalContent = if ($npmrcHadOriginal) { Get-Content $npmrcPath -Raw } else { $null }
     $defenderExclusionAdded = $false
     $deployFailed = $false
+    $npmrcRestoreFailed = $false
 
     # Temporarily exclude the deploy target from Defender scanning. Defender can
     # lock freshly-written files in .bin/ during pnpm deploy; remove the
@@ -137,13 +138,16 @@ if (-not $SkipBundleDeps) {
             } else {
                 Remove-Item $npmrcPath -ErrorAction SilentlyContinue
             }
-        } catch {}
+        } catch {
+            Write-Err "Failed to restore temporary .npmrc: $($_.Exception.Message)"
+            $npmrcRestoreFailed = $true
+        }
         if ($defenderExclusionAdded) {
             try { Remove-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
         }
     }
 
-    if ($deployFailed) { exit 1 }
+    if ($deployFailed -or $npmrcRestoreFailed) { exit 1 }
 
     # Web's pre-built .next artifact is not copied by `pnpm deploy` (it's outside
     # the package `files` field), so inject it explicitly.

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -131,11 +131,13 @@ if (-not $SkipBundleDeps) {
         } else {
             $env:npm_config_bin_links = $prevBinLinks
         }
-        if ($npmrcHadOriginal) {
-            Set-Content -Path $npmrcPath -Value $npmrcOriginalContent -NoNewline -Encoding utf8
-        } else {
-            Remove-Item $npmrcPath -ErrorAction SilentlyContinue
-        }
+        try {
+            if ($npmrcHadOriginal) {
+                Set-Content -Path $npmrcPath -Value $npmrcOriginalContent -NoNewline -Encoding utf8
+            } else {
+                Remove-Item $npmrcPath -ErrorAction SilentlyContinue
+            }
+        } catch {}
         if ($defenderExclusionAdded) {
             try { Remove-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
         }

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -49,3 +49,14 @@ test('windows desktop build script restores temporary pnpm deploy npmrc config',
   );
   assert.match(buildScript, /else\s*\{\s*Remove-Item \$npmrcPath -ErrorAction SilentlyContinue\s*\}/s);
 });
+
+test('windows desktop build script cannot skip Defender cleanup when npmrc restore fails', async () => {
+  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
+
+  assert.match(buildScript, /\$npmrcRestoreFailed = \$false/);
+  assert.match(
+    buildScript,
+    /try\s*\{\s*if \(\$npmrcHadOriginal\)[\s\S]*\}\s*catch\s*\{[\s\S]*\$npmrcRestoreFailed = \$true[\s\S]*\}\s*if \(\$defenderExclusionAdded\)/,
+  );
+  assert.match(buildScript, /if \(\$deployFailed -or \$npmrcRestoreFailed\) \{ exit 1 \}/);
+});

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -47,7 +47,7 @@ test('windows desktop build script restores temporary pnpm deploy npmrc config',
     buildScript,
     /if \(\$npmrcHadOriginal\)\s*\{\s*Set-Content -Path \$npmrcPath -Value \$npmrcOriginalContent -NoNewline -Encoding utf8/s,
   );
-  assert.match(buildScript, /else\s*\{\s*Remove-Item \$npmrcPath -ErrorAction SilentlyContinue\s*\}/s);
+  assert.match(buildScript, /else\s*\{\s*if \(Test-Path \$npmrcPath\) \{\s*Remove-Item \$npmrcPath -ErrorAction Stop/s);
 });
 
 test('windows desktop build script cannot skip Defender cleanup when npmrc restore fails', async () => {
@@ -58,5 +58,6 @@ test('windows desktop build script cannot skip Defender cleanup when npmrc resto
     buildScript,
     /try\s*\{\s*if \(\$npmrcHadOriginal\)[\s\S]*\}\s*catch\s*\{[\s\S]*\$npmrcRestoreFailed = \$true[\s\S]*\}\s*if \(\$defenderExclusionAdded\)/,
   );
+  assert.doesNotMatch(buildScript, /Remove-Item \$npmrcPath -ErrorAction SilentlyContinue/);
   assert.match(buildScript, /if \(\$deployFailed -or \$npmrcRestoreFailed\) \{ exit 1 \}/);
 });

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -35,3 +35,17 @@ test('windows desktop build script restores npm_config_bin_links after deploy', 
   );
   assert.match(buildScript, /else\s*\{\s*\$env:npm_config_bin_links = \$prevBinLinks/s);
 });
+
+test('windows desktop build script restores temporary pnpm deploy npmrc config', async () => {
+  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
+
+  assert.match(buildScript, /\$npmrcPath = Join-Path \$ProjectRoot "\.npmrc"/);
+  assert.match(buildScript, /\$npmrcOriginalContent = if \(\$npmrcHadOriginal\) \{ Get-Content \$npmrcPath -Raw \}/);
+  assert.match(buildScript, /bin-links=false`n/);
+  assert.match(buildScript, /Set-Content -Path \$npmrcPath -Value \$npmrcDeployContent -NoNewline -Encoding utf8/);
+  assert.match(
+    buildScript,
+    /if \(\$npmrcHadOriginal\)\s*\{\s*Set-Content -Path \$npmrcPath -Value \$npmrcOriginalContent -NoNewline -Encoding utf8/s,
+  );
+  assert.match(buildScript, /else\s*\{\s*Remove-Item \$npmrcPath -ErrorAction SilentlyContinue\s*\}/s);
+});


### PR DESCRIPTION
## Summary
- write a temporary project .npmrc with bin-links=false around Windows pnpm deploy
- restore the original .npmrc in finally, alongside npm_config_bin_links and Defender cleanup
- mirror the source-side regression coverage for the cleanup path

## Verification
- node --test packages/api/test/build-script-cross-platform.test.js
- pnpm exec biome check packages/api/test/build-script-cross-platform.test.js

## Context
The v0.9.1 dry-run on main still failed in the Windows release job: pnpm deploy continued creating node_modules/.bin shims despite npm_config_bin_links=false. This promotes bin-links=false to project-level .npmrc for the deploy process only.

Source PR: zts212653/cat-cafe#1516

[砚砚/GPT-5.5🐾]