### PR TITLE
fix(marketplace): browse mode 400 error + filter/search interaction bugs

### DIFF
--- a/packages/api/src/routes/marketplace.ts
+++ b/packages/api/src/routes/marketplace.ts
@@ -19,12 +19,8 @@ export const marketplaceRoutes: FastifyPluginAsync<MarketplaceRouteOptions> = as
       limit?: string;
     };
 
-    if (!q) {
-      return reply.status(400).send({ error: 'Missing required query parameter: q' });
-    }
-
     const results = await registry.search({
-      query: q,
+      query: q ?? '',
       ecosystems: ecosystems?.split(',') as MarketplaceEcosystem[] | undefined,
       trustLevels: trustLevels?.split(',') as TrustLevel[] | undefined,
       artifactKinds: artifactKinds?.split(',') as MarketplaceArtifactKind[] | undefined,

--- a/packages/api/test/marketplace/marketplace-routes.test.js
+++ b/packages/api/test/marketplace/marketplace-routes.test.js
@@ -96,14 +96,15 @@ describe('Marketplace Routes', () => {
     }
   });
 
-  it('GET /api/marketplace/search returns 400 without q param', async () => {
+  it('GET /api/marketplace/search returns all items when q is omitted (browse)', async () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/marketplace/search',
     });
-    assert.strictEqual(res.statusCode, 400);
+    assert.strictEqual(res.statusCode, 200);
     const body = res.json();
-    assert.ok(body.error.includes('q'));
+    assert.ok(Array.isArray(body.results));
+    assert.ok(body.results.length >= 3, `expected >=3 items for browse, got ${body.results.length}`);
   });
 
   it('POST /api/marketplace/install/plan returns install plan', async () => {

--- a/packages/web/src/components/__tests__/marketplace-panel.test.ts
+++ b/packages/web/src/components/__tests__/marketplace-panel.test.ts
@@ -1,0 +1,81 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = {
+  apiFetch: vi.fn(),
+};
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: (...args: unknown[]) => mocks.apiFetch(...args),
+}));
+
+import { useMarketplaceStore } from '@/stores/marketplaceStore';
+import { MarketplacePanel } from '../marketplace/marketplace-panel';
+
+const MOCK_RESULT = {
+  artifactId: 'mcp-memory',
+  artifactKind: 'mcp_server' as const,
+  displayName: 'MCP Memory',
+  ecosystem: 'claude' as const,
+  sourceLocator: 'npm:@anthropic/mcp-memory',
+  trustLevel: 'verified' as const,
+  componentSummary: 'Persistent memory using local knowledge graph',
+  transport: 'stdio' as const,
+};
+
+describe('MarketplacePanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.apiFetch.mockReset();
+    useMarketplaceStore.setState({
+      results: [MOCK_RESULT],
+      selectedResult: null,
+      installPlan: null,
+      loading: false,
+      error: 'Browse failed (400)',
+      query: '',
+      ecosystemFilter: [],
+      trustFilter: [],
+      artifactKindsFilter: [],
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('retry in browse mode calls browse instead of no-oping', async () => {
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
+
+    await act(async () => {
+      root.render(React.createElement(MarketplacePanel));
+    });
+
+    const retryButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('重试'),
+    );
+    expect(retryButton).toBeTruthy();
+
+    await act(async () => {
+      retryButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mocks.apiFetch).toHaveBeenCalledWith('/api/marketplace/search?');
+    expect(useMarketplaceStore.getState().error).toBeNull();
+  });
+});

--- a/packages/web/src/components/marketplace/marketplace-panel.tsx
+++ b/packages/web/src/components/marketplace/marketplace-panel.tsx
@@ -91,7 +91,8 @@ export function MarketplacePanel({
 
   const handleRetry = useCallback(() => {
     if (query) search(query);
-  }, [query, search]);
+    else browse();
+  }, [browse, query, search]);
 
   useEffect(() => {
     return () => clearSelection();

--- a/packages/web/src/components/marketplace/marketplace-search.tsx
+++ b/packages/web/src/components/marketplace/marketplace-search.tsx
@@ -23,6 +23,7 @@ export function MarketplaceSearch() {
   const [inputValue, setInputValue] = useState('');
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const search = useMarketplaceStore((s) => s.search);
+  const browse = useMarketplaceStore((s) => s.browse);
   const ecosystemFilter = useMarketplaceStore((s) => s.ecosystemFilter);
   const setEcosystemFilter = useMarketplaceStore((s) => s.setEcosystemFilter);
   const trustFilter = useMarketplaceStore((s) => s.trustFilter);
@@ -35,9 +36,11 @@ export function MarketplaceSearch() {
       if (debounceRef.current) clearTimeout(debounceRef.current);
       if (v.trim()) {
         debounceRef.current = setTimeout(() => search(v.trim()), 300);
+      } else {
+        browse();
       }
     },
-    [search],
+    [search, browse],
   );
 
   const handleKeyDown = useCallback(

--- a/packages/web/src/stores/__tests__/marketplaceStore.test.ts
+++ b/packages/web/src/stores/__tests__/marketplaceStore.test.ts
@@ -152,12 +152,14 @@ describe('marketplaceStore', () => {
     expect(mocks.apiFetch).not.toHaveBeenCalled();
   });
 
-  it('setEcosystemFilter does not search when no query', async () => {
+  it('setEcosystemFilter triggers browse when no query', async () => {
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     useMarketplaceStore.getState().setEcosystemFilter(['codex']);
+    await vi.waitFor(() => expect(mocks.apiFetch).toHaveBeenCalledTimes(1));
 
-    expect(mocks.apiFetch).not.toHaveBeenCalled();
+    expect(mocks.apiFetch).toHaveBeenCalledWith(expect.stringContaining('ecosystems=codex'));
   });
 
   it('setTrustFilter re-triggers search when query exists', async () => {

--- a/packages/web/src/stores/__tests__/marketplaceStore.test.ts
+++ b/packages/web/src/stores/__tests__/marketplaceStore.test.ts
@@ -47,7 +47,7 @@ describe('marketplaceStore', () => {
   });
 
   it('search populates results from API', async () => {
-    mocks.apiFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     await useMarketplaceStore.getState().search('memory');
@@ -58,7 +58,7 @@ describe('marketplaceStore', () => {
   });
 
   it('search passes ecosystem filter as CSV', async () => {
-    mocks.apiFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
     useMarketplaceStore.setState({ ecosystemFilter: ['claude', 'codex'] });
 
@@ -68,7 +68,7 @@ describe('marketplaceStore', () => {
   });
 
   it('search passes trust filter as CSV', async () => {
-    mocks.apiFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
     useMarketplaceStore.setState({ trustFilter: ['verified'] });
 
@@ -89,7 +89,7 @@ describe('marketplaceStore', () => {
     const promise = useMarketplaceStore.getState().search('memory');
     expect(useMarketplaceStore.getState().loading).toBe(true);
 
-    resolveApi!({ json: () => Promise.resolve({ results: [] }) });
+    resolveApi!({ ok: true, json: () => Promise.resolve({ results: [] }) });
     await promise;
     expect(useMarketplaceStore.getState().loading).toBe(false);
   });
@@ -105,7 +105,7 @@ describe('marketplaceStore', () => {
   });
 
   it('getInstallPlan fetches plan via POST', async () => {
-    mocks.apiFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ plan: MOCK_PLAN }) });
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ plan: MOCK_PLAN }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     await useMarketplaceStore.getState().getInstallPlan('claude', 'mcp-memory');
@@ -125,12 +125,12 @@ describe('marketplaceStore', () => {
   });
 
   it('setEcosystemFilter re-triggers search when query exists', async () => {
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     await useMarketplaceStore.getState().search('memory');
     mocks.apiFetch.mockClear();
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
 
     useMarketplaceStore.getState().setEcosystemFilter(['claude']);
     await vi.waitFor(() => expect(mocks.apiFetch).toHaveBeenCalledTimes(1));
@@ -140,7 +140,7 @@ describe('marketplaceStore', () => {
   });
 
   it('setEcosystemFilter skips re-search when value unchanged', async () => {
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     useMarketplaceStore.setState({ ecosystemFilter: ['claude'] });
@@ -161,12 +161,12 @@ describe('marketplaceStore', () => {
   });
 
   it('setTrustFilter re-triggers search when query exists', async () => {
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     await useMarketplaceStore.getState().search('test');
     mocks.apiFetch.mockClear();
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
 
     useMarketplaceStore.getState().setTrustFilter(['official']);
     await vi.waitFor(() => expect(mocks.apiFetch).toHaveBeenCalledTimes(1));
@@ -175,7 +175,7 @@ describe('marketplaceStore', () => {
   });
 
   it('search passes artifactKinds filter as CSV', async () => {
-    mocks.apiFetch.mockResolvedValueOnce({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
     useMarketplaceStore.setState({ artifactKindsFilter: ['mcp_server'] });
 
@@ -185,17 +185,59 @@ describe('marketplaceStore', () => {
   });
 
   it('setArtifactKindsFilter re-triggers search when query exists', async () => {
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
     const { useMarketplaceStore } = await import('../marketplaceStore');
 
     await useMarketplaceStore.getState().search('memory');
     mocks.apiFetch.mockClear();
-    mocks.apiFetch.mockResolvedValue({ json: () => Promise.resolve({ results: [] }) });
+    mocks.apiFetch.mockResolvedValue({ ok: true, json: () => Promise.resolve({ results: [] }) });
 
     useMarketplaceStore.getState().setArtifactKindsFilter(['mcp_server']);
     await vi.waitFor(() => expect(mocks.apiFetch).toHaveBeenCalledTimes(1));
 
     expect(mocks.apiFetch).toHaveBeenCalledWith(expect.stringContaining('artifactKinds=mcp_server'));
+  });
+
+  it('browse populates results without query param', async () => {
+    mocks.apiFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ results: [MOCK_RESULT] }) });
+    const { useMarketplaceStore } = await import('../marketplaceStore');
+
+    await useMarketplaceStore.getState().browse();
+
+    expect(useMarketplaceStore.getState().results).toHaveLength(1);
+    expect(useMarketplaceStore.getState().results[0].artifactId).toBe('mcp-memory');
+    expect(useMarketplaceStore.getState().loading).toBe(false);
+    expect(useMarketplaceStore.getState().error).toBeNull();
+  });
+
+  it('browse sets error when API returns non-ok response', async () => {
+    mocks.apiFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: 'Missing required query parameter: q' }),
+    });
+    const { useMarketplaceStore } = await import('../marketplaceStore');
+
+    await useMarketplaceStore.getState().browse();
+
+    expect(useMarketplaceStore.getState().error).toBeTruthy();
+    expect(useMarketplaceStore.getState().results).toEqual([]);
+    expect(useMarketplaceStore.getState().loading).toBe(false);
+  });
+
+  it('search sets error when API returns non-ok response', async () => {
+    mocks.apiFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve({ error: 'Internal server error' }),
+    });
+    const { useMarketplaceStore } = await import('../marketplaceStore');
+
+    await useMarketplaceStore.getState().search('test');
+
+    expect(useMarketplaceStore.getState().error).toBeTruthy();
+    expect(useMarketplaceStore.getState().results).toEqual([]);
+    expect(useMarketplaceStore.getState().loading).toBe(false);
   });
 
   it('clearSelection resets selectedResult and installPlan', async () => {

--- a/packages/web/src/stores/marketplaceStore.ts
+++ b/packages/web/src/stores/marketplaceStore.ts
@@ -65,7 +65,7 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
   },
 
   browse: async () => {
-    set({ loading: true, error: null });
+    set({ loading: true, error: null, query: '' });
     try {
       const params = new URLSearchParams();
       const { ecosystemFilter, trustFilter, artifactKindsFilter } = get();
@@ -85,22 +85,25 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
     const prev = get().ecosystemFilter;
     if (ecosystems.length === prev.length && ecosystems.every((e, i) => e === prev[i])) return;
     set({ ecosystemFilter: ecosystems });
-    const { query, search } = get();
+    const { query, search, browse } = get();
     if (query) search(query);
+    else browse();
   },
   setTrustFilter: (levels) => {
     const prev = get().trustFilter;
     if (levels.length === prev.length && levels.every((l, i) => l === prev[i])) return;
     set({ trustFilter: levels });
-    const { query, search } = get();
+    const { query, search, browse } = get();
     if (query) search(query);
+    else browse();
   },
   setArtifactKindsFilter: (kinds) => {
     const prev = get().artifactKindsFilter;
     if (kinds.length === prev.length && kinds.every((k, i) => k === prev[i])) return;
     set({ artifactKindsFilter: kinds });
-    const { query, search } = get();
+    const { query, search, browse } = get();
     if (query) search(query);
+    else browse();
   },
   selectResult: (result) => set({ selectedResult: result }),
 

--- a/packages/web/src/stores/marketplaceStore.ts
+++ b/packages/web/src/stores/marketplaceStore.ts
@@ -56,8 +56,9 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
         params.set('artifactKinds', artifactKindsFilter.join(','));
       }
       const res = await apiFetch(`/api/marketplace/search?${params}`);
+      if (!res.ok) throw new Error(`Search failed (${res.status})`);
       const data = (await res.json()) as { results: MarketplaceSearchResult[] };
-      set({ results: data.results, loading: false });
+      set({ results: data.results ?? [], loading: false });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : 'Search failed', loading: false });
     }
@@ -72,8 +73,9 @@ export const useMarketplaceStore = create<MarketplaceState>((set, get) => ({
       if (trustFilter.length > 0) params.set('trustLevels', trustFilter.join(','));
       if (artifactKindsFilter.length > 0) params.set('artifactKinds', artifactKindsFilter.join(','));
       const res = await apiFetch(`/api/marketplace/search?${params}`);
+      if (!res.ok) throw new Error(`Browse failed (${res.status})`);
       const data = (await res.json()) as { results: MarketplaceSearchResult[] };
-      set({ results: data.results, loading: false });
+      set({ results: data.results ?? [], loading: false });
     } catch (err) {
       set({ error: err instanceof Error ? err.message : 'Browse failed', loading: false });
     }


### PR DESCRIPTION
## Summary

Fixes three related bugs in the Marketplace (能力中心) page:

1. **Browse returns 400** — `GET /api/marketplace/search` without `q` param returned 400 because the route required it. Now treats missing `q` as empty string (matches all items).
2. **Filter tabs don't update in browse mode** — `setEcosystemFilter`/`setTrustFilter`/`setArtifactKindsFilter` only re-searched when `query` was non-empty. Now calls `browse()` when there is no active search query.
3. **Clearing search doesn't restore list** — Deleting search input text did nothing. Now calls `browse()` when input is cleared, and `browse()` resets `query` state.

## Changes

### API (`packages/api/src/routes/marketplace.ts`)
- Remove `if (!q)` 400 guard — use `q ?? ''` so empty query matches all artifacts

### Frontend Store (`packages/web/src/stores/marketplaceStore.ts`)
- `search()` and `browse()`: check `res.ok` before parsing response body
- `browse()`: resets `query` to `''`
- Filter setters: call `browse()` when no query instead of silently skipping

### Frontend Component (`packages/web/src/components/marketplace/marketplace-search.tsx`)
- `handleInput`: calls `browse()` when input is cleared (empty after trim)

## Test coverage

- `marketplaceStore.test.ts`: 17 tests (browse happy/error, search error, filter-triggers-browse)
- `marketplace-routes.test.js`: 8 tests (browse-without-query scenario)
- tsc, biome check clean


Fixes #711
