### PR TITLE
fix(windows): rename $Args to $CommandArgs in Redis RESP probe (#672)

### DIFF
--- a/packages/api/test/windows-portable-redis-url.test.js
+++ b/packages/api/test/windows-portable-redis-url.test.js
@@ -165,7 +165,7 @@ test('Windows installer prefers plain portable Redis zips before service bundles
 
 test('Windows Redis URL handling validates connectivity with RESP and detects external backends for shutdown skip', () => {
   assert.match(startWindowsScript, /Test-RedisReachable -RedisUrl \$configuredRedisUrl/);
-  assert.match(helpersScript, /Format-RedisRespCommand -Args @\("PING"\)/);
+  assert.match(helpersScript, /Format-RedisRespCommand -CommandArgs @\("PING"\)/);
   assert.match(startWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
   assert.match(stopWindowsScript, /Test-LocalRedisUrl -RedisUrl \$configuredRedisUrl -RedisPort \$RedisPort/);
   assert.match(

--- a/scripts/install-windows-helpers.ps1
+++ b/scripts/install-windows-helpers.ps1
@@ -260,10 +260,10 @@ function Get-RedisAuthArgs {
 }
 
 function Format-RedisRespCommand {
-    param([string[]]$Args)
+    param([string[]]$CommandArgs)
 
-    $parts = "*$($Args.Count)`r`n"
-    foreach ($arg in $Args) {
+    $parts = "*$($CommandArgs.Count)`r`n"
+    foreach ($arg in $CommandArgs) {
         $byteLength = [System.Text.Encoding]::UTF8.GetByteCount($arg)
         $parts += "`$$byteLength`r`n$arg`r`n"
     }
@@ -293,11 +293,11 @@ function Get-RedisAuthRespCommand {
     $password = if ($parts.Count -ge 2) { [System.Uri]::UnescapeDataString($parts[1]) } else { "" }
 
     if ($parts.Count -ge 2 -and $username) {
-        return Format-RedisRespCommand -Args @("AUTH", $username, $password)
+        return Format-RedisRespCommand -CommandArgs @("AUTH", $username, $password)
     } elseif ($username) {
-        return Format-RedisRespCommand -Args @("AUTH", $username)
+        return Format-RedisRespCommand -CommandArgs @("AUTH", $username)
     }
-    return Format-RedisRespCommand -Args @("AUTH", $password)
+    return Format-RedisRespCommand -CommandArgs @("AUTH", $password)
 }
 
 # Pure-PowerShell Redis connectivity check via TCP + RESP PING/PONG.
@@ -344,7 +344,7 @@ function Test-RedisReachable {
         }
 
         # PING
-        Write-RedisRespCommand -Stream $stream -Command (Format-RedisRespCommand -Args @("PING"))
+        Write-RedisRespCommand -Stream $stream -Command (Format-RedisRespCommand -CommandArgs @("PING"))
         $pingLine = $reader.ReadLine()
         return $pingLine -eq '+PONG'
     } catch {
@@ -397,7 +397,7 @@ function Send-RedisShutdown {
         }
 
         # SHUTDOWN SAVE
-        Write-RedisRespCommand -Stream $stream -Command (Format-RedisRespCommand -Args @("SHUTDOWN", "SAVE"))
+        Write-RedisRespCommand -Stream $stream -Command (Format-RedisRespCommand -CommandArgs @("SHUTDOWN", "SAVE"))
         $reader.ReadLine() | Out-Null
         return $true
     } catch {


### PR DESCRIPTION
## Summary

- `Format-RedisRespCommand` used `$Args` as parameter name, which collides with PowerShell's automatic variable `$args`
- Inside the function, `$Args.Count` always returns 0 → RESP commands are empty → Redis PING never sent → probe always returns false → startup falls back to memory mode
- Renamed to `$CommandArgs` across declaration + 5 call sites; updated test assertion

## Root cause chain

1. **PR #621** (`dd790036`) introduced `Format-RedisRespCommand` with `$Args` parameter — bug introduction point
2. **Issue #647** reported BOM corruption (StreamWriter emitting UTF-8 BOM into NetworkStream)
3. **PR #649** (`ebd0736a`) fixed both: BOM → raw bytes + `$Args` → `$CommandArgs`
4. **Sync `ddaca354`** (by Lysander Su, syncing cat-cafe snapshot `a04a9b67`) overwrote `install-windows-helpers.ps1`, reverting the `$CommandArgs` rename. BOM fix survived through a different code path (`Write-RedisRespCommand` helper), but `$Args` collision was re-introduced
5. Upstream cat-cafe repo never had the `$CommandArgs` fix, so any sync will revert it unless upstream is also patched

## What this PR does

Renames `$Args` → `$CommandArgs` in `Format-RedisRespCommand` (1 declaration + 5 call sites). This is the only remaining regression from the sync — BOM writes are already handled by `Write-RedisRespCommand`.

## Confirmed by Windows user diagnostic

```
PS> $result = Format-RedisRespCommand -Args @("PING")
PS> [BitConverter]::ToString([UTF8].GetBytes($result))
2A-30-0D-0A    ← *0\r\n (empty array, PING never sent)
```

Expected: `2A-31-0D-0A-24-34-0D-0A-50-49-4E-47-0D-0A` (14 bytes)

## Test plan

- [x] `node --test packages/api/test/windows-portable-redis-url.test.js` — 21/21 pass
- [ ] Windows user verifies: dot-source helpers → `Test-RedisReachable` returns True
- [ ] Windows user verifies: `start-windows.ps1` detects running Redis correctly

## Note

Upstream cat-cafe needs the same fix to prevent future syncs from reverting it again.

Fixes #672

🤖 Generated with [Claude Code](https://claude.com/claude-code)