### PR TITLE
fix(desktop): use pnpm user-level config to disable deploy bin-links

### DIFF
--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -77,21 +77,20 @@ if (-not $SkipBundleDeps) {
     if (Test-Path $deployRoot) { Remove-Item $deployRoot -Recurse -Force }
     New-Item -ItemType Directory -Path $deployRoot -Force | Out-Null
 
-    # Force disable bin-link creation for pnpm deploy's internal install step.
-    # `pnpm deploy` has ignored both the CLI flag and npm_config env override on
-    # Windows release runners, so write a temporary project-level .npmrc and
-    # restore it before leaving this step.
-    $prevBinLinks = $env:npm_config_bin_links
-    $npmrcPath = Join-Path $ProjectRoot ".npmrc"
-    $npmrcHadOriginal = Test-Path $npmrcPath
-    $npmrcOriginalContent = if ($npmrcHadOriginal) { Get-Content $npmrcPath -Raw } else { $null }
+    # pnpm deploy's internal install ignores CLI flags, env vars, and
+    # project-root .npmrc for bin-links — it only reads user-level config.
+    # Set it via `pnpm config` (writes ~/.npmrc) and clean up after.
+    $binLinksDisabled = $false
     $defenderExclusionAdded = $false
     $deployFailed = $false
-    $npmrcRestoreFailed = $false
 
-    # Temporarily exclude the deploy target from Defender scanning. Defender can
-    # lock freshly-written files in .bin/ during pnpm deploy; remove the
-    # exclusion before continuing so the host is not left with a broad bypass.
+    try {
+        pnpm config set bin-links false 2>$null
+        $binLinksDisabled = $true
+    } catch {
+        Write-Host "  pnpm config set bin-links failed: $($_.Exception.Message)" -ForegroundColor Yellow
+    }
+
     try {
         Add-MpPreference -ExclusionPath $deployRoot -ErrorAction Stop
         $defenderExclusionAdded = $true
@@ -100,18 +99,6 @@ if (-not $SkipBundleDeps) {
     }
 
     try {
-        $env:npm_config_bin_links = "false"
-        $npmrcDeployContent = if ($npmrcHadOriginal) {
-            $npmrcOriginalContent -replace "(?m)^\s*bin-links\s*=.*\r?\n?", ""
-        } else {
-            ""
-        }
-        if ($npmrcDeployContent.Length -gt 0 -and -not $npmrcDeployContent.EndsWith("`n")) {
-            $npmrcDeployContent += "`n"
-        }
-        $npmrcDeployContent += "bin-links=false`n"
-        Set-Content -Path $npmrcPath -Value $npmrcDeployContent -NoNewline -Encoding utf8
-
         Push-Location $ProjectRoot
         try {
             foreach ($pkg in @('api', 'web', 'mcp-server')) {
@@ -127,29 +114,15 @@ if (-not $SkipBundleDeps) {
         Write-Err $_.Exception.Message
         $deployFailed = $true
     } finally {
-        if ($null -eq $prevBinLinks) {
-            Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue
-        } else {
-            $env:npm_config_bin_links = $prevBinLinks
-        }
-        try {
-            if ($npmrcHadOriginal) {
-                Set-Content -Path $npmrcPath -Value $npmrcOriginalContent -NoNewline -Encoding utf8
-            } else {
-                if (Test-Path $npmrcPath) {
-                    Remove-Item $npmrcPath -ErrorAction Stop
-                }
-            }
-        } catch {
-            Write-Err "Failed to restore temporary .npmrc: $($_.Exception.Message)"
-            $npmrcRestoreFailed = $true
+        if ($binLinksDisabled) {
+            pnpm config delete bin-links 2>$null
         }
         if ($defenderExclusionAdded) {
             try { Remove-MpPreference -ExclusionPath $deployRoot -ErrorAction SilentlyContinue } catch {}
         }
     }
 
-    if ($deployFailed -or $npmrcRestoreFailed) { exit 1 }
+    if ($deployFailed) { exit 1 }
 
     # Web's pre-built .next artifact is not copied by `pnpm deploy` (it's outside
     # the package `files` field), so inject it explicitly.

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -24,40 +24,20 @@ test('windows desktop build script cleans up temporary Defender exclusions', asy
   assert.match(buildScript, /finally\s*\{[\s\S]*Remove-MpPreference -ExclusionPath \$deployRoot[\s\S]*\}/);
 });
 
-test('windows desktop build script restores npm_config_bin_links after deploy', async () => {
+test('windows desktop build script disables bin-links via pnpm user-level config', async () => {
   const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
 
-  assert.match(buildScript, /\$prevBinLinks = \$env:npm_config_bin_links/);
-  assert.match(buildScript, /\$env:npm_config_bin_links = "false"/);
-  assert.match(
-    buildScript,
-    /if \(\$null -eq \$prevBinLinks\)\s*\{\s*Remove-Item Env:npm_config_bin_links -ErrorAction SilentlyContinue/s,
-  );
-  assert.match(buildScript, /else\s*\{\s*\$env:npm_config_bin_links = \$prevBinLinks/s);
+  assert.match(buildScript, /pnpm config set bin-links false/);
+  assert.match(buildScript, /pnpm config delete bin-links/);
+  assert.match(buildScript, /finally\s*\{[\s\S]*pnpm config delete bin-links[\s\S]*\}/);
 });
 
-test('windows desktop build script restores temporary pnpm deploy npmrc config', async () => {
+test('windows desktop build script cleans up both pnpm config and Defender in finally block', async () => {
   const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
 
-  assert.match(buildScript, /\$npmrcPath = Join-Path \$ProjectRoot "\.npmrc"/);
-  assert.match(buildScript, /\$npmrcOriginalContent = if \(\$npmrcHadOriginal\) \{ Get-Content \$npmrcPath -Raw \}/);
-  assert.match(buildScript, /bin-links=false`n/);
-  assert.match(buildScript, /Set-Content -Path \$npmrcPath -Value \$npmrcDeployContent -NoNewline -Encoding utf8/);
-  assert.match(
-    buildScript,
-    /if \(\$npmrcHadOriginal\)\s*\{\s*Set-Content -Path \$npmrcPath -Value \$npmrcOriginalContent -NoNewline -Encoding utf8/s,
-  );
-  assert.match(buildScript, /else\s*\{\s*if \(Test-Path \$npmrcPath\) \{\s*Remove-Item \$npmrcPath -ErrorAction Stop/s);
-});
-
-test('windows desktop build script cannot skip Defender cleanup when npmrc restore fails', async () => {
-  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
-
-  assert.match(buildScript, /\$npmrcRestoreFailed = \$false/);
-  assert.match(
-    buildScript,
-    /try\s*\{\s*if \(\$npmrcHadOriginal\)[\s\S]*\}\s*catch\s*\{[\s\S]*\$npmrcRestoreFailed = \$true[\s\S]*\}\s*if \(\$defenderExclusionAdded\)/,
-  );
-  assert.doesNotMatch(buildScript, /Remove-Item \$npmrcPath -ErrorAction SilentlyContinue/);
-  assert.match(buildScript, /if \(\$deployFailed -or \$npmrcRestoreFailed\) \{ exit 1 \}/);
+  const finallyMatch = buildScript.match(/finally\s*\{([\s\S]*?)\}\s*\n\s*if \(\$deployFailed\)/);
+  assert.ok(finallyMatch, 'finally block with cleanup must exist');
+  const finallyBody = finallyMatch[1];
+  assert.match(finallyBody, /pnpm config delete bin-links/);
+  assert.match(finallyBody, /Remove-MpPreference -ExclusionPath \$deployRoot/);
 });


### PR DESCRIPTION
## Summary

- `pnpm deploy` internal install only reads user-level `~/.npmrc`, not project-root `.npmrc`
- Replace env var + project .npmrc + Defender triple with `pnpm config set/delete bin-links`
- 4th dry-run confirmed: api (no .bin entries) passed but web (.bin/acorn.CMD) still hit EPERM

Synced from cat-cafe #1518.

[宪宪/Opus-46🐾]

🤖 Generated with [Claude Code](https://claude.com/claude-code)