### PR TITLE
fix(test): update formatter truncation assertion for K3 split behavior

### DIFF
--- a/packages/api/test/telegram-html-formatter.test.js
+++ b/packages/api/test/telegram-html-formatter.test.js
@@ -42,11 +42,13 @@ describe('formatTelegramHtml', () => {
     assert.ok(html.includes('&amp;'));
   });
 
-  it('respects Telegram 4096 char limit with truncation', () => {
+  it('preserves full content for long bodies (adapter handles splitting)', () => {
     const longBody = 'x'.repeat(5000);
     const blocks = [{ id: 'b1', kind: 'card', v: 1, title: 'Big', bodyMarkdown: longBody }];
     const html = formatTelegramHtml(blocks, '布偶猫');
-    assert.ok(html.length <= 4096);
+    // K3: formatter no longer truncates — adapter splitHtml handles chunking
+    assert.ok(html.includes('x'.repeat(100)));
+    assert.ok(html.length > 4096);
   });
 
   it('formats audio block with text', () => {


### PR DESCRIPTION
## Summary

Fixes the failing `Test (Public)` CI from PR #654.

K3 moved long-text handling out of `formatTelegramHtml` (which previously truncated at 4096) into the adapter layer (`splitHtml` in `TelegramAdapter.sendRichMessage`). The test was still asserting old truncation behavior.

**Change**: Update `respects Telegram 4096 char limit with truncation` → `preserves full content for long bodies (adapter handles splitting)` — verifies formatter passes through full content, not that it truncates.

No behavior change; test-only fix.