### PR TITLE
fix(wsl): add nc/redis-cli timeouts to prevent WSL port probe hangs

### DIFF
--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -413,6 +413,8 @@ status_runtime_worktree() {
 }
 
 start_runtime_worktree() {
+  info "preparing runtime worktree (checking ports, syncing origin/main…)"
+
   if ! is_git_repo; then
     RUNTIME_DIR="$PROJECT_DIR"
     ensure_restart_authorized

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -134,7 +134,7 @@ probe_port_with_ss() {
 
 probe_port_with_nc() {
   local port="$1"
-  nc -z 127.0.0.1 "$port" >/dev/null 2>&1 || nc -z localhost "$port" >/dev/null 2>&1
+  timeout 1 nc -z 127.0.0.1 "$port" >/dev/null 2>&1 || timeout 1 nc -z localhost "$port" >/dev/null 2>&1
 }
 
 probe_port_with_dev_tcp() {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -988,7 +988,7 @@ archive_redis_snapshot() {
     local dir=""
     local dbfile=""
 
-    if redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
+    if timeout 2 redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
         redis-cli -p "$REDIS_PORT" bgsave &> /dev/null || true
         sleep 0.2
         dir=$(redis-cli -p "$REDIS_PORT" config get dir 2>/dev/null | sed -n '2p' || true)
@@ -1114,7 +1114,7 @@ setup_storage() {
     archive_redis_snapshot "pre-start"
 
     # 默认: 尝试 Redis 持久化 (专属端口，避免与系统 Redis 冲突)
-    if redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
+    if timeout 2 redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
         echo -e "${GREEN}  ✓ Redis 已运行 (端口 $REDIS_PORT)${NC}"
         export REDIS_URL="redis://localhost:$REDIS_PORT"
         print_redis_runtime_info
@@ -1138,7 +1138,7 @@ setup_storage() {
             --logfile "$REDIS_LOGFILE" \
             >/dev/null 2>&1 || true
         sleep 1
-        if redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
+        if timeout 2 redis-cli -p "$REDIS_PORT" ping &> /dev/null; then
             echo -e "${GREEN}  ✓ Redis 已启动 (端口 $REDIS_PORT)${NC}"
             export REDIS_URL="redis://localhost:$REDIS_PORT"
             STARTED_REDIS=true
@@ -1172,7 +1172,7 @@ cleanup() {
     terminate_managed_pids
 
     # 关闭我们启动的专属 Redis (不影响其他 Redis 实例)
-    if [ "$USE_REDIS" = true ] && [ "$STARTED_REDIS" = true ] && redis-cli -p "$REDIS_PORT" ping &> /dev/null 2>&1; then
+    if [ "$USE_REDIS" = true ] && [ "$STARTED_REDIS" = true ] && timeout 2 redis-cli -p "$REDIS_PORT" ping &> /dev/null 2>&1; then
         archive_redis_snapshot "pre-stop"
         redis-cli -p "$REDIS_PORT" shutdown save &> /dev/null || true
         echo "  Redis (端口 $REDIS_PORT) 已关闭"

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1186,7 +1186,9 @@ cleanup() {
     echo "再见！🐾"
 }
 
-trap cleanup EXIT INT TERM
+trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
 
 guard_main_branch_start() {
     if [ "${CAT_CAFE_ALLOW_MAIN_DEV:-0}" = "1" ]; then

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -453,7 +453,7 @@ probe_port_with_ss() {
 
 probe_port_with_nc() {
     local port=$1
-    nc -z 127.0.0.1 "$port" >/dev/null 2>&1 || nc -z localhost "$port" >/dev/null 2>&1
+    timeout 1 nc -z 127.0.0.1 "$port" >/dev/null 2>&1 || timeout 1 nc -z localhost "$port" >/dev/null 2>&1
 }
 
 probe_port_with_dev_tcp() {


### PR DESCRIPTION
## Summary

- Add `timeout 1` to `nc` port probe commands in startup scripts to prevent indefinite hangs in WSL environments
- Add `timeout 2` to `redis-cli ping` probes for the same reason
- Restore startup print message and clean `Ctrl+C` exit behavior

## Background

In WSL2, `nc` (netcat) and `redis-cli ping` can hang indefinitely when the target port is unreachable or the network stack is slow to respond. This caused startup scripts to stall with no output, making it appear the service had frozen.

## Changes

- `scripts/start-dev.sh` — `nc` probes now use `timeout 1 nc ...`; `redis-cli ping` uses `timeout 2 redis-cli ...`
- `scripts/runtime-worktree.sh` — same nc timeout fix
- Startup print and `Ctrl+C` handler restored

## Test plan

- [ ] Start dev environment in WSL2 — should not hang at port probe step
- [ ] Confirm `Ctrl+C` exits cleanly with expected message
- [ ] Confirm startup banner prints as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: 宪宪/claude-sonnet-4-6 🐾 <noreply@anthropic.com>