### PR TITLE
fix(codex): auto-approve Cat Cafe MCP tools for non-interactive sessions

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -191,6 +191,11 @@ function buildCatCafeMcpConfigArgs(workingDirectory?: string, callbackEnv?: Reco
       `mcp_servers.${serverName}.args=[${toTomlString(serverPath)}]`,
       '--config',
       `mcp_servers.${serverName}.enabled=true`,
+      // Codex ≥0.130: auto-approve MCP tool calls for trusted Cat Cafe servers.
+      // Without this, non-interactive `codex exec` has no UI to approve and
+      // write tools get auto-cancelled ("user cancelled MCP tool call").
+      '--config',
+      `mcp_servers.${serverName}.default_tools_approval_mode="approve"`,
     );
 
     for (const key of callbackKeys) {

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -183,6 +183,15 @@ test('injects cat-cafe MCP config when workingDirectory contains mcp-server', as
     assert.ok(args.includes('mcp_servers.cat-cafe-collab.env.CAT_CAFE_API_URL="http://127.0.0.1:3004"'));
     assert.ok(args.includes('mcp_servers.cat-cafe-collab.env.CAT_CAFE_INVOCATION_ID="inv-test-1"'));
     assert.ok(args.includes('mcp_servers.cat-cafe-collab.env.CAT_CAFE_CALLBACK_TOKEN="tok-test-1"'));
+
+    // Codex ≥0.130: each Cat Cafe MCP server must have auto-approve to avoid
+    // "user cancelled MCP tool call" in non-interactive codex exec mode.
+    for (const serverName of ['cat-cafe', 'cat-cafe-collab', 'cat-cafe-memory', 'cat-cafe-signals']) {
+      assert.ok(
+        args.includes(`mcp_servers.${serverName}.default_tools_approval_mode="approve"`),
+        `${serverName} must have default_tools_approval_mode="approve"`,
+      );
+    }
   } finally {
     rmSync(tmpRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- Cat Cafe MCP write tools (`post_message`, `create_task`, `hold_ball`, etc.) fail with `user cancelled MCP tool call` in non-interactive `codex exec` mode
- Root cause: Codex CLI's MCP tool approval gate requires human confirmation for write tools; no UI exists in `codex exec` → auto-cancel
- Fix: inject `default_tools_approval_mode="approve"` for all 4 Cat Cafe internal MCP servers in `buildCatCafeMcpConfigArgs()`
- Scoped to Cat Cafe's trusted servers only — user-configured MCP servers are unaffected

## Changes

- `CodexAgentService.ts`: +1 config line per server in `buildCatCafeMcpConfigArgs()`
- `codex-agent-service.test.js`: regression test asserting all 4 servers have approval config

## Verification

A/B test confirms deterministic behavior:
- Without config → `user cancelled MCP tool call`
- With config → tool executes to handler layer

Fixes #703

🐾 [宪宪/Opus-4.6]