### PR TITLE
fix(wsl): secure /dev/tcp probe + Redis localhost normalization

### DIFF
--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -333,7 +333,7 @@ test('direct command mode can prefer current .env ports over ambient shell ports
   }
 });
 
-test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398', () => {
+test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398 (IPv4 normalization)', () => {
   const scriptPath = resolve(process.cwd(), '../../scripts/start-dev.sh');
   const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-start-dev-redis-dev-default-'));
   const tempScriptPath = join(tempRoot, 'scripts', 'start-dev.sh');
@@ -359,7 +359,7 @@ test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398', (
     );
 
     assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
-    assert.equal(result.stdout.trim(), '6398|redis://localhost:6398');
+    assert.equal(result.stdout.trim(), '6398|redis://127.0.0.1:6398');
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -140,7 +140,10 @@ probe_port_with_nc() {
 probe_port_with_dev_tcp() {
   local port="$1"
   # Bash-only: requires net redirections support (enabled in most mainstream builds).
-  (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || (exec 3<>"/dev/tcp/localhost/$port") >/dev/null 2>&1
+  # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
+  # Positional param avoids interpolating $port into bash -c command string.
+  timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+    || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_is_listening() {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -238,8 +238,8 @@ normalize_raw_dev_redis_defaults() {
 
     REDIS_PORT="6398"
     case "${REDIS_URL:-}" in
-        ""|"redis://localhost:6399"|"redis://127.0.0.1:6399")
-            REDIS_URL="redis://localhost:6398"
+        ""|"redis://127.0.0.1:6399"|"redis://localhost:6399")
+            REDIS_URL="redis://127.0.0.1:6398"
             ;;
     esac
 }
@@ -459,7 +459,10 @@ probe_port_with_nc() {
 probe_port_with_dev_tcp() {
     local port=$1
     # Bash-only: requires net redirections support (enabled in most mainstream builds).
-    (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || (exec 3<>"/dev/tcp/localhost/$port") >/dev/null 2>&1
+    # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
+    # Positional param avoids interpolating $port into bash -c command string.
+    timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+        || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_listen_pids() {


### PR DESCRIPTION
## What

- Reopen the WSL startup fix on a clean `upstream/main` base so the upstream PR contains only this change.
- Update `scripts/start-dev.sh` and `scripts/runtime-worktree.sh` to wrap `/dev/tcp` probes with `timeout 1` and pass the port via positional params.
- Normalize raw dev Redis defaults from `:6399` to `redis://127.0.0.1:6398`, including `.env` values that still use `redis://localhost:6399`.
- Keep the regression coverage in `packages/api/test/start-dev-script.test.js` aligned with the IPv4 normalization.

## Why

- Closed-port `/dev/tcp` probes can hang on WSL, so the shell fallback needs an explicit timeout.
- Redis startup had already moved toward IPv4-only localhost handling; the raw dev remap path needed to normalize `redis://localhost:6399` as well so startup stays consistent.
- The previous PR was opened against the fork repo `main`; upstream needs a clean PR based on `zts212653/clowder-ai:main`.

## Issue Closure

- None

## Original Requirements（必填）

- Discussion/Interview: *(internal reference removed)*
- **原始需求摘录（≤5 行，直接粘贴铲屎官原话）**：
  > 看下这个branch,让狸花猫创建下pr
  > pr提交到upstream啊,不是origin
- 铲屎官核心痛点：这个修复需要提交到 upstream，而不是只在 fork 上开 PR。
- **请 Reviewer 对照上面的摘录判断：交付物是否解决了铲屎官的问题？**

## Plan / ADR

- Plan: *(internal reference removed)*
- ADR: None
- BACKLOG: None

## Tradeoff

- Did not reuse `fix/wsl-startup-p1-followup` directly for upstream because that branch is based on the fork's newer `main` and would carry extra unrelated commits into upstream.
- Reopened the change as a clean single-commit branch from `upstream/main`, which required resolving one `scripts/start-dev.sh` cherry-pick conflict in favor of the IPv4 normalization behavior.

## Test Evidence

`node --test test/start-dev-script.test.js test/runtime-worktree-script.test.js test/review-start-script.test.js`  
48 passed, 0 failed

## Open Questions

- Non-blocking follow-up: `scripts/review-start.sh` still has the older `/dev/tcp` fallback without the new timeout/positional-param hardening.

---

**本地 Review**: [x] gpt52 已 review 并放行
**云端 Review**: [ ] PR 创建后在 **comment** 中触发（见模板）

<!-- 猫猫签名（纯文本，禁止 @）: Maine Coon/gpt-5.4 -->
