### PR TITLE
fix(gemini): per-turn context fill detection + handoff handle resilience

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1550,7 +1550,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
                       },
                       'Gemini auto-seal skipped: no per-turn lastTurnInputTokens; running on cumulative usage only',
                     );
-                    geminiContextFallback.add(1, { 'agent.id': catId, reason: 'no_per_turn_signal' });
+                    geminiContextFallback.add(1, { [AGENT_ID]: catId, [TRIGGER]: 'no_per_turn_signal' });
                   }
                   if (
                     !skipAutoSealForApproxApiKey &&

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1517,7 +1517,20 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
                   const isAnthropicApiKey = provider === 'anthropic' && profileMode === ANTHROPIC_PROFILE_MODE_API_KEY;
                   const skipAutoSealForApproxApiKey = isAnthropicApiKey && health.source === 'approx';
                   const skipAutoSealForApiKeyCompress = isAnthropicApiKey && strategy.strategy === 'compress';
-                  if (!skipAutoSealForApproxApiKey && !skipAutoSealForApiKeyCompress) {
+                  // Gemini CLI's stream stats are session-level cumulative, not per-turn.
+                  // When usedFrom !== 'last_turn' for a google provider, fillRatio is
+                  // computed from cumulative inputTokens/totalTokens which inflate
+                  // beyond windowSize and cap at 1.0 → spurious auto-seal.
+                  // GeminiAgentService injects per-turn lastTurnInputTokens from local
+                  // jsonl when possible; if it could not (assistantText empty / no
+                  // matching local message / jsonl unavailable), skip auto-seal here
+                  // and keep context_health as observability only.
+                  const skipAutoSealForGeminiCumulative = provider === 'google' && usedFrom !== 'last_turn';
+                  if (
+                    !skipAutoSealForApproxApiKey &&
+                    !skipAutoSealForApiKeyCompress &&
+                    !skipAutoSealForGeminiCumulative
+                  ) {
                     const activeRecord = await deps.sessionChainStore.getActive(catId, threadId);
                     const action = shouldTakeAction(
                       health.fillRatio,

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1466,6 +1466,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
                 windowTokens: windowSize,
                 fillRatio: Math.min(usedTokens / windowSize, 1.0),
                 source,
+                usedFrom: usedFrom ?? undefined,
                 measuredAt: Date.now(),
               };
               // Update SessionRecord (best-effort): persist health + usage snapshot

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -40,6 +40,7 @@ import {
   activeInvocations,
   catInvocationCount,
   catResponseDuration,
+  geminiContextFallback,
   invocationCompleted,
   invocationDuration,
   llmCallDuration,
@@ -1526,6 +1527,31 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
                   // matching local message / jsonl unavailable), skip auto-seal here
                   // and keep context_health as observability only.
                   const skipAutoSealForGeminiCumulative = provider === 'google' && usedFrom !== 'last_turn';
+                  // Telemetry: when this guard kicks in, the cat is "blind-running"
+                  // past Gemini CLI's cumulative-only usage signal. Surface via
+                  // structured log + OTel counter so operators can see when
+                  // sessions are unguarded; do NOT emit a system_info event
+                  // because the frontend would render unknown system_info as a
+                  // visible system bubble.
+                  if (
+                    skipAutoSealForGeminiCumulative &&
+                    !skipAutoSealForApproxApiKey &&
+                    !skipAutoSealForApiKeyCompress
+                  ) {
+                    log.warn(
+                      {
+                        catId,
+                        threadId,
+                        invocationId,
+                        cumulativeUsedTokens: usedTokens,
+                        windowSize: windowSize ?? null,
+                        fillRatio: health.fillRatio,
+                        usedFrom,
+                      },
+                      'Gemini auto-seal skipped: no per-turn lastTurnInputTokens; running on cumulative usage only',
+                    );
+                    geminiContextFallback.add(1, { 'agent.id': catId, reason: 'no_per_turn_signal' });
+                  }
                   if (
                     !skipAutoSealForApproxApiKey &&
                     !skipAutoSealForApiKeyCompress &&

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -70,7 +70,17 @@ interface GeminiStoredSession {
 }
 
 function normalizeGeminiContent(value: string | undefined): string {
-  return (value ?? '').replace(/\s+/g, ' ').trim();
+  // Strip ALL whitespace (not just fold). Gemini CLI can emit one logical turn
+  // as multiple `message/assistant` events; GeminiAgentService stitches them
+  // with `\n\n` into `fullAssistantText`. The jsonl, by contrast, stores the
+  // CLI's final reassembled content with NO extra separator. If the inter-
+  // event boundary lands mid-CJK / mid-digit / mid-path, folding to a single
+  // space leaves the two strings unequal (e.g. "调 用" vs "调用"). Removing
+  // all whitespace is safe because the only consumer (latest-matching-message
+  // lookup within ONE sessionId-bound jsonl) walks candidates in reverse —
+  // collisions across turns are resolved to the latest, which IS the turn we
+  // just yielded.
+  return (value ?? '').replace(/\s+/g, '');
 }
 
 function formatGeminiThoughts(thoughts: readonly GeminiStoredThought[]): string {

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -18,7 +18,7 @@
 
 import { spawn as nodeSpawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { closeSync, existsSync, openSync, readdirSync, readFileSync, readSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { type CatId, createCatId } from '@cat-cafe/shared';
@@ -34,10 +34,10 @@ import {
   spawnCli,
 } from '../../../../../utils/cli-spawn.js';
 import type { SpawnFn } from '../../../../../utils/cli-types.js';
+import { readJsonlTail } from '../../../../../utils/jsonl-tail-reader.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata, TokenUsage } from '../../types.js';
 import { appendLocalImagePathHints, collectImageAccessDirectories } from '../providers/image-cli-bridge.js';
 import { extractImagePaths } from '../providers/image-paths.js';
-import { readJsonlTail } from '../../../../../utils/jsonl-tail-reader.js';
 import { isKnownPostResponseCandidatesCrash, isResultErrorEvent, transformGeminiEvent } from './gemini-event-parser.js';
 
 const log = createModuleLogger('gemini-agent');
@@ -145,12 +145,66 @@ interface GeminiSessionFileLocation {
   readonly ext: '.json' | '.jsonl';
 }
 
+/** Max bytes scanned to extract the in-file sessionId header from a `.jsonl`. */
+const JSONL_HEADER_MAX_BYTES = 1024;
+
+/**
+ * Lightweight `.jsonl` header read: open fd, readSync up to 1 KiB, parse the
+ * first newline-terminated line as a JSON header `{ sessionId, ... }`.
+ *
+ * Critical: does NOT load the entire file. The previous implementation called
+ * `parseGeminiSessionFile` here, which `readFileSync`'d the whole multi-MB
+ * jsonl just to read its sessionId — defeating the reverse-tail optimization.
+ *
+ * Returns the header sessionId if present, or `undefined` (header missing,
+ * first line longer than 1 KiB, file unreadable, etc.) — the caller falls
+ * back to filename-prefix match.
+ */
+function readJsonlHeaderSessionId(filePath: string): string | undefined {
+  let fd: number;
+  try {
+    fd = openSync(filePath, 'r');
+  } catch {
+    return undefined;
+  }
+  try {
+    const buffer = Buffer.alloc(JSONL_HEADER_MAX_BYTES);
+    const n = readSync(fd, buffer, 0, JSONL_HEADER_MAX_BYTES, 0);
+    if (n === 0) return undefined;
+    const text = buffer.toString('utf8', 0, n);
+    const newlineIdx = text.indexOf('\n');
+    // First line must fit in JSONL_HEADER_MAX_BYTES; otherwise treat as missing.
+    if (newlineIdx === -1) return undefined;
+    const firstLine = text.substring(0, newlineIdx);
+    try {
+      const parsed = JSON.parse(firstLine) as { sessionId?: unknown; type?: unknown };
+      // A header row has sessionId and no message-style `type` field.
+      if (typeof parsed.sessionId === 'string' && typeof parsed.type === 'undefined') {
+        return parsed.sessionId;
+      }
+    } catch {
+      // First line not JSON-parseable — treat as missing header.
+    }
+    return undefined;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
 /**
  * Locate Gemini's local session file for `sessionId`. Returns the file path +
  * extension, or `undefined` if no matching file is found.
  *
- * sessionId resolution priority: in-file header > filename prefix (fallback
- * for `.jsonl` when header is missing or unreadable).
+ * sessionId resolution priority for `.jsonl`:
+ *   1. lightweight header read (1 KiB) — preferred
+ *   2. filename prefix (first 8 chars of sessionId) — fallback when header missing
+ *
+ * For `.json` legacy files we still parse the whole document to read its
+ * `sessionId`; these files are small single-document JSON.
  *
  * Searches `~/.gemini/tmp/<projectDir>/chats/session-*.{json,jsonl}` —
  * preferring the project dir whose basename matches `workingDirectory`.
@@ -189,31 +243,20 @@ function findGeminiSessionFile(
       .sort((a, b) => b.mtimeMs - a.mtimeMs);
 
     for (const file of sessionFiles) {
-      const parsed = parseGeminiSessionFile(file.path, file.ext);
-      // Prefer in-file sessionId header. For .jsonl files where the header
-      // is missing/unreadable, accept filename-prefix match as a fallback.
-      const headerMatch = parsed.sessionId === sessionId;
-      const filenameMatch = file.ext === '.jsonl' && !parsed.sessionId && file.name.includes(sessionId.slice(0, 8));
-      if (!headerMatch && !filenameMatch) continue;
-      return { path: file.path, ext: file.ext };
+      if (file.ext === '.jsonl') {
+        // Lightweight header read (no full-file parse).
+        const headerSessionId = readJsonlHeaderSessionId(file.path);
+        const headerMatch = headerSessionId === sessionId;
+        const filenameMatch = headerSessionId == null && file.name.includes(sessionId.slice(0, 8));
+        if (headerMatch || filenameMatch) return { path: file.path, ext: '.jsonl' };
+      } else {
+        // .json legacy: small single-document JSON, full parse OK.
+        const parsed = parseGeminiSessionFile(file.path, '.json');
+        if (parsed.sessionId === sessionId) return { path: file.path, ext: '.json' };
+      }
     }
   }
   return undefined;
-}
-
-/**
- * Resolve the message list for `sessionId` (full-file parse). Used by thinking
- * extraction which needs broader breadth than just the latest match.
- */
-function readGeminiSessionMessages(
-  sessionId: string | undefined,
-  workingDirectory?: string,
-): readonly GeminiStoredMessage[] {
-  const location = findGeminiSessionFile(sessionId, workingDirectory);
-  if (!location) return [];
-  const parsed = parseGeminiSessionFile(location.path, location.ext);
-  if (!Array.isArray(parsed.messages)) return [];
-  return parsed.messages;
 }
 
 function readGeminiThinkingFromLocalSession(
@@ -221,9 +264,36 @@ function readGeminiThinkingFromLocalSession(
   assistantText: string,
   workingDirectory?: string,
 ): string | null {
-  const messages = readGeminiSessionMessages(sessionId, workingDirectory);
-  if (messages.length === 0) return null;
+  const location = findGeminiSessionFile(sessionId, workingDirectory);
+  if (!location) return null;
 
+  const normalizedAssistantText = normalizeGeminiContent(assistantText);
+
+  // Predicate: a `gemini`-type message with non-empty thoughts. Content match
+  // when assistantText is provided; otherwise (tool-only paths) take the
+  // tail-most message with thoughts.
+  const matchesThoughts = (parsed: unknown): boolean => {
+    if (parsed == null || typeof parsed !== 'object') return false;
+    const m = parsed as GeminiStoredMessage;
+    if (m.type !== 'gemini') return false;
+    if (!Array.isArray(m.thoughts) || m.thoughts.length === 0) return false;
+    if (typeof m.content !== 'string') return false;
+    if (normalizedAssistantText.length === 0) return true;
+    return normalizeGeminiContent(m.content) === normalizedAssistantText;
+  };
+
+  // Fast path for `.jsonl`: reverse-tail reader stops at the first match
+  // from EOF. Avoids loading the whole multi-megabyte session into memory
+  // on every model turn (Gemini hot path runs once per invocation).
+  if (location.ext === '.jsonl') {
+    const match = readJsonlTail<GeminiStoredMessage>(location.path, { predicate: matchesThoughts });
+    if (!match) return null;
+    return formatGeminiThoughts(match.thoughts ?? []) || null;
+  }
+
+  // Legacy `.json` path: full-file parse + reverse find. Files are small.
+  const parsed = parseGeminiSessionFile(location.path, '.json');
+  const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
   const candidates = messages.filter(
     (message): message is GeminiStoredMessage =>
       message?.type === 'gemini' &&
@@ -232,8 +302,6 @@ function readGeminiThinkingFromLocalSession(
       typeof message.content === 'string',
   );
   if (candidates.length === 0) return null;
-
-  const normalizedAssistantText = normalizeGeminiContent(assistantText);
   const exact =
     normalizedAssistantText.length > 0
       ? [...candidates].reverse().find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText)

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -48,10 +48,20 @@ interface GeminiStoredThought {
   readonly description?: string;
 }
 
+interface GeminiStoredTokenStats {
+  readonly total?: number;
+  readonly input?: number;
+  readonly output?: number;
+  readonly cached?: number;
+  readonly thoughts?: number;
+  readonly tool?: number;
+}
+
 interface GeminiStoredMessage {
   readonly type?: string;
   readonly content?: string;
   readonly thoughts?: readonly GeminiStoredThought[];
+  readonly tokens?: GeminiStoredTokenStats;
 }
 
 interface GeminiStoredSession {
@@ -77,15 +87,64 @@ function formatGeminiThoughts(thoughts: readonly GeminiStoredThought[]): string 
     .join('\n\n---\n\n');
 }
 
-function readGeminiThinkingFromLocalSession(
+/**
+ * Parse one Gemini session file. Supports both legacy `.json` (whole-file
+ * `{sessionId, messages: [...]}`) and current `.jsonl` (line-by-line: header
+ * row with `sessionId`, `$set` update rows to skip, then individual messages).
+ *
+ * Returns the resolved sessionId (in-file header preferred) and the message
+ * list. On any parse error returns `{ messages: [] }`.
+ */
+function parseGeminiSessionFile(filePath: string, ext: '.json' | '.jsonl'): GeminiStoredSession {
+  try {
+    const raw = readFileSync(filePath, 'utf8');
+    if (ext === '.json') {
+      return JSON.parse(raw) as GeminiStoredSession;
+    }
+    // .jsonl
+    let sessionId: string | undefined;
+    const messages: GeminiStoredMessage[] = [];
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        // Header row: has sessionId but no message-like `type`
+        if (typeof obj.sessionId === 'string' && typeof obj.type === 'undefined') {
+          sessionId = sessionId ?? (obj.sessionId as string);
+          continue;
+        }
+        // Mongo-style update row, skip
+        if (Object.hasOwn(obj, '$set')) continue;
+        // Message row
+        if (typeof obj.type === 'string') {
+          messages.push(obj as unknown as GeminiStoredMessage);
+        }
+      } catch {
+        // Skip a malformed/partial line while Gemini is still writing.
+      }
+    }
+    return { sessionId, messages };
+  } catch {
+    return { messages: [] };
+  }
+}
+
+/**
+ * Locate Gemini's local session file for `sessionId` and return its message
+ * list. sessionId resolution priority: in-file header > filename prefix
+ * (fallback for .jsonl when header is missing or unreadable).
+ *
+ * Searches `~/.gemini/tmp/<projectDir>/chats/session-*.{json,jsonl}` —
+ * preferring the project dir whose basename matches `workingDirectory`.
+ */
+function readGeminiSessionMessages(
   sessionId: string | undefined,
-  assistantText: string,
   workingDirectory?: string,
-): string | null {
-  if (!sessionId) return null;
+): readonly GeminiStoredMessage[] {
+  if (!sessionId) return [];
 
   const geminiTmpRoot = join(homedir(), '.gemini', 'tmp');
-  if (!existsSync(geminiTmpRoot)) return null;
+  if (!existsSync(geminiTmpRoot)) return [];
 
   const preferredProjectDir = workingDirectory ? basename(workingDirectory) : null;
   const projectDirs = readdirSync(geminiTmpRoot, { withFileTypes: true })
@@ -97,49 +156,100 @@ function readGeminiThinkingFromLocalSession(
       return 0;
     });
 
-  const normalizedAssistantText = normalizeGeminiContent(assistantText);
-
   for (const projectDir of projectDirs) {
     const chatsDir = join(geminiTmpRoot, projectDir, 'chats');
     if (!existsSync(chatsDir)) continue;
 
     const sessionFiles = readdirSync(chatsDir)
-      .filter((name) => name.startsWith('session-') && name.endsWith('.json'))
+      .filter((name) => name.startsWith('session-') && (name.endsWith('.json') || name.endsWith('.jsonl')))
       .map((name) => ({
         path: join(chatsDir, name),
+        ext: (name.endsWith('.jsonl') ? '.jsonl' : '.json') as '.json' | '.jsonl',
+        name,
         mtimeMs: statSync(join(chatsDir, name)).mtimeMs,
       }))
       .sort((a, b) => b.mtimeMs - a.mtimeMs);
 
     for (const file of sessionFiles) {
-      try {
-        const parsed = JSON.parse(readFileSync(file.path, 'utf8')) as GeminiStoredSession;
-        if (parsed.sessionId !== sessionId || !Array.isArray(parsed.messages)) continue;
-
-        const candidates = parsed.messages.filter(
-          (message): message is GeminiStoredMessage =>
-            message?.type === 'gemini' &&
-            Array.isArray(message.thoughts) &&
-            message.thoughts.length > 0 &&
-            typeof message.content === 'string',
-        );
-        if (candidates.length === 0) return null;
-
-        const exact =
-          normalizedAssistantText.length > 0
-            ? [...candidates]
-                .reverse()
-                .find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText)
-            : candidates[candidates.length - 1];
-        const selected = exact ?? null;
-        return selected ? formatGeminiThoughts(selected.thoughts ?? []) || null : null;
-      } catch {
-        // Best effort: skip malformed/partial session files while Gemini is still writing them.
-      }
+      const parsed = parseGeminiSessionFile(file.path, file.ext);
+      // Prefer in-file sessionId header. For .jsonl files where the header
+      // is missing/unreadable, accept filename-prefix match as a fallback.
+      const headerMatch = parsed.sessionId === sessionId;
+      const filenameMatch = file.ext === '.jsonl' && !parsed.sessionId && file.name.includes(sessionId.slice(0, 8));
+      if (!headerMatch && !filenameMatch) continue;
+      if (!Array.isArray(parsed.messages)) continue;
+      return parsed.messages;
     }
   }
+  return [];
+}
 
-  return null;
+function readGeminiThinkingFromLocalSession(
+  sessionId: string | undefined,
+  assistantText: string,
+  workingDirectory?: string,
+): string | null {
+  const messages = readGeminiSessionMessages(sessionId, workingDirectory);
+  if (messages.length === 0) return null;
+
+  const candidates = messages.filter(
+    (message): message is GeminiStoredMessage =>
+      message?.type === 'gemini' &&
+      Array.isArray(message.thoughts) &&
+      message.thoughts.length > 0 &&
+      typeof message.content === 'string',
+  );
+  if (candidates.length === 0) return null;
+
+  const normalizedAssistantText = normalizeGeminiContent(assistantText);
+  const exact =
+    normalizedAssistantText.length > 0
+      ? [...candidates].reverse().find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText)
+      : candidates[candidates.length - 1];
+  const selected = exact ?? null;
+  return selected ? formatGeminiThoughts(selected.thoughts ?? []) || null : null;
+}
+
+/**
+ * Returns the per-turn `tokens.total` from the LATEST gemini-type message in
+ * the local session whose normalized content matches `assistantText`.
+ *
+ * Returns `undefined` when:
+ *   - assistantText is empty (tool-only paths — caller decides fallback)
+ *   - no matching message found (do NOT degrade to latest unconditionally —
+ *     this is the safe path: caller will then disable auto-seal rather than
+ *     act on a wrong context-fill estimate)
+ *
+ * Used to populate `metadata.usage.lastTurnInputTokens` so invoke-single-cat's
+ * fillRatio uses per-turn context size instead of cumulative session metrics
+ * from Gemini CLI's `result.stats` (which would otherwise spuriously trigger
+ * a 100% seal).
+ */
+function readLatestGeminiContextTokens(
+  sessionId: string | undefined,
+  assistantText: string,
+  workingDirectory?: string,
+): number | undefined {
+  const normalizedAssistantText = normalizeGeminiContent(assistantText);
+  if (normalizedAssistantText.length === 0) return undefined;
+
+  const messages = readGeminiSessionMessages(sessionId, workingDirectory);
+  if (messages.length === 0) return undefined;
+
+  const candidates = messages.filter(
+    (message): message is GeminiStoredMessage =>
+      message?.type === 'gemini' && typeof message.content === 'string' && typeof message.tokens?.total === 'number',
+  );
+  if (candidates.length === 0) return undefined;
+
+  // Walk in reverse to pick the LATEST matching message (handles streamed
+  // duplicate rows where Gemini CLI rewrites the same message id with
+  // updated tokens).
+  const exact = [...candidates]
+    .reverse()
+    .find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText);
+
+  return exact?.tokens?.total;
 }
 /**
  * Options for constructing GeminiAgentService (dependency injection)
@@ -388,6 +498,17 @@ export class GeminiAgentService implements AgentService {
           metadata,
           timestamp: Date.now(),
         };
+      }
+
+      // Inject per-turn tokens.total as lastTurnInputTokens so invoke-single-cat
+      // uses the correct context-fill numerator (vs Gemini CLI's cumulative stats).
+      const lastTurnTokens = readLatestGeminiContextTokens(
+        metadata.sessionId,
+        fullAssistantText,
+        options?.workingDirectory,
+      );
+      if (lastTurnTokens != null) {
+        metadata.usage = { ...(metadata.usage ?? {}), lastTurnInputTokens: lastTurnTokens };
       }
 
       yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -84,6 +84,42 @@ function normalizeGeminiContent(value: string | undefined): string {
   return (value ?? '').replace(/\s+/g, '');
 }
 
+/**
+ * Does a jsonl message's content correspond to (the tail of) the current
+ * assistant text? Accepts either strict equality OR suffix-match — i.e.
+ * `normalizedAssistantText.endsWith(normalizedMessageContent)`.
+ *
+ * The suffix branch handles a real-world Gemini CLI shape (observed
+ * 2026-05-11): when the model thinks before producing a final reply, the
+ * CLI emits MULTIPLE `message/assistant` events — one per thinking step
+ * plus one final text. GeminiAgentService stitches them with `\n\n` into
+ * `fullAssistantText`, so the assembled string looks like
+ * `**Thinking step 1**\n\n**Thinking step 2**\n\nfinal text`. The jsonl,
+ * however, stores ONE row per logical step (each thinking step + the
+ * final each in its own row), so the final row's content equals only
+ * the "final text" tail. Strict equality would miss it; checking that
+ * the assistantText *ends with* the candidate row's normalized content
+ * recovers the match without falling back to cumulative tokens.
+ *
+ * Why suffix (not arbitrary substring): Gemini CLI's per-step output is
+ * the LAST piece appended for that step; for the final row we want it
+ * to live at the END of the stitched assistant text. Forward/middle
+ * substring would also match thinking-rows whose text appears as a
+ * prefix or middle slice — those have STALE tokens.input (computed
+ * before later steps' prompts were sent), so we must not pick them up.
+ *
+ * Returns `false` for empty `messageContent` or non-string content, so
+ * the caller can still distinguish "no usable content" from a match.
+ */
+function matchesCurrentAssistantText(messageContent: string | undefined, normalizedAssistantText: string): boolean {
+  if (typeof messageContent !== 'string') return false;
+  const normalizedMessageContent = normalizeGeminiContent(messageContent);
+  if (normalizedMessageContent.length === 0) return false;
+  return (
+    normalizedMessageContent === normalizedAssistantText || normalizedAssistantText.endsWith(normalizedMessageContent)
+  );
+}
+
 function formatGeminiThoughts(thoughts: readonly GeminiStoredThought[]): string {
   return thoughts
     .map((thought) => {
@@ -270,8 +306,11 @@ function readGeminiThinkingFromLocalSession(
   const normalizedAssistantText = normalizeGeminiContent(assistantText);
 
   // Predicate: a `gemini`-type message with non-empty thoughts. Content match
-  // when assistantText is provided; otherwise (tool-only paths) take the
-  // tail-most message with thoughts.
+  // when assistantText is provided (uses `matchesCurrentAssistantText`, which
+  // accepts strict equality OR suffix-match — see helper docstring for why
+  // suffix-match is necessary when the model thinks first and final text is
+  // only the tail of the stitched fullAssistantText). Empty assistantText
+  // (tool-only paths) takes the tail-most message with thoughts.
   const matchesThoughts = (parsed: unknown): boolean => {
     if (parsed == null || typeof parsed !== 'object') return false;
     const m = parsed as GeminiStoredMessage;
@@ -279,7 +318,7 @@ function readGeminiThinkingFromLocalSession(
     if (!Array.isArray(m.thoughts) || m.thoughts.length === 0) return false;
     if (typeof m.content !== 'string') return false;
     if (normalizedAssistantText.length === 0) return true;
-    return normalizeGeminiContent(m.content) === normalizedAssistantText;
+    return matchesCurrentAssistantText(m.content, normalizedAssistantText);
   };
 
   // Fast path for `.jsonl`: reverse-tail reader stops at the first match
@@ -304,32 +343,39 @@ function readGeminiThinkingFromLocalSession(
   if (candidates.length === 0) return null;
   const exact =
     normalizedAssistantText.length > 0
-      ? [...candidates].reverse().find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText)
+      ? [...candidates]
+          .reverse()
+          .find((message) => matchesCurrentAssistantText(message.content, normalizedAssistantText))
       : candidates[candidates.length - 1];
   const selected = exact ?? null;
   return selected ? formatGeminiThoughts(selected.thoughts ?? []) || null : null;
 }
 
 /**
- * Returns the per-turn `tokens.total` from the LATEST gemini-type message in
+ * Returns the per-turn `tokens.input` from the LATEST gemini-type message in
  * the local session.
  *
  * Resolution strategy:
- *   - assistantText non-empty: strict normalized-content match (walks
- *     candidates in reverse, picks LATEST match). When the model emits both
- *     thinking rows and a final assistant text row, only the final row
- *     matches, so this remains safe across multiple turns sharing one
- *     sessionId-bound jsonl.
+ *   - assistantText non-empty: normalized-content match via
+ *     `matchesCurrentAssistantText` (strict equality OR suffix-match — see
+ *     helper docstring for why suffix-match is required to handle the
+ *     thinking-prefix shape where multiple thinking messages plus a final
+ *     are stitched into one fullAssistantText but stored as separate jsonl
+ *     rows). Walks candidates in reverse, picks LATEST match.
  *   - assistantText empty (tool-only turn — model produced no user-visible
  *     text, only thinking + tool_use): fall back to the tail-most candidate.
- *     This is safe because sessionId already uniquely scopes the jsonl, and
- *     the tail-most message is THIS turn's latest (Gemini CLI flushes the
- *     turn's rows before invokeGeminiCLI yields done). Without this fallback
- *     tool-only turns get no `lastTurnInputTokens` and fillRatio silently
- *     degrades back to cumulative inputTokens.
- *   - non-empty assistantText that matches no jsonl row: undefined. The
- *     caller (`invoke-single-cat`) treats undefined as "skip auto-seal";
- *     this is the safe path versus picking a wrong message.
+ *     Safe because sessionId already uniquely scopes the jsonl, and the
+ *     tail-most message IS this turn's latest (Gemini CLI flushes the turn's
+ *     rows before invokeGeminiCLI yields done).
+ *   - non-empty assistantText that matches no jsonl row: undefined (caller
+ *     treats undefined as "skip auto-seal"; safer than picking a wrong row).
+ *
+ * Why `tokens.input`, not `tokens.total`: the metadata field is named
+ * `lastTurnInputTokens` and the UI's `ContextHealthBar` expects an input-only
+ * value for `usedTokens / windowSize`. `tokens.total` also includes output
+ * and thinking, which makes the per-turn bar overshoot the cumulative
+ * `usage.inputTokens` widget on single-turn invocations (LD reported
+ * "↓ 92k < 进度条 98k" on 2026-05-11 — Bug A in the analysis md).
  *
  * Used to populate `metadata.usage.lastTurnInputTokens` so invoke-single-cat's
  * fillRatio uses per-turn context size instead of cumulative session metrics
@@ -347,30 +393,33 @@ function readLatestGeminiContextTokens(
   const normalizedAssistantText = normalizeGeminiContent(assistantText);
 
   // Two predicates share both the fast (.jsonl) and legacy (.json) paths.
-  // - hasTokens: any gemini-type row with numeric tokens.total. Used for
-  //   tool-only turns (empty assistantText) — the tail-most such row IS
+  // - hasInputTokens: any gemini-type row with numeric tokens.input. Used
+  //   for tool-only turns (empty assistantText) — the tail-most such row IS
   //   this turn's latest message (sessionId already scopes the file).
-  // - matchesAssistantText: stricter — also requires normalized content
-  //   to equal the current assistant text. Used when assistantText is
-  //   non-empty so we don't misattribute tokens across turns.
-  const hasTokens = (parsed: unknown): parsed is GeminiStoredMessage => {
+  //   We check tokens.input (not tokens.total) so a row missing input never
+  //   silently degrades to total.
+  // - matchesAssistantText: stricter — also requires normalized content to
+  //   correspond to current assistant text (strict equality OR suffix-match,
+  //   per matchesCurrentAssistantText). Used when assistantText is non-empty
+  //   so we don't misattribute tokens across turns.
+  const hasInputTokens = (parsed: unknown): parsed is GeminiStoredMessage => {
     if (parsed == null || typeof parsed !== 'object') return false;
     const m = parsed as GeminiStoredMessage;
-    return m.type === 'gemini' && typeof m.tokens?.total === 'number';
+    return m.type === 'gemini' && typeof m.tokens?.input === 'number';
   };
   const matchesAssistantText = (parsed: unknown): boolean => {
-    if (!hasTokens(parsed)) return false;
+    if (!hasInputTokens(parsed)) return false;
     const m = parsed as GeminiStoredMessage;
-    return typeof m.content === 'string' && normalizeGeminiContent(m.content) === normalizedAssistantText;
+    return matchesCurrentAssistantText(m.content, normalizedAssistantText);
   };
 
   // Fast path for `.jsonl`: reverse-tail reader stops at the first match
   // from EOF. Avoids loading the whole multi-megabyte session into memory
   // on every model turn. See utils/jsonl-tail-reader.ts.
   if (location.ext === '.jsonl') {
-    const predicate = normalizedAssistantText.length === 0 ? hasTokens : matchesAssistantText;
+    const predicate = normalizedAssistantText.length === 0 ? hasInputTokens : matchesAssistantText;
     const match = readJsonlTail<GeminiStoredMessage>(location.path, { predicate });
-    return match?.tokens?.total;
+    return match?.tokens?.input;
   }
 
   // Legacy `.json` path: full-file parse + reverse find. Historical Gemini
@@ -378,24 +427,21 @@ function readLatestGeminiContextTokens(
   // and rare enough that perf optimization isn't justified.
   const parsed = parseGeminiSessionFile(location.path, location.ext);
   const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
-  const candidates = messages.filter(hasTokens);
+  const candidates = messages.filter(hasInputTokens);
   if (candidates.length === 0) return undefined;
 
   if (normalizedAssistantText.length === 0) {
     // Tool-only turn: tail-most candidate IS this turn's latest message.
-    return candidates[candidates.length - 1].tokens?.total;
+    return candidates[candidates.length - 1].tokens?.input;
   }
 
   // Walk in reverse to pick the LATEST matching message (handles streamed
   // duplicate rows where Gemini CLI rewrites the same message id with
-  // updated tokens).
+  // updated tokens, AND the thinking-prefix shape via suffix-match).
   const exact = [...candidates]
     .reverse()
-    .find(
-      (message) =>
-        typeof message.content === 'string' && normalizeGeminiContent(message.content) === normalizedAssistantText,
-    );
-  return exact?.tokens?.total;
+    .find((message) => matchesCurrentAssistantText(message.content, normalizedAssistantText));
+  return exact?.tokens?.input;
 }
 /**
  * Options for constructing GeminiAgentService (dependency injection)

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -37,6 +37,7 @@ import type { SpawnFn } from '../../../../../utils/cli-types.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata, TokenUsage } from '../../types.js';
 import { appendLocalImagePathHints, collectImageAccessDirectories } from '../providers/image-cli-bridge.js';
 import { extractImagePaths } from '../providers/image-paths.js';
+import { readJsonlTail } from '../../../../../utils/jsonl-tail-reader.js';
 import { isKnownPostResponseCandidatesCrash, isResultErrorEvent, transformGeminiEvent } from './gemini-event-parser.js';
 
 const log = createModuleLogger('gemini-agent');
@@ -139,22 +140,29 @@ function parseGeminiSessionFile(filePath: string, ext: '.json' | '.jsonl'): Gemi
   }
 }
 
+interface GeminiSessionFileLocation {
+  readonly path: string;
+  readonly ext: '.json' | '.jsonl';
+}
+
 /**
- * Locate Gemini's local session file for `sessionId` and return its message
- * list. sessionId resolution priority: in-file header > filename prefix
- * (fallback for .jsonl when header is missing or unreadable).
+ * Locate Gemini's local session file for `sessionId`. Returns the file path +
+ * extension, or `undefined` if no matching file is found.
+ *
+ * sessionId resolution priority: in-file header > filename prefix (fallback
+ * for `.jsonl` when header is missing or unreadable).
  *
  * Searches `~/.gemini/tmp/<projectDir>/chats/session-*.{json,jsonl}` —
  * preferring the project dir whose basename matches `workingDirectory`.
  */
-function readGeminiSessionMessages(
+function findGeminiSessionFile(
   sessionId: string | undefined,
   workingDirectory?: string,
-): readonly GeminiStoredMessage[] {
-  if (!sessionId) return [];
+): GeminiSessionFileLocation | undefined {
+  if (!sessionId) return undefined;
 
   const geminiTmpRoot = join(homedir(), '.gemini', 'tmp');
-  if (!existsSync(geminiTmpRoot)) return [];
+  if (!existsSync(geminiTmpRoot)) return undefined;
 
   const preferredProjectDir = workingDirectory ? basename(workingDirectory) : null;
   const projectDirs = readdirSync(geminiTmpRoot, { withFileTypes: true })
@@ -187,11 +195,25 @@ function readGeminiSessionMessages(
       const headerMatch = parsed.sessionId === sessionId;
       const filenameMatch = file.ext === '.jsonl' && !parsed.sessionId && file.name.includes(sessionId.slice(0, 8));
       if (!headerMatch && !filenameMatch) continue;
-      if (!Array.isArray(parsed.messages)) continue;
-      return parsed.messages;
+      return { path: file.path, ext: file.ext };
     }
   }
-  return [];
+  return undefined;
+}
+
+/**
+ * Resolve the message list for `sessionId` (full-file parse). Used by thinking
+ * extraction which needs broader breadth than just the latest match.
+ */
+function readGeminiSessionMessages(
+  sessionId: string | undefined,
+  workingDirectory?: string,
+): readonly GeminiStoredMessage[] {
+  const location = findGeminiSessionFile(sessionId, workingDirectory);
+  if (!location) return [];
+  const parsed = parseGeminiSessionFile(location.path, location.ext);
+  if (!Array.isArray(parsed.messages)) return [];
+  return parsed.messages;
 }
 
 function readGeminiThinkingFromLocalSession(
@@ -251,18 +273,48 @@ function readLatestGeminiContextTokens(
   assistantText: string,
   workingDirectory?: string,
 ): number | undefined {
-  const messages = readGeminiSessionMessages(sessionId, workingDirectory);
-  if (messages.length === 0) return undefined;
-
-  const candidates = messages.filter(
-    (message): message is GeminiStoredMessage =>
-      message?.type === 'gemini' && typeof message.tokens?.total === 'number',
-  );
-  if (candidates.length === 0) return undefined;
+  const location = findGeminiSessionFile(sessionId, workingDirectory);
+  if (!location) return undefined;
 
   const normalizedAssistantText = normalizeGeminiContent(assistantText);
+
+  // Two predicates share both the fast (.jsonl) and legacy (.json) paths.
+  // - hasTokens: any gemini-type row with numeric tokens.total. Used for
+  //   tool-only turns (empty assistantText) — the tail-most such row IS
+  //   this turn's latest message (sessionId already scopes the file).
+  // - matchesAssistantText: stricter — also requires normalized content
+  //   to equal the current assistant text. Used when assistantText is
+  //   non-empty so we don't misattribute tokens across turns.
+  const hasTokens = (parsed: unknown): parsed is GeminiStoredMessage => {
+    if (parsed == null || typeof parsed !== 'object') return false;
+    const m = parsed as GeminiStoredMessage;
+    return m.type === 'gemini' && typeof m.tokens?.total === 'number';
+  };
+  const matchesAssistantText = (parsed: unknown): boolean => {
+    if (!hasTokens(parsed)) return false;
+    const m = parsed as GeminiStoredMessage;
+    return typeof m.content === 'string' && normalizeGeminiContent(m.content) === normalizedAssistantText;
+  };
+
+  // Fast path for `.jsonl`: reverse-tail reader stops at the first match
+  // from EOF. Avoids loading the whole multi-megabyte session into memory
+  // on every model turn. See utils/jsonl-tail-reader.ts.
+  if (location.ext === '.jsonl') {
+    const predicate = normalizedAssistantText.length === 0 ? hasTokens : matchesAssistantText;
+    const match = readJsonlTail<GeminiStoredMessage>(location.path, { predicate });
+    return match?.tokens?.total;
+  }
+
+  // Legacy `.json` path: full-file parse + reverse find. Historical Gemini
+  // CLI output was a single JSON document; these files are typically small
+  // and rare enough that perf optimization isn't justified.
+  const parsed = parseGeminiSessionFile(location.path, location.ext);
+  const messages = Array.isArray(parsed.messages) ? parsed.messages : [];
+  const candidates = messages.filter(hasTokens);
+  if (candidates.length === 0) return undefined;
+
   if (normalizedAssistantText.length === 0) {
-    // Tool-only turn: no user-visible text. Tail-most candidate IS this turn.
+    // Tool-only turn: tail-most candidate IS this turn's latest message.
     return candidates[candidates.length - 1].tokens?.total;
   }
 
@@ -275,7 +327,6 @@ function readLatestGeminiContextTokens(
       (message) =>
         typeof message.content === 'string' && normalizeGeminiContent(message.content) === normalizedAssistantText,
     );
-
   return exact?.tokens?.total;
 }
 /**

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -222,13 +222,24 @@ function readGeminiThinkingFromLocalSession(
 
 /**
  * Returns the per-turn `tokens.total` from the LATEST gemini-type message in
- * the local session whose normalized content matches `assistantText`.
+ * the local session.
  *
- * Returns `undefined` when:
- *   - assistantText is empty (tool-only paths — caller decides fallback)
- *   - no matching message found (do NOT degrade to latest unconditionally —
- *     this is the safe path: caller will then disable auto-seal rather than
- *     act on a wrong context-fill estimate)
+ * Resolution strategy:
+ *   - assistantText non-empty: strict normalized-content match (walks
+ *     candidates in reverse, picks LATEST match). When the model emits both
+ *     thinking rows and a final assistant text row, only the final row
+ *     matches, so this remains safe across multiple turns sharing one
+ *     sessionId-bound jsonl.
+ *   - assistantText empty (tool-only turn — model produced no user-visible
+ *     text, only thinking + tool_use): fall back to the tail-most candidate.
+ *     This is safe because sessionId already uniquely scopes the jsonl, and
+ *     the tail-most message is THIS turn's latest (Gemini CLI flushes the
+ *     turn's rows before invokeGeminiCLI yields done). Without this fallback
+ *     tool-only turns get no `lastTurnInputTokens` and fillRatio silently
+ *     degrades back to cumulative inputTokens.
+ *   - non-empty assistantText that matches no jsonl row: undefined. The
+ *     caller (`invoke-single-cat`) treats undefined as "skip auto-seal";
+ *     this is the safe path versus picking a wrong message.
  *
  * Used to populate `metadata.usage.lastTurnInputTokens` so invoke-single-cat's
  * fillRatio uses per-turn context size instead of cumulative session metrics
@@ -240,24 +251,30 @@ function readLatestGeminiContextTokens(
   assistantText: string,
   workingDirectory?: string,
 ): number | undefined {
-  const normalizedAssistantText = normalizeGeminiContent(assistantText);
-  if (normalizedAssistantText.length === 0) return undefined;
-
   const messages = readGeminiSessionMessages(sessionId, workingDirectory);
   if (messages.length === 0) return undefined;
 
   const candidates = messages.filter(
     (message): message is GeminiStoredMessage =>
-      message?.type === 'gemini' && typeof message.content === 'string' && typeof message.tokens?.total === 'number',
+      message?.type === 'gemini' && typeof message.tokens?.total === 'number',
   );
   if (candidates.length === 0) return undefined;
+
+  const normalizedAssistantText = normalizeGeminiContent(assistantText);
+  if (normalizedAssistantText.length === 0) {
+    // Tool-only turn: no user-visible text. Tail-most candidate IS this turn.
+    return candidates[candidates.length - 1].tokens?.total;
+  }
 
   // Walk in reverse to pick the LATEST matching message (handles streamed
   // duplicate rows where Gemini CLI rewrites the same message id with
   // updated tokens).
   const exact = [...candidates]
     .reverse()
-    .find((message) => normalizeGeminiContent(message.content) === normalizedAssistantText);
+    .find(
+      (message) =>
+        typeof message.content === 'string' && normalizeGeminiContent(message.content) === normalizedAssistantText,
+    );
 
   return exact?.tokens?.total;
 }

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -692,7 +692,7 @@ export class GeminiAgentService implements AgentService {
         };
       }
 
-      // Inject per-turn tokens.total as lastTurnInputTokens so invoke-single-cat
+      // Inject per-turn tokens.input as lastTurnInputTokens so invoke-single-cat
       // uses the correct context-fill numerator (vs Gemini CLI's cumulative stats).
       const lastTurnTokens = readLatestGeminiContextTokens(
         metadata.sessionId,

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts
@@ -28,10 +28,39 @@ export const TOKEN_BOUNDARY_RE = /[\s,.:;!?()[\]{}<>，。！？、：；（）�
 /** @internal Exported for a2a-shadow-detection.ts. */
 export const HANDLE_CONTINUATION_RE = /[a-z0-9_.-]/;
 const LEADING_MARKDOWN_MENTION_PREFIX_RE = /^(?:(?:>\s*)|(?:[-*+]\s+)|(?:\d+[.)]\s+))+/;
+const LINE_START_MARKDOWN_PREFIX_PATTERN = String.raw`\s*(?:(?:>\s*)|(?:[-*+]\s+)|(?:\d+[.)]\s+))*`;
+const HANDLE_BOUNDARY_PATTERN = String.raw`(?=$|[\s,.:;!?()\[\]{}<>，。！？、：；（）【】《》「」『』〈〉]|[^a-z0-9_.-])`;
 
 interface MentionPatternEntry {
   readonly catId: CatId;
   readonly pattern: string;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function buildWhitespaceTolerantMentionPattern(pattern: string): RegExp {
+  const interleaved = Array.from(pattern)
+    .map((ch) => escapeRegExp(ch))
+    .join(String.raw`\s*`);
+  return new RegExp(`(^|\\n)(${LINE_START_MARKDOWN_PREFIX_PATTERN})${interleaved}${HANDLE_BOUNDARY_PATTERN}`, 'giu');
+}
+
+function repairLineStartMentionWhitespace(text: string, entries: readonly MentionPatternEntry[]): string {
+  let repaired = text;
+  for (const entry of entries) {
+    // Gemini CLI can split a logical assistant message across `message/assistant`
+    // events. GeminiAgentService inserts paragraph separators between those
+    // events, which can turn a legitimate final-slot handoff like `@小狸` into
+    // `@小\n\n狸`. Repair only pure whitespace inside known line-start handles;
+    // inline mentions and ordinary prose remain governed by the normal parser.
+    repaired = repaired.replace(
+      buildWhitespaceTolerantMentionPattern(entry.pattern),
+      (_match, lineStart: string, prefix: string) => `${lineStart}${prefix}${entry.pattern}`,
+    );
+  }
+  return repaired;
 }
 
 /** @deprecated Suppression system removed — line-start mentions always route. Kept for backward compat. */
@@ -99,12 +128,13 @@ export function analyzeA2AMentions(
     }
   }
   entries.sort((a, b) => b.pattern.length - a.pattern.length);
+  const normalizedText = repairLineStartMentionWhitespace(stripped, entries);
 
   // 3. Line-start matching with token boundary — always actionable (no keyword gate)
   const found: CatId[] = [];
   const seen = new Set<string>();
   const routing_warnings: CatRoutingError[] = [];
-  const lines = stripped.split(/\r?\n/);
+  const lines = normalizedText.split(/\r?\n/);
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
     const rawLine = lines[lineIndex]!;
     if (found.length >= MAX_A2A_MENTION_TARGETS) break; // 5. Safety limit

--- a/packages/api/src/infrastructure/telemetry/instruments.ts
+++ b/packages/api/src/infrastructure/telemetry/instruments.ts
@@ -113,6 +113,23 @@ export const lineStartDetected = lazy(() =>
   }),
 );
 
+/**
+ * Counts how often a Gemini-family invocation falls back to the
+ * `skipAutoSealForGeminiCumulative` guard because no per-turn
+ * `lastTurnInputTokens` could be derived from the local Gemini session jsonl
+ * (e.g. assistantText empty / no matching local message / jsonl unavailable).
+ *
+ * When this counter rises, the cat is "blind-running" past the cumulative
+ * usage signal — auto-seal is suppressed but the underlying context could
+ * actually be approaching the window limit. Pair with a log warn to alert
+ * operators.
+ */
+export const geminiContextFallback = lazy(() =>
+  meter().createCounter('cat_cafe.gemini.context_fill_fallback', {
+    description: 'Gemini auto-seal skipped due to cumulative-only usage (no per-turn signal)',
+  }),
+);
+
 export const antigravityStreamErrorBuffered = lazy(() =>
   meter().createCounter('cat_cafe.antigravity.stream_error.buffered_total', {
     description: 'Buffered Antigravity stream_error after partial text while waiting for a recovery tail',

--- a/packages/api/src/utils/jsonl-tail-reader.ts
+++ b/packages/api/src/utils/jsonl-tail-reader.ts
@@ -13,13 +13,20 @@
  *
  * Edge cases handled:
  * - empty file → undefined
+ * - missing / unreadable file → undefined (no throw)
  * - last line written partially (CLI mid-write race) → unparseable, skipped
  * - non-matching lines (user / `$set` / wrong type) → predicate filter
  * - chunk boundary mid-line → buffered across chunk reads
  * - budget exhausted before match → undefined (caller's fallback path)
- *
- * NOTE: stub implementation. Real reverse-tail logic to follow.
  */
+
+import { closeSync, openSync, readSync, statSync } from 'node:fs';
+
+const DEFAULT_CHUNK_SIZE = 8192;
+const DEFAULT_MAX_LINES = 10_000;
+const DEFAULT_MAX_BYTES = 1_048_576; // 1 MiB
+/** Cap leading-buffer growth so a pathological multi-MB single line cannot exhaust memory. */
+const LEADING_BUFFER_CAP = 1_048_576;
 
 export interface ReadJsonlTailOptions {
   /** Max lines to scan from EOF backward before giving up. Default: 10_000. */
@@ -35,7 +42,85 @@ export interface ReadJsonlTailOptions {
  * parsed JSON matches `predicate`. Returns `undefined` when no match is
  * found within the budget or when the file is unreadable / empty.
  */
-export function readJsonlTail<T = unknown>(_filePath: string, _opts: ReadJsonlTailOptions): T | undefined {
-  // Stub: real implementation lands in the GREEN commit.
-  return undefined;
+export function readJsonlTail<T = unknown>(filePath: string, opts: ReadJsonlTailOptions): T | undefined {
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
+
+  let fd: number;
+  let size: number;
+  try {
+    fd = openSync(filePath, 'r');
+    size = statSync(filePath).size;
+  } catch {
+    return undefined;
+  }
+
+  try {
+    if (size === 0) return undefined;
+
+    const buffer = Buffer.alloc(DEFAULT_CHUNK_SIZE);
+    let position = size;
+    let bytesRead = 0;
+    let linesScanned = 0;
+    /** Partial leading from the previous (newer) chunk's first split element. */
+    let leadingBuffer = '';
+
+    while (position > 0) {
+      const chunkSize = Math.min(DEFAULT_CHUNK_SIZE, position);
+      position -= chunkSize;
+      bytesRead += chunkSize;
+
+      const n = readSync(fd, buffer, 0, chunkSize, position);
+      if (n === 0) break;
+
+      // chunkText is older content; leadingBuffer is newer content (already-read
+      // chunk's first element that was a partial line). Concatenated they form
+      // a contiguous slice of the file [position, position+chunkSize+|leadingBuffer|).
+      const combined = buffer.toString('utf8', 0, n) + leadingBuffer;
+      const parts = combined.split('\n');
+
+      // When position > 0 we cannot trust parts[0] is a complete line — it may
+      // be the back half of a line whose front half lives in the next (older)
+      // chunk. Save it as leadingBuffer for the next iteration.
+      // When position === 0 there is no more chunk; parts[0] is the file's
+      // first line (complete) and must be processed.
+      let processFromIndex: number;
+      if (position === 0) {
+        processFromIndex = 0;
+        leadingBuffer = '';
+      } else {
+        processFromIndex = 1;
+        leadingBuffer = parts[0] ?? '';
+        if (leadingBuffer.length > LEADING_BUFFER_CAP) return undefined;
+      }
+
+      // Process complete lines in REVERSE (newest first). Skip empty (trailing
+      // newline at EOF) and unparseable (partial-write race) lines.
+      for (let i = parts.length - 1; i >= processFromIndex; i--) {
+        const line = parts[i];
+        if (line === '') continue;
+        linesScanned++;
+        if (linesScanned > maxLines) return undefined;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (opts.predicate(parsed)) {
+          return parsed as T;
+        }
+      }
+
+      if (bytesRead >= maxBytes) return undefined;
+    }
+
+    return undefined;
+  } finally {
+    try {
+      closeSync(fd);
+    } catch {
+      /* best-effort */
+    }
+  }
 }

--- a/packages/api/src/utils/jsonl-tail-reader.ts
+++ b/packages/api/src/utils/jsonl-tail-reader.ts
@@ -4,9 +4,9 @@
  * Reads a JSONL file from EOF backward, parsing entries one at a time
  * (most-recent first), and returns the first entry that matches `predicate`.
  *
- * Designed for the Gemini per-turn `tokens.total` use case: the local
- * Gemini CLI session jsonl can grow to multi-megabyte sizes, but we only
- * ever need the latest matching message. Loading the whole file with
+ * Designed for the Gemini per-turn token lookup: the local Gemini CLI
+ * session jsonl can grow to multi-megabyte sizes, but we only ever need
+ * the latest matching message. Loading the whole file with
  * `readFileSync + split('\n')` on every model turn would block the Node.js
  * event loop. This helper opens an fd, reads small chunks from the tail,
  * and stops as soon as a match is found OR a budget is exhausted.

--- a/packages/api/src/utils/jsonl-tail-reader.ts
+++ b/packages/api/src/utils/jsonl-tail-reader.ts
@@ -1,0 +1,41 @@
+/**
+ * Reverse-tail JSONL reader.
+ *
+ * Reads a JSONL file from EOF backward, parsing entries one at a time
+ * (most-recent first), and returns the first entry that matches `predicate`.
+ *
+ * Designed for the Gemini per-turn `tokens.total` use case: the local
+ * Gemini CLI session jsonl can grow to multi-megabyte sizes, but we only
+ * ever need the latest matching message. Loading the whole file with
+ * `readFileSync + split('\n')` on every model turn would block the Node.js
+ * event loop. This helper opens an fd, reads small chunks from the tail,
+ * and stops as soon as a match is found OR a budget is exhausted.
+ *
+ * Edge cases handled:
+ * - empty file → undefined
+ * - last line written partially (CLI mid-write race) → unparseable, skipped
+ * - non-matching lines (user / `$set` / wrong type) → predicate filter
+ * - chunk boundary mid-line → buffered across chunk reads
+ * - budget exhausted before match → undefined (caller's fallback path)
+ *
+ * NOTE: stub implementation. Real reverse-tail logic to follow.
+ */
+
+export interface ReadJsonlTailOptions {
+  /** Max lines to scan from EOF backward before giving up. Default: 10_000. */
+  readonly maxLines?: number;
+  /** Max bytes to read from EOF before giving up. Default: 1_048_576 (1 MiB). */
+  readonly maxBytes?: number;
+  /** Returns true if the parsed JSON entry is the one we want. */
+  readonly predicate: (parsed: unknown) => boolean;
+}
+
+/**
+ * Read a JSONL file from EOF backward and return the latest entry whose
+ * parsed JSON matches `predicate`. Returns `undefined` when no match is
+ * found within the budget or when the file is unreadable / empty.
+ */
+export function readJsonlTail<T = unknown>(_filePath: string, _opts: ReadJsonlTailOptions): T | undefined {
+  // Stub: real implementation lands in the GREEN commit.
+  return undefined;
+}

--- a/packages/api/src/utils/jsonl-tail-reader.ts
+++ b/packages/api/src/utils/jsonl-tail-reader.ts
@@ -62,8 +62,13 @@ export function readJsonlTail<T = unknown>(filePath: string, opts: ReadJsonlTail
     let position = size;
     let bytesRead = 0;
     let linesScanned = 0;
-    /** Partial leading from the previous (newer) chunk's first split element. */
-    let leadingBuffer = '';
+    // Partial leading from the previous (newer) chunk's first segment. Kept
+    // as raw bytes so multi-byte UTF-8 sequences that span a chunk boundary
+    // (CJK content is 3 bytes/char and easily crosses an 8 KiB cut) decode
+    // correctly when the full line is finally assembled. Decoding per-chunk
+    // would insert U+FFFD replacement chars and silently corrupt content,
+    // breaking strict-equality predicates.
+    let leadingBuffer: Buffer = Buffer.alloc(0);
 
     while (position > 0) {
       const chunkSize = Math.min(DEFAULT_CHUNK_SIZE, position);
@@ -73,37 +78,53 @@ export function readJsonlTail<T = unknown>(filePath: string, opts: ReadJsonlTail
       const n = readSync(fd, buffer, 0, chunkSize, position);
       if (n === 0) break;
 
-      // chunkText is older content; leadingBuffer is newer content (already-read
-      // chunk's first element that was a partial line). Concatenated they form
-      // a contiguous slice of the file [position, position+chunkSize+|leadingBuffer|).
-      const combined = buffer.toString('utf8', 0, n) + leadingBuffer;
-      const parts = combined.split('\n');
+      // Older bytes (this chunk) + newer bytes (leadingBuffer from previous
+      // iteration). Together they form a contiguous file slice
+      // [position, position + chunkSize + |leadingBuffer|).
+      const combined = Buffer.concat([buffer.subarray(0, n), leadingBuffer]);
+
+      // Split on newline byte (0x0a). subarray() returns Buffer views sharing
+      // memory with `combined`, so no extra allocation per segment.
+      const parts: Buffer[] = [];
+      let segmentStart = 0;
+      for (let i = 0; i < combined.length; i++) {
+        if (combined[i] === 0x0a) {
+          parts.push(combined.subarray(segmentStart, i));
+          segmentStart = i + 1;
+        }
+      }
+      parts.push(combined.subarray(segmentStart));
 
       // When position > 0 we cannot trust parts[0] is a complete line — it may
       // be the back half of a line whose front half lives in the next (older)
-      // chunk. Save it as leadingBuffer for the next iteration.
+      // chunk. Copy its bytes into leadingBuffer for the next iteration (copy
+      // is required because the next readSync will overwrite `buffer`, and
+      // `combined`/parts views into it).
       // When position === 0 there is no more chunk; parts[0] is the file's
       // first line (complete) and must be processed.
       let processFromIndex: number;
       if (position === 0) {
         processFromIndex = 0;
-        leadingBuffer = '';
+        leadingBuffer = Buffer.alloc(0);
       } else {
         processFromIndex = 1;
-        leadingBuffer = parts[0] ?? '';
+        leadingBuffer = Buffer.from(parts[0] ?? Buffer.alloc(0));
         if (leadingBuffer.length > LEADING_BUFFER_CAP) return undefined;
       }
 
       // Process complete lines in REVERSE (newest first). Skip empty (trailing
       // newline at EOF) and unparseable (partial-write race) lines.
       for (let i = parts.length - 1; i >= processFromIndex; i--) {
-        const line = parts[i];
-        if (line === '') continue;
+        const lineBytes = parts[i];
+        if (lineBytes.length === 0) continue;
         linesScanned++;
         if (linesScanned > maxLines) return undefined;
         let parsed: unknown;
         try {
-          parsed = JSON.parse(line);
+          // Single utf8 decode of a complete line. Multi-byte sequences are
+          // intact because we collected ALL bytes between newlines before
+          // decoding (vs the previous per-chunk decode which split mid-char).
+          parsed = JSON.parse(lineBytes.toString('utf8'));
         } catch {
           continue;
         }

--- a/packages/api/test/fixtures/gemini-session-chunk-boundary.jsonl
+++ b/packages/api/test/fixtures/gemini-session-chunk-boundary.jsonl
@@ -1,0 +1,3 @@
+{"sessionId":"test-session-chunk-001","startedAt":"2026-05-09T01:00:00.000Z"}
+{"id":"msg-001","timestamp":"2026-05-09T01:00:01.000Z","type":"user","content":"测试"}
+{"id":"msg-002","timestamp":"2026-05-09T01:00:02.000Z","type":"gemini","content":"调用工具完成了","tokens":{"input":50,"output":10,"cached":0,"thoughts":0,"tool":0,"total":77},"model":"gemini-test"}

--- a/packages/api/test/fixtures/gemini-session-decoy.jsonl
+++ b/packages/api/test/fixtures/gemini-session-decoy.jsonl
@@ -1,0 +1,3 @@
+{"sessionId":"DECOY-different-session-uuid","startedAt":"2026-05-09T02:00:00.000Z"}
+{"id":"d-msg-001","timestamp":"2026-05-09T02:00:01.000Z","type":"user","content":"unrelated user prompt"}
+{"id":"d-msg-002","timestamp":"2026-05-09T02:00:02.000Z","type":"gemini","content":"Hi there!","tokens":{"input":900,"output":99,"cached":0,"thoughts":0,"tool":0,"total":999},"model":"gemini-test"}

--- a/packages/api/test/fixtures/gemini-session-with-tokens.jsonl
+++ b/packages/api/test/fixtures/gemini-session-with-tokens.jsonl
@@ -1,0 +1,8 @@
+{"sessionId":"test-session-uuid-001","startedAt":"2026-05-09T01:00:00.000Z"}
+{"id":"msg-001","timestamp":"2026-05-09T01:00:01.000Z","type":"user","content":"Hello"}
+{"id":"msg-002","timestamp":"2026-05-09T01:00:02.000Z","type":"gemini","content":"Hi there!","tokens":{"input":50,"output":10,"cached":0,"thoughts":0,"tool":0,"total":60},"model":"gemini-test"}
+{"$set":{"lastUpdated":"2026-05-09T01:00:02.000Z"}}
+{"id":"msg-003","timestamp":"2026-05-09T01:00:03.000Z","type":"user","content":"Tell me more"}
+{"id":"msg-004","timestamp":"2026-05-09T01:00:04.000Z","type":"gemini","content":"Here is more info about the topic","thoughts":[{"subject":"Analyzing","description":"Considering the user request"}],"tokens":{"input":100,"output":20,"cached":50,"thoughts":5,"tool":0,"total":125},"model":"gemini-test"}
+{"$set":{"lastUpdated":"2026-05-09T01:00:04.000Z"}}
+{"id":"msg-004","timestamp":"2026-05-09T01:00:04.500Z","type":"gemini","content":"Here is more info about the topic","thoughts":[{"subject":"Analyzing","description":"Considering the user request"}],"tokens":{"input":105,"output":25,"cached":50,"thoughts":5,"tool":0,"total":130},"model":"gemini-test","toolCalls":[{"id":"tc1","name":"read_file","args":{}}]}

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -963,7 +963,7 @@ test('prefers latest matching gemini message when same content appears multiple 
 
     emitGeminiEvents(proc, [
       { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
-      // Content matches both msg-004 occurrences (line 6: total=125, line 8: total=130)
+      // Content matches both msg-004 occurrences (line 6: input=100, line 8: input=105)
       { type: 'message', role: 'assistant', content: 'Here is more info about the topic', delta: true },
       { type: 'result', status: 'success', stats: { total_tokens: 200 } },
     ]);

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -865,12 +865,12 @@ test('skips Gemini local thinking hydration when the latest session content does
 // per-turn. Cat Cafe currently uses the cumulative value as fillRatio numerator,
 // causing Gemini sessions to spuriously cap at 100% after a few turns.
 //
-// Fix direction: read per-turn `tokens.total` from local Gemini session jsonl
+// Fix direction: read per-turn `tokens.input` from local Gemini session jsonl
 // file, write to `metadata.usage.lastTurnInputTokens` so invoke-single-cat's
 // usedFrom priority picks the per-turn value over the cumulative inputTokens.
 //
 // These tests use the real Gemini CLI file format (.jsonl with header + $set +
-// gemini messages with tokens.total) which also exposes a latent bug in the
+// gemini messages with tokens) which also exposes a latent bug in the
 // existing readGeminiThinkingFromLocalSession (filters .json, parses whole-file
 // JSON — neither works on real Gemini output).
 // ===========================================================================
@@ -889,15 +889,15 @@ test('extracts lastTurnInputTokens from local Gemini session jsonl when assistan
   process.env.HOME = fakeHome;
 
   try {
-    // Matching session fixture — sessionId="test-session-uuid-001", "Hi there!" tokens.total=60
+    // Matching session fixture — sessionId="test-session-uuid-001", "Hi there!" tokens.input=50
     const matchPath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
     const matchContent = readFileSync(matchPath, 'utf8');
     const matchFile = join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl');
     writeFileSync(matchFile, matchContent);
 
-    // Decoy session fixture — different sessionId, SAME content "Hi there!", tokens.total=999
+    // Decoy session fixture — different sessionId, SAME content "Hi there!", tokens.input=900
     // If implementation reads "the latest .jsonl file" instead of matching sessionId,
-    // it would pick up 999 here. Correct implementation must return 60.
+    // it would pick up 900 here. Correct implementation must return 50.
     const decoyPath = join(import.meta.dirname, 'fixtures', 'gemini-session-decoy.jsonl');
     const decoyContent = readFileSync(decoyPath, 'utf8');
     const decoyFile = join(sessionDir, 'session-2026-05-09T02-00-decoy.jsonl');
@@ -913,8 +913,8 @@ test('extracts lastTurnInputTokens from local Gemini session jsonl when assistan
 
     emitGeminiEvents(proc, [
       { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
-      // Assistant content matches msg-002 in matching fixture (tokens.total=60)
-      // AND d-msg-002 in decoy fixture (tokens.total=999)
+      // Assistant content matches msg-002 in matching fixture (tokens.input=50)
+      // AND d-msg-002 in decoy fixture (tokens.input=900)
       { type: 'message', role: 'assistant', content: 'Hi there!', delta: true },
       // Cumulative stats from CLI inflated to mimic the bug
       { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
@@ -926,11 +926,13 @@ test('extracts lastTurnInputTokens from local Gemini session jsonl when assistan
     // Cumulative stats from CLI preserved as-is for telemetry
     assert.equal(done.metadata.usage.inputTokens, 8888);
     assert.equal(done.metadata.usage.totalTokens, 9999);
-    // Per-turn lastTurnInputTokens MUST come from matching session (60), NOT decoy (999)
+    // Per-turn lastTurnInputTokens MUST come from matching session (50), NOT decoy (900).
+    // Also: returns tokens.input (50), NOT tokens.total (60) — the metadata field is
+    // semantically input tokens only, not total. (Bug A regression: previously total.)
     assert.equal(
       done.metadata.usage.lastTurnInputTokens,
-      60,
-      'lastTurnInputTokens MUST match by sessionId (=60), NOT pick decoy by mtime (=999)',
+      50,
+      'lastTurnInputTokens MUST match by sessionId AND return tokens.input (=50), NOT tokens.total (=60) and NOT decoy (=900)',
     );
   } finally {
     process.env.HOME = previousHome;
@@ -939,8 +941,8 @@ test('extracts lastTurnInputTokens from local Gemini session jsonl when assistan
 
 test('prefers latest matching gemini message when same content appears multiple times in same session', async () => {
   // Fixture line 6 and line 8 both have content "Here is more info about the topic"
-  // but tokens.total=125 (line 6) vs tokens.total=130 (line 8). Implementation must
-  // pick the latest matching message (130), not the first (125), to handle Gemini
+  // but tokens.input=100 (line 6) vs tokens.input=105 (line 8). Implementation must
+  // pick the latest matching message (105), not the first (100), to handle Gemini
   // CLI's streamed duplicate-row updates.
   const proc = createMockProcess();
   const spawnFn = createMockSpawnFn(proc);
@@ -971,8 +973,8 @@ test('prefers latest matching gemini message when same content appears multiple 
     assert.ok(done?.metadata?.usage, 'done should have usage metadata');
     assert.equal(
       done.metadata.usage.lastTurnInputTokens,
-      130,
-      'lastTurnInputTokens must equal the LATEST matching message tokens.total (130), not the first (125)',
+      105,
+      'lastTurnInputTokens must equal the LATEST matching message tokens.input (105), not the first (100)',
     );
   } finally {
     process.env.HOME = previousHome;
@@ -1046,7 +1048,7 @@ test('injects lastTurnInputTokens for tool-only turn (no message/assistant event
     const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
 
     // No message/assistant event at all — tool-only turn shape. fixture
-    // tail-most gemini-with-tokens is msg-004 (line 8) with tokens.total=130.
+    // tail-most gemini-with-tokens is msg-004 (line 8) with tokens.input=105.
     emitGeminiEvents(proc, [
       { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
       { type: 'tool_use', tool_name: 'read_file', tool_id: 't1', parameters: { path: '/tmp/x' } },
@@ -1060,8 +1062,8 @@ test('injects lastTurnInputTokens for tool-only turn (no message/assistant event
     assert.equal(done.metadata.usage.inputTokens, 8888);
     assert.equal(
       done.metadata.usage.lastTurnInputTokens,
-      130,
-      'tool-only turn (empty assistantText) must still inject lastTurnInputTokens from tail-most jsonl candidate',
+      105,
+      'tool-only turn (empty assistantText) must still inject lastTurnInputTokens from tail-most jsonl candidate tokens.input',
     );
   } finally {
     process.env.HOME = previousHome;
@@ -1109,8 +1111,91 @@ test('matches jsonl content even when Gemini CLI emits multiple text events (\\n
     assert.equal(done.metadata.usage.inputTokens, 8888);
     assert.equal(
       done.metadata.usage.lastTurnInputTokens,
-      77,
-      'lastTurnInputTokens must match the jsonl message even when fullAssistantText has \\n\\n boundaries inserted between events',
+      50,
+      'lastTurnInputTokens must match the jsonl message even when fullAssistantText has \\n\\n boundaries inserted between events (tokens.input=50, not tokens.total=77)',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
+test('matches jsonl final row when fullAssistantText is thinking-prefix + final (suffix match)', async () => {
+  // Repro of runtime bug observed 2026-05-11 (LD visual verification rounds 4 & 6):
+  // when the model thinks first then produces a final reply, Gemini CLI emits
+  // MULTIPLE `message/assistant` events (one per thinking step + one final).
+  // GeminiAgentService stitches them with `\n\n` into fullAssistantText, e.g.:
+  //   "**Counting lines in source files**...\n\n**Calculating Line Counts**...\n\n实际 final text"
+  // The jsonl, however, stores each step in its own row — the FINAL row's
+  // content equals only "实际 final text" (the tail). Strict equality would
+  // miss this; the suffix-match branch of matchesCurrentAssistantText must
+  // recover the match without falling back to cumulative tokens.
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    // Build a custom jsonl with thinking-prefix shape: 2 thinking rows + 1 final row.
+    // Only the final row carries tokens.input=42 (this is THIS turn's value).
+    const sessionId = 'test-session-thinking-001';
+    const jsonl = [
+      JSON.stringify({ sessionId, startedAt: '2026-05-11T16:00:00.000Z' }),
+      JSON.stringify({
+        id: 'th-001',
+        timestamp: '2026-05-11T16:00:01.000Z',
+        type: 'gemini',
+        content: '**Counting lines in source files**',
+        thoughts: [{ subject: 'thinking step 1' }],
+        tokens: { input: 10, output: 5, total: 15 },
+        model: 'gemini-test',
+      }),
+      JSON.stringify({
+        id: 'th-002',
+        timestamp: '2026-05-11T16:00:02.000Z',
+        type: 'gemini',
+        content: '**Calculating Line Counts**',
+        thoughts: [{ subject: 'thinking step 2' }],
+        tokens: { input: 20, output: 5, total: 25 },
+        model: 'gemini-test',
+      }),
+      JSON.stringify({
+        id: 'final-001',
+        timestamp: '2026-05-11T16:00:03.000Z',
+        type: 'gemini',
+        content: '实际 final text',
+        tokens: { input: 42, output: 10, total: 52 },
+        model: 'gemini-test',
+      }),
+      '',
+    ].join('\n');
+    writeFileSync(join(sessionDir, `session-2026-05-11T16-00-thinking001.jsonl`), jsonl);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: sessionId, model: 'gemini-test' },
+      // Three assistant events; cat cafe stitches them as
+      //   "**Counting lines in source files**\n\n**Calculating Line Counts**\n\n实际 final text"
+      // Only the LAST piece equals the jsonl final-row content.
+      { type: 'message', role: 'assistant', content: '**Counting lines in source files**', delta: true },
+      { type: 'message', role: 'assistant', content: '**Calculating Line Counts**', delta: true },
+      { type: 'message', role: 'assistant', content: '实际 final text', delta: true },
+      { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    assert.equal(done.metadata.usage.inputTokens, 8888); // cumulative preserved
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      42,
+      'thinking-prefix shape (stitched assistantText, separate jsonl rows) MUST still resolve via suffix-match — final row tokens.input (=42), NOT cumulative (=8888), NOT thinking-row tokens (=10 / =20)',
     );
   } finally {
     process.env.HOME = previousHome;

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -1018,6 +1018,55 @@ test('does not fall back to latest message when assistant text matches no jsonl 
   }
 });
 
+test('matches jsonl content even when Gemini CLI emits multiple text events (\\n\\n chunk boundary)', async () => {
+  // Repro of runtime bug observed 2026-05-11: Gemini CLI sometimes emits the
+  // same logical turn as multiple `type:"message", role:"assistant"` events,
+  // which GeminiAgentService concatenates with `\n\n` separators into
+  // `fullAssistantText`. Local jsonl, however, stores the CLI's final
+  // re-assembled content as a single string with NO `\n\n`. With the prior
+  // normalize (`\s+` → ' '), these would diverge for any inter-event boundary
+  // that fell mid-CJK / mid-digit / mid-path: "调\n\n用" → "调 用" != "调用".
+  // Fix: normalize strips all whitespace, not just folds it.
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    const fixturePath = join(import.meta.dirname, 'fixtures', 'gemini-session-chunk-boundary.jsonl');
+    const jsonlContent = readFileSync(fixturePath, 'utf8');
+    writeFileSync(join(sessionDir, 'session-2026-05-09T01-00-chunk001.jsonl'), jsonlContent);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    // Two assistant events; together they assemble into "调用工具完成了" in the
+    // jsonl, but GeminiAgentService stitches them as "调\n\n用工具完成了".
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-chunk-001', model: 'gemini-test' },
+      { type: 'message', role: 'assistant', content: '调', delta: true },
+      { type: 'message', role: 'assistant', content: '用工具完成了', delta: true },
+      { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    assert.equal(done.metadata.usage.inputTokens, 8888);
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      77,
+      'lastTurnInputTokens must match the jsonl message even when fullAssistantText has \\n\\n boundaries inserted between events',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
 test('reads .jsonl files (Gemini CLI real format) and extracts thinking from matching message', async () => {
   // Latent bug regression: existing readGeminiThinkingFromLocalSession previously
   // filtered for .json only, but real Gemini CLI writes .jsonl. This test ensures

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -5,7 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
@@ -853,6 +853,206 @@ test('skips Gemini local thinking hydration when the latest session content does
     const msgs = await promise;
     const thinkingMsg = msgs.find((m) => m.type === 'system_info' && m.content.includes('"type":"thinking"'));
     assert.equal(thinkingMsg, undefined);
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
+// ===========================================================================
+// lastTurnInputTokens from local Gemini session jsonl
+// ---------------------------------------------------------------------------
+// Bug: Gemini CLI's stream `result.stats` is session-level cumulative, not
+// per-turn. Cat Cafe currently uses the cumulative value as fillRatio numerator,
+// causing Gemini sessions to spuriously cap at 100% after a few turns.
+//
+// Fix direction: read per-turn `tokens.total` from local Gemini session jsonl
+// file, write to `metadata.usage.lastTurnInputTokens` so invoke-single-cat's
+// usedFrom priority picks the per-turn value over the cumulative inputTokens.
+//
+// These tests use the real Gemini CLI file format (.jsonl with header + $set +
+// gemini messages with tokens.total) which also exposes a latent bug in the
+// existing readGeminiThinkingFromLocalSession (filters .json, parses whole-file
+// JSON — neither works on real Gemini output).
+// ===========================================================================
+
+test('extracts lastTurnInputTokens from local Gemini session jsonl when assistant text matches', async () => {
+  // Includes a decoy .jsonl with same content but different sessionId and newer
+  // mtime, to lock in "must match by sessionId, not by file freshness".
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    // Matching session fixture — sessionId="test-session-uuid-001", "Hi there!" tokens.total=60
+    const matchPath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
+    const matchContent = readFileSync(matchPath, 'utf8');
+    const matchFile = join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl');
+    writeFileSync(matchFile, matchContent);
+
+    // Decoy session fixture — different sessionId, SAME content "Hi there!", tokens.total=999
+    // If implementation reads "the latest .jsonl file" instead of matching sessionId,
+    // it would pick up 999 here. Correct implementation must return 60.
+    const decoyPath = join(import.meta.dirname, 'fixtures', 'gemini-session-decoy.jsonl');
+    const decoyContent = readFileSync(decoyPath, 'utf8');
+    const decoyFile = join(sessionDir, 'session-2026-05-09T02-00-decoy.jsonl');
+    writeFileSync(decoyFile, decoyContent);
+
+    // Force decoy to have NEWER mtime so a "sort by mtime desc, take first match"
+    // implementation that ignores sessionId would pick decoy first.
+    const now = Date.now() / 1000;
+    utimesSync(matchFile, now - 60, now - 60);
+    utimesSync(decoyFile, now, now);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
+      // Assistant content matches msg-002 in matching fixture (tokens.total=60)
+      // AND d-msg-002 in decoy fixture (tokens.total=999)
+      { type: 'message', role: 'assistant', content: 'Hi there!', delta: true },
+      // Cumulative stats from CLI inflated to mimic the bug
+      { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    // Cumulative stats from CLI preserved as-is for telemetry
+    assert.equal(done.metadata.usage.inputTokens, 8888);
+    assert.equal(done.metadata.usage.totalTokens, 9999);
+    // Per-turn lastTurnInputTokens MUST come from matching session (60), NOT decoy (999)
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      60,
+      'lastTurnInputTokens MUST match by sessionId (=60), NOT pick decoy by mtime (=999)',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
+test('prefers latest matching gemini message when same content appears multiple times in same session', async () => {
+  // Fixture line 6 and line 8 both have content "Here is more info about the topic"
+  // but tokens.total=125 (line 6) vs tokens.total=130 (line 8). Implementation must
+  // pick the latest matching message (130), not the first (125), to handle Gemini
+  // CLI's streamed duplicate-row updates.
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    const fixturePath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
+    const jsonlContent = readFileSync(fixturePath, 'utf8');
+    writeFileSync(join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl'), jsonlContent);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
+      // Content matches both msg-004 occurrences (line 6: total=125, line 8: total=130)
+      { type: 'message', role: 'assistant', content: 'Here is more info about the topic', delta: true },
+      { type: 'result', status: 'success', stats: { total_tokens: 200 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      130,
+      'lastTurnInputTokens must equal the LATEST matching message tokens.total (130), not the first (125)',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
+test('does not fall back to latest message when assistant text matches no jsonl message', async () => {
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    const fixturePath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
+    const jsonlContent = readFileSync(fixturePath, 'utf8');
+    writeFileSync(join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl'), jsonlContent);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
+      // Content matches NO gemini message in fixture (don't degrade to latest!)
+      { type: 'message', role: 'assistant', content: 'completely unrelated reply text', delta: true },
+      { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    assert.equal(done.metadata.usage.inputTokens, 8888); // cumulative preserved
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      undefined,
+      'lastTurnInputTokens MUST be undefined when no message matches; do NOT fall back to latest',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
+test('reads .jsonl files (Gemini CLI real format) and extracts thinking from matching message', async () => {
+  // Latent bug regression: existing readGeminiThinkingFromLocalSession previously
+  // filtered for .json only, but real Gemini CLI writes .jsonl. This test ensures
+  // thinking extraction now works end-to-end on the real format.
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    const fixturePath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
+    const jsonlContent = readFileSync(fixturePath, 'utf8');
+    writeFileSync(join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl'), jsonlContent);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
+      // Match msg-004 in fixture (which has thoughts)
+      { type: 'message', role: 'assistant', content: 'Here is more info about the topic', delta: true },
+      { type: 'result', status: 'success', stats: { total_tokens: 100 } },
+    ]);
+
+    const msgs = await promise;
+    const thinkingMsg = msgs.find((m) => m.type === 'system_info' && m.content?.includes?.('"type":"thinking"'));
+    assert.ok(thinkingMsg, 'should extract thinking from matching gemini message in .jsonl');
+    const parsed = JSON.parse(thinkingMsg.content);
+    assert.equal(parsed.type, 'thinking');
+    assert.match(parsed.text, /\*\*Analyzing\*\*/);
+    assert.match(parsed.text, /Considering the user request/);
   } finally {
     process.env.HOME = previousHome;
   }

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -1018,6 +1018,56 @@ test('does not fall back to latest message when assistant text matches no jsonl 
   }
 });
 
+test('injects lastTurnInputTokens for tool-only turn (no message/assistant event, fullAssistantText empty)', async () => {
+  // Repro of runtime bug observed 2026-05-11 endurance run: when Gemini CLI
+  // performs a turn that produces ONLY thinking + tool_use (no
+  // message/assistant event), GeminiAgentService leaves `fullAssistantText`
+  // empty. Previously the empty-assistantText guard in
+  // readLatestGeminiContextTokens returned undefined unconditionally — so
+  // tool-only turns silently degraded to cumulative inputTokens (UI's ↓
+  // widget == ContextHealthBar number).
+  // Fix: empty assistantText falls back to tail-most jsonl candidate, which
+  // IS this turn's latest message (sessionId-bound, CLI flushed before done).
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = new GeminiAgentService({ spawnFn, adapter: 'gemini-cli' });
+
+  const fakeHome = mkdtempSync(join(tmpdir(), 'gemini-home-'));
+  const sessionDir = join(fakeHome, '.gemini', 'tmp', 'clowder-ai', 'chats');
+  mkdirSync(sessionDir, { recursive: true });
+  const previousHome = process.env.HOME;
+  process.env.HOME = fakeHome;
+
+  try {
+    const fixturePath = join(import.meta.dirname, 'fixtures', 'gemini-session-with-tokens.jsonl');
+    const jsonlContent = readFileSync(fixturePath, 'utf8');
+    writeFileSync(join(sessionDir, 'session-2026-05-09T01-00-test001.jsonl'), jsonlContent);
+
+    const promise = collect(service.invoke('test', { workingDirectory: '/home/user/clowder-ai' }));
+
+    // No message/assistant event at all — tool-only turn shape. fixture
+    // tail-most gemini-with-tokens is msg-004 (line 8) with tokens.total=130.
+    emitGeminiEvents(proc, [
+      { type: 'init', session_id: 'test-session-uuid-001', model: 'gemini-test' },
+      { type: 'tool_use', tool_name: 'read_file', tool_id: 't1', parameters: { path: '/tmp/x' } },
+      { type: 'tool_result', tool_id: 't1', status: 'success', output: 'file content' },
+      { type: 'result', status: 'success', stats: { total_tokens: 9999, input_tokens: 8888 } },
+    ]);
+
+    const msgs = await promise;
+    const done = msgs.find((m) => m.type === 'done');
+    assert.ok(done?.metadata?.usage, 'done should have usage metadata');
+    assert.equal(done.metadata.usage.inputTokens, 8888);
+    assert.equal(
+      done.metadata.usage.lastTurnInputTokens,
+      130,
+      'tool-only turn (empty assistantText) must still inject lastTurnInputTokens from tail-most jsonl candidate',
+    );
+  } finally {
+    process.env.HOME = previousHome;
+  }
+});
+
 test('matches jsonl content even when Gemini CLI emits multiple text events (\\n\\n chunk boundary)', async () => {
   // Repro of runtime bug observed 2026-05-11: Gemini CLI sometimes emits the
   // same logical turn as multiple `type:"message", role:"assistant"` events,

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -934,6 +934,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(payload.health.usedTokens, 50000);
     assert.equal(payload.health.windowTokens, 200000);
     assert.equal(payload.health.source, 'exact');
+    assert.equal(payload.health.usedFrom, 'input');
     assert.ok(payload.health.fillRatio > 0 && payload.health.fillRatio <= 1);
   });
 
@@ -1075,6 +1076,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(active.contextHealth.windowTokens, 200000);
     assert.equal(active.contextHealth.fillRatio, 0.7);
     assert.equal(active.contextHealth.source, 'exact');
+    assert.equal(active.contextHealth.usedFrom, 'input');
   });
 
   it('F24-fix: prefers lastTurnInputTokens over aggregated inputTokens for context health', async () => {
@@ -1131,6 +1133,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       44000,
       'context health should use lastTurnInputTokens, not aggregated inputTokens',
     );
+    assert.equal(payload.health.usedFrom, 'last_turn');
     assert.equal(payload.health.windowTokens, 200000);
     // fillRatio should be 44000/200000 = 0.22, not 192000/200000 = 0.96
     const expectedRatio = 44000 / 200000;
@@ -1189,6 +1192,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       50000,
       'should fall back to inputTokens when lastTurnInputTokens is absent',
     );
+    assert.equal(payload.health.usedFrom, 'input');
   });
 
   it('F24: falls back to totalTokens when inputTokens are unavailable (totalTokens-only provider)', async () => {
@@ -1238,6 +1242,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(payload.catId, 'codex');
     assert.equal(payload.health.usedTokens, 4200);
     assert.equal(payload.health.source, 'approx');
+    assert.equal(payload.health.usedFrom, 'total');
   });
 
   it('F24: marks source as approx when usedTokens falls back to totalTokens despite exact window', async () => {
@@ -5270,6 +5275,11 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       healthPayload.health.fillRatio,
       0.9,
       'fillRatio computed from cumulative usage (telemetry visible) but auto-seal is gated below',
+    );
+    assert.equal(
+      healthPayload.health.usedFrom,
+      'input',
+      'context_health should expose that this Gemini health value came from cumulative inputTokens fallback',
     );
 
     // session_seal_requested MUST NOT emit; requestSeal MUST NOT be called

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5178,6 +5178,196 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       await rmWithRetry(devRoot);
     }
   });
+
+  // ===========================================================================
+  // Gemini cumulative-only auto-seal guard
+  // ---------------------------------------------------------------------------
+  // Bug: Gemini CLI's stream `result.stats` is session-level cumulative, not
+  // per-turn. Without the guard, fillRatio is computed from cumulative
+  // inputTokens which inflate beyond windowSize and cap at 1.0 → spurious
+  // auto-seal for google provider after a few turns.
+  //
+  // Fix: GeminiAgentService injects per-turn lastTurnInputTokens from local
+  // jsonl when possible; if it could not, invoke-single-cat skips auto-seal
+  // (telemetry preserved).
+  //
+  // Two behavior tests:
+  //   1. Google + cumulative-only → no seal (validates the guard kicks in)
+  //   2. Google + per-turn over threshold → still seals (validates guard not
+  //      written too wide; Gemini can still seal when context-fill is real)
+  // ===========================================================================
+
+  it('F-Gemini-cumulative: skips auto-seal for google provider when only cumulative usage available', async () => {
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    sessionChainStore.create({
+      cliSessionId: 'cli-gemini-cumulative',
+      threadId: 'thread-gemini-cumulative',
+      catId: 'gemini',
+      userId: 'user1',
+    });
+
+    const sealRequests = [];
+    const sessionSealer = {
+      requestSeal: async (input) => {
+        sealRequests.push(input);
+        return { accepted: true, status: 'sealing' };
+      },
+      finalize: async () => {},
+      reconcileStuck: async () => 0,
+      reconcileAllStuck: async () => 0,
+    };
+
+    const service = {
+      async *invoke() {
+        yield { type: 'session_init', catId: 'gemini', sessionId: 'cli-gemini-cumulative', timestamp: Date.now() };
+        yield {
+          type: 'done',
+          catId: 'gemini',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'google',
+            model: 'gemini-3.1-pro-preview',
+            usage: {
+              // Cumulative session metrics (the bug scenario): 90% of 1M window
+              // far above google action threshold (0.65) — would normally seal.
+              inputTokens: 900_000,
+              outputTokens: 10,
+              contextWindowSize: 1_000_000,
+              // No lastTurnInputTokens: GeminiAgentService GREEN couldn't inject
+              // (e.g. assistantText empty / no matching local jsonl message).
+            },
+          },
+        };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore, sessionSealer };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'gemini',
+        service,
+        prompt: 'test cumulative-only no-seal',
+        userId: 'user1',
+        threadId: 'thread-gemini-cumulative',
+        isLastCat: true,
+      }),
+    );
+
+    // context_health MUST still emit for telemetry / observability
+    const healthInfo = msgs.find((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'context_health';
+      } catch {
+        return false;
+      }
+    });
+    assert.ok(healthInfo, 'should still emit context_health for observability');
+    const healthPayload = JSON.parse(healthInfo.content);
+    assert.equal(
+      healthPayload.health.fillRatio,
+      0.9,
+      'fillRatio computed from cumulative usage (telemetry visible) but auto-seal is gated below',
+    );
+
+    // session_seal_requested MUST NOT emit; requestSeal MUST NOT be called
+    const hasSealRequested = msgs.some((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'session_seal_requested';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(
+      hasSealRequested,
+      false,
+      'should NOT emit session_seal_requested when only cumulative usage available',
+    );
+    assert.equal(sealRequests.length, 0, 'should NOT call requestSeal on Gemini cumulative-only telemetry');
+  });
+
+  it('F-Gemini-per-turn: still seals for google provider when lastTurnInputTokens exceeds threshold', async () => {
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    sessionChainStore.create({
+      cliSessionId: 'cli-gemini-perturn',
+      threadId: 'thread-gemini-perturn',
+      catId: 'gemini',
+      userId: 'user1',
+    });
+
+    const sealRequests = [];
+    const sessionSealer = {
+      requestSeal: async (input) => {
+        sealRequests.push(input);
+        return { accepted: true, status: 'sealing' };
+      },
+      finalize: async () => {},
+      reconcileStuck: async () => 0,
+      reconcileAllStuck: async () => 0,
+    };
+
+    const service = {
+      async *invoke() {
+        yield { type: 'session_init', catId: 'gemini', sessionId: 'cli-gemini-perturn', timestamp: Date.now() };
+        yield {
+          type: 'done',
+          catId: 'gemini',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'google',
+            model: 'gemini-3.1-pro-preview',
+            usage: {
+              // Per-turn lastTurnInputTokens — the real context fill (above
+              // google action threshold 0.65). Guard must NOT skip seal here,
+              // otherwise Gemini would never seal.
+              lastTurnInputTokens: 900_000,
+              // Cumulative inputTokens kept low to confirm the guard reads
+              // usedFrom (which prefers last_turn) rather than cumulative.
+              inputTokens: 8_888,
+              outputTokens: 10,
+              contextWindowSize: 1_000_000,
+            },
+          },
+        };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore, sessionSealer };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'gemini',
+        service,
+        prompt: 'test per-turn seals normally',
+        userId: 'user1',
+        threadId: 'thread-gemini-perturn',
+        isLastCat: true,
+      }),
+    );
+
+    const hasSealRequested = msgs.some((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'session_seal_requested';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(
+      hasSealRequested,
+      true,
+      'should emit session_seal_requested when lastTurnInputTokens exceeds threshold (guard MUST NOT block per-turn seal)',
+    );
+    assert.equal(
+      sealRequests.length,
+      1,
+      'should call requestSeal exactly once when per-turn context fill exceeds google action threshold',
+    );
+  });
 });
 
 // F155: Old pre-invocation guide routing hook tests removed.

--- a/packages/api/test/jsonl-tail-reader.test.js
+++ b/packages/api/test/jsonl-tail-reader.test.js
@@ -101,6 +101,23 @@ describe('readJsonlTail', () => {
     assert.equal(result, undefined, 'missing file should return undefined, not throw');
   });
 
+  test('respects maxBytes budget — bounds total bytes read from tail', () => {
+    // Build a ~512 KB jsonl: only entry at the very FRONT, padded user lines
+    // after. With a small maxBytes the tail reader must give up before
+    // reaching the front match.
+    const front = { type: 'gemini', content: 'oldest', tokens: { total: 4242 } };
+    const padding = Array.from({ length: 5000 }, (_, i) => ({
+      type: 'user',
+      content: `pad-${i}`.padEnd(100, 'x'),
+    }));
+    const path = makeJsonlFile([front, ...padding]);
+    const result = readJsonlTail(path, {
+      maxBytes: 16 * 1024, // 16 KiB — far less than the file size
+      predicate: (m) => m?.type === 'gemini' && typeof m?.tokens?.total === 'number',
+    });
+    assert.equal(result, undefined, 'must give up after maxBytes; should not read entire file to find front match');
+  });
+
   test('handles a large jsonl by reading from tail (sanity, not perf assertion)', () => {
     // ~5000 padded user lines + 1 gemini at the very end. Real perf assertion
     // (e.g. measuring fs.readSync invocations) is left for follow-up; here we

--- a/packages/api/test/jsonl-tail-reader.test.js
+++ b/packages/api/test/jsonl-tail-reader.test.js
@@ -118,6 +118,35 @@ describe('readJsonlTail', () => {
     assert.equal(result, undefined, 'must give up after maxBytes; should not read entire file to find front match');
   });
 
+  test('preserves multi-byte UTF-8 (CJK) when a line spans multiple chunks', () => {
+    // 3000 CJK chars × 3 bytes ≈ 9 KB → a single line exceeds the 8 KiB
+    // default chunk; at least one chunk boundary lands mid-character.
+    // The previous per-chunk toString('utf8') would inject U+FFFD into the
+    // half-character on each side of the cut, corrupting content and breaking
+    // strict-equality predicates used by readLatestGeminiContextTokens.
+    const longCjk = '汉'.repeat(3000);
+    const target = { type: 'gemini', content: longCjk, tokens: { total: 12345 } };
+    const path = makeJsonlFile([
+      { type: 'user', content: 'first' },
+      target,
+      { type: 'user', content: 'last' }, // tail entry is NOT the target — target sits before EOF.
+    ]);
+
+    const result = readJsonlTail(path, {
+      predicate: (m) =>
+        m != null &&
+        typeof m === 'object' &&
+        m.type === 'gemini' &&
+        m.content === longCjk &&
+        typeof m.tokens?.total === 'number',
+    });
+    assert.equal(
+      result?.tokens?.total,
+      12345,
+      'must find target message via strict content equality even when the line spans multiple chunks',
+    );
+  });
+
   test('handles a large jsonl by reading from tail (sanity, not perf assertion)', () => {
     // ~5000 padded user lines + 1 gemini at the very end. Real perf assertion
     // (e.g. measuring fs.readSync invocations) is left for follow-up; here we

--- a/packages/api/test/jsonl-tail-reader.test.js
+++ b/packages/api/test/jsonl-tail-reader.test.js
@@ -1,0 +1,119 @@
+/**
+ * RED tests for `readJsonlTail` — reverse-tail JSONL reader used by
+ * `readLatestGeminiContextTokens` to avoid full-file readFileSync on
+ * potentially-multi-megabyte Gemini local session jsonl files.
+ *
+ * The current GREEN dependency (parseGeminiSessionFile) loads the whole
+ * file with readFileSync + split('\n') on every Gemini invocation
+ * completion. For long sessions this is sync I/O on the Node event loop
+ * after every model turn. The reverse-tail reader stops as soon as the
+ * latest match is found.
+ *
+ * These tests will fail against the stub implementation that always
+ * returns undefined, and pass after the real implementation lands.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+
+const { readJsonlTail } = await import('../dist/utils/jsonl-tail-reader.js');
+
+/**
+ * Build a temp jsonl file from a list of entries. String entries are written
+ * verbatim (use to inject malformed lines). Object entries are JSON.stringified.
+ * Adds trailing newline only if the last entry is not a raw string (to allow
+ * partial-last-line tests).
+ */
+function makeJsonlFile(entries) {
+  const dir = mkdtempSync(join(tmpdir(), 'jsonl-tail-'));
+  const path = join(dir, 'session.jsonl');
+  const lines = entries.map((e) => (typeof e === 'string' ? e : JSON.stringify(e)));
+  // Always end with newline UNLESS the last entry was a raw string (caller
+  // is simulating a partial write — let it be partial).
+  const lastIsRaw = entries.length > 0 && typeof entries[entries.length - 1] === 'string';
+  const body = lines.join('\n') + (lastIsRaw ? '' : '\n');
+  writeFileSync(path, body);
+  return path;
+}
+
+describe('readJsonlTail', () => {
+  test('returns LATEST matching entry from a small jsonl', () => {
+    const path = makeJsonlFile([
+      { type: 'user', content: 'first' },
+      { type: 'gemini', content: 'reply 1', tokens: { total: 100 } },
+      { $set: { lastUpdated: 'x' } },
+      { type: 'gemini', content: 'reply 2', tokens: { total: 200 } },
+    ]);
+    const result = readJsonlTail(path, {
+      predicate: (m) =>
+        m != null && typeof m === 'object' && m.type === 'gemini' && typeof m.tokens?.total === 'number',
+    });
+    assert.equal(result?.tokens?.total, 200, 'should return the LATEST gemini-with-tokens, not the first');
+  });
+
+  test('returns undefined when no entry matches predicate', () => {
+    const path = makeJsonlFile([
+      { type: 'user', content: 'only' },
+      { $set: { lastUpdated: 'x' } },
+      { type: 'gemini', content: 'no tokens here' },
+    ]);
+    const result = readJsonlTail(path, {
+      predicate: (m) => m?.type === 'gemini' && typeof m?.tokens?.total === 'number',
+    });
+    assert.equal(result, undefined);
+  });
+
+  test('tolerates partial last line (CLI mid-write race) — falls back to previous valid entry', () => {
+    const path = makeJsonlFile([
+      { type: 'gemini', content: 'a', tokens: { total: 50 } },
+      // Raw string injected as last entry → no trailing newline → simulates
+      // CLI writing the line right now (incomplete JSON).
+      '{"type":"gemini","content":"b","tokens":{"total":',
+    ]);
+    const result = readJsonlTail(path, {
+      predicate: (m) => m?.type === 'gemini' && typeof m?.tokens?.total === 'number',
+    });
+    assert.equal(result?.tokens?.total, 50, 'should skip unparseable last line and return the previous valid entry');
+  });
+
+  test('respects maxLines budget — returns undefined when match is older than budget', () => {
+    const filler = Array.from({ length: 100 }, (_, i) => ({ type: 'user', content: `msg-${i}` }));
+    const entries = [{ type: 'gemini', content: 'far_back', tokens: { total: 999 } }, ...filler];
+    const path = makeJsonlFile(entries);
+    const result = readJsonlTail(path, {
+      maxLines: 50,
+      predicate: (m) => m?.type === 'gemini' && typeof m?.tokens?.total === 'number',
+    });
+    assert.equal(result, undefined, 'match buried beyond maxLines budget should return undefined (caller falls back)');
+  });
+
+  test('returns undefined for an empty file', () => {
+    const path = makeJsonlFile([]);
+    const result = readJsonlTail(path, { predicate: () => true });
+    assert.equal(result, undefined);
+  });
+
+  test('returns undefined for a missing / unreadable file (no throw)', () => {
+    const result = readJsonlTail('/no/such/file.jsonl', { predicate: () => true });
+    assert.equal(result, undefined, 'missing file should return undefined, not throw');
+  });
+
+  test('handles a large jsonl by reading from tail (sanity, not perf assertion)', () => {
+    // ~5000 padded user lines + 1 gemini at the very end. Real perf assertion
+    // (e.g. measuring fs.readSync invocations) is left for follow-up; here we
+    // just sanity-check correctness on a multi-MB file.
+    const filler = Array.from({ length: 5000 }, (_, i) => ({
+      type: 'user',
+      content: `msg-${i}`.padEnd(200, 'x'),
+    }));
+    filler.push({ type: 'gemini', content: 'last', tokens: { total: 7777 } });
+    const path = makeJsonlFile(filler);
+    const result = readJsonlTail(path, {
+      predicate: (m) => m?.type === 'gemini' && typeof m?.tokens?.total === 'number',
+    });
+    assert.equal(result?.tokens?.total, 7777, 'should find the tail-most matching entry on a large file');
+  });
+});

--- a/packages/api/test/opencode-mention-routing.test.js
+++ b/packages/api/test/opencode-mention-routing.test.js
@@ -157,6 +157,18 @@ describe('parseA2AMentions — opencode A2A chain', () => {
     assert.deepEqual(result, ['opencode']);
   });
 
+  it('repairs whitespace split inside line-start CJK handles', () => {
+    const text = '交给金渐层\n@金\n\n渐\n\n层 帮忙看看这段代码';
+    const result = parseA2AMentions(text, 'opus');
+    assert.deepEqual(result, ['opencode']);
+  });
+
+  it('repairs whitespace split inside line-start ASCII handles', () => {
+    const text = '安全复核如下\n@co\n\ndex 请继续';
+    const result = parseA2AMentions(text, 'opus');
+    assert.deepEqual(result, ['codex']);
+  });
+
   it('detects multi-target: @opencode and @codex', () => {
     const text = '请两位协助\n@opencode 看架构\n@codex 看安全';
     const result = parseA2AMentions(text, 'opus');

--- a/packages/api/test/telemetry/gemini-context-fallback-attrs.test.js
+++ b/packages/api/test/telemetry/gemini-context-fallback-attrs.test.js
@@ -1,0 +1,44 @@
+/**
+ * Invariant test: attributes used by `geminiContextFallback` counter
+ * (in invoke-single-cat.ts) must be in ALLOWED_METRIC_ATTRIBUTES, otherwise
+ * the OTel SDK's allowlist View will silently drop them and we lose the
+ * `trigger` dimension we need for diagnosing fallback patterns.
+ *
+ * If you change the attribute keys passed to `geminiContextFallback.add(...)`,
+ * either update this test to match OR add the new attribute to the allowlist
+ * via `genai-semconv.ts` + `metric-allowlist.ts`.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+const { ALLOWED_METRIC_ATTRIBUTES } = await import('../../dist/infrastructure/telemetry/metric-allowlist.js');
+const { AGENT_ID, TRIGGER } = await import('../../dist/infrastructure/telemetry/genai-semconv.js');
+
+describe('geminiContextFallback metric attributes', () => {
+  test('AGENT_ID is in the metric allowlist', () => {
+    assert.ok(
+      ALLOWED_METRIC_ATTRIBUTES.has(AGENT_ID),
+      `AGENT_ID (${AGENT_ID}) must be in ALLOWED_METRIC_ATTRIBUTES so it survives the SDK allowlist View`,
+    );
+  });
+
+  test('TRIGGER is in the metric allowlist', () => {
+    assert.ok(
+      ALLOWED_METRIC_ATTRIBUTES.has(TRIGGER),
+      `TRIGGER (${TRIGGER}) must be in ALLOWED_METRIC_ATTRIBUTES so it survives the SDK allowlist View`,
+    );
+  });
+
+  test('"reason" (the previous attr name) is NOT in the allowlist — guards against regression', () => {
+    // Previous version of this counter used { reason: 'no_per_turn_signal' }
+    // which the SDK silently dropped. If this test starts failing, it means
+    // someone added 'reason' to the allowlist — which is fine, but please also
+    // confirm the geminiContextFallback.add(...) call site is updated.
+    assert.equal(
+      ALLOWED_METRIC_ATTRIBUTES.has('reason'),
+      false,
+      '"reason" should NOT be a generic metric attribute — use TRIGGER for categorical labels',
+    );
+  });
+});

--- a/packages/shared/src/types/session.ts
+++ b/packages/shared/src/types/session.ts
@@ -49,7 +49,10 @@ export interface SessionUsageSnapshot {
 }
 
 export interface ContextHealth {
-  /** Current used tokens (= inputTokens from last invocation) */
+  /**
+   * Tokens used for context health.
+   * Check usedFrom before interpreting this as true current context fill.
+   */
   usedTokens: number;
   /** Total context window capacity */
   windowTokens: number;
@@ -57,6 +60,13 @@ export interface ContextHealth {
   fillRatio: number;
   /** exact = CLI reported; approx = hardcoded fallback */
   source: 'exact' | 'approx';
+  /**
+   * Which usage field fed usedTokens.
+   * - last_turn: true per-turn context fill when the provider exposes it
+   * - input: inputTokens fallback; may be cumulative for some CLIs
+   * - total: totalTokens fallback; approximate only
+   */
+  usedFrom?: 'last_turn' | 'input' | 'total';
   measuredAt: number;
 }
 

--- a/packages/web/src/components/ContextHealthBar.tsx
+++ b/packages/web/src/components/ContextHealthBar.tsx
@@ -31,6 +31,13 @@ function formatTokenCount(n: number): string {
   return String(n);
 }
 
+function describeContextHealthSource(health: ContextHealthData): string {
+  if (health.usedFrom === 'last_turn') return 'Current context fill';
+  if (health.usedFrom === 'input') return 'Input-token fallback for context health; may be cumulative';
+  if (health.usedFrom === 'total') return 'Total-token fallback estimate for context health';
+  return health.source === 'approx' ? 'Estimated context fill' : 'Current context fill';
+}
+
 /**
  * F24: Context health progress bar.
  * Thin bar showing context window fill ratio with color coding:
@@ -63,12 +70,9 @@ export function ContextHealthBar({
     barColor = CAT_BG_COLORS[catId] ?? CAT_BG_COLORS.opus;
   }
 
-  const approxPrefix = health.source === 'approx' ? '~' : '';
+  const approxPrefix = health.source === 'approx' || health.usedFrom === 'total' ? '~' : '';
   const percent = Math.round(health.fillRatio * 100);
-  // "Current context fill:" prefix (vs the SessionChainPanel ↓ widget which
-  // shows CLI-reported cumulative input) clarifies that the bar reflects
-  // per-turn context usage. See UI spec U-A+ for rationale.
-  const tooltip = `Current context fill: ${approxPrefix}${percent}% (${formatTokenCount(health.usedTokens)} / ${formatTokenCount(health.windowTokens)} tokens)`;
+  const tooltip = `${describeContextHealthSource(health)}: ${approxPrefix}${percent}% (${formatTokenCount(health.usedTokens)} / ${formatTokenCount(health.windowTokens)} tokens)`;
 
   return (
     <div className="mt-1" title={tooltip} data-testid={`context-health-${catId}`}>

--- a/packages/web/src/components/ContextHealthBar.tsx
+++ b/packages/web/src/components/ContextHealthBar.tsx
@@ -65,7 +65,10 @@ export function ContextHealthBar({
 
   const approxPrefix = health.source === 'approx' ? '~' : '';
   const percent = Math.round(health.fillRatio * 100);
-  const tooltip = `Context: ${approxPrefix}${percent}% (${formatTokenCount(health.usedTokens)} / ${formatTokenCount(health.windowTokens)} tokens)`;
+  // "Current context fill:" prefix (vs the SessionChainPanel ↓ widget which
+  // shows CLI-reported cumulative input) clarifies that the bar reflects
+  // per-turn context usage. See UI spec U-A+ for rationale.
+  const tooltip = `Current context fill: ${approxPrefix}${percent}% (${formatTokenCount(health.usedTokens)} / ${formatTokenCount(health.windowTokens)} tokens)`;
 
   return (
     <div className="mt-1" title={tooltip} data-testid={`context-health-${catId}`}>

--- a/packages/web/src/components/SessionChainPanel.tsx
+++ b/packages/web/src/components/SessionChainPanel.tsx
@@ -256,7 +256,10 @@ export function SessionChainPanel({ threadId, catInvocations, onViewSession }: S
               {usage && (usage.inputTokens != null || usage.outputTokens != null) && (
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[10px] font-mono mb-1">
                   {usage.inputTokens != null && (
-                    <span className="text-cafe-secondary" title="CLI-reported cumulative input / not context fill">
+                    <span
+                      className="text-cafe-secondary"
+                      title="Input tokens reported for this invocation; may include multiple model calls and can reset after CLI compression/session changes. Not necessarily context fill."
+                    >
                       {fmtTokens(usage.inputTokens)}
                       <span className="text-cafe-muted ml-0.5">↓</span>
                     </span>

--- a/packages/web/src/components/SessionChainPanel.tsx
+++ b/packages/web/src/components/SessionChainPanel.tsx
@@ -256,7 +256,7 @@ export function SessionChainPanel({ threadId, catInvocations, onViewSession }: S
               {usage && (usage.inputTokens != null || usage.outputTokens != null) && (
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-[10px] font-mono mb-1">
                   {usage.inputTokens != null && (
-                    <span className="text-cafe-secondary">
+                    <span className="text-cafe-secondary" title="CLI-reported cumulative input / not context fill">
                       {fmtTokens(usage.inputTokens)}
                       <span className="text-cafe-muted ml-0.5">↓</span>
                     </span>

--- a/packages/web/src/components/__tests__/context-health-bar-family-color.test.ts
+++ b/packages/web/src/components/__tests__/context-health-bar-family-color.test.ts
@@ -30,4 +30,38 @@ describe('ContextHealthBar family variant colors', () => {
     const html = render('sonnet');
     expect(html).toContain('background-color:#B39DDB');
   });
+
+  it('labels last-turn health as current context fill', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ContextHealthBar, {
+        catId: 'gemini',
+        health: {
+          usedTokens: 34000,
+          windowTokens: 1000000,
+          fillRatio: 0.034,
+          source: 'exact',
+          usedFrom: 'last_turn',
+          measuredAt: Date.now(),
+        },
+      }),
+    );
+    expect(html).toContain('Current context fill: 3%');
+  });
+
+  it('labels input fallback so cumulative values are not mistaken for context fill', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ContextHealthBar, {
+        catId: 'gemini',
+        health: {
+          usedTokens: 452200,
+          windowTokens: 1000000,
+          fillRatio: 0.4522,
+          source: 'exact',
+          usedFrom: 'input',
+          measuredAt: Date.now(),
+        },
+      }),
+    );
+    expect(html).toContain('Input-token fallback for context health; may be cumulative');
+  });
 });

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -383,6 +383,8 @@ export interface ContextHealthData {
   windowTokens: number;
   fillRatio: number;
   source: 'exact' | 'approx';
+  /** Backend usage field that fed usedTokens. Older records may omit it. */
+  usedFrom?: 'last_turn' | 'input' | 'total';
   measuredAt: number;
 }
 


### PR DESCRIPTION
## What

Restores per-turn context-fill detection for Gemini-family cats so that long-running sessions no longer trigger spurious 100% auto-seal, and recovers `@handle` routing under Gemini's whitespace-splitting output shape. 13 commits touch:

- `packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts` — per-turn token lookup from local Gemini CLI jsonl, with normalize + suffix-match resilience
- `packages/api/src/utils/jsonl-tail-reader.ts` (new) — reverse-tail JSONL reader, byte-level UTF-8 safe across chunk boundaries
- `packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts` — skip auto-seal when only cumulative usage available; emit OTel counter on fallback
- `packages/api/src/domains/cats/services/agents/routing/a2a-mentions.ts` — line-start known-handle whitespace repair (does NOT relax inline `@`)
- `packages/shared/src/types/session.ts` + `packages/web/src/components/{ContextHealthBar,SessionChainPanel}.tsx` — `ContextHealth.usedFrom` field + honest tooltips distinguishing `last_turn` (exact context fill) from `input`/`total` fallback
- New test suites: `jsonl-tail-reader.test.js` (8 cases incl. CJK chunk boundary), `gemini-context-fallback-attrs.test.js` (3 OTel allowlist invariants), `context-health-bar-family-color.test.ts`
- Extended `gemini-agent-service.test.js` + `invoke-single-cat.test.js` with chunk-boundary / tool-only / thinking-prefix / Bug-A (`tokens.input` vs `tokens.total`) regression coverage

## Why

Gemini CLI's stream-json `result.stats` reports session-level cumulative tokens, not per-turn. Cat Cafe used those cumulative values as the `fillRatio` numerator, so any Gemini-family cat hit 100% after ~5 turns and auto-sealed despite the per-turn context being well under the 1M window. Other providers (Claude/Codex/Kimi) already had per-turn fields; Gemini did not.

Full reproduction, comparison with other providers, and acceptance criteria are in issue #679 (which I filed before opening this PR). The upstream maintainer's reply on that issue confirmed the diagnosis and root cause.

## Issue Closure

- Closes #679

## Original Requirements

- Discussion/Interview: *(internal reference removed)*
- Original user-visible symptom, quoted from issue #679:
  > `<cat-id> 的会话 #N 已封存（上下文 100%），下次调用将自动创建新会话`
- Core pain: Gemini-family cats become unusable after a few turns of real work — sessions seal even though context is nowhere near full, breaking long-form workflows.
- Reviewer guidance: please verify that (a) Gemini per-turn `fillRatio` now reflects the *current* context window fill rather than cumulative session metrics, (b) when local jsonl is unavailable, the cat does not seal based on cumulative-only readings, and (c) Claude/Codex/Kimi behavior is unchanged.

## Plan / ADR

- Plan: *(internal reference removed)*
- ADR: none — bug fix only, no architectural change.
- Aligned with acceptance criteria from issue #679; all 6 ACs + 3 known follow-ups (UI cumulative vs per-turn display, silent fallback observability, perf full-file read) addressed.

## Tradeoff

- **`normalizeGeminiContent` strips ALL whitespace** (not just folds `\s+ → ' '`). Necessary because Gemini emits one logical turn as multiple `message/assistant` events stitched with `\n\n` in `fullAssistantText`, but the jsonl stores a single reassembled string. Folding leaves a stale single space mid-CJK / mid-digit / mid-path. Safe because the only consumer scans within one sessionId-bound jsonl and picks the latest match in reverse.
- **`matchesCurrentAssistantText` accepts strict equality OR `endsWith` (suffix)**, not arbitrary substring. Forward/middle substring would risk pulling stale `tokens.input` from a thinking-row whose text appears earlier in the stitched assistant text.
- **A2A whitespace repair only fixes line-start known handles**. Inline mention semantics are unchanged. Repair iterates registered handles only — never invents.
- **`readJsonlTail` uses byte-level newline split + single utf-8 decode per assembled line**, not per-chunk decode. Per-chunk decode would inject `U+FFFD` into CJK characters that straddle the 8 KiB chunk boundary, silently corrupting content equality.
- **Did not switch to fuzzy matching for non-empty mismatch** (e.g. Levenshtein). Kept the safe-default "non-empty assistant text that matches nothing → `undefined`" so unrelated future drift fails loudly rather than silently picking a wrong row.

## Test Evidence

```
bash ./scripts/pre-merge-check.sh --no-rebase
  build         OK
  tsc --noEmit  OK
  api tests     OK (relevant suites with setup-cat-registry: gemini-agent-service / invoke-single-cat / jsonl-tail-reader / telemetry/gemini-context-fallback-attrs all pass; 161/161 across the audited set)
  web tests     33 failed / 2815 passed
                — failures isolated to two files (session-chain-panel.test.ts cat-color RGB triples,
                  settings-nav-search.test.ts section count) whose last touch on origin/main is
                  05fd61d5 feat(F190): console restructure follow-up. This PR does not modify
                  either test file or the production code they cover; the failures pre-date and
                  are independent of this change. The four web files actually modified by this
                  PR (ContextHealthBar.tsx, SessionChainPanel.tsx tooltip strings, chat-types.ts,
                  context-health-bar-family-color.test.ts) all pass.
  pnpm check    OK (biome + features + skills + env-ports + env-registry +
                     start-profile-isolation + pre-merge-gate + guides +
                     followup-tails)
```

(`--no-rebase` because the worktree has long-standing untracked side files unrelated to this PR; HEAD was already rebased onto latest `origin/main` = `943fbe34` before submitting. `local ahead origin/main: 15, behind: 0`.)

Beyond automated tests, two headless agent verifications were performed against this branch HEAD:

- **Visual verification**: 9-turn session, all rounds reported `usedFrom = last_turn` with `Current context fill` tooltip (no `Input-token fallback` / `Total-token fallback` for any normal turn). Hover screenshots captured for multi-call turns 7/8/9.
- **Endurance test** (Gemini `handoff` strategy thresholds: `warn=0.55`, `action=0.65`, window=1M): driven to threshold across 11 turns; turn 10 at 64.55% remained active, turn 11 at 70.75% sealed with `sealReason=threshold`; a new session was immediately created and continued at ~3%. No cumulative-fallback false trigger observed across all turns.

## Open Questions

- Whether the upstream repository has a cloud-review connector enabled. I will post the standard one-line cloud-review trigger as a separate comment after PR creation per Cat Cafe's `merge-gate` convention; if the bot is not configured here, please feel free to ignore or remove.
- Whether you'd like a follow-up PR to apply the same per-turn-token correction direction to any other future provider added with a Gemini-like cumulative-stats output, or whether you'd prefer that be handled per-provider as they're integrated.

---

**Local Review**: [x] Maine Coon (gpt-5.5) reviewed and approved across R-next + R-final + endurance verification; [x] Tabby (deepseek-v4-pro) reviewed and approved review-of-review.
**Cloud Review**: [ ] Triggered separately via PR comment after creation.

Ragdoll (Opus-4.7) · Maine Coon (gpt-5.5) · Tabby (deepseek-v4-pro)
