### PR TITLE
feat(telemetry): F181 cross-route A2A trace propagation

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/IAuthInvocationBackend.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/IAuthInvocationBackend.ts
@@ -10,6 +10,7 @@
  * `Promise.resolve` (negligible overhead).
  */
 
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import type { InvocationRecord, VerifyResult } from './InvocationRegistry.js';
 
 /** Subset of InvocationRecord fields the backend stores; expiresAt is computed by ttlMs. */
@@ -74,4 +75,7 @@ export interface IAuthInvocationBackend {
    * Implementation must be racy-safe (Redis SET NX EX, or per-key Map check).
    */
   tryClaimRefreshCooldown(invocationId: string, cooldownMs: number): Promise<boolean>;
+
+  /** F181: Persist caller trace context on an invocation for cross-route A2A propagation. */
+  setTraceContext(invocationId: string, ctx: CallerTraceContext): Promise<void>;
 }

--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -12,6 +12,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 
 export interface QueueEntry {
   id: string;
@@ -45,6 +46,8 @@ export interface QueueEntry {
   position?: number;
   /** F175: skill hint for connector triggers — flows through as promptTags on execution */
   suggestedSkill?: string;
+  /** F181: caller trace context for cross-route A2A propagation */
+  callerTraceContext?: CallerTraceContext;
 }
 
 export interface EnqueueResult {
@@ -133,11 +136,13 @@ export class InvocationQueue {
       | 'priority'
       | 'position'
       | 'suggestedSkill'
+      | 'callerTraceContext'
     > & {
       autoExecute?: boolean;
       callerCatId?: string;
       priority?: 'urgent' | 'normal';
       suggestedSkill?: string;
+      callerTraceContext?: CallerTraceContext;
     },
   ): EnqueueResult {
     const key = this.scopeKey(input.threadId, input.userId);
@@ -189,6 +194,7 @@ export class InvocationQueue {
       sourceCategory: input.sourceCategory,
       continuationKey: input.continuationKey,
       suggestedSkill: input.suggestedSkill,
+      callerTraceContext: input.callerTraceContext,
       position: undefined,
     };
     q.push(entry);

--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationRegistry.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationRegistry.ts
@@ -13,6 +13,7 @@
 
 import { randomUUID } from 'node:crypto';
 import type { CatId } from '@cat-cafe/shared';
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import type { IAuthInvocationBackend } from './IAuthInvocationBackend.js';
 import { MemoryAuthInvocationBackend } from './MemoryAuthInvocationBackend.js';
 
@@ -27,6 +28,7 @@ export interface InvocationRecord {
   parentInvocationId?: string;
   /** F121: The A2A trigger message ID — the @mention message that caused this cat to be invoked */
   a2aTriggerMessageId?: string;
+  traceContext?: CallerTraceContext;
   /** In-invocation idempotency keys for callback post-message de-duplication. */
   clientMessageIds: Set<string>;
   createdAt: number;
@@ -163,6 +165,10 @@ export class InvocationRegistry {
    */
   async tryClaimRefreshCooldown(invocationId: string, cooldownMs: number): Promise<boolean> {
     return this.backend.tryClaimRefreshCooldown(invocationId, cooldownMs);
+  }
+
+  async setTraceContext(invocationId: string, ctx: CallerTraceContext): Promise<void> {
+    return this.backend.setTraceContext(invocationId, ctx);
   }
 
   /**

--- a/packages/api/src/domains/cats/services/agents/invocation/MemoryAuthInvocationBackend.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/MemoryAuthInvocationBackend.ts
@@ -13,6 +13,7 @@
  * - claimClientMessageId enforces MAX_CLIENT_MESSAGE_IDS bound per record
  */
 
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import type { AuthInvocationInput, IAuthInvocationBackend } from './IAuthInvocationBackend.js';
 import type { InvocationRecord, VerifyResult } from './InvocationRegistry.js';
 
@@ -190,6 +191,11 @@ export class MemoryAuthInvocationBackend implements IAuthInvocationBackend {
     if (this.latestByThreadCat.get(key) === invocationId) {
       this.latestByThreadCat.delete(key);
     }
+  }
+
+  async setTraceContext(invocationId: string, ctx: CallerTraceContext): Promise<void> {
+    const record = this.records.get(invocationId);
+    if (record) record.traceContext = ctx;
   }
 
   private cleanupExpired(): void {

--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -907,6 +907,7 @@ export class QueueProcessor {
           cursorBoundaries,
           persistenceContext,
           ...(invocationId ? { parentInvocationId: invocationId } : {}),
+          callerTraceContext: entry.callerTraceContext,
         },
       )) {
         if (controller.signal.aborted) {

--- a/packages/api/src/domains/cats/services/agents/invocation/RedisAuthInvocationBackend.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/RedisAuthInvocationBackend.ts
@@ -21,6 +21,7 @@
 
 import type { CatId } from '@cat-cafe/shared';
 import type { RedisClient } from '@cat-cafe/shared/utils';
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import type { AuthInvocationInput, IAuthInvocationBackend } from './IAuthInvocationBackend.js';
 import type { InvocationRecord, VerifyResult } from './InvocationRegistry.js';
 
@@ -162,6 +163,9 @@ function recordFromHash(fields: Record<string, string>, msgs: Set<string>): Invo
   };
   if (fields.parentInvocationId) record.parentInvocationId = fields.parentInvocationId;
   if (fields.a2aTriggerMessageId) record.a2aTriggerMessageId = fields.a2aTriggerMessageId;
+  if (fields.traceId && fields.spanId) {
+    record.traceContext = { traceId: fields.traceId, spanId: fields.spanId, traceFlags: Number(fields.traceFlags ?? 0) };
+  }
   return record;
 }
 
@@ -395,5 +399,10 @@ export class RedisAuthInvocationBackend implements IAuthInvocationBackend {
     // Returns 'OK' on first claim, null when key already exists (still cooling down).
     const result = await this.redis.set(KEY_REFRESH_COOLDOWN(invocationId), '1', 'PX', cooldownMs, 'NX');
     return result === 'OK';
+  }
+
+  async setTraceContext(invocationId: string, ctx: CallerTraceContext): Promise<void> {
+    const key = KEY_INV(invocationId);
+    await this.redis.hset(key, 'traceId', ctx.traceId, 'spanId', ctx.spanId, 'traceFlags', String(ctx.traceFlags));
   }
 }

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -26,6 +26,7 @@ import { getContextWindowFallback } from '../../../../../config/context-window-s
 import { getSessionStrategy, shouldTakeAction } from '../../../../../config/session-strategy.js';
 import { assertSafeTestConfigRoot } from '../../../../../config/test-config-write-guard.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import {
   AGENT_ID,
   GENAI_MODEL,
@@ -278,6 +279,8 @@ export interface InvocationParams {
   readonly a2aTriggerMessageId?: string;
   /** F153 Phase E: Parent route span — invocation span becomes its child */
   readonly routeSpan?: import('@opentelemetry/api').Span;
+  /** F181: mutable ref so caller can capture the invocation span for trace propagation */
+  readonly invocationSpanRef?: { current?: import('@opentelemetry/api').Span };
   /** #502 PR2: structured route control state to persist on threshold seal. */
   readonly continuityCapsule?: RouteStateContinuityCapsule;
 }
@@ -484,6 +487,11 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     { attributes: { [AGENT_ID]: catId, [OPERATION_NAME]: 'invoke', invocationId } },
     parentCtx,
   );
+
+  // F181: Expose invocation span to caller + persist trace context for A2A propagation
+  if (params.invocationSpanRef) params.invocationSpanRef.current = invocationSpan;
+  const sc = invocationSpan.spanContext();
+  await deps.registry.setTraceContext(invocationId, { traceId: sc.traceId, spanId: sc.spanId, traceFlags: sc.traceFlags });
 
   try {
     // F152: Track active invocations — must be inside try so add/sub symmetry

--- a/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
@@ -21,9 +21,10 @@
 import type { CatId, MessageContent } from '@cat-cafe/shared';
 import { catRegistry, escapeRegExp } from '@cat-cafe/shared';
 import type { SessionStore } from '@cat-cafe/shared/utils';
-import { SpanStatusCode, trace } from '@opentelemetry/api';
+import { context as ctxApi, SpanStatusCode, trace } from '@opentelemetry/api';
 import { getDefaultCatId, isCatAvailable } from '../../../../../config/cat-config-loader.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import type { CallerTraceContext } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import {
   ROUTING_INTENT,
   ROUTING_STRATEGY,
@@ -819,10 +820,22 @@ export class AgentRouter {
       persistenceContext?: PersistenceContext;
       /** F108: parentInvocationId for WorklistRegistry concurrent isolation */
       parentInvocationId?: string;
+      /** F181: caller trace context for cross-route A2A propagation */
+      callerTraceContext?: CallerTraceContext;
     },
   ): AsyncIterable<AgentMessage> {
     const cleanMessage = stripIntentTags(message);
     const strategy = intent.intent === 'ideate' && targetCats.length > 1 ? 'parallel' : 'serial';
+
+    // F181: Reconstruct remote parent context for cross-route A2A trace propagation
+    const parentCtx = options?.callerTraceContext
+      ? trace.setSpanContext(ctxApi.active(), {
+          traceId: options.callerTraceContext.traceId,
+          spanId: options.callerTraceContext.spanId,
+          traceFlags: options.callerTraceContext.traceFlags,
+          isRemote: true,
+        })
+      : undefined;
 
     const routeSpan = routeTracer.startSpan('cat_cafe.route', {
       attributes: {
@@ -831,7 +844,7 @@ export class AgentRouter {
         [ROUTING_STRATEGY]: strategy,
         ...(options?.parentInvocationId ? { invocationId: options.parentInvocationId } : {}),
       },
-    });
+    }, parentCtx);
 
     // Fetch thread for thinkingMode + update lastActive
     // Default to play mode when no threadStore is available: stream thinking stays isolated.

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -8,6 +8,11 @@ import { catRegistry } from '@cat-cafe/shared';
 import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import {
+  ROUTE_HAS_A2A_HANDOFF,
+  ROUTE_TOTAL_CATS_INVOKED,
+  ROUTE_TOTAL_TOKENS,
+} from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import { estimateTokens } from '../../../../../utils/token-counter.js';
 import {
   ackGuideCompletion,
@@ -429,6 +434,8 @@ export async function* routeParallel(
   const catPayloadStrippers = new Map<string, ReturnType<typeof createLeakedToolCallStreamStripper>>();
   let completedCount = 0;
   let yieldedFinalDone = false;
+  // F181: Accumulate total tokens across all parallel streams for route aggregate
+  let routeTotalTokens = 0;
 
   // #80: Per-cat draft flush state
   const catFlushTime = new Map<string, number>();
@@ -532,6 +539,10 @@ export async function* routeParallel(
             const arr = catStreamRichBlocks.get(effectiveMsg.catId) ?? [];
             arr.push(parsed.block);
             catStreamRichBlocks.set(effectiveMsg.catId, arr);
+          }
+          // F181: Accumulate invocation tokens for route aggregate
+          if (parsed.type === 'invocation_usage' && parsed.usage) {
+            routeTotalTokens += (parsed.usage.inputTokens ?? 0) + (parsed.usage.outputTokens ?? 0);
           }
         } catch {
           /* ignore parse errors */
@@ -1086,6 +1097,14 @@ export async function* routeParallel(
       yield { ...msg, isFinal };
       if (isFinal) yieldedFinalDone = true;
     }
+  }
+
+  // F181: Set route aggregate attributes on the parent route span
+  if (options.routeSpan) {
+    options.routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED, completedCount);
+    options.routeSpan.setAttribute(ROUTE_TOTAL_TOKENS, routeTotalTokens);
+    // Parallel routes never produce A2A handoffs (MVP safety boundary)
+    options.routeSpan.setAttribute(ROUTE_HAS_A2A_HANDOFF, false);
   }
 
   // done-guarantee safety net: synthesize final done if loop exited without one

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -12,10 +12,18 @@
 
 import type { CatConfig, CatId } from '@cat-cafe/shared';
 import { catRegistry } from '@cat-cafe/shared';
+import type { Span } from '@opentelemetry/api';
+import { context, trace } from '@opentelemetry/api';
 import { getCatContextBudget } from '../../../../../config/cat-budgets.js';
 import { getConfigSessionStrategy, isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { getCatVoice } from '../../../../../config/cat-voices.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import {
+  AGENT_ID,
+  ROUTE_HAS_A2A_HANDOFF,
+  ROUTE_TOTAL_CATS_INVOKED,
+  ROUTE_TOTAL_TOKENS,
+} from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import {
   inlineActionChecked,
   inlineActionDetected,
@@ -89,6 +97,7 @@ import { shouldWarnVoidHold } from './void-hold-detect.js';
 import { buildVoteTally, checkVoteCompletion, extractVoteFromText, VOTE_RESULT_SOURCE } from './vote-intercept.js';
 
 const log = createModuleLogger('route-serial');
+const routeSerialTracer = trace.getTracer('cat-cafe-api', '0.1.0');
 
 function collectStructuredTargetCatsFromInput(input: unknown): string[] {
   if (!input || typeof input !== 'object') return [];
@@ -301,6 +310,12 @@ export async function* routeSerial(
     }
   }
   const bootcampMemberCount = getThreadBootcampMemberCount(routeThread);
+
+  // F181: Trace propagation — track per-invocation spans and route-level token totals
+  const catInvocationSpans = new Map<number, Span>();
+  const mentionParentSpan = new Map<number, Span>();
+  const pendingDispatchSpans: { span: Span; lastChildIndex: number }[] = [];
+  let routeTotalTokens = 0;
 
   // F155: Guide interceptor — resume existing guide state only
   const guideCtx = await prepareGuideContext({
@@ -658,6 +673,7 @@ export async function* routeSerial(
       );
       const leakedPayloadStripper = createLeakedToolCallStreamStripper();
       const invocationStartedAt = Date.now();
+      const invocationSpanRef: { current?: Span } = {};
       for await (const msg of invokeSingleCat(deps.invocationDeps, {
         catId,
         service: getService(deps.services, catId),
@@ -675,6 +691,7 @@ export async function* routeSerial(
           ? { a2aTriggerMessageId: worklistEntry.a2aTriggerMessageId.get(catId) }
           : {}),
         ...(options.routeSpan ? { routeSpan: options.routeSpan } : {}),
+        invocationSpanRef,
         isLastCat: false,
       })) {
         // F39 bugfix: stop yielding after cancel (pipe buffer may still drain)
@@ -756,6 +773,10 @@ export async function* routeSerial(
               // F060: Collect inline rich_block for persistence (P1 fix)
               if (parsed.type === 'rich_block' && parsed.block && isValidRichBlock(parsed.block)) {
                 streamRichBlocks.push(parsed.block);
+              }
+              // F181: Accumulate invocation tokens for route aggregate
+              if (parsed.type === 'invocation_usage' && parsed.usage) {
+                routeTotalTokens += (parsed.usage.inputTokens ?? 0) + (parsed.usage.outputTokens ?? 0);
               }
             } catch {
               /* ignore parse errors */
@@ -1381,6 +1402,8 @@ export async function* routeSerial(
           }
         }
 
+        if (invocationSpanRef.current) catInvocationSpans.set(index, invocationSpanRef.current);
+
         // A2A: extend worklist if mention found + depth allows + queue fairness gate
         // F27: dedup only against pending (not-yet-executed) tail — cats that already ran
         // can be re-enqueued for another round (e.g. A→B→A review ping-pong).
@@ -1411,6 +1434,8 @@ export async function* routeSerial(
         }
 
         if (a2aMentions.length > 0 && worklistEntry.a2aCount < maxDepth && !signal?.aborted && !queuedMessagesPending) {
+          // F181: mention_dispatch span — tracks the causal link between mentioner and dispatched targets
+          let dispatchSpan: Span | undefined;
           const pendingTail = worklist.slice(index + 1);
           const pendingOriginalTargets = targetCats.slice(index + 1);
           for (const nextCat of a2aMentions) {
@@ -1460,12 +1485,41 @@ export async function* routeSerial(
               continue;
             }
 
+            // F181: lazily create mention_dispatch span on first actual push
+            if (!dispatchSpan) {
+              const mentionerSpan = catInvocationSpans.get(index);
+              if (mentionerSpan) {
+                const parentCtx = trace.setSpan(context.active(), mentionerSpan);
+                dispatchSpan = routeSerialTracer.startSpan(
+                  'cat_cafe.mention_dispatch',
+                  {
+                    attributes: { [AGENT_ID]: catId as string, 'dispatch.target_count': a2aMentions.length },
+                  },
+                  parentCtx,
+                );
+              }
+            }
+
             worklist.push(nextCat);
             worklistEntry.a2aCount++;
             pendingTail.push(nextCat); // Keep dedup view in sync
             worklistEntry.a2aFrom.set(nextCat, catId);
             // F121: response-text path — set trigger message for auto-replyTo
             if (storedMsgId) worklistEntry.a2aTriggerMessageId.set(nextCat, storedMsgId);
+            // F181: record mention parent span for dispatched target
+            if (dispatchSpan) mentionParentSpan.set(worklist.length - 1, dispatchSpan);
+          }
+          // F181: end or defer dispatch span based on child execution
+          if (dispatchSpan) {
+            let maxChildIdx = -1;
+            for (const [idx, s] of mentionParentSpan) {
+              if (s === dispatchSpan && idx > maxChildIdx) maxChildIdx = idx;
+            }
+            if (maxChildIdx > index) {
+              pendingDispatchSpans.push({ span: dispatchSpan, lastChildIndex: maxChildIdx });
+            } else {
+              dispatchSpan.end();
+            }
           }
         }
 
@@ -1819,6 +1873,17 @@ export async function* routeSerial(
       index++;
     }
   } finally {
+    // F181: Set route aggregate attributes on the parent route span
+    if (options.routeSpan) {
+      options.routeSpan.setAttribute(ROUTE_TOTAL_CATS_INVOKED, index);
+      options.routeSpan.setAttribute(ROUTE_TOTAL_TOKENS, routeTotalTokens);
+      options.routeSpan.setAttribute(ROUTE_HAS_A2A_HANDOFF, worklist.length > targetCats.length);
+    }
+    // F181: End any pending dispatch spans whose children have all completed
+    for (const entry of pendingDispatchSpans) {
+      if (index >= entry.lastChildIndex) entry.span.end();
+    }
+
     if (options.invocationController && options.completeA2ASlots && activeTrackedA2ASlots.size > 0) {
       options.completeA2ASlots(threadId, [...activeTrackedA2ASlots], options.invocationController);
     }

--- a/packages/api/src/infrastructure/telemetry/genai-semconv.ts
+++ b/packages/api/src/infrastructure/telemetry/genai-semconv.ts
@@ -34,3 +34,18 @@ export const ROUTING_INTENT = 'cat_cafe.routing.intent';
 // --- F174 Phase D1: callback auth failure attributes ---
 export const CALLBACK_TOOL = 'callback.tool';
 export const CALLBACK_REASON = 'callback.reason';
+
+// --- Route aggregate attributes (set at route completion) ---
+export const ROUTE_TOTAL_CATS_INVOKED = 'route.total_cats_invoked';
+export const ROUTE_TOTAL_TOKENS = 'route.total_tokens';
+export const ROUTE_HAS_A2A_HANDOFF = 'route.has_a2a_handoff';
+
+/**
+ * F181: Caller trace context for cross-route A2A propagation.
+ * Aligns with W3C TraceContext fields (traceId, spanId, traceFlags).
+ */
+export interface CallerTraceContext {
+  readonly traceId: string;
+  readonly spanId: string;
+  readonly traceFlags: number;
+}

--- a/packages/api/src/routes/callback-a2a-trigger.ts
+++ b/packages/api/src/routes/callback-a2a-trigger.ts
@@ -14,6 +14,7 @@
 
 import type { CatId } from '@cat-cafe/shared';
 import type { FastifyBaseLogger } from 'fastify';
+import type { CallerTraceContext } from '../infrastructure/telemetry/genai-semconv.js';
 import { getDefaultCatId } from '../config/cat-config-loader.js';
 import type { InvocationQueue } from '../domains/cats/services/agents/invocation/InvocationQueue.js';
 import type { InvocationTracker } from '../domains/cats/services/agents/invocation/InvocationTracker.js';
@@ -68,6 +69,8 @@ export async function enqueueA2ATargets(
     callerCatId?: CatId;
     /** F108: parentInvocationId for concurrent worklist isolation. */
     parentInvocationId?: string;
+    /** F181: caller trace context for cross-route A2A propagation */
+    callerTraceContext?: CallerTraceContext;
   },
 ): Promise<{ enqueued: CatId[]; fallback: boolean }> {
   const { log } = deps;
@@ -158,6 +161,7 @@ export async function enqueueA2ATargets(
         intent: 'execute',
         autoExecute: true,
         callerCatId: callerCatId ?? undefined,
+        callerTraceContext: opts.callerTraceContext,
       });
       queueDiagnostics.push({
         catId,
@@ -351,6 +355,8 @@ export async function triggerA2AInvocation(
     userId: string;
     threadId: string;
     triggerMessage: StoredMessage;
+    /** F181: caller trace context for cross-route A2A propagation */
+    callerTraceContext?: CallerTraceContext;
   },
 ): Promise<void> {
   const { router, invocationRecordStore, socketManager, invocationTracker, log } = deps;
@@ -436,6 +442,7 @@ export async function triggerA2AInvocation(
       for await (const msg of router.routeExecution(userId, content, threadId, triggerMessage.id, targetCats, intent, {
         ...(controller?.signal ? { signal: controller.signal } : {}),
         parentInvocationId: createResult.invocationId,
+        callerTraceContext: opts.callerTraceContext,
       })) {
         // #768: Broadcast intent_mode on first CLI event — proves CLI is alive.
         if (!intentModeBroadcast) {

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -764,6 +764,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
             triggerMessage: storedMsg,
             callerCatId: senderCatId,
             parentInvocationId: record.parentInvocationId,
+            callerTraceContext: record.traceContext,
           },
         ),
       markDelivered: (deliveredAt) => messageStore.markDelivered?.(storedMsg.id, deliveredAt),
@@ -1618,6 +1619,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
         threadId: record.threadId,
         triggerMessage: notificationMsg,
         callerCatId: record.catId as CatId,
+        callerTraceContext: record.traceContext,
       };
       try {
         const { enqueued } = await enqueueA2ATargets(a2aDeps, a2aOpts);

--- a/packages/api/test/auth-invocation-backend-contract.test.js
+++ b/packages/api/test/auth-invocation-backend-contract.test.js
@@ -259,5 +259,85 @@ for (const [name, factory] of backends) {
         assert.equal(earlyReclaim, true, 'tiny cap must evict aggressively');
       });
     }
+
+    test('F181: setTraceContext persists and is readable via getRecord', async () => {
+      const { backend, cleanup } = await factory();
+      try {
+        await backend.create(fixture('inv-tc', 'tok-tc'), 60_000);
+        await backend.setTraceContext('inv-tc', {
+          traceId: 'aaaa1111bbbb2222cccc3333dddd4444',
+          spanId: '1122334455667788',
+          traceFlags: 1,
+        });
+        const record = await backend.getRecord('inv-tc');
+        assert.ok(record, 'record must exist');
+        assert.deepEqual(record.traceContext, {
+          traceId: 'aaaa1111bbbb2222cccc3333dddd4444',
+          spanId: '1122334455667788',
+          traceFlags: 1,
+        });
+      } finally {
+        await cleanup();
+      }
+    });
+
+    test('F181: setTraceContext on unknown invocation is a no-op', async () => {
+      const { backend, cleanup } = await factory();
+      try {
+        await backend.setTraceContext('nonexistent', {
+          traceId: 'aaaa',
+          spanId: 'bbbb',
+          traceFlags: 0,
+        });
+        const record = await backend.getRecord('nonexistent');
+        assert.equal(record, null);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    test('F181: traceContext survives verify TTL slide', async () => {
+      const { backend, cleanup } = await factory();
+      try {
+        await backend.create(fixture('inv-slide', 'tok-slide'), 60_000);
+        await backend.setTraceContext('inv-slide', {
+          traceId: 'trace1234',
+          spanId: 'span5678',
+          traceFlags: 1,
+        });
+        const result = await backend.verify('inv-slide', 'tok-slide', 60_000);
+        assert.equal(result.ok, true);
+        assert.deepEqual(result.record.traceContext, {
+          traceId: 'trace1234',
+          spanId: 'span5678',
+          traceFlags: 1,
+        });
+      } finally {
+        await cleanup();
+      }
+    });
+
+    test('F181: peekRecord returns traceContext even after expiry', async () => {
+      const { backend, cleanup } = await factory();
+      try {
+        await backend.create(fixture('inv-peek', 'tok-peek'), 10);
+        await backend.setTraceContext('inv-peek', {
+          traceId: 'deadbeef',
+          spanId: 'cafebabe',
+          traceFlags: 0,
+        });
+        await new Promise((r) => setTimeout(r, 30));
+        const record = await backend.peekRecord('inv-peek');
+        if (record) {
+          assert.deepEqual(record.traceContext, {
+            traceId: 'deadbeef',
+            spanId: 'cafebabe',
+            traceFlags: 0,
+          });
+        }
+      } finally {
+        await cleanup();
+      }
+    });
   });
 }

--- a/packages/api/test/invocation-queue.test.js
+++ b/packages/api/test/invocation-queue.test.js
@@ -1194,4 +1194,19 @@ describe('InvocationQueue', () => {
     const contents = batch.map((e) => e.content);
     assert.deepStrictEqual(contents, ['E', 'B'], 'batch should follow comparator order: E(pos=1) then B(no pos)');
   });
+
+  // ── F181: callerTraceContext propagation ──
+
+  it('F181: callerTraceContext flows through enqueue + dequeue', () => {
+    const ctx = { traceId: 'aabb', spanId: 'ccdd', traceFlags: 1 };
+    queue.enqueue(entry({ callerTraceContext: ctx }));
+    const d = queue.dequeue('t1', 'u1');
+    assert.deepEqual(d.callerTraceContext, ctx);
+  });
+
+  it('F181: entries without callerTraceContext have undefined', () => {
+    queue.enqueue(entry());
+    const d = queue.dequeue('t1', 'u1');
+    assert.equal(d.callerTraceContext, undefined);
+  });
 });


### PR DESCRIPTION
## Summary

PR A of the F181 split (trace propagation only, no Prompt X-Ray).

- Extract `CallerTraceContext` as shared type in `genai-semconv.ts` (W3C TraceContext aligned)
- Add `setTraceContext` as proper `IAuthInvocationBackend` method (Memory + Redis implementations)
- Propagate `callerTraceContext` through all 3 A2A paths: text-scan @mention (worklist), `post_message` callback, `InvocationQueue` callback
- Reconstruct remote parent context in `AgentRouter.routeExecution()` for cross-route span parenting
- Add `mention_dispatch` spans in route-serial for A2A handoff causality
- Emit route aggregate attributes (`total_cats_invoked`, `total_tokens`, `has_a2a_handoff`)
- Behavioral tests: backend contract suite (setTraceContext round-trip, TTL slide survival, peekRecord after expiry), queue callerTraceContext flow-through

## Files changed (15 files, +258 lines)

| Layer | Files | What |
|-------|-------|------|
| Shared type | `genai-semconv.ts` | `CallerTraceContext` interface + route aggregate constants |
| Backend | `IAuthInvocationBackend.ts`, `MemoryAuthInvocationBackend.ts`, `RedisAuthInvocationBackend.ts` | `setTraceContext` method |
| Registry | `InvocationRegistry.ts` | Facade delegation + `traceContext` field on `InvocationRecord` |
| Invocation | `invoke-single-cat.ts` | Store span context after invocation start via `invocationSpanRef` |
| Queue | `InvocationQueue.ts`, `QueueProcessor.ts` | `callerTraceContext` field on `QueueEntry`, pass-through |
| Routes | `callback-a2a-trigger.ts`, `callbacks.ts` | Thread `callerTraceContext` from invocation record |
| Router | `AgentRouter.ts` | Remote parent context reconstruction |
| Routing | `route-serial.ts`, `route-parallel.ts` | Span tracking, mention_dispatch, route aggregates |
| Tests | `auth-invocation-backend-contract.test.js`, `invocation-queue.test.js` | Behavioral coverage |

## Reviewer findings addressed (from PR #619 codex review)

- [x] #1: Shared type extraction (`CallerTraceContext` in genai-semconv)
- [x] #2: W3C TraceContext alignment (traceId/spanId/traceFlags)
- [x] #5: Redis-safe `setTraceContext` as backend interface method
- [x] #6: Behavioral tests (not source-string assertions)
- [x] PR split by concern (this is PR A; PR B = Prompt X-Ray)

Closes part of #583.

## Test plan

- [x] `auth-invocation-backend-contract.test.js` — 31 tests pass (memory + redis)
- [x] `invocation-queue.test.js` — 99 tests pass
- [x] `tsc --noEmit` clean (no new errors)
- [x] `biome check` clean (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)