### PR TITLE
fix(windows): replace StreamWriter with raw byte writes to avoid BOM …

### DIFF
--- a/packages/api/test/windows-portable-redis-url.test.js
+++ b/packages/api/test/windows-portable-redis-url.test.js
@@ -112,6 +112,12 @@ test('Windows RESP helpers use UTF-8 byte counts for bulk string lengths', () =>
   assert.doesNotMatch(helpersScript, /\$\(\$arg\.Length\)/);
 });
 
+test('Windows RESP probes write raw bytes instead of StreamWriter to avoid BOM corruption', () => {
+  assert.doesNotMatch(helpersScript, /\[System\.IO\.StreamWriter\]::new\(\$stream/);
+  assert.match(helpersScript, /\$utf8NoBom\.GetBytes\(/);
+  assert.match(helpersScript, /\$stream\.Write\(\$.*Bytes, 0, \$.*Bytes\.Length\)/);
+});
+
 test('Windows portable Redis defers REDIS_URL to runtime instead of hardcoding localhost:6379', () => {
   assert.match(uiHelpersScript, /function Apply-InstallerRedisPlan/);
   assert.match(uiHelpersScript, /Add-InstallerEnvDelete \$State "REDIS_URL"/);
@@ -161,7 +167,7 @@ test('Windows installer prefers plain portable Redis zips before service bundles
 
 test('Windows Redis URL handling validates connectivity with RESP and detects external backends for shutdown skip', () => {
   assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$configuredRedisUrl/);
-  assert.match(helpersScript, /Format-RedisRespCommand -Args @\("PING"\)/);
+  assert.match(helpersScript, /Format-RedisRespCommand -CommandArgs @\("PING"\)/);
   assert.match(startWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
   assert.match(stopWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
   assert.match(

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -260,10 +260,10 @@ function Get-RedisAuthArgs {
 }
 
 function Format-RedisRespCommand {
-    param([string[]]$Args)
+    param([string[]]$CommandArgs)
 
-    $parts = "*$($Args.Count)`r`n"
-    foreach ($arg in $Args) {
+    $parts = "*$($CommandArgs.Count)`r`n"
+    foreach ($arg in $CommandArgs) {
         $byteLength = [System.Text.Encoding]::UTF8.GetByteCount($arg)
         $parts += "`$$byteLength`r`n$arg`r`n"
     }
@@ -301,8 +301,7 @@ function Test-RedisReachable {
         $stream = $client.GetStream()
         $stream.ReadTimeout = $TimeoutMs
         $stream.WriteTimeout = $TimeoutMs
-        $writer = [System.IO.StreamWriter]::new($stream, [System.Text.Encoding]::UTF8)
-        $writer.AutoFlush = $true
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
         $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
 
         # AUTH if credentials embedded in URL
@@ -312,13 +311,14 @@ function Test-RedisReachable {
             $password = if ($parts.Count -ge 2) { [System.Uri]::UnescapeDataString($parts[1]) } else { "" }
 
             if ($parts.Count -ge 2 -and $username) {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username, $password)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $username, $password)
             } elseif ($username) {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $username)
             } else {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $password)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $password)
             }
-            $writer.Write($authCmd)
+            $authBytes = $utf8NoBom.GetBytes($authCmd)
+            $stream.Write($authBytes, 0, $authBytes.Length)
             $authLine = $reader.ReadLine()
             if ($authLine -notmatch '^\+OK') {
                 return $false
@@ -326,10 +326,16 @@ function Test-RedisReachable {
         }
 
         # PING
-        $writer.Write((Format-RedisRespCommand -Args @("PING")))
+        $pingBytes = $utf8NoBom.GetBytes((Format-RedisRespCommand -CommandArgs @("PING")))
+        $stream.Write($pingBytes, 0, $pingBytes.Length)
         $pingLine = $reader.ReadLine()
-        return $pingLine -eq '+PONG'
+        if ($pingLine -eq '+PONG') {
+            return $true
+        }
+        Write-Warn "Redis 'PING' received: $pingLine"
+        return $false
     } catch {
+        Write-Warn $_
         return $false
     } finally {
         if ($client) { $client.Dispose() }
@@ -366,8 +372,7 @@ function Send-RedisShutdown {
         $stream = $client.GetStream()
         $stream.ReadTimeout = $TimeoutMs
         $stream.WriteTimeout = $TimeoutMs
-        $writer = [System.IO.StreamWriter]::new($stream, [System.Text.Encoding]::UTF8)
-        $writer.AutoFlush = $true
+        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
         $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
 
         # AUTH if needed
@@ -377,13 +382,14 @@ function Send-RedisShutdown {
             $password = if ($parts.Count -ge 2) { [System.Uri]::UnescapeDataString($parts[1]) } else { "" }
 
             if ($parts.Count -ge 2 -and $username) {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username, $password)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $username, $password)
             } elseif ($username) {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $username)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $username)
             } else {
-                $authCmd = Format-RedisRespCommand -Args @("AUTH", $password)
+                $authCmd = Format-RedisRespCommand -CommandArgs @("AUTH", $password)
             }
-            $writer.Write($authCmd)
+            $authBytes = $utf8NoBom.GetBytes($authCmd)
+            $stream.Write($authBytes, 0, $authBytes.Length)
             $authLine = $reader.ReadLine()
             if ($authLine -notmatch '^\+OK') {
                 return $false
@@ -391,10 +397,12 @@ function Send-RedisShutdown {
         }
 
         # SHUTDOWN SAVE
-        $writer.Write((Format-RedisRespCommand -Args @("SHUTDOWN", "SAVE")))
+        $shutdownBytes = $utf8NoBom.GetBytes((Format-RedisRespCommand -CommandArgs @("SHUTDOWN", "SAVE")))
+        $stream.Write($shutdownBytes, 0, $shutdownBytes.Length)
         $reader.ReadLine() | Out-Null
         return $true
     } catch {
+        Write-Warn $_
         return $false
     } finally {
         if ($client) { $client.Dispose() }


### PR DESCRIPTION
…corruption

StreamWriter emits UTF-8 BOM (EF BB BF) preamble into the NetworkStream on first flush when using Encoding.UTF8 on .NET Framework. This corrupts RESP commands sent by Test-RedisReachable and Send-RedisShutdown, causing Redis to respond with "ERR unknown command *0".

Fix: bypass StreamWriter entirely and write raw bytes via Encoding.GetBytes() + Stream.Write(). Also rename Format-RedisRespCommand parameter from $Args to $CommandArgs to avoid shadowing the PowerShell automatic variable.

Fixes #647

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

[宪宪/deepseek-v4-pro🐾]

## PR Type

<!-- Check one -->
- [x] 🐛 **Patch** — Bug fix, typo, test gap (no Feature Doc needed)
- [ ] ✨ **Feature** — New capability or behavior change (requires Feature Doc)
- [ ] 📋 **Protocol** — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

<!-- Link the GitHub Issue. Use "Closes #XX" for auto-close, or "Refs #XX" for reference. -->

Fixes #647

## Feature Doc (Feature PRs only)

<!-- Link to the Feature Doc. Maintainers assign F-numbers — see CONTRIBUTING.md. -->
<!-- Example: docs/features/F115-multi-platform-deploy.md -->

## What

<!-- What did you change? List key files and modifications. -->

## Why

<!-- Why this change? Constraints, risks, goals. -->

## Tradeoff

<!-- What alternatives were considered? Why not those? -->

## Test Evidence

<!-- How was this tested? Paste relevant output. -->

```
pnpm check                                    # result
pnpm lint                                     # result
pnpm --filter @cat-cafe/api run test:public   # result
```

## AC Checklist (Feature PRs only)

<!-- Copy Acceptance Criteria from the Feature Doc and check off completed items. -->
<!-- - [x] AC 1: description (evidence: test / screenshot) -->
<!-- - [ ] AC 2: description (Phase 2 scope) -->