### PR TITLE
fix(embedding): batch splitting, reprobe recovery, and collection embed wiring

### DIFF
--- a/packages/api/src/domains/memory/CollectionIndexBuilder.ts
+++ b/packages/api/src/domains/memory/CollectionIndexBuilder.ts
@@ -1,9 +1,11 @@
 import { createHash } from 'node:crypto';
 import type { CollectionManifest } from './collection-types.js';
-import type { EvidenceItem, RepoScanner, ScannedEvidence } from './interfaces.js';
+import { embedIndexedItems } from './embed-utils.js';
+import type { EvidenceItem, IEmbeddingService, RepoScanner, ScannedEvidence } from './interfaces.js';
 import type { SecretFinding } from './SecretScanner.js';
 import { SecretScanner } from './SecretScanner.js';
 import type { SqliteEvidenceStore } from './SqliteEvidenceStore.js';
+import type { VectorStore } from './VectorStore.js';
 
 export interface CollectionRebuildResult {
   indexed: number;
@@ -12,11 +14,17 @@ export interface CollectionRebuildResult {
   secretFindings: SecretFinding[];
 }
 
+export interface CollectionEmbedDeps {
+  embedding: IEmbeddingService;
+  vectorStore: VectorStore;
+}
+
 export class CollectionIndexBuilder {
   constructor(
     private readonly store: SqliteEvidenceStore,
     private readonly manifest: CollectionManifest,
     private readonly scanner: RepoScanner,
+    private readonly embedDeps?: CollectionEmbedDeps,
   ) {}
 
   async rebuild(options?: { force?: boolean }): Promise<CollectionRebuildResult> {
@@ -32,7 +40,16 @@ export class CollectionIndexBuilder {
       return { indexed: 0, skipped: 0, blocked: true, secretFindings: findings };
     }
 
-    const { indexed, skipped } = await this.indexResults(results, force);
+    const { indexed, skipped, indexedItems } = await this.indexResults(results, force);
+
+    if (this.embedDeps && indexedItems.length > 0) {
+      try {
+        await embedIndexedItems(indexedItems, this.embedDeps.embedding, this.embedDeps.vectorStore);
+      } catch {
+        // fail-open: embedding errors don't block indexing
+      }
+    }
+
     return { indexed, skipped, blocked: false, secretFindings: [] };
   }
 
@@ -41,6 +58,7 @@ export class CollectionIndexBuilder {
     let indexed = 0;
     let skipped = 0;
     const currentAnchors = new Set<string>();
+    const indexedItems: EvidenceItem[] = [];
 
     for (const result of results) {
       const hash = createHash('sha256').update(result.rawContent).digest('hex');
@@ -62,11 +80,12 @@ export class CollectionIndexBuilder {
         authority: this.manifest.reviewPolicy.authorityCeiling,
       };
       await this.store.upsert([item]);
+      indexedItems.push(item);
       indexed++;
     }
 
     await this.cleanStale(currentAnchors);
-    return { indexed, skipped };
+    return { indexed, skipped, indexedItems };
   }
 
   private async purgeCollection(): Promise<void> {

--- a/packages/api/src/domains/memory/EmbeddingService.ts
+++ b/packages/api/src/domains/memory/EmbeddingService.ts
@@ -67,6 +67,11 @@ export class EmbeddingService implements IEmbeddingService {
     return this.ready;
   }
 
+  async reprobeIfNeeded(): Promise<void> {
+    if (this.ready) return;
+    await this.load();
+  }
+
   getModelInfo(): EmbedModelInfo {
     return {
       modelId: this.modelId || this.config.embedModel,

--- a/packages/api/src/domains/memory/IndexBuilder.ts
+++ b/packages/api/src/domains/memory/IndexBuilder.ts
@@ -19,6 +19,7 @@ import type {
 // Re-export for backward compatibility — external code imports KIND_DIRS from IndexBuilder
 export { KIND_DIRS } from './CatCafeScanner.js';
 
+import { embedIndexedItems } from './embed-utils.js';
 import type { SqliteEvidenceStore } from './SqliteEvidenceStore.js';
 import { SIGNAL_FLAGS } from './summary-config.js';
 import type { VectorStore } from './VectorStore.js';
@@ -399,8 +400,29 @@ export class IndexBuilder implements IIndexBuilder {
       }
     }
 
-    // Phase C: generate embeddings for indexed items
-    await this.embedIndexedItems(indexedItems);
+    // Phase C: generate embeddings for indexed items (shared utility with batch splitting)
+    if (this.embedDeps) {
+      const { embedding, vectorStore } = this.embedDeps;
+      const consistency = vectorStore.checkMetaConsistency(embedding.getModelInfo());
+      let toEmbed = indexedItems;
+      if (!consistency.consistent) {
+        vectorStore.clearAll();
+        const db = this.store.getDb();
+        const allDocs = db.prepare('SELECT anchor, title, summary FROM evidence_docs').all() as Array<{
+          anchor: string;
+          title: string;
+          summary: string | null;
+        }>;
+        toEmbed = allDocs.map(
+          (d) => ({ anchor: d.anchor, title: d.title, summary: d.summary ?? undefined }) as EvidenceItem,
+        );
+      }
+      try {
+        await embedIndexedItems(toEmbed, embedding, vectorStore);
+      } catch {
+        // fail-open: embedding errors don't block indexing
+      }
+    }
 
     // Persist current indexing version so next startup can detect changes
     await this.storeIndexingVersion();
@@ -503,44 +525,6 @@ export class IndexBuilder implements IIndexBuilder {
   }
 
   // ── Private ──────────────────────────────────────────────────────
-
-  /**
-   * Batch-embed indexed items when embedding service is ready.
-   * AC-C6: check meta consistency — if model changed, clearAll + re-embed all docs.
-   */
-  private async embedIndexedItems(items: EvidenceItem[]): Promise<void> {
-    if (!this.embedDeps?.embedding.isReady() || items.length === 0) return;
-
-    const { embedding, vectorStore } = this.embedDeps;
-
-    // Version anchor check: model/dim change → full re-embed
-    const consistency = vectorStore.checkMetaConsistency(embedding.getModelInfo());
-    let itemsToEmbed = items;
-    if (!consistency.consistent) {
-      vectorStore.clearAll();
-      // Re-embed ALL docs in store, not just newly indexed ones
-      const db = this.store.getDb();
-      const allDocs = db.prepare('SELECT anchor, title, summary FROM evidence_docs').all() as Array<{
-        anchor: string;
-        title: string;
-        summary: string | null;
-      }>;
-      itemsToEmbed = allDocs.map(
-        (d) => ({ anchor: d.anchor, title: d.title, summary: d.summary ?? undefined }) as EvidenceItem,
-      );
-    }
-
-    try {
-      const texts = itemsToEmbed.map((i) => `${i.title} ${i.summary ?? ''}`);
-      const vectors = await embedding.embed(texts);
-      for (let i = 0; i < itemsToEmbed.length; i++) {
-        vectorStore.upsert(itemsToEmbed[i].anchor, vectors[i]);
-      }
-      vectorStore.initMeta(embedding.getModelInfo());
-    } catch {
-      // fail-open: embedding errors don't block indexing
-    }
-  }
 
   /** F152: Bridge — delegate single-file parsing to scanner (for incrementalUpdate) */
   private parseSingleFile(filePath: string): EvidenceItem | null {

--- a/packages/api/src/domains/memory/embed-utils.ts
+++ b/packages/api/src/domains/memory/embed-utils.ts
@@ -1,0 +1,22 @@
+import type { EvidenceItem, IEmbeddingService } from './interfaces.js';
+import type { VectorStore } from './VectorStore.js';
+
+const EMBED_BATCH_SIZE = 64;
+
+export async function embedIndexedItems(
+  items: EvidenceItem[],
+  embedding: IEmbeddingService,
+  vectorStore: VectorStore,
+): Promise<void> {
+  if (!embedding.isReady() || items.length === 0) return;
+
+  for (let offset = 0; offset < items.length; offset += EMBED_BATCH_SIZE) {
+    const batch = items.slice(offset, offset + EMBED_BATCH_SIZE);
+    const texts = batch.map((i) => `${i.title} ${i.summary ?? ''}`);
+    const vectors = await embedding.embed(texts);
+    for (let i = 0; i < batch.length; i++) {
+      vectorStore.upsert(batch[i].anchor, vectors[i]);
+    }
+  }
+  vectorStore.initMeta(embedding.getModelInfo());
+}

--- a/packages/api/src/domains/memory/embed-utils.ts
+++ b/packages/api/src/domains/memory/embed-utils.ts
@@ -8,7 +8,9 @@ export async function embedIndexedItems(
   embedding: IEmbeddingService,
   vectorStore: VectorStore,
 ): Promise<void> {
-  if (!embedding.isReady() || items.length === 0) return;
+  if (items.length === 0) return;
+  await embedding.reprobeIfNeeded();
+  if (!embedding.isReady()) return;
 
   for (let offset = 0; offset < items.length; offset += EMBED_BATCH_SIZE) {
     const batch = items.slice(offset, offset + EMBED_BATCH_SIZE);

--- a/packages/api/src/domains/memory/interfaces.ts
+++ b/packages/api/src/domains/memory/interfaces.ts
@@ -308,6 +308,7 @@ export interface IEmbeddingService {
   load(): Promise<void>;
   embed(texts: string[]): Promise<Float32Array[]>;
   isReady(): boolean;
+  reprobeIfNeeded(): Promise<void>;
   getModelInfo(): EmbedModelInfo;
   dispose(): void;
 }

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1848,6 +1848,7 @@ async function main(): Promise<void> {
       catalog: memoryServices.catalog,
       stores: libraryStores,
       dataDir: memoryServices.dataDir,
+      embeddingService: memoryServices.embeddingService,
     });
   }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1844,11 +1844,13 @@ async function main(): Promise<void> {
     if (!libraryStores.has('project:cat-cafe')) libraryStores.set('project:cat-cafe', memoryServices.store);
     if (memoryServices.globalStore && !libraryStores.has('global:methods'))
       libraryStores.set('global:methods', memoryServices.globalStore);
+    const embedMode = process.env.EMBED_MODE as 'shadow' | 'on' | undefined;
     await app.register(libraryRoutes, {
       catalog: memoryServices.catalog,
       stores: libraryStores,
       dataDir: memoryServices.dataDir,
       embeddingService: memoryServices.embeddingService,
+      embedMode: embedMode && embedMode !== ('off' as string) ? embedMode : undefined,
     });
   }
 

--- a/packages/api/src/routes/library.ts
+++ b/packages/api/src/routes/library.ts
@@ -9,16 +9,18 @@ import type { CollectionKind, CollectionManifest, CollectionSensitivity } from '
 import { validateManifestInput } from '../domains/memory/collection-types.js';
 import { resolveCollectionStorePath, saveExternalCollection } from '../domains/memory/external-collections.js';
 import { GraphResolver } from '../domains/memory/GraphResolver.js';
-import type { IEvidenceStore } from '../domains/memory/interfaces.js';
+import type { IEmbeddingService, IEvidenceStore } from '../domains/memory/interfaces.js';
 import type { LibraryCatalog } from '../domains/memory/LibraryCatalog.js';
 import { SqliteEvidenceStore } from '../domains/memory/SqliteEvidenceStore.js';
 import { resolveCollectionScanner } from '../domains/memory/scanner-resolver.js';
+import { ensureVectorTable } from '../domains/memory/schema.js';
+import { VectorStore } from '../domains/memory/VectorStore.js';
 
 export interface LibraryRoutesOptions {
   catalog: LibraryCatalog;
   stores: Map<string, IEvidenceStore>;
   dataDir?: string;
-  embedDeps?: CollectionEmbedDeps;
+  embeddingService?: IEmbeddingService;
 }
 
 type StoreWithDb = IEvidenceStore & { getDb?: () => import('better-sqlite3').Database };
@@ -167,7 +169,23 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
     }
     const scanner = resolveCollectionScanner(manifest);
     const body = request.body as { force?: boolean } | undefined;
-    const builder = new CollectionIndexBuilder(store as SqliteEvidenceStore, manifest, scanner, opts.embedDeps);
+
+    let embedDeps: CollectionEmbedDeps | undefined;
+    const db = (store as StoreWithDb).getDb?.();
+    if (opts.embeddingService && db) {
+      try {
+        const sqliteVecMod = await import('sqlite-vec');
+        sqliteVecMod.load(db);
+        const dim = opts.embeddingService.getModelInfo().dim;
+        if (ensureVectorTable(db, dim)) {
+          embedDeps = { embedding: opts.embeddingService, vectorStore: new VectorStore(db, dim) };
+        }
+      } catch {
+        // fail-open: sqlite-vec not available → FTS-only
+      }
+    }
+
+    const builder = new CollectionIndexBuilder(store as SqliteEvidenceStore, manifest, scanner, embedDeps);
     const result = await builder.rebuild({ force: body?.force ?? false });
     return result;
   });

--- a/packages/api/src/routes/library.ts
+++ b/packages/api/src/routes/library.ts
@@ -21,6 +21,7 @@ export interface LibraryRoutesOptions {
   stores: Map<string, IEvidenceStore>;
   dataDir?: string;
   embeddingService?: IEmbeddingService;
+  embedMode?: 'shadow' | 'on';
 }
 
 type StoreWithDb = IEvidenceStore & { getDb?: () => import('better-sqlite3').Database };
@@ -178,7 +179,10 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
         sqliteVecMod.load(db);
         const dim = opts.embeddingService.getModelInfo().dim;
         if (ensureVectorTable(db, dim)) {
-          embedDeps = { embedding: opts.embeddingService, vectorStore: new VectorStore(db, dim) };
+          const vectorStore = new VectorStore(db, dim);
+          embedDeps = { embedding: opts.embeddingService, vectorStore };
+          const mode = opts.embedMode ?? 'shadow';
+          (store as SqliteEvidenceStore).setEmbedDeps({ embedding: opts.embeddingService, vectorStore, mode });
         }
       } catch {
         // fail-open: sqlite-vec not available → FTS-only

--- a/packages/api/src/routes/library.ts
+++ b/packages/api/src/routes/library.ts
@@ -2,6 +2,7 @@ import { mkdirSync, statSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { FastifyPluginAsync } from 'fastify';
 import { BindingDryRun } from '../domains/memory/BindingDryRun.js';
+import type { CollectionEmbedDeps } from '../domains/memory/CollectionIndexBuilder.js';
 import { CollectionIndexBuilder } from '../domains/memory/CollectionIndexBuilder.js';
 import { CollectionReadModel } from '../domains/memory/CollectionReadModel.js';
 import type { CollectionKind, CollectionManifest, CollectionSensitivity } from '../domains/memory/collection-types.js';
@@ -17,6 +18,7 @@ export interface LibraryRoutesOptions {
   catalog: LibraryCatalog;
   stores: Map<string, IEvidenceStore>;
   dataDir?: string;
+  embedDeps?: CollectionEmbedDeps;
 }
 
 type StoreWithDb = IEvidenceStore & { getDb?: () => import('better-sqlite3').Database };
@@ -164,8 +166,9 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
       return { error: 'Store not found' };
     }
     const scanner = resolveCollectionScanner(manifest);
-    const builder = new CollectionIndexBuilder(store as SqliteEvidenceStore, manifest, scanner);
-    const result = await builder.rebuild();
+    const body = request.body as { force?: boolean } | undefined;
+    const builder = new CollectionIndexBuilder(store as SqliteEvidenceStore, manifest, scanner, opts.embedDeps);
+    const result = await builder.rebuild({ force: body?.force ?? false });
     return result;
   });
 

--- a/packages/api/test/memory/collection-rebuild-embed.test.js
+++ b/packages/api/test/memory/collection-rebuild-embed.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+describe('CollectionIndexBuilder embedding integration (bug #6)', () => {
+  let CollectionIndexBuilder, FlatScanner, SqliteEvidenceStore;
+  let store, dbPath;
+
+  beforeEach(async () => {
+    ({ CollectionIndexBuilder } = await import('../../dist/domains/memory/CollectionIndexBuilder.js'));
+    ({ FlatScanner } = await import('../../dist/domains/memory/FlatScanner.js'));
+    ({ SqliteEvidenceStore } = await import('../../dist/domains/memory/SqliteEvidenceStore.js'));
+    dbPath = join(mkdtempSync(join(tmpdir(), 'col-embed-')), 'test.sqlite');
+    store = new SqliteEvidenceStore(dbPath);
+    await store.initialize();
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  const makeManifest = (root) => ({
+    id: 'test:embed',
+    kind: 'domain',
+    name: 'embed',
+    displayName: 'Embed Test',
+    root,
+    sensitivity: 'internal',
+    scannerLevel: 0,
+    indexPolicy: { autoRebuild: true },
+    reviewPolicy: { authorityCeiling: 'validated', requireOwnerApproval: false },
+    createdAt: '2026-05-13',
+    updatedAt: '2026-05-13',
+  });
+
+  it('rebuild produces embeddings when embedDeps provided', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'col-edocs-'));
+    writeFileSync(join(dir, 'a.md'), '# Alpha\n\nAlpha content about testing.');
+    writeFileSync(join(dir, 'b.md'), '# Beta\n\nBeta content about embedding.');
+
+    const manifest = makeManifest(dir);
+    const scanner = new FlatScanner('test:embed');
+
+    const embedded = [];
+    const mockEmbedding = {
+      isReady: () => true,
+      embed: async (texts) => texts.map(() => new Float32Array([0.1, 0.2])),
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
+    };
+    const mockVectorStore = {
+      upsert: (anchor, vec) => embedded.push(anchor),
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    const builder = new CollectionIndexBuilder(store, manifest, scanner, {
+      embedding: mockEmbedding,
+      vectorStore: mockVectorStore,
+    });
+    const result = await builder.rebuild();
+
+    assert.equal(result.indexed, 2, 'should index 2 docs');
+    assert.equal(embedded.length, 2, 'should produce 2 embeddings');
+  });
+
+  it('rebuild works without embedDeps (FTS-only fallback)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'col-noembed-'));
+    writeFileSync(join(dir, 'c.md'), '# Charlie\n\nCharlie content.');
+
+    const manifest = makeManifest(dir);
+    const scanner = new FlatScanner('test:embed');
+
+    const builder = new CollectionIndexBuilder(store, manifest, scanner);
+    const result = await builder.rebuild();
+
+    assert.equal(result.indexed, 1, 'should index without embedDeps');
+  });
+});

--- a/packages/api/test/memory/collection-rebuild-embed.test.js
+++ b/packages/api/test/memory/collection-rebuild-embed.test.js
@@ -46,6 +46,7 @@ describe('CollectionIndexBuilder embedding integration (bug #6)', () => {
     const embedded = [];
     const mockEmbedding = {
       isReady: () => true,
+      reprobeIfNeeded: async () => {},
       embed: async (texts) => texts.map(() => new Float32Array([0.1, 0.2])),
       getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
     };

--- a/packages/api/test/memory/embed-utils.test.js
+++ b/packages/api/test/memory/embed-utils.test.js
@@ -8,6 +8,7 @@ describe('embedIndexedItems (shared utility with batch splitting)', () => {
     const batchSizes = [];
     const mockEmbedding = {
       isReady: () => true,
+      reprobeIfNeeded: async () => {},
       embed: async (texts) => {
         batchSizes.push(texts.length);
         return texts.map(() => new Float32Array([0.1, 0.2]));
@@ -44,6 +45,7 @@ describe('embedIndexedItems (shared utility with batch splitting)', () => {
     let callCount = 0;
     const mockEmbedding = {
       isReady: () => true,
+      reprobeIfNeeded: async () => {},
       embed: async (texts) => {
         callCount++;
         return texts.map(() => new Float32Array([0.1]));
@@ -66,12 +68,13 @@ describe('embedIndexedItems (shared utility with batch splitting)', () => {
     assert.equal(callCount, 1, 'exactly 64 items should be one batch');
   });
 
-  it('skips when embedding service not ready', async () => {
+  it('skips when embedding service not ready and reprobe fails', async () => {
     const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
 
     let embedCalled = false;
     const mockEmbedding = {
       isReady: () => false,
+      reprobeIfNeeded: async () => {},
       embed: async () => {
         embedCalled = true;
         return [];
@@ -89,14 +92,16 @@ describe('embedIndexedItems (shared utility with batch splitting)', () => {
     assert.equal(embedCalled, false, 'should not call embed when service not ready');
   });
 
-  it('skips empty items array', async () => {
+  it('skips empty items array without calling reprobeIfNeeded', async () => {
     const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
 
-    let embedCalled = false;
+    let reprobeCalled = false;
     const mockEmbedding = {
       isReady: () => true,
+      reprobeIfNeeded: async () => {
+        reprobeCalled = true;
+      },
       embed: async () => {
-        embedCalled = true;
         return [];
       },
       getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 1 }),
@@ -109,6 +114,30 @@ describe('embedIndexedItems (shared utility with batch splitting)', () => {
     };
 
     await embedIndexedItems([], mockEmbedding, mockVectorStore);
-    assert.equal(embedCalled, false, 'should not call embed for empty array');
+    assert.equal(reprobeCalled, false, 'should not call reprobeIfNeeded for empty array');
+  });
+
+  it('recovers via reprobeIfNeeded when embed-api starts late (bug #2)', async () => {
+    const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
+
+    let ready = false;
+    const mockEmbedding = {
+      isReady: () => ready,
+      reprobeIfNeeded: async () => {
+        ready = true;
+      },
+      embed: async (texts) => texts.map(() => new Float32Array([0.1])),
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 1 }),
+    };
+
+    const upserted = [];
+    const mockVectorStore = {
+      upsert: (anchor, vec) => upserted.push(anchor),
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    await embedIndexedItems([{ anchor: 'doc-1', title: 'Doc 1' }], mockEmbedding, mockVectorStore);
+    assert.equal(upserted.length, 1, 'should embed after reprobe recovers ready state');
   });
 });

--- a/packages/api/test/memory/embed-utils.test.js
+++ b/packages/api/test/memory/embed-utils.test.js
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('embedIndexedItems (shared utility with batch splitting)', () => {
+  it('splits >64 items into batches of 64', async () => {
+    const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
+
+    const batchSizes = [];
+    const mockEmbedding = {
+      isReady: () => true,
+      embed: async (texts) => {
+        batchSizes.push(texts.length);
+        return texts.map(() => new Float32Array([0.1, 0.2]));
+      },
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
+    };
+
+    const upserted = [];
+    const mockVectorStore = {
+      upsert: (anchor, vec) => upserted.push({ anchor, vec }),
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    const items = Array.from({ length: 150 }, (_, i) => ({
+      anchor: `doc-${i}`,
+      title: `Doc ${i}`,
+      summary: `Summary ${i}`,
+    }));
+
+    await embedIndexedItems(items, mockEmbedding, mockVectorStore);
+
+    assert.equal(upserted.length, 150, 'all 150 items should be embedded');
+    assert.ok(
+      batchSizes.every((s) => s <= 64),
+      `no batch should exceed 64, got: ${batchSizes}`,
+    );
+    assert.equal(batchSizes.length, 3, 'should split 150 into 3 batches (64+64+22)');
+  });
+
+  it('handles exactly 64 items in single batch', async () => {
+    const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
+
+    let callCount = 0;
+    const mockEmbedding = {
+      isReady: () => true,
+      embed: async (texts) => {
+        callCount++;
+        return texts.map(() => new Float32Array([0.1]));
+      },
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 1 }),
+    };
+
+    const mockVectorStore = {
+      upsert: () => {},
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    const items = Array.from({ length: 64 }, (_, i) => ({
+      anchor: `doc-${i}`,
+      title: `Doc ${i}`,
+    }));
+
+    await embedIndexedItems(items, mockEmbedding, mockVectorStore);
+    assert.equal(callCount, 1, 'exactly 64 items should be one batch');
+  });
+
+  it('skips when embedding service not ready', async () => {
+    const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
+
+    let embedCalled = false;
+    const mockEmbedding = {
+      isReady: () => false,
+      embed: async () => {
+        embedCalled = true;
+        return [];
+      },
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 1 }),
+    };
+
+    const mockVectorStore = {
+      upsert: () => {},
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    await embedIndexedItems([{ anchor: 'a', title: 'A' }], mockEmbedding, mockVectorStore);
+    assert.equal(embedCalled, false, 'should not call embed when service not ready');
+  });
+
+  it('skips empty items array', async () => {
+    const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
+
+    let embedCalled = false;
+    const mockEmbedding = {
+      isReady: () => true,
+      embed: async () => {
+        embedCalled = true;
+        return [];
+      },
+      getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 1 }),
+    };
+
+    const mockVectorStore = {
+      upsert: () => {},
+      checkMetaConsistency: () => ({ consistent: true, reason: 'ok' }),
+      initMeta: () => {},
+    };
+
+    await embedIndexedItems([], mockEmbedding, mockVectorStore);
+    assert.equal(embedCalled, false, 'should not call embed for empty array');
+  });
+});

--- a/packages/api/test/memory/embedding-reprobe.test.js
+++ b/packages/api/test/memory/embedding-reprobe.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('EmbeddingService reprobe (bug #2: isReady permanently false)', () => {
+  it('reprobeIfNeeded recovers when embed-api becomes available after initial failure', async () => {
+    const { EmbeddingService } = await import('../../dist/domains/memory/EmbeddingService.js');
+    const svc = new EmbeddingService({
+      embedModel: 'test-model',
+      embedDim: 2,
+      embedTimeoutMs: 3000,
+      maxModelMemMb: 800,
+    });
+
+    // Simulate initial load failure (embed-api not yet started)
+    let serverUp = false;
+    svc._setLoaderForTest(async () => {
+      if (!serverUp) return; // stays not ready
+      svc._setPipelineForTest('mock'); // mark ready
+    });
+    await svc.load();
+    assert.equal(svc.isReady(), false, 'initially not ready');
+
+    // Now embed-api starts
+    serverUp = true;
+
+    // reprobeIfNeeded should re-check and recover
+    await svc.reprobeIfNeeded();
+    assert.equal(svc.isReady(), true, 'should be ready after reprobe');
+  });
+
+  it('reprobeIfNeeded is a no-op when already ready', async () => {
+    const { EmbeddingService } = await import('../../dist/domains/memory/EmbeddingService.js');
+    const svc = new EmbeddingService({
+      embedModel: 'test-model',
+      embedDim: 2,
+      embedTimeoutMs: 3000,
+      maxModelMemMb: 800,
+    });
+    svc._setPipelineForTest('mock');
+    assert.equal(svc.isReady(), true);
+
+    let loadCalled = false;
+    svc._setLoaderForTest(async () => {
+      loadCalled = true;
+    });
+    await svc.reprobeIfNeeded();
+
+    assert.equal(loadCalled, false, 'should not re-probe when already ready');
+    assert.equal(svc.isReady(), true);
+  });
+});

--- a/packages/api/test/memory/index-builder.test.js
+++ b/packages/api/test/memory/index-builder.test.js
@@ -637,6 +637,7 @@ describe('IndexBuilder with embedding', () => {
     embedCallCount = 0;
     mockEmbedding = {
       isReady: () => true,
+      reprobeIfNeeded: async () => {},
       embed: async (texts) => {
         embedCallCount++;
         return texts.map(() => new Float32Array([0.5, 0.5, 0.5, 0.5]));


### PR DESCRIPTION
## Summary

Fixes three embedding subsystem bugs from the side-bug list in #693:

- **Bug #1 — Batch overflow**: `embed-api` has `MAX_BATCH_SIZE=64`, but `IndexBuilder` sent all items at once → silent HTTP 400 (fail-open catch swallowed errors). Extracted shared `embed-utils.ts` with 64-item batch splitting, used by both `IndexBuilder` and `CollectionIndexBuilder`.
- **Bug #2 — `isReady()` permanently false**: `EmbeddingService.load()` probes `/health` once at startup; if `embed-api` starts later, `ready` stays false forever. Added `reprobeIfNeeded()` to `IEmbeddingService` interface, called automatically inside `embedIndexedItems()` before the `isReady()` gate.
- **Bug #6 — Collection rebuild missing embedding**: External collection `rebuild` only did FTS document indexing with zero vector embedding support. Added `CollectionEmbedDeps` to `CollectionIndexBuilder`, wired `embeddingService` through `libraryRoutes`, and dynamically constructs per-collection `VectorStore` (prevents cross-DB vector pollution). Also calls `store.setEmbedDeps()` so the collection's search path can use hybrid/semantic mode.

### Key design decisions
- `reprobeIfNeeded()` lives inside the shared `embedIndexedItems()` — single fix covers all callers
- Per-collection `VectorStore` created at rebuild time from the collection's own SQLite DB (not the root project's)
- `embedMode` passed from `EMBED_MODE` env var, defaults to `shadow` (safe: writes vectors + re-rank without breaking lexical search)
- All embedding paths remain fail-open (try/catch) — embedding errors never block FTS indexing

### Files changed
| File | Change |
|------|--------|
| `embed-utils.ts` | **New** — shared batch-splitting utility with `reprobeIfNeeded()` call |
| `EmbeddingService.ts` | Added `reprobeIfNeeded()` method |
| `interfaces.ts` | Added `reprobeIfNeeded()` to `IEmbeddingService` interface |
| `IndexBuilder.ts` | Replaced private embed method with shared `embedIndexedItems` import |
| `CollectionIndexBuilder.ts` | Added optional `CollectionEmbedDeps` param + embedding in `rebuild()` |
| `library.ts` | Accept `embeddingService` + `embedMode`, construct per-collection VectorStore, call `setEmbedDeps` |
| `index.ts` | Wire `embeddingService` and `embedMode` to `libraryRoutes` |

## Test plan
- [x] 9 new tests: embed-utils batch splitting (5), reprobe recovery (2), collection rebuild embed (2)
- [x] Existing IndexBuilder embedding tests updated with `reprobeIfNeeded` mock (68/68 pass)
- [x] Full memory test suite: 735/737 pass (2 pre-existing failures unrelated to this PR)
- [x] Biome check clean, TypeScript build passes (pre-existing type issues only)
- [x] Cross-family peer review approved, no P1/P2

Closes side-bugs #1, #2, #6 from #693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)