### PR TITLE
sync(F088-K2/K3): Telegram inline streaming + robustness

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -1299,7 +1299,7 @@ export class QueueProcessor {
         Promise.allSettled(inflightDeliverPromises).then((results) => {
           if (results.every((r) => r.status === 'fulfilled')) {
             cleanupFn(threadId, invocationId).catch((err) => {
-              log.warn({ err, threadId }, '[QueueProcessor] Late-success placeholder cleanup failed');
+              log.warn({ err, threadId }, '[QueueProcessor] Placeholder cleanup failed after late-success delivery');
             });
           }
         });

--- a/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
+++ b/packages/api/src/infrastructure/connectors/adapters/TelegramAdapter.ts
@@ -19,6 +19,62 @@ const TELEGRAM_MAX_MESSAGE_LENGTH = 4096;
 const TELEGRAM_POLLING_BACKOFF_MS = [5_000, 15_000, 30_000, 60_000] as const;
 const TELEGRAM_MAX_CONFLICT_RETRIES = 10;
 
+function splitText(text: string): string[] {
+  if (text.length <= TELEGRAM_MAX_MESSAGE_LENGTH) return [text];
+  const parts: string[] = [];
+  let start = 0;
+  while (start < text.length) {
+    let end = Math.min(start + TELEGRAM_MAX_MESSAGE_LENGTH, text.length);
+    // Back up one code unit if we'd split a surrogate pair (high surrogate at boundary).
+    if (end < text.length) {
+      const charCode = text.charCodeAt(end - 1);
+      if (charCode >= 0xd800 && charCode <= 0xdbff) end--;
+    }
+    parts.push(text.slice(start, end));
+    start = end;
+  }
+  return parts;
+}
+
+function splitHtml(html: string): string[] {
+  if (html.length <= TELEGRAM_MAX_MESSAGE_LENGTH) return [html];
+  const parts: string[] = [];
+  let start = 0;
+  while (start < html.length) {
+    let end = Math.min(start + TELEGRAM_MAX_MESSAGE_LENGTH, html.length);
+    if (end < html.length) {
+      // Don't split a surrogate pair
+      if ((html.charCodeAt(end - 1) & 0xfc00) === 0xd800) end--;
+      // Don't split inside an HTML entity (&amp; &lt; &gt;)
+      const entityStart = html.lastIndexOf('&', end - 1);
+      if (entityStart >= start) {
+        const entityEnd = html.indexOf(';', entityStart);
+        if (entityEnd === -1 || entityEnd >= end) end = entityStart;
+      }
+      // Don't split inside a tag
+      if (end > start) {
+        const tagStart = html.lastIndexOf('<', end - 1);
+        if (tagStart >= start) {
+          const tagEnd = html.indexOf('>', tagStart);
+          if (tagEnd === -1 || tagEnd >= end) end = tagStart;
+        }
+      }
+      if (end <= start) end = start + 1;
+    }
+    parts.push(html.slice(start, end));
+    start = end;
+  }
+  return parts;
+}
+
+function isTelegramHtmlParseError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { error_code?: unknown; description?: string; message?: string };
+  if (e.error_code !== 400) return false;
+  const desc = (e.description ?? e.message ?? '').toLowerCase();
+  return desc.includes('parse entities') || desc.includes('button_data_invalid');
+}
+
 type TelegramStartOptions = Parameters<Bot['start']>[0];
 
 interface TelegramPollingControls {
@@ -59,6 +115,7 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
   private sendMessageFn: ((chatId: string, text: string, opts?: Record<string, unknown>) => Promise<unknown>) | null =
     null;
   private readonly placeholderChats = new Map<string, string>();
+  private readonly pendingInlineFinal = new Map<string, string[]>();
   private botApiSendMessageFn: ((chatId: number, text: string) => Promise<{ message_id: number }>) | null = null;
   private botApiDeleteMessageFn: ((chatId: number, messageId: number) => Promise<void>) | null = null;
   private sendMediaFns: {
@@ -162,18 +219,56 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
 
   /**
    * Send a reply to a Telegram chat.
-   * Truncates messages exceeding Telegram's 4096 char limit.
+   * K2: If a pending inline placeholder exists, edits it in-place (consumed on first use).
+   *     If editMessage fails (message deleted etc.), falls back to sending a new message.
+   * K3: Splits content exceeding 4096 chars into multiple messages.
    */
   async sendReply(externalChatId: string, content: string): Promise<void> {
-    const text =
-      content.length > TELEGRAM_MAX_MESSAGE_LENGTH ? `${content.slice(0, TELEGRAM_MAX_MESSAGE_LENGTH - 1)}…` : content;
-
-    if (this.sendMessageFn) {
-      await this.sendMessageFn(externalChatId, text);
+    const queue = this.pendingInlineFinal.get(externalChatId);
+    // Consume (shift) before the async editMessage call so two concurrent deliveries
+    // for the same chatId cannot both select the same placeholder ID.
+    const inlineMsgId = queue?.shift();
+    if (queue !== undefined && queue.length === 0) this.pendingInlineFinal.delete(externalChatId);
+    if (inlineMsgId !== undefined) {
+      const [firstPart, ...restParts] = splitText(content);
+      let editSucceeded = false;
+      try {
+        await this.editMessage(externalChatId, inlineMsgId, firstPart);
+        editSucceeded = true;
+        this.placeholderChats.delete(inlineMsgId);
+      } catch (err) {
+        this.log.warn({ err }, '[TelegramAdapter] sendReply: editMessage failed, falling back to send');
+        // ID already consumed from queue; delete the stale streaming card before sending.
+        await this.deleteMessage(inlineMsgId, externalChatId).catch(() => {});
+      }
+      if (editSucceeded) {
+        // ID already consumed above — send any remaining split parts.
+        for (const part of restParts) {
+          if (this.sendMessageFn) {
+            await this.sendMessageFn(externalChatId, part);
+          } else {
+            await this.bot.api.sendMessage(externalChatId, part);
+          }
+        }
+        return;
+      }
+      for (const segment of splitText(content)) {
+        if (this.sendMessageFn) {
+          await this.sendMessageFn(externalChatId, segment);
+        } else {
+          await this.bot.api.sendMessage(externalChatId, segment);
+        }
+      }
       return;
     }
 
-    await this.bot.api.sendMessage(externalChatId, text);
+    for (const segment of splitText(content)) {
+      if (this.sendMessageFn) {
+        await this.sendMessageFn(externalChatId, segment);
+      } else {
+        await this.bot.api.sendMessage(externalChatId, segment);
+      }
+    }
   }
 
   /**
@@ -276,6 +371,10 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
 
   /**
    * Send a rich message as Telegram HTML-formatted text.
+   * K2: If a pending inline placeholder exists, edits it in-place.
+   *     Falls back to plain text edit if HTML parse fails.
+   *     Falls back to sending a new message if editMessage fails entirely.
+   * K3: HTML parse error falls back to plain text; long plain text is split.
    */
   async sendRichMessage(
     externalChatId: string,
@@ -285,12 +384,195 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
   ): Promise<void> {
     const html = formatTelegramHtml(blocks, catDisplayName, textContent);
 
-    if (this.sendMessageFn) {
-      await this.sendMessageFn(externalChatId, html, { parse_mode: 'HTML' });
+    const richQueue = this.pendingInlineFinal.get(externalChatId);
+    // Consume (shift) before the async editMessage call to prevent concurrent deliveries
+    // from selecting the same placeholder ID.
+    const inlineMsgId = richQueue?.shift();
+    if (richQueue !== undefined && richQueue.length === 0) this.pendingInlineFinal.delete(externalChatId);
+    if (inlineMsgId !== undefined) {
+      const [firstHtmlPart, ...restHtmlParts] = splitHtml(html);
+      let richEditSucceeded = false;
+      try {
+        await this.editMessage(externalChatId, inlineMsgId, firstHtmlPart!, { parse_mode: 'HTML' });
+        richEditSucceeded = true;
+        this.placeholderChats.delete(inlineMsgId);
+      } catch (err) {
+        this.log.warn({ err }, '[TelegramAdapter] sendRichMessage: editMessage failed, falling back to send');
+        // ID already consumed; delete the stale streaming card before sending.
+        await this.deleteMessage(inlineMsgId, externalChatId).catch(() => {});
+      }
+      if (richEditSucceeded) {
+        // ID already consumed above — send any overflow segments as new messages.
+        // K3 cloud-R11 P1: apply the same HTML-parse-error fallback as the non-inline path.
+        let overflowUseHtml = true;
+        for (const part of restHtmlParts) {
+          if (!overflowUseHtml) {
+            const stripped = part
+              .replace(/<[^>]+>/g, '')
+              .replace(/&amp;/g, '&')
+              .replace(/&lt;/g, '<')
+              .replace(/&gt;/g, '>')
+              .trim();
+            if (this.sendMessageFn) {
+              await this.sendMessageFn(externalChatId, stripped || part);
+            } else {
+              await this.bot.api.sendMessage(externalChatId, stripped || part);
+            }
+            continue;
+          }
+          try {
+            if (this.sendMessageFn) {
+              await this.sendMessageFn(externalChatId, part, { parse_mode: 'HTML' });
+            } else {
+              await this.bot.api.sendMessage(externalChatId, part, { parse_mode: 'HTML' } as Record<string, unknown>);
+            }
+          } catch (htmlErr) {
+            if (!isTelegramHtmlParseError(htmlErr)) throw htmlErr;
+            overflowUseHtml = false;
+            const stripped = part
+              .replace(/<[^>]+>/g, '')
+              .replace(/&amp;/g, '&')
+              .replace(/&lt;/g, '<')
+              .replace(/&gt;/g, '>')
+              .trim();
+            if (this.sendMessageFn) {
+              await this.sendMessageFn(externalChatId, stripped || part);
+            } else {
+              await this.bot.api.sendMessage(externalChatId, stripped || part);
+            }
+          }
+        }
+        return;
+      }
+      // Fallback: split long HTML across multiple messages.
+      // Mid-stream HTML parse error: switch to plain-text for the failing chunk and all remaining.
+      let inlineSentCount = 0;
+      let inlineUseHtml = true;
+      for (const part of splitHtml(html)) {
+        if (!inlineUseHtml) {
+          const stripped = part
+            .replace(/<[^>]+>/g, '')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .trim();
+          if (this.sendMessageFn) {
+            await this.sendMessageFn(externalChatId, stripped || part);
+          } else {
+            await this.bot.api.sendMessage(externalChatId, stripped || part);
+          }
+          continue;
+        }
+        try {
+          if (this.sendMessageFn) {
+            await this.sendMessageFn(externalChatId, part, { parse_mode: 'HTML' });
+          } else {
+            await this.bot.api.sendMessage(externalChatId, part, { parse_mode: 'HTML' } as Record<string, unknown>);
+          }
+          inlineSentCount++;
+        } catch (htmlErr) {
+          if (!isTelegramHtmlParseError(htmlErr)) throw htmlErr;
+          if (inlineSentCount === 0) {
+            this.log.warn(
+              { err: htmlErr },
+              '[TelegramAdapter] sendRichMessage: HTML parse error, falling back to plain text',
+            );
+            const strippedHtml = html
+              .replace(/<[^>]+>/g, '')
+              .replace(/&amp;/g, '&')
+              .replace(/&lt;/g, '<')
+              .replace(/&gt;/g, '>')
+              .trim();
+            const plainFallback = strippedHtml || textContent;
+            for (const segment of splitText(plainFallback)) {
+              if (this.sendMessageFn) {
+                await this.sendMessageFn(externalChatId, segment);
+              } else {
+                await this.bot.api.sendMessage(externalChatId, segment);
+              }
+            }
+            return;
+          }
+          inlineUseHtml = false;
+          const stripped = part
+            .replace(/<[^>]+>/g, '')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .trim();
+          if (this.sendMessageFn) {
+            await this.sendMessageFn(externalChatId, stripped || part);
+          } else {
+            await this.bot.api.sendMessage(externalChatId, stripped || part);
+          }
+        }
+      }
       return;
     }
 
-    await this.bot.api.sendMessage(externalChatId, html, { parse_mode: 'HTML' });
+    // Non-inline send path: split long HTML across multiple messages.
+    // Mid-stream HTML parse error: switch to plain-text for the failing chunk and all remaining.
+    let sentCount = 0;
+    let useHtml = true;
+    for (const part of splitHtml(html)) {
+      if (!useHtml) {
+        const stripped = part
+          .replace(/<[^>]+>/g, '')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .trim();
+        if (this.sendMessageFn) {
+          await this.sendMessageFn(externalChatId, stripped || part);
+        } else {
+          await this.bot.api.sendMessage(externalChatId, stripped || part);
+        }
+        continue;
+      }
+      try {
+        if (this.sendMessageFn) {
+          await this.sendMessageFn(externalChatId, part, { parse_mode: 'HTML' });
+        } else {
+          await this.bot.api.sendMessage(externalChatId, part, { parse_mode: 'HTML' } as Record<string, unknown>);
+        }
+        sentCount++;
+      } catch (htmlErr) {
+        if (!isTelegramHtmlParseError(htmlErr)) throw htmlErr;
+        if (sentCount === 0) {
+          this.log.warn(
+            { err: htmlErr },
+            '[TelegramAdapter] sendRichMessage: HTML parse error, falling back to plain text',
+          );
+          const strippedHtml = html
+            .replace(/<[^>]+>/g, '')
+            .replace(/&amp;/g, '&')
+            .replace(/&lt;/g, '<')
+            .replace(/&gt;/g, '>')
+            .trim();
+          const plainFallback = strippedHtml || textContent;
+          for (const segment of splitText(plainFallback)) {
+            if (this.sendMessageFn) {
+              await this.sendMessageFn(externalChatId, segment);
+            } else {
+              await this.bot.api.sendMessage(externalChatId, segment);
+            }
+          }
+          return;
+        }
+        useHtml = false;
+        const stripped = part
+          .replace(/<[^>]+>/g, '')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .trim();
+        if (this.sendMessageFn) {
+          await this.sendMessageFn(externalChatId, stripped || part);
+        } else {
+          await this.bot.api.sendMessage(externalChatId, stripped || part);
+        }
+      }
+    }
   }
 
   /**
@@ -328,13 +610,69 @@ export class TelegramAdapter implements IStreamableOutboundAdapter {
   }
 
   /**
-   * Edit an already-sent message in place (for streaming progressive updates).
+   * Edit an already-sent message in place (for streaming progressive updates and K2 inline final).
    * Truncates to Telegram's 4096-char limit.
+   * opts.parse_mode: pass 'HTML' when editing with rich HTML content (K2 sendRichMessage inline).
    */
-  async editMessage(externalChatId: string, platformMessageId: string, text: string): Promise<void> {
+  async editMessage(
+    externalChatId: string,
+    platformMessageId: string,
+    text: string,
+    opts?: { parse_mode?: string },
+  ): Promise<void> {
     const truncated =
       text.length > TELEGRAM_MAX_MESSAGE_LENGTH ? `${text.slice(0, TELEGRAM_MAX_MESSAGE_LENGTH - 1)}…` : text;
-    await this.bot.api.editMessageText(Number(externalChatId), Number(platformMessageId), truncated);
+    if (opts?.parse_mode) {
+      await this.bot.api.editMessageText(
+        Number(externalChatId),
+        Number(platformMessageId),
+        truncated,
+        opts as Record<string, unknown>,
+      );
+    } else {
+      await this.bot.api.editMessageText(Number(externalChatId), Number(platformMessageId), truncated);
+    }
+  }
+
+  /**
+   * K2: Register a pending inline-final placeholder.
+   * The next sendReply or sendRichMessage to this chatId will edit this placeholder
+   * instead of sending a new message. Consumed on first use.
+   */
+  registerInlinePlaceholder(externalChatId: string, platformMessageId: string): void {
+    const queue = this.pendingInlineFinal.get(externalChatId) ?? [];
+    queue.push(platformMessageId);
+    this.pendingInlineFinal.set(externalChatId, queue);
+  }
+
+  /**
+   * K2: Clear a registered inline-final placeholder without delivering content.
+   * Called when delivery is skipped so stale state doesn't corrupt the next delivery.
+   * Removes the specific platformMessageId from the FIFO queue (K3: queue per chatId).
+   * If the placeholder was already consumed by sendReply/sendRichMessage, this is a no-op.
+   * Deletes the streaming card from Telegram when entry was still pending (delivery skipped).
+   */
+  async clearInlinePlaceholder(chatId: string, platformMessageId?: string): Promise<void> {
+    if (platformMessageId) {
+      const queue = this.pendingInlineFinal.get(chatId);
+      if (queue) {
+        const idx = queue.indexOf(platformMessageId);
+        if (idx !== -1) {
+          // ID still pending: delivery was skipped — remove from queue and delete the streaming card.
+          queue.splice(idx, 1);
+          if (queue.length === 0) this.pendingInlineFinal.delete(chatId);
+          await this.deleteMessage(platformMessageId, chatId).catch(() => {});
+        } else {
+          // ID already consumed by delivery — just clean the tracking map to prevent unbounded growth.
+          this.placeholderChats.delete(platformMessageId);
+        }
+      } else {
+        // No queue at all — ID was consumed and queue was deleted — still clean tracking map.
+        this.placeholderChats.delete(platformMessageId);
+      }
+    } else {
+      this.pendingInlineFinal.delete(chatId);
+    }
   }
 
   /**

--- a/packages/api/src/infrastructure/connectors/adapters/telegram-html-formatter.ts
+++ b/packages/api/src/infrastructure/connectors/adapters/telegram-html-formatter.ts
@@ -1,7 +1,5 @@
 import type { RichBlock } from '@cat-cafe/shared';
 
-const TELEGRAM_MAX = 4096;
-
 function esc(s: string): string {
   return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
@@ -42,7 +40,5 @@ export function formatTelegramHtml(blocks: RichBlock[], catDisplayName: string, 
     parts.push(esc(textContent));
   }
   parts.push(blocks.map(blockToHtml).join('\n\n'));
-  const full = parts.join('\n\n');
-  if (full.length <= TELEGRAM_MAX) return full;
-  return `${full.slice(0, TELEGRAM_MAX - 1)}…`;
+  return parts.join('\n\n');
 }

--- a/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
+++ b/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
@@ -602,16 +602,15 @@ export class ConnectorInvokeTrigger {
               log.warn({ err, threadId }, '[ConnectorInvokeTrigger] StreamingHook.cleanupPlaceholders failed');
             });
           } else if (deliveryFailed && this.opts.streamingHook?.cleanupPlaceholders) {
-            // Cloud-R4-P2: schedule late-success cleanup — if timed-out deliveries
-            // eventually succeed, clean up placeholder cards so the user doesn't see
-            // a stale "thinking…" card alongside the real response.
             const cleanupHook = this.opts.streamingHook;
             const scopedInvocationId = createResult.invocationId;
             Promise.allSettled(inflightDeliverPromises).then((results) => {
-              const allSucceeded = results.every((r) => r.status === 'fulfilled');
-              if (allSucceeded) {
+              if (results.every((r) => r.status === 'fulfilled')) {
                 cleanupHook.cleanupPlaceholders(threadId, scopedInvocationId).catch((err) => {
-                  log.warn({ err, threadId }, '[ConnectorInvokeTrigger] Late-success placeholder cleanup failed');
+                  log.warn(
+                    { err, threadId },
+                    '[ConnectorInvokeTrigger] Placeholder cleanup failed after late-success delivery',
+                  );
                 });
               }
             });

--- a/packages/api/test/telegram-adapter.test.js
+++ b/packages/api/test/telegram-adapter.test.js
@@ -127,7 +127,7 @@ describe('TelegramAdapter', () => {
       assert.equal(sendCalls[0].text, 'Hello from cat!');
     });
 
-    it('truncates messages over 4096 chars', async () => {
+    it('splits messages over 4096 chars into multiple sends', async () => {
       const adapter = new TelegramAdapter('test-token', noopLog());
       const sendCalls = [];
       adapter._injectSendMessage(async (chatId, text, _opts) => {
@@ -136,9 +136,13 @@ describe('TelegramAdapter', () => {
 
       const longMsg = 'a'.repeat(5000);
       await adapter.sendReply('1001', longMsg);
-      assert.equal(sendCalls.length, 1);
-      assert.ok(sendCalls[0].text.length <= 4096);
-      assert.ok(sendCalls[0].text.endsWith('…'));
+      // K3: split instead of truncate — all content preserved
+      assert.ok(sendCalls.length >= 2);
+      const combined = sendCalls.map((c) => c.text).join('');
+      assert.equal(combined, longMsg);
+      for (const c of sendCalls) {
+        assert.ok(c.text.length <= 4096);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Syncs F088 K2 and K3 Telegram reliability fixes from cat-cafe (source of truth).

- **K2** — Inline final streaming: `registerInlinePlaceholder` + FIFO `pendingInlineFinal` queue; `sendReply`/`sendRichMessage` edit placeholder in-place instead of delete+resend
- **K3** — Robustness: `splitText` (surrogate-safe), `splitHtml` (entity/tag-aware), HTML parse error → plain text fallback, `editMessage` failure → `sendMessage` fallback, inline overflow chunk error handling

## Community acknowledgment

This supersedes draft PRs **#641** and **#642** — thank you to the contributors who identified the root cause of Telegram duplicate messages and rich delivery issues in clowder-ai#524. The fix was developed as source-owned changes in cat-cafe and is now synced here.

Closes #524

## Test plan

- 21/21 `telegram-adapter.test.js` tests pass
- Updated `truncates messages` test → `splits messages` (new split-not-truncate behavior)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)