### PR TITLE
[codex] Preserve Telegram final rich/media delivery

### DIFF
--- a/.dir-exceptions.json
+++ b/.dir-exceptions.json
@@ -4,14 +4,14 @@
       "path": "packages/api/src/routes",
       "owner": "opus",
       "reason": "Routes 按功能已分文件，ADR-010 重构 scope 不含 routes，后续评估是否拆子目录",
-      "expiresAt": "2026-05-01",
+      "expiresAt": "2026-05-17",
       "ticket": "F23"
     },
     {
       "path": "packages/api/src/config",
       "owner": "opus",
       "reason": "Config 文件数接近 warn，均为独立配置项（cat-budgets/cat-config/env 等），暂不拆",
-      "expiresAt": "2026-05-01",
+      "expiresAt": "2026-05-17",
       "ticket": "F23"
     },
     {

--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -81,6 +81,7 @@ export interface OutboundDeliveryHookLike {
     threadMeta?: { threadShortId?: string; threadTitle?: string; deepLinkUrl?: string },
     origin?: string,
     triggerMessageId?: string,
+    skipConnectorIds?: ReadonlySet<string>,
   ): Promise<void>;
 }
 
@@ -93,7 +94,13 @@ export interface StreamingOutboundHookLike {
     senderHint?: { id: string; name?: string },
   ): Promise<void>;
   onStreamChunk(threadId: string, accumulatedText: string, invocationId: string): Promise<void>;
-  onStreamEnd(threadId: string, finalText: string, invocationId: string): Promise<void>;
+  onStreamEnd(
+    threadId: string,
+    finalText: string,
+    invocationId: string,
+    richBlocks?: ReadonlyArray<{ kind: string; [key: string]: unknown }>,
+  ): Promise<{ inlineDeliveredConnectorIds?: string[] } | undefined>;
+  getInlineFinalDeliveryConnectorIds?(threadId: string, invocationId?: string): string[];
   cleanupPlaceholders?(threadId: string, invocationId: string): Promise<void>;
   /** F151: Signal adapters that delivery batch is complete for a thread. */
   notifyDeliveryBatchDone?(threadId: string, chainDone: boolean): Promise<void>;
@@ -869,6 +876,11 @@ export class QueueProcessor {
       // F151: Mid-loop delivery to preserve ordering (same fix as ConnectorInvokeTrigger)
       const deliveredTurnIndices = new Set<number>();
       const DELIVER_TIMEOUT_MS = 10_000;
+      const getPendingInlineSkipConnectorIds = (): ReadonlySet<string> | undefined => {
+        const connectorIds =
+          this.deps.streamingHook?.getInlineFinalDeliveryConnectorIds?.(threadId, invocationId) ?? [];
+        return connectorIds.length > 0 ? new Set(connectorIds) : undefined;
+      };
       let threadMeta: ThreadMetaLike | undefined;
       let threadMetaPromise: Promise<ThreadMetaLike | undefined> | undefined;
       if (this.deps.outboundHook && this.deps.threadMetaLookup) {
@@ -971,6 +983,7 @@ export class QueueProcessor {
                     threadMeta,
                     undefined,
                     messageId ?? undefined,
+                    getPendingInlineSkipConnectorIds(),
                   ),
                   new Promise<void>((_, reject) =>
                     setTimeout(() => reject(new Error('deliver timeout')), DELIVER_TIMEOUT_MS),
@@ -1149,8 +1162,11 @@ export class QueueProcessor {
   ): Promise<void> {
     const finalContent =
       outboundTurns.length > 0 ? flattenTurnTextParts(outboundTurns) : flattenTextParts(collectedTextParts);
+    const allFinalRichBlocks = outboundTurns.flatMap((turn) => turn.richBlocks ?? []);
+    const finalRichBlocks = allFinalRichBlocks.length > 0 ? allFinalRichBlocks : persistenceContext.richBlocks;
 
     // Finalize streaming — ensure start completed before ending
+    let streamEndResult: { inlineDeliveredConnectorIds?: string[] } | undefined;
     if (this.deps.streamingHook) {
       if (streamStartPromise) {
         const STREAM_START_TIMEOUT_MS = 5000;
@@ -1159,10 +1175,16 @@ export class QueueProcessor {
           new Promise<void>((resolve) => setTimeout(resolve, STREAM_START_TIMEOUT_MS)),
         ]);
       }
-      await this.deps.streamingHook.onStreamEnd(threadId, finalContent, invocationId).catch((err) => {
-        log.warn({ err, threadId }, '[QueueProcessor] StreamingHook.onStreamEnd failed');
-      });
+      streamEndResult = await this.deps.streamingHook
+        .onStreamEnd(threadId, finalContent, invocationId, finalRichBlocks)
+        .catch((err) => {
+          log.warn({ err, threadId }, '[QueueProcessor] StreamingHook.onStreamEnd failed');
+          return undefined;
+        });
     }
+    const inlineDeliveredConnectorIds = streamEndResult?.inlineDeliveredConnectorIds ?? [];
+    const skipConnectorIds =
+      inlineDeliveredConnectorIds.length > 0 ? new Set<string>(inlineDeliveredConnectorIds) : undefined;
 
     const hasContent = collectedTextParts.length > 0 || outboundTurns.length > 0;
     if (this.deps.outboundHook && hasContent) {
@@ -1211,6 +1233,7 @@ export class QueueProcessor {
             threadMeta,
             undefined,
             triggerMessageId,
+            skipConnectorIds,
           );
           inflightDeliverPromises.push(deliverPromise);
           try {
@@ -1236,6 +1259,7 @@ export class QueueProcessor {
           threadMeta,
           undefined,
           triggerMessageId,
+          skipConnectorIds,
         );
         inflightDeliverPromises.push(deliverPromise);
         try {
@@ -1261,6 +1285,7 @@ export class QueueProcessor {
             threadMeta,
             undefined,
             triggerMessageId,
+            skipConnectorIds,
           );
           inflightDeliverPromises.push(deliverPromise);
           try {

--- a/packages/api/src/infrastructure/connectors/OutboundDeliveryHook.ts
+++ b/packages/api/src/infrastructure/connectors/OutboundDeliveryHook.ts
@@ -41,6 +41,14 @@ export interface IStreamableOutboundAdapter extends IOutboundAdapter {
   sendPlaceholder(externalChatId: string, text: string): Promise<string>;
   /** Edit an already-sent message in place. */
   editMessage(externalChatId: string, platformMessageId: string, text: string): Promise<void>;
+  /** Edit an already-sent message in place with rich-block formatting. */
+  editRichMessage?(
+    externalChatId: string,
+    platformMessageId: string,
+    textContent: string,
+    blocks: RichBlock[],
+    catDisplayName: string,
+  ): Promise<void>;
   /** Delete a message by platform message ID (cleanup after streaming). */
   deleteMessage?(platformMessageId: string): Promise<void>;
   /**
@@ -94,8 +102,18 @@ export class OutboundDeliveryHook {
     threadMeta?: ThreadMeta,
     origin?: MessageOrigin,
     triggerMessageId?: string,
+    skipConnectorIds?: ReadonlySet<string>,
   ): Promise<void> {
-    return this.executeDelivery(threadId, content, catId, richBlocks, threadMeta, origin, triggerMessageId);
+    return this.executeDelivery(
+      threadId,
+      content,
+      catId,
+      richBlocks,
+      threadMeta,
+      origin,
+      triggerMessageId,
+      skipConnectorIds,
+    );
   }
 
   private async executeDelivery(
@@ -106,12 +124,15 @@ export class OutboundDeliveryHook {
     threadMeta?: ThreadMeta,
     origin?: MessageOrigin,
     triggerMessageId?: string,
+    skipConnectorIds?: ReadonlySet<string>,
   ): Promise<void> {
     this.opts.log.info(
       { threadId, catId, contentLen: content.length, hasRichBlocks: !!(richBlocks && richBlocks.length) },
       '[OutboundDeliveryHook] deliver() called',
     );
-    const bindings = await this.opts.bindingStore.getByThread(threadId);
+    const bindings = (await this.opts.bindingStore.getByThread(threadId)).filter(
+      (binding) => !skipConnectorIds?.has(binding.connectorId),
+    );
     if (bindings.length === 0) {
       this.opts.log.warn(
         { threadId },

--- a/packages/api/src/infrastructure/connectors/OutboundDeliveryHook.ts
+++ b/packages/api/src/infrastructure/connectors/OutboundDeliveryHook.ts
@@ -9,6 +9,12 @@ import { ConnectorMessageFormatter, type MessageEnvelope, type MessageOrigin } f
 import type { IConnectorThreadBindingStore } from './ConnectorThreadBindingStore.js';
 import { renderAllRichBlocksPlaintext } from './rich-block-plaintext.js';
 
+const MEDIA_RICH_BLOCK_KINDS = new Set(['audio', 'file', 'media_gallery']);
+
+function hasMediaRichBlocks(blocks?: readonly RichBlock[]): boolean {
+  return blocks?.some((block) => MEDIA_RICH_BLOCK_KINDS.has(block.kind)) ?? false;
+}
+
 export interface IOutboundAdapter {
   readonly connectorId: string;
   sendReply(externalChatId: string, content: string, metadata?: Record<string, unknown>): Promise<void>;
@@ -37,6 +43,8 @@ export interface IOutboundAdapter {
 
 /** Adapter that supports edit-in-place streaming (placeholder → progressive edits). */
 export interface IStreamableOutboundAdapter extends IOutboundAdapter {
+  /** Adapter explicitly wants final non-media streaming output to be edited in place. */
+  readonly finalDeliveryMode?: 'inline-edit';
   /** Send a placeholder message and return its platform-level message ID. */
   sendPlaceholder(externalChatId: string, text: string): Promise<string>;
   /** Edit an already-sent message in place. */
@@ -50,7 +58,7 @@ export interface IStreamableOutboundAdapter extends IOutboundAdapter {
     catDisplayName: string,
   ): Promise<void>;
   /** Delete a message by platform message ID (cleanup after streaming). */
-  deleteMessage?(platformMessageId: string): Promise<void>;
+  deleteMessage?(platformMessageId: string, externalChatId?: string): Promise<void>;
   /**
    * F157: Edit a streaming placeholder to a minimal completion state (e.g. "✅ 已回复").
    * When present, cleanup prefers this over deleteMessage to avoid "recall" notifications.
@@ -130,8 +138,9 @@ export class OutboundDeliveryHook {
       { threadId, catId, contentLen: content.length, hasRichBlocks: !!(richBlocks && richBlocks.length) },
       '[OutboundDeliveryHook] deliver() called',
     );
+    const currentDeliveryHasMedia = hasMediaRichBlocks(richBlocks);
     const bindings = (await this.opts.bindingStore.getByThread(threadId)).filter(
-      (binding) => !skipConnectorIds?.has(binding.connectorId),
+      (binding) => currentDeliveryHasMedia || !skipConnectorIds?.has(binding.connectorId),
     );
     if (bindings.length === 0) {
       this.opts.log.warn(

--- a/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
+++ b/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
@@ -6,6 +6,11 @@ import type { IStreamableOutboundAdapter } from './OutboundDeliveryHook.js';
 
 const DEFAULT_UPDATE_INTERVAL_MS = 2000;
 const DEFAULT_MIN_DELTA_CHARS = 200;
+const MEDIA_RICH_BLOCK_KINDS = new Set(['audio', 'file', 'media_gallery']);
+
+function hasMediaRichBlocks(blocks?: readonly RichBlock[]): boolean {
+  return blocks?.some((block) => MEDIA_RICH_BLOCK_KINDS.has(block.kind)) ?? false;
+}
 
 interface StreamingSession {
   readonly connectorId: string;
@@ -47,7 +52,10 @@ export class StreamingOutboundHook {
 
   private isInlineFinalDeliverySession(session: StreamingSession): boolean {
     const adapter = this.opts.adapters.get(session.connectorId);
-    return !!adapter?.editMessage && !adapter.deleteMessage && !adapter.finalizeStreamCard;
+    return (
+      !!adapter?.editMessage &&
+      (adapter.finalDeliveryMode === 'inline-edit' || (!adapter.deleteMessage && !adapter.finalizeStreamCard))
+    );
   }
 
   getInlineFinalDeliveryConnectorIds(threadId: string, invocationId?: string): string[] {
@@ -138,14 +146,18 @@ export class StreamingOutboundHook {
     if (!sessions) return { inlineDeliveredConnectorIds: [] };
     this.sessions.delete(key);
 
+    const currentDeliveryHasMedia = hasMediaRichBlocks(richBlocks);
     const deferred: StreamingSession[] = [];
     const inlineDeliveredConnectorIds = new Set<string>();
     for (const session of sessions) {
       const adapter = this.opts.adapters.get(session.connectorId);
       if (!session.platformMessageId) continue;
-      if (adapter?.deleteMessage || adapter?.finalizeStreamCard) {
-        // Defer cleanup — keep placeholder as fallback until outbound delivery succeeds
-        deferred.push(session);
+
+      if (currentDeliveryHasMedia) {
+        if (adapter?.deleteMessage || adapter?.finalizeStreamCard) {
+          // Media cannot be represented by message edits; let outbound delivery send it, then clean up.
+          deferred.push(session);
+        }
       } else if (this.isInlineFinalDeliverySession(session)) {
         try {
           if (richBlocks?.length && adapter?.editRichMessage) {
@@ -163,6 +175,9 @@ export class StreamingOutboundHook {
         } catch (err) {
           this.opts.log.warn({ err }, '[StreamingOutbound] onStreamEnd editMessage failed');
         }
+      } else if (adapter?.deleteMessage || adapter?.finalizeStreamCard) {
+        // Defer cleanup — keep placeholder as fallback until outbound delivery succeeds
+        deferred.push(session);
       }
     }
     if (deferred.length > 0) {
@@ -190,7 +205,7 @@ export class StreamingOutboundHook {
           // F157: Edit to completion state instead of deleting (no recall notification)
           await adapter.finalizeStreamCard(session.externalChatId, session.platformMessageId, session.catDisplayName);
         } else if (adapter?.deleteMessage) {
-          await adapter.deleteMessage(session.platformMessageId);
+          await adapter.deleteMessage(session.platformMessageId, session.externalChatId);
         }
       } catch (err) {
         this.opts.log.warn({ err }, '[StreamingOutbound] cleanupPlaceholders failed');

--- a/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
+++ b/packages/api/src/infrastructure/connectors/StreamingOutboundHook.ts
@@ -1,4 +1,4 @@
-import { type CatId, catRegistry } from '@cat-cafe/shared';
+import { type CatId, catRegistry, type RichBlock } from '@cat-cafe/shared';
 import type { FastifyBaseLogger } from 'fastify';
 import type { IConnectorThreadBindingStore } from './ConnectorThreadBindingStore.js';
 import { pickReceiptLine } from './feishu-receipt-lines.js';
@@ -15,6 +15,10 @@ interface StreamingSession {
   platformMessageId: string;
   lastUpdateAt: number;
   lastContentLength: number;
+}
+
+export interface StreamEndResult {
+  readonly inlineDeliveredConnectorIds: string[];
 }
 
 export interface StreamingOutboundHookOptions {
@@ -39,6 +43,22 @@ export class StreamingOutboundHook {
   /** Scope key for isolation: `threadId:invocationId` when available, else `threadId`. */
   private scopeKey(threadId: string, invocationId?: string): string {
     return invocationId ? `${threadId}:${invocationId}` : threadId;
+  }
+
+  private isInlineFinalDeliverySession(session: StreamingSession): boolean {
+    const adapter = this.opts.adapters.get(session.connectorId);
+    return !!adapter?.editMessage && !adapter.deleteMessage && !adapter.finalizeStreamCard;
+  }
+
+  getInlineFinalDeliveryConnectorIds(threadId: string, invocationId?: string): string[] {
+    const key = this.scopeKey(threadId, invocationId);
+    const sessions = this.sessions.get(key);
+    if (!sessions) return [];
+    return [
+      ...new Set(
+        sessions.filter((session) => this.isInlineFinalDeliverySession(session)).map((session) => session.connectorId),
+      ),
+    ];
   }
 
   async onStreamStart(
@@ -107,22 +127,39 @@ export class StreamingOutboundHook {
     }
   }
 
-  async onStreamEnd(threadId: string, finalText: string, invocationId?: string): Promise<void> {
+  async onStreamEnd(
+    threadId: string,
+    finalText: string,
+    invocationId?: string,
+    richBlocks?: RichBlock[],
+  ): Promise<StreamEndResult> {
     const key = this.scopeKey(threadId, invocationId);
     const sessions = this.sessions.get(key);
-    if (!sessions) return;
+    if (!sessions) return { inlineDeliveredConnectorIds: [] };
     this.sessions.delete(key);
 
     const deferred: StreamingSession[] = [];
+    const inlineDeliveredConnectorIds = new Set<string>();
     for (const session of sessions) {
       const adapter = this.opts.adapters.get(session.connectorId);
       if (!session.platformMessageId) continue;
       if (adapter?.deleteMessage || adapter?.finalizeStreamCard) {
         // Defer cleanup — keep placeholder as fallback until outbound delivery succeeds
         deferred.push(session);
-      } else if (adapter?.editMessage) {
+      } else if (this.isInlineFinalDeliverySession(session)) {
         try {
-          await adapter.editMessage(session.externalChatId, session.platformMessageId, finalText);
+          if (richBlocks?.length && adapter?.editRichMessage) {
+            await adapter.editRichMessage(
+              session.externalChatId,
+              session.platformMessageId,
+              finalText,
+              richBlocks,
+              session.catDisplayName,
+            );
+          } else {
+            await adapter?.editMessage(session.externalChatId, session.platformMessageId, finalText);
+          }
+          inlineDeliveredConnectorIds.add(session.connectorId);
         } catch (err) {
           this.opts.log.warn({ err }, '[StreamingOutbound] onStreamEnd editMessage failed');
         }
@@ -131,6 +168,7 @@ export class StreamingOutboundHook {
     if (deferred.length > 0) {
       this.pendingCleanup.set(key, deferred);
     }
+    return { inlineDeliveredConnectorIds: [...inlineDeliveredConnectorIds] };
   }
 
   /**

--- a/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
+++ b/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
@@ -309,6 +309,22 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
   }
 
   /**
+   * Edit an already-sent message in place with Telegram HTML rich-block formatting.
+   */
+  async editRichMessage(
+    externalChatId: string,
+    platformMessageId: string,
+    textContent: string,
+    blocks: RichBlock[],
+    catDisplayName: string,
+  ): Promise<void> {
+    const html = formatTelegramHtml(blocks, catDisplayName, textContent);
+    await this.bot.api.editMessageText(Number(externalChatId), Number(platformMessageId), html, {
+      parse_mode: 'HTML',
+    });
+  }
+
+  /**
    * Phase 5+6: Send a media message (image, file, or audio) to a Telegram chat.
    * Handles both public URLs and local file paths (via grammy InputFile).
    */

--- a/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
+++ b/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
@@ -54,6 +54,7 @@ function isTelegramConflictError(err: unknown): boolean {
 
 export class TelegramAdapter implements IStreamableOutboundAdapter {
   readonly connectorId = 'telegram';
+  readonly finalDeliveryMode = 'inline-edit';
   private readonly bot: Bot;
   private readonly log: FastifyBaseLogger;
   private sendMessageFn: ((chatId: string, text: string, opts?: Record<string, unknown>) => Promise<unknown>) | null =
@@ -322,6 +323,13 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
     await this.bot.api.editMessageText(Number(externalChatId), Number(platformMessageId), html, {
       parse_mode: 'HTML',
     });
+  }
+
+  async deleteMessage(platformMessageId: string, externalChatId?: string): Promise<void> {
+    if (!externalChatId) {
+      throw new Error('Telegram deleteMessage requires externalChatId');
+    }
+    await this.bot.api.deleteMessage(Number(externalChatId), Number(platformMessageId));
   }
 
   /**

--- a/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
+++ b/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
@@ -290,6 +290,11 @@ export class ConnectorInvokeTrigger {
       // post_message callbacks from later cats interleave with earlier outboundTurns.
       const deliveredTurnIndices = new Set<number>();
       const DELIVER_TIMEOUT_MS = this.opts.deliverTimeoutMs ?? 10_000;
+      const getPendingInlineSkipConnectorIds = (): ReadonlySet<string> | undefined => {
+        const connectorIds =
+          this.opts.streamingHook?.getInlineFinalDeliveryConnectorIds(threadId, createResult.invocationId) ?? [];
+        return connectorIds.length > 0 ? new Set(connectorIds) : undefined;
+      };
 
       // Start threadMeta lookup early — resolved lazily when first delivery needs it.
       let threadMeta: ThreadMeta | undefined;
@@ -375,6 +380,7 @@ export class ConnectorInvokeTrigger {
                     threadMeta,
                     undefined,
                     messageId,
+                    getPendingInlineSkipConnectorIds(),
                   ),
                   new Promise<void>((_, reject) =>
                     setTimeout(() => reject(new Error('deliver timeout')), DELIVER_TIMEOUT_MS),
@@ -442,8 +448,12 @@ export class ConnectorInvokeTrigger {
 
         // ⑥ Outbound delivery: send final text + rich blocks to bound external chats
         const finalContent = collectedTextParts.join('');
+        const allFinalRichBlocks = outboundTurns.flatMap((turn) => turn.richBlocks ?? []);
+        const finalRichBlocks =
+          allFinalRichBlocks.length > 0 ? allFinalRichBlocks : persistenceContext.richBlocks;
 
         // Phase 4: Finalize streaming — ensure start completed before ending
+        let streamEndResult: { inlineDeliveredConnectorIds?: string[] } | undefined;
         if (this.opts.streamingHook) {
           if (streamStartPromise) {
             const STREAM_START_TIMEOUT_MS = 5000;
@@ -452,10 +462,16 @@ export class ConnectorInvokeTrigger {
               new Promise<void>((resolve) => setTimeout(resolve, STREAM_START_TIMEOUT_MS)),
             ]);
           }
-          await this.opts.streamingHook.onStreamEnd(threadId, finalContent, createResult.invocationId).catch((err) => {
-            log.warn({ err, threadId }, '[ConnectorInvokeTrigger] StreamingHook.onStreamEnd failed');
-          });
+          streamEndResult = await this.opts.streamingHook
+            .onStreamEnd(threadId, finalContent, createResult.invocationId, finalRichBlocks)
+            .catch((err) => {
+              log.warn({ err, threadId }, '[ConnectorInvokeTrigger] StreamingHook.onStreamEnd failed');
+              return undefined;
+            });
         }
+        const inlineDeliveredConnectorIds = streamEndResult?.inlineDeliveredConnectorIds ?? [];
+        const skipConnectorIds =
+          inlineDeliveredConnectorIds.length > 0 ? new Set<string>(inlineDeliveredConnectorIds) : undefined;
 
         // R1-P1 fix: restore OR condition — richBlocks-only replies must also trigger delivery
         const hasContent = collectedTextParts.length > 0 || outboundTurns.length > 0;
@@ -502,6 +518,7 @@ export class ConnectorInvokeTrigger {
                 threadMeta,
                 undefined,
                 messageId,
+                skipConnectorIds,
               );
               inflightDeliverPromises.push(deliverPromise);
               try {
@@ -527,6 +544,7 @@ export class ConnectorInvokeTrigger {
               threadMeta,
               undefined,
               messageId,
+              skipConnectorIds,
             );
             inflightDeliverPromises.push(deliverPromise);
             try {
@@ -551,6 +569,7 @@ export class ConnectorInvokeTrigger {
               threadMeta,
               undefined,
               messageId,
+              skipConnectorIds,
             );
             inflightDeliverPromises.push(deliverPromise);
             try {

--- a/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
+++ b/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
@@ -449,8 +449,7 @@ export class ConnectorInvokeTrigger {
         // ⑥ Outbound delivery: send final text + rich blocks to bound external chats
         const finalContent = collectedTextParts.join('');
         const allFinalRichBlocks = outboundTurns.flatMap((turn) => turn.richBlocks ?? []);
-        const finalRichBlocks =
-          allFinalRichBlocks.length > 0 ? allFinalRichBlocks : persistenceContext.richBlocks;
+        const finalRichBlocks = allFinalRichBlocks.length > 0 ? allFinalRichBlocks : persistenceContext.richBlocks;
 
         // Phase 4: Finalize streaming — ensure start completed before ending
         let streamEndResult: { inlineDeliveredConnectorIds?: string[] } | undefined;

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -66,6 +66,7 @@ interface OutboundDeliveryHookLike {
     threadMeta?: { threadShortId: string; threadTitle?: string; deepLinkUrl?: string },
     origin?: string,
     triggerMessageId?: string,
+    skipConnectorIds?: ReadonlySet<string>,
   ): Promise<void>;
 }
 
@@ -78,7 +79,13 @@ interface StreamingHookLike {
     senderHint?: { id: string; name?: string },
   ): Promise<void>;
   onStreamChunk(threadId: string, accumulatedText: string, invocationId?: string): Promise<void>;
-  onStreamEnd(threadId: string, finalText: string, invocationId?: string): Promise<void>;
+  onStreamEnd(
+    threadId: string,
+    finalText: string,
+    invocationId?: string,
+    richBlocks?: unknown[],
+  ): Promise<{ inlineDeliveredConnectorIds?: string[] } | undefined>;
+  getInlineFinalDeliveryConnectorIds?(threadId: string, invocationId?: string): string[];
   cleanupPlaceholders?(threadId: string, invocationId?: string): Promise<void>;
   /** F151: Signal adapters that an invocation's delivery batch is complete. */
   notifyDeliveryBatchDone?(threadId: string, chainDone: boolean): Promise<void>;
@@ -1492,7 +1499,17 @@ export async function deliverOutboundFromWeb(
 ): Promise<void> {
   const finalContent =
     outboundTurns.length > 0 ? flattenTurnTextParts(outboundTurns) : flattenTextParts(collectedTextParts);
+  const nonEmptyTurns = outboundTurns.filter(
+    (t) => t.textParts.length > 0 || (t.richBlocks && t.richBlocks.length > 0),
+  );
+  const finalRichBlocks =
+    nonEmptyTurns.length > 1
+      ? nonEmptyTurns.flatMap((turn) => turn.richBlocks ?? [])
+      : nonEmptyTurns.length === 1
+        ? (persistenceContext.richBlocks ?? nonEmptyTurns[0].richBlocks)
+        : persistenceContext.richBlocks;
 
+  let streamEndResult: { inlineDeliveredConnectorIds?: string[] } | undefined;
   if (opts.streamingHook) {
     if (streamStartPromise) {
       await Promise.race([
@@ -1500,10 +1517,16 @@ export async function deliverOutboundFromWeb(
         new Promise<void>((resolve) => setTimeout(resolve, STREAM_START_TIMEOUT_MS)),
       ]);
     }
-    await opts.streamingHook.onStreamEnd(threadId, finalContent, invocationId).catch((err) => {
-      logger.warn({ err, threadId }, '[messages] StreamingHook.onStreamEnd failed');
-    });
+    streamEndResult = await opts.streamingHook
+      .onStreamEnd(threadId, finalContent, invocationId, finalRichBlocks)
+      .catch((err) => {
+        logger.warn({ err, threadId }, '[messages] StreamingHook.onStreamEnd failed');
+        return undefined;
+      });
   }
+  const inlineDeliveredConnectorIds = streamEndResult?.inlineDeliveredConnectorIds ?? [];
+  const skipConnectorIds =
+    inlineDeliveredConnectorIds.length > 0 ? new Set<string>(inlineDeliveredConnectorIds) : undefined;
 
   const hasContent = collectedTextParts.length > 0 || outboundTurns.length > 0;
   if (!opts.outboundHook || !hasContent) {
@@ -1537,17 +1560,22 @@ export async function deliverOutboundFromWeb(
   }
 
   const DELIVER_TIMEOUT_MS = 10_000;
-  const nonEmptyTurns = outboundTurns.filter(
-    (t) => t.textParts.length > 0 || (t.richBlocks && t.richBlocks.length > 0),
-  );
-
   let deliveryFailed = false;
   const inflightDeliverPromises: Promise<void>[] = [];
 
   if (nonEmptyTurns.length > 1) {
     for (const turn of nonEmptyTurns) {
       const turnContent = turn.textParts.join('');
-      const deliverPromise = opts.outboundHook.deliver(threadId, turnContent, turn.catId, turn.richBlocks, threadMeta);
+      const deliverPromise = opts.outboundHook.deliver(
+        threadId,
+        turnContent,
+        turn.catId,
+        turn.richBlocks,
+        threadMeta,
+        undefined,
+        undefined,
+        skipConnectorIds,
+      );
       inflightDeliverPromises.push(deliverPromise);
       try {
         await Promise.race([
@@ -1562,7 +1590,16 @@ export async function deliverOutboundFromWeb(
   } else if (nonEmptyTurns.length === 1) {
     const turn = nonEmptyTurns[0];
     const richBlocks = persistenceContext.richBlocks ?? turn.richBlocks;
-    const deliverPromise = opts.outboundHook.deliver(threadId, finalContent, turn.catId, richBlocks, threadMeta);
+    const deliverPromise = opts.outboundHook.deliver(
+      threadId,
+      finalContent,
+      turn.catId,
+      richBlocks,
+      threadMeta,
+      undefined,
+      undefined,
+      skipConnectorIds,
+    );
     inflightDeliverPromises.push(deliverPromise);
     try {
       await Promise.race([
@@ -1576,7 +1613,16 @@ export async function deliverOutboundFromWeb(
   } else {
     const richBlocks = persistenceContext.richBlocks;
     if (richBlocks) {
-      const deliverPromise = opts.outboundHook.deliver(threadId, finalContent, primaryCat, richBlocks, threadMeta);
+      const deliverPromise = opts.outboundHook.deliver(
+        threadId,
+        finalContent,
+        primaryCat,
+        richBlocks,
+        threadMeta,
+        undefined,
+        undefined,
+        skipConnectorIds,
+      );
       inflightDeliverPromises.push(deliverPromise);
       try {
         await Promise.race([

--- a/packages/api/test/connector-invoke-trigger.test.js
+++ b/packages/api/test/connector-invoke-trigger.test.js
@@ -514,6 +514,42 @@ describe('ConnectorInvokeTrigger', () => {
     assert.strictEqual(deliverCalls[0].content, 'Review noted. Working on it.');
   });
 
+  it('passes inline-delivered connectors from streaming end to connector outbound delivery', async () => {
+    const deliverCalls = /** @type {Array<{skipConnectorIds: Set<string> | undefined}>} */ ([]);
+    const outboundHook = {
+      deliver: async (
+        _threadId,
+        _content,
+        _catId,
+        _richBlocks,
+        _threadMeta,
+        _origin,
+        _triggerMessageId,
+        skipConnectorIds,
+      ) => {
+        deliverCalls.push({ skipConnectorIds });
+      },
+    };
+    const streamingHook = {
+      async onStreamStart() {},
+      async onStreamChunk() {},
+      async onStreamEnd() {
+        return { inlineDeliveredConnectorIds: ['telegram'] };
+      },
+      getInlineFinalDeliveryConnectorIds() {
+        return ['telegram'];
+      },
+      async cleanupPlaceholders() {},
+    };
+
+    const trigger = createTrigger({ outboundHook, streamingHook });
+    trigger.trigger('thread-1', /** @type {any} */ ('opus'), 'user-1', 'Review msg', 'msg-1');
+    await waitForTrigger();
+
+    assert.strictEqual(deliverCalls.length, 1);
+    assert.deepStrictEqual([...(deliverCalls[0].skipConnectorIds ?? [])], ['telegram']);
+  });
+
   it('R1-P1: delivers richBlocks-only reply (no text) via outbound hook', async () => {
     // Router yields only richBlocks with no text content
     const richOnlyRouter = /** @type {any} */ ({

--- a/packages/api/test/outbound-delivery-hook.test.js
+++ b/packages/api/test/outbound-delivery-hook.test.js
@@ -93,7 +93,16 @@ describe('OutboundDeliveryHook', () => {
 
     bindingStore.bind('feishu', 'chat-1', 'thread-abc', 'user-1');
     bindingStore.bind('telegram', 'chat-2', 'thread-abc', 'user-1');
-    await hook.deliver('thread-abc', 'Hello!', undefined, undefined, undefined, undefined, undefined, new Set(['telegram']));
+    await hook.deliver(
+      'thread-abc',
+      'Hello!',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      new Set(['telegram']),
+    );
 
     assert.equal(feishuMock.sent.length, 1);
     assert.equal(telegramMock.sent.length, 0);

--- a/packages/api/test/outbound-delivery-hook.test.js
+++ b/packages/api/test/outbound-delivery-hook.test.js
@@ -79,6 +79,26 @@ describe('OutboundDeliveryHook', () => {
     assert.equal(telegramMock.sent.length, 1);
   });
 
+  it('skips delivery to connectors already finalized inline by streaming', async () => {
+    const telegramMock = mockAdapter('telegram');
+    const adapters = new Map([
+      ['feishu', feishuMock.adapter],
+      ['telegram', telegramMock.adapter],
+    ]);
+    hook = new OutboundDeliveryHook({
+      bindingStore,
+      adapters,
+      log: noopLog(),
+    });
+
+    bindingStore.bind('feishu', 'chat-1', 'thread-abc', 'user-1');
+    bindingStore.bind('telegram', 'chat-2', 'thread-abc', 'user-1');
+    await hook.deliver('thread-abc', 'Hello!', undefined, undefined, undefined, undefined, undefined, new Set(['telegram']));
+
+    assert.equal(feishuMock.sent.length, 1);
+    assert.equal(telegramMock.sent.length, 0);
+  });
+
   it('does not throw when adapter.sendReply fails', async () => {
     const failAdapter = {
       connectorId: 'feishu',

--- a/packages/api/test/outbound-delivery-hook.test.js
+++ b/packages/api/test/outbound-delivery-hook.test.js
@@ -99,6 +99,39 @@ describe('OutboundDeliveryHook', () => {
     assert.equal(telegramMock.sent.length, 0);
   });
 
+  it('does not skip media rich block delivery for connectors marked inline-delivered', async () => {
+    const mediaSent = [];
+    const telegramAdapter = {
+      connectorId: 'telegram',
+      async sendReply() {},
+      async sendRichMessage() {},
+      async sendMedia(externalChatId, payload) {
+        mediaSent.push({ externalChatId, payload });
+      },
+    };
+    hook = new OutboundDeliveryHook({
+      bindingStore,
+      adapters: new Map([['telegram', telegramAdapter]]),
+      log: noopLog(),
+    });
+
+    bindingStore.bind('telegram', 'chat-2', 'thread-abc', 'user-1');
+    await hook.deliver(
+      'thread-abc',
+      'Here is the image',
+      undefined,
+      [{ kind: 'media_gallery', items: [{ type: 'image', url: 'https://example.com/cat.png' }] }],
+      undefined,
+      undefined,
+      undefined,
+      new Set(['telegram']),
+    );
+
+    assert.equal(mediaSent.length, 1);
+    assert.equal(mediaSent[0].externalChatId, 'chat-2');
+    assert.equal(mediaSent[0].payload.type, 'image');
+  });
+
   it('does not throw when adapter.sendReply fails', async () => {
     const failAdapter = {
       connectorId: 'feishu',

--- a/packages/api/test/streaming-outbound-hook.test.js
+++ b/packages/api/test/streaming-outbound-hook.test.js
@@ -12,6 +12,7 @@ describe('StreamingOutboundHook', () => {
   function createMockAdapter(opts = {}) {
     return {
       connectorId: 'feishu',
+      finalDeliveryMode: opts.finalDeliveryMode,
       sendReply: async () => {},
       sendPlaceholder: async (_chatId, _text) => 'msg-placeholder-1',
       editMessage: async (_chatId, _msgId, _text) => {},
@@ -247,6 +248,52 @@ describe('StreamingOutboundHook', () => {
     assert.equal(adapter._calls.editRichMessage.length, 1);
     assert.deepEqual(adapter._calls.editRichMessage[0].blocks, richBlocks);
     assert.deepEqual(result.inlineDeliveredConnectorIds, ['feishu']);
+  });
+
+  it('onStreamEnd honors inline-edit mode even when delete cleanup is available', async () => {
+    const { hook, adapter } = createHook({ noFinalize: true, finalDeliveryMode: 'inline-edit' });
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text');
+
+    assert.equal(adapter._calls.editMessage.length, 1);
+    assert.equal(adapter._calls.deleteMessage.length, 0);
+    assert.deepEqual(result.inlineDeliveredConnectorIds, ['feishu']);
+  });
+
+  it('onStreamEnd does not use rich in-place edit for media richBlocks', async () => {
+    const { hook, adapter } = createHook({ noDelete: true, noFinalize: true, richEdit: true });
+    const richBlocks = [
+      {
+        kind: 'media_gallery',
+        items: [{ type: 'image', url: 'https://example.com/cat.png' }],
+      },
+    ];
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text', undefined, richBlocks);
+
+    assert.equal(adapter._calls.editRichMessage.length, 0);
+    assert.deepEqual(result.inlineDeliveredConnectorIds, []);
+  });
+
+  it('onStreamEnd defers media richBlocks for inline-edit connectors with delete cleanup', async () => {
+    const { hook, adapter } = createHook({ noFinalize: true, finalDeliveryMode: 'inline-edit', richEdit: true });
+    const richBlocks = [
+      {
+        kind: 'media_gallery',
+        items: [{ type: 'image', url: 'https://example.com/cat.png' }],
+      },
+    ];
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text', undefined, richBlocks);
+    await hook.cleanupPlaceholders('thread-1');
+
+    assert.equal(adapter._calls.editRichMessage.length, 0);
+    assert.deepEqual(result.inlineDeliveredConnectorIds, []);
+    assert.equal(adapter._calls.deleteMessage.length, 1);
+    assert.equal(adapter._calls.deleteMessage[0].msgId, 'msg-placeholder-1');
   });
 
   it('onStreamEnd does not report inline delivery when rich in-place edit fails', async () => {

--- a/packages/api/test/streaming-outbound-hook.test.js
+++ b/packages/api/test/streaming-outbound-hook.test.js
@@ -15,9 +15,14 @@ describe('StreamingOutboundHook', () => {
       sendReply: async () => {},
       sendPlaceholder: async (_chatId, _text) => 'msg-placeholder-1',
       editMessage: async (_chatId, _msgId, _text) => {},
+      editRichMessage: opts.richEdit
+        ? async (_chatId, _msgId, _text, _blocks, _catName) => {
+            if (opts.richEditError) throw new Error('edit rich failed');
+          }
+        : undefined,
       deleteMessage: opts.noDelete ? undefined : async (_msgId) => {},
       finalizeStreamCard: opts.noFinalize ? undefined : async (_chatId, _msgId, _catName) => {},
-      _calls: { sendPlaceholder: [], editMessage: [], deleteMessage: [], finalizeStreamCard: [] },
+      _calls: { sendPlaceholder: [], editMessage: [], editRichMessage: [], deleteMessage: [], finalizeStreamCard: [] },
     };
   }
 
@@ -25,6 +30,7 @@ describe('StreamingOutboundHook', () => {
     const original = {
       sendPlaceholder: adapter.sendPlaceholder,
       editMessage: adapter.editMessage,
+      editRichMessage: adapter.editRichMessage,
       deleteMessage: adapter.deleteMessage,
       finalizeStreamCard: adapter.finalizeStreamCard,
     };
@@ -36,6 +42,12 @@ describe('StreamingOutboundHook', () => {
       adapter._calls.editMessage.push({ chatId, msgId, text });
       return original.editMessage(chatId, msgId, text);
     };
+    if (adapter.editRichMessage) {
+      adapter.editRichMessage = async (chatId, msgId, text, blocks, catName) => {
+        adapter._calls.editRichMessage.push({ chatId, msgId, text, blocks, catName });
+        return original.editRichMessage(chatId, msgId, text, blocks, catName);
+      };
+    }
     if (adapter.deleteMessage) {
       adapter.deleteMessage = async (msgId) => {
         adapter._calls.deleteMessage.push({ msgId });
@@ -213,6 +225,46 @@ describe('StreamingOutboundHook', () => {
     assert.equal(adapter._calls.editMessage.length, 1);
     assert.ok(adapter._calls.editMessage[0].text.includes('Final complete response'));
     assert.ok(!adapter._calls.editMessage[0].text.includes('▌'));
+  });
+
+  it('onStreamEnd reports edit-only connectors as inline delivered', async () => {
+    const { hook } = createHook({ noDelete: true, noFinalize: true });
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text');
+
+    assert.deepEqual(result.inlineDeliveredConnectorIds, ['feishu']);
+  });
+
+  it('onStreamEnd uses rich in-place edit for edit-only connectors with richBlocks', async () => {
+    const { hook, adapter } = createHook({ noDelete: true, noFinalize: true, richEdit: true });
+    const richBlocks = [{ kind: 'diff', filePath: 'src/example.ts', diff: '+const answer = 42;' }];
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text', undefined, richBlocks);
+
+    assert.equal(adapter._calls.editMessage.length, 0);
+    assert.equal(adapter._calls.editRichMessage.length, 1);
+    assert.deepEqual(adapter._calls.editRichMessage[0].blocks, richBlocks);
+    assert.deepEqual(result.inlineDeliveredConnectorIds, ['feishu']);
+  });
+
+  it('onStreamEnd does not report inline delivery when rich in-place edit fails', async () => {
+    const { hook, adapter } = createHook({ noDelete: true, noFinalize: true, richEdit: true, richEditError: true });
+    const richBlocks = [{ kind: 'diff', filePath: 'src/example.ts', diff: '+const answer = 42;' }];
+    await hook.onStreamStart('thread-1');
+
+    const result = await hook.onStreamEnd('thread-1', 'Final complete response text', undefined, richBlocks);
+
+    assert.equal(adapter._calls.editRichMessage.length, 1);
+    assert.deepEqual(result.inlineDeliveredConnectorIds, []);
+  });
+
+  it('reports pending edit-only connectors before stream end', async () => {
+    const { hook } = createHook({ noDelete: true, noFinalize: true });
+    await hook.onStreamStart('thread-1');
+
+    assert.deepEqual(hook.getInlineFinalDeliveryConnectorIds('thread-1'), ['feishu']);
   });
 
   it('onStreamEnd cleans up session (second call is no-op)', async () => {

--- a/packages/api/test/telegram-adapter.test.js
+++ b/packages/api/test/telegram-adapter.test.js
@@ -206,6 +206,20 @@ describe('TelegramAdapter', () => {
     });
   });
 
+  describe('deleteMessage()', () => {
+    it('deletes the existing Telegram placeholder message', async () => {
+      const adapter = new TelegramAdapter('test-token', noopLog());
+      const deleteCalls = [];
+      adapter.bot.api.deleteMessage = async (chatId, messageId) => {
+        deleteCalls.push({ chatId, messageId });
+      };
+
+      await adapter.deleteMessage('2002', '1001');
+
+      assert.deepEqual(deleteCalls, [{ chatId: 1001, messageId: 2002 }]);
+    });
+  });
+
   describe('startPolling()', () => {
     it('releases the Telegram session and retries after a 409 polling conflict', async () => {
       const { entries, log } = recordingLog();

--- a/packages/api/test/telegram-adapter.test.js
+++ b/packages/api/test/telegram-adapter.test.js
@@ -186,6 +186,26 @@ describe('TelegramAdapter', () => {
     });
   });
 
+  describe('editRichMessage()', () => {
+    it('edits the existing Telegram message with HTML parse mode', async () => {
+      const adapter = new TelegramAdapter('test-token', noopLog());
+      const editCalls = [];
+      adapter.bot.api.editMessageText = async (chatId, messageId, text, opts) => {
+        editCalls.push({ chatId, messageId, text, opts });
+      };
+
+      const blocks = [{ id: 'b1', kind: 'card', v: 1, title: 'Review', bodyMarkdown: 'LGTM' }];
+      await adapter.editRichMessage('1001', '2002', 'text', blocks, '布偶猫');
+
+      assert.equal(editCalls.length, 1);
+      assert.equal(editCalls[0].chatId, 1001);
+      assert.equal(editCalls[0].messageId, 2002);
+      assert.deepEqual(editCalls[0].opts, { parse_mode: 'HTML' });
+      assert.ok(editCalls[0].text.includes('Review'));
+      assert.ok(editCalls[0].text.includes('text'));
+    });
+  });
+
   describe('startPolling()', () => {
     it('releases the Telegram session and retries after a 409 polling conflict', async () => {
       const { entries, log } = recordingLog();

--- a/packages/api/test/web-outbound-delivery.test.js
+++ b/packages/api/test/web-outbound-delivery.test.js
@@ -28,8 +28,17 @@ describe('deliverOutboundFromWeb (F088 ISSUE-15)', () => {
     streamCalls = { start: [], chunk: [], end: [], cleanup: [] };
 
     mockOutboundHook = {
-      async deliver(threadId, content, catId, richBlocks, threadMeta) {
-        deliverCalls.push({ threadId, content, catId, richBlocks, threadMeta });
+      async deliver(threadId, content, catId, richBlocks, threadMeta, origin, triggerMessageId, skipConnectorIds) {
+        deliverCalls.push({
+          threadId,
+          content,
+          catId,
+          richBlocks,
+          threadMeta,
+          origin,
+          triggerMessageId,
+          skipConnectorIds,
+        });
       },
     };
 
@@ -40,8 +49,8 @@ describe('deliverOutboundFromWeb (F088 ISSUE-15)', () => {
       async onStreamChunk(threadId, text, invocationId) {
         streamCalls.chunk.push({ threadId, text, invocationId });
       },
-      async onStreamEnd(threadId, text, invocationId) {
-        streamCalls.end.push({ threadId, text, invocationId });
+      async onStreamEnd(threadId, text, invocationId, richBlocks) {
+        streamCalls.end.push({ threadId, text, invocationId, richBlocks });
       },
       async cleanupPlaceholders(threadId, invocationId) {
         streamCalls.cleanup.push({ threadId, invocationId });
@@ -160,6 +169,56 @@ describe('deliverOutboundFromWeb (F088 ISSUE-15)', () => {
     assert.equal(streamCalls.end[0].text, 'hi');
     assert.equal(streamCalls.cleanup.length, 1);
     assert.equal(streamCalls.cleanup[0].threadId, 't-1');
+  });
+
+  it('passes inline-delivered connectors from streaming end to outbound delivery', async () => {
+    mockStreamingHook.onStreamEnd = async (threadId, text, invocationId) => {
+      streamCalls.end.push({ threadId, text, invocationId });
+      return { inlineDeliveredConnectorIds: ['telegram'] };
+    };
+    const opts = makeOpts({
+      outboundHook: mockOutboundHook,
+      streamingHook: mockStreamingHook,
+    });
+    const turns = [{ catId: 'opus', textParts: ['hi'] }];
+    const ctx = { failed: false, errors: [] };
+
+    await deliverOutboundFromWeb('t-1', 'opus', 'inv-1', ['hi'], turns, ctx, undefined, opts, noopLog());
+
+    assert.equal(deliverCalls.length, 1);
+    assert.deepEqual([...deliverCalls[0].skipConnectorIds], ['telegram']);
+  });
+
+  it('does not skip outbound delivery when streaming end reports no inline delivery', async () => {
+    mockStreamingHook.onStreamEnd = async (threadId, text, invocationId) => {
+      streamCalls.end.push({ threadId, text, invocationId });
+      return { inlineDeliveredConnectorIds: [] };
+    };
+    const opts = makeOpts({
+      outboundHook: mockOutboundHook,
+      streamingHook: mockStreamingHook,
+    });
+    const turns = [{ catId: 'opus', textParts: ['hi'] }];
+    const ctx = { failed: false, errors: [] };
+
+    await deliverOutboundFromWeb('t-1', 'opus', 'inv-1', ['hi'], turns, ctx, undefined, opts, noopLog());
+
+    assert.equal(deliverCalls.length, 1);
+    assert.equal(deliverCalls[0].skipConnectorIds, undefined);
+  });
+
+  it('passes final richBlocks to streaming end for inline final rich edit', async () => {
+    const opts = makeOpts({
+      outboundHook: mockOutboundHook,
+      streamingHook: mockStreamingHook,
+    });
+    const richBlocks = [{ kind: 'diff', filePath: 'src/example.ts', diff: '+const answer = 42;' }];
+    const turns = [{ catId: 'opus', textParts: ['hi'], richBlocks }];
+    const ctx = { failed: false, errors: [] };
+
+    await deliverOutboundFromWeb('t-1', 'opus', 'inv-1', ['hi'], turns, ctx, undefined, opts, noopLog());
+
+    assert.deepEqual(streamCalls.end[0].richBlocks, richBlocks);
   });
 
   it('cleans up placeholders even when no outbound hook (stream-only)', async () => {


### PR DESCRIPTION
## Summary
- finalize Telegram streaming replies in place instead of sending duplicate final text
- preserve rich block delivery, including media galleries and files, by only skipping outbound delivery when inline edit actually completed the final content
- clean up placeholders after successful deferred outbound delivery and cover edit-failure fallback paths

## Root cause
Telegram finalization treated every inline-edit-capable connector as fully delivered, so the downstream outbound hook skipped connector delivery even when the final response still needed rich/media handling. That fixed duplicate text for plain replies but could drop structured content or media.

## Validation
- `pnpm --dir packages/api run build`
- `node --import file:///D:/Develop/Project/GitHub/clowder/.worktrees/clowder-tg-edit-pr624/packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/connector-invoke-trigger.test.js packages/api/test/outbound-delivery-hook.test.js packages/api/test/streaming-outbound-hook.test.js packages/api/test/telegram-adapter.test.js packages/api/test/web-outbound-delivery.test.js` (134 tests passed)

## Notes
Pushed from fork because `amazing-fish` does not have direct write permission to `zts212653/clowder-ai`.