### PR TITLE
fix(wsl): secure /dev/tcp probe + Redis localhost normalization

### DIFF
--- a/packages/api/test/review-start-script.test.js
+++ b/packages/api/test/review-start-script.test.js
@@ -27,6 +27,7 @@ function createSandbox() {
 
   const binDir = join(root, 'bin');
   mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, 'bash'), '#!/bin/sh\nexec /bin/bash "$@"\n', { mode: 0o755 });
   writeFileSync(join(binDir, 'lsof'), '#!/bin/sh\nexit 127\n', { mode: 0o755 });
   writeFileSync(join(binDir, 'ss'), '#!/bin/sh\nexit 127\n', { mode: 0o755 });
   writeFileSync(
@@ -64,6 +65,32 @@ afterEach(async () => {
 });
 
 describe('review-start.sh', () => {
+  it('dev tcp probe falls back when timeout is unavailable', async () => {
+    const { root, binDir } = createSandbox();
+    const server = await listen(0);
+    const port = server.address().port;
+    const scriptPath = join(root, 'scripts', 'review-start.sh');
+
+    const result = spawnSync(
+      'bash',
+      [
+        '-lc',
+        `set -e
+source "${scriptPath}" --source-only
+PATH="${binDir}"
+probe_port_with_dev_tcp "${port}"
+printf 'ok'`,
+      ],
+      {
+        cwd: root,
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), 'ok');
+  });
+
   it('falls back when lsof is unavailable and skips occupied review ports', async () => {
     const { root, binDir } = createSandbox();
     const occupiedServer = await listen(0);

--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { execFileSync, spawn, spawnSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
-import { createConnection } from 'node:net';
+import { createConnection, createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
@@ -28,6 +28,24 @@ function createTempProject(name) {
     mode: 0o755,
   });
   return projectDir;
+}
+
+function createBashOnlyPath(projectDir) {
+  const binDir = join(projectDir, 'bash-only-bin');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, 'bash'), '#!/bin/sh\nexec /bin/bash "$@"\n', { mode: 0o755 });
+  return binDir;
+}
+
+function listenOnLoopback() {
+  const server = createServer();
+  return new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      tempProcs.push(server);
+      resolvePromise(server);
+    });
+  });
 }
 
 function createPnpmStub(projectDir) {
@@ -121,7 +139,11 @@ async function waitForLocalPort(port, attempts = 20) {
 afterEach(async () => {
   while (tempProcs.length > 0) {
     const proc = tempProcs.pop();
-    proc.kill('SIGKILL');
+    if (typeof proc.kill === 'function') {
+      proc.kill('SIGKILL');
+    } else {
+      await new Promise((resolve) => proc.close(resolve));
+    }
   }
   while (tempDirs.length > 0) {
     await rm(tempDirs.pop(), { recursive: true, force: true });
@@ -132,6 +154,32 @@ describe('runtime-worktree.sh', () => {
   it('keeps the runtime-worktree entrypoint executable in the repository', () => {
     const mode = statSync(runtimeScriptSource).mode & 0o111;
     assert.notEqual(mode, 0, 'runtime-worktree.sh should retain an executable bit');
+  });
+
+  it('dev tcp probe falls back when timeout is unavailable', async () => {
+    const projectDir = createTempProject('runtime-no-timeout');
+    const server = await listenOnLoopback();
+    const binDir = createBashOnlyPath(projectDir);
+    const port = server.address().port;
+
+    const result = spawnSync(
+      'bash',
+      [
+        '-lc',
+        `set -e
+source "${join(projectDir, 'scripts', 'runtime-worktree.sh')}" --source-only
+PATH="${binDir}"
+probe_port_with_dev_tcp "${port}"
+printf 'ok'`,
+      ],
+      {
+        cwd: projectDir,
+        encoding: 'utf8',
+      },
+    );
+
+    assert.equal(result.status, 0, `stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), 'ok');
   });
 
   it('starts in-place when project is not a git repository', () => {

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
 import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { test } from 'node:test';
@@ -26,6 +27,21 @@ function runSourceOnlySnippet(scriptPath, snippet, envOverrides = {}) {
   return result.stdout.trim();
 }
 
+function createBashOnlyPath(root) {
+  const binDir = join(root, 'bin');
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(join(binDir, 'bash'), '#!/bin/sh\nexec /bin/bash "$@"\n', { mode: 0o755 });
+  return binDir;
+}
+
+function listenOnLoopback() {
+  const server = createServer();
+  return new Promise((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolvePromise(server));
+  });
+}
+
 test('source-only exposes helper functions for testing seams', () => {
   const scriptPath = resolve(process.cwd(), '../../scripts/start-dev.sh');
   const output = runSourceOnlySnippet(
@@ -46,6 +62,30 @@ printf 'ok'
   );
 
   assert.equal(output, 'ok');
+});
+
+test('probe_port_with_dev_tcp falls back when timeout is unavailable', async () => {
+  const scriptPath = resolve(process.cwd(), '../../scripts/start-dev.sh');
+  const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-start-dev-no-timeout-'));
+  const server = await listenOnLoopback();
+
+  try {
+    const binDir = createBashOnlyPath(tempRoot);
+    const port = server.address().port;
+    const output = runSourceOnlySnippet(
+      scriptPath,
+      `
+PATH="${binDir}"
+probe_port_with_dev_tcp "${port}"
+printf 'ok'
+`,
+    );
+
+    assert.equal(output, 'ok');
+  } finally {
+    await new Promise((resolvePromise) => server.close(resolvePromise));
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });
 
 test('configure_mcp_server_path sets default path when env is unset', () => {

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -333,7 +333,7 @@ test('direct command mode can prefer current .env ports over ambient shell ports
   }
 });
 
-test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398', () => {
+test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398 (IPv4 normalization)', () => {
   const scriptPath = resolve(process.cwd(), '../../scripts/start-dev.sh');
   const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-start-dev-redis-dev-default-'));
   const tempScriptPath = join(tempRoot, 'scripts', 'start-dev.sh');
@@ -359,7 +359,7 @@ test('raw dev entry remaps setup-style Redis 6399 defaults to dev Redis 6398', (
     );
 
     assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
-    assert.equal(result.stdout.trim(), '6398|redis://localhost:6398');
+    assert.equal(result.stdout.trim(), '6398|redis://127.0.0.1:6398');
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/review-start.sh
+++ b/scripts/review-start.sh
@@ -55,7 +55,12 @@ probe_port_with_nc() {
 
 probe_port_with_dev_tcp() {
     local port="$1"
-    (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || (exec 3<>"/dev/tcp/localhost/$port") >/dev/null 2>&1
+    local timeout_cmd=""
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout 1"
+    fi
+    ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+        || ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_is_listening() {
@@ -145,6 +150,8 @@ pick_port_pair() {
     done
     return 1
 }
+
+[[ "${1:-}" == "--source-only" ]] && { return 0 2>/dev/null; exit 0; }
 
 for arg in "$@"; do
     case "$arg" in

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -464,6 +464,8 @@ start_runtime_worktree() {
   exec env CAT_CAFE_STRICT_PROFILE_DEFAULTS=1 ./scripts/start-dev.sh --prod-web --profile=opensource ${START_ARGS[@]+"${START_ARGS[@]}"}
 }
 
+[[ "${1:-}" == "--source-only" ]] && { return 0 2>/dev/null; exit 0; }
+
 COMMAND="${1:-status}"
 shift || true
 

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -139,11 +139,12 @@ probe_port_with_nc() {
 
 probe_port_with_dev_tcp() {
   local port="$1"
-  # Bash-only: requires net redirections support (enabled in most mainstream builds).
-  # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
-  # Positional param avoids interpolating $port into bash -c command string.
-  timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
-    || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
+  local timeout_cmd=""
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd="timeout 1"
+  fi
+  ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+    || ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_is_listening() {

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -140,7 +140,10 @@ probe_port_with_nc() {
 probe_port_with_dev_tcp() {
   local port="$1"
   # Bash-only: requires net redirections support (enabled in most mainstream builds).
-  (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || (exec 3<>"/dev/tcp/localhost/$port") >/dev/null 2>&1
+  # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
+  # Positional param avoids interpolating $port into bash -c command string.
+  timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+    || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_is_listening() {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -461,8 +461,13 @@ probe_port_with_dev_tcp() {
     # Bash-only: requires net redirections support (enabled in most mainstream builds).
     # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
     # Positional param avoids interpolating $port into bash -c command string.
-    timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
-        || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
+    # When timeout is unavailable (stock macOS, minimal images), fall back to bare /dev/tcp.
+    local timeout_cmd=""
+    if command -v timeout >/dev/null 2>&1; then
+        timeout_cmd="timeout 1"
+    fi
+    ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+        || ${timeout_cmd} bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_listen_pids() {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -238,8 +238,8 @@ normalize_raw_dev_redis_defaults() {
 
     REDIS_PORT="6398"
     case "${REDIS_URL:-}" in
-        ""|"redis://localhost:6399"|"redis://127.0.0.1:6399")
-            REDIS_URL="redis://localhost:6398"
+        ""|"redis://127.0.0.1:6399"|"redis://localhost:6399")
+            REDIS_URL="redis://127.0.0.1:6398"
             ;;
     esac
 }
@@ -459,7 +459,10 @@ probe_port_with_nc() {
 probe_port_with_dev_tcp() {
     local port=$1
     # Bash-only: requires net redirections support (enabled in most mainstream builds).
-    (exec 3<>"/dev/tcp/127.0.0.1/$port") >/dev/null 2>&1 || (exec 3<>"/dev/tcp/localhost/$port") >/dev/null 2>&1
+    # timeout prevents WSL hangs on closed ports (no built-in /dev/tcp timeout).
+    # Positional param avoids interpolating $port into bash -c command string.
+    timeout 1 bash -c 'exec 3<>/dev/tcp/127.0.0.1/$1' probe "$port" >/dev/null 2>&1 \
+        || timeout 1 bash -c 'exec 3<>/dev/tcp/localhost/$1' probe "$port" >/dev/null 2>&1
 }
 
 port_listen_pids() {


### PR DESCRIPTION
## Bug Issue

Closes zts212653/clowder-ai#661

## Summary

Fixes for WSL startup port-probe reliability and `timeout` binary availability:

### 1. Guarded `/dev/tcp` port probe (all startup scripts)
- `scripts/start-dev.sh`, `scripts/runtime-worktree.sh`, and `scripts/review-start.sh` now check `command -v timeout` before using it
- When `timeout` is available: uses `timeout 1` to prevent WSL hangs on closed ports
- When `timeout` is unavailable (stock macOS, minimal images): falls back to bare `/dev/tcp` probe
- Uses positional `$1` parameter to avoid interpolating port into `bash -c` command string

### 2. Redis localhost normalization (`scripts/start-dev.sh`)
- `normalize_raw_dev_redis_defaults()` normalizes both `redis://localhost:6399` and `redis://127.0.0.1:6399` to `redis://127.0.0.1:6398`

### 3. Regression coverage
- `start-dev-script.test.js`, `runtime-worktree-script.test.js`, and `review-start-script.test.js` cover the no-`timeout` fallback path
- `runtime-worktree.sh` and `review-start.sh` expose `--source-only` seams for script helper tests, matching existing `start-dev.sh` test style

## Files Changed
- `scripts/start-dev.sh` — guarded timeout in `/dev/tcp` probe + Redis URL normalization
- `scripts/runtime-worktree.sh` — guarded timeout in `/dev/tcp` probe + source-only test seam
- `scripts/review-start.sh` — guarded timeout in `/dev/tcp` probe + source-only test seam
- `packages/api/test/start-dev-script.test.js` — Redis expectation + no-`timeout` fallback test
- `packages/api/test/runtime-worktree-script.test.js` — no-`timeout` fallback test
- `packages/api/test/review-start-script.test.js` — no-`timeout` fallback test

## Test Results
```
node --test test/start-dev-script.test.js test/runtime-worktree-script.test.js test/review-start-script.test.js
✓ 51 tests passed, 0 failed
```

## Review
- Reviewed-by: 缅因猫/GPT-5.5
- Codex bot P2 (timeout guard) — fixed across startup scripts
- zts212653 review blockers — addressed
