### PR TITLE
fix(#723): owner gate permissive + MemoryHub service entry + avatar member link

### DIFF
--- a/packages/api/src/routes/services-lifecycle-helpers.ts
+++ b/packages/api/src/routes/services-lifecycle-helpers.ts
@@ -18,7 +18,7 @@ export function requireLifecycleOwner(request: FastifyRequest, reply: FastifyRep
     return null;
   }
   const ownerId = process.env.DEFAULT_OWNER_USER_ID?.trim();
-  if (!ownerId || userId !== ownerId) {
+  if (ownerId && userId !== ownerId) {
     reply.status(403);
     return null;
   }

--- a/packages/api/test/services-lifecycle-route.test.js
+++ b/packages/api/test/services-lifecycle-route.test.js
@@ -62,9 +62,13 @@ describe('service lifecycle write routes', () => {
     }
   });
 
-  it('fails closed for lifecycle writes when DEFAULT_OWNER_USER_ID is missing', async () => {
+  it('allows lifecycle writes when DEFAULT_OWNER_USER_ID is unset (permissive mode)', async () => {
     delete process.env.DEFAULT_OWNER_USER_ID;
-    const app = await buildApp();
+    const app = await buildApp({
+      lifecycle: {
+        runScript: async () => ({ code: 0, output: 'installed' }),
+      },
+    });
     try {
       const res = await app.inject({
         method: 'POST',
@@ -73,8 +77,7 @@ describe('service lifecycle write routes', () => {
         payload: { model: 'mlx-community/whisper-large-v3-turbo' },
       });
 
-      assert.equal(res.statusCode, 403, res.payload);
-      assert.match(JSON.parse(res.payload).error, /DEFAULT_OWNER_USER_ID/);
+      assert.equal(res.statusCode, 200, `expected 200 but got ${res.statusCode}: ${res.payload}`);
     } finally {
       await app.close();
       restoreOwner(ORIGINAL_OWNER_ID);

--- a/packages/web/src/components/CatAvatar.tsx
+++ b/packages/web/src/components/CatAvatar.tsx
@@ -21,6 +21,7 @@ interface CatAvatarProps {
   catId: string;
   size?: number;
   status?: CatStatus;
+  onClick?: () => void;
   /** F174 D2b-2: corner status dot for callback-auth health surface (明厨亮灶 实体层). */
   callbackAuthStatus?: CallbackAuthStatus;
   /** Optional aria-label / hover hint for the status dot (e.g. "broken · 12 fails"). */
@@ -43,6 +44,7 @@ export function CatAvatar({
   callbackAuthLabel,
   callbackAuthPopover,
   onCallbackAuthClick,
+  onClick,
 }: CatAvatarProps) {
   const [imgError, setImgError] = useState(false);
   const [popoverOpen, setPopoverOpen] = useState(false);
@@ -54,6 +56,8 @@ export function CatAvatar({
   const ringColor = cat?.color.primary ?? '#9CA3AF'; // gray-400 fallback
   const glowShadow = isStreaming && cat ? `0 0 10px ${hexToRgba(ringColor, 0.5)}` : undefined;
 
+  const Wrapper = onClick ? 'button' : 'div';
+
   // F174 D2b-2: dot is ~28% of avatar size (min 8px), absolute positioned bottom-right.
   // White ring lifts it off the avatar and survives most cat colors.
   const dotSize = Math.max(8, Math.round(size * 0.28));
@@ -61,10 +65,11 @@ export function CatAvatar({
 
   return (
     <div className="relative flex-shrink-0" style={{ width: size, height: size }}>
-      <div
+      <Wrapper
+        {...(onClick ? { type: 'button' as const, onClick, 'aria-label': `${cat?.displayName ?? catId}` } : {})}
         className={`rounded-full ring-2 overflow-hidden bg-cafe-surface-elevated flex items-center justify-center transition-shadow duration-300 ${
           isStreaming ? 'animate-pulse' : ''
-        }`}
+        } ${onClick ? 'cursor-pointer hover:ring-[var(--console-accent)] transition-[box-shadow,--tw-ring-color]' : ''}`}
         style={{
           width: size,
           height: size,
@@ -85,7 +90,7 @@ export function CatAvatar({
             onError={() => setImgError(true)}
           />
         )}
-      </div>
+      </Wrapper>
       {callbackAuthStatus && (
         <span
           className="absolute"

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { type CatData, formatCatName } from '@/hooks/useCatData';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
 import { useTts } from '@/hooks/useTts';
@@ -69,6 +70,7 @@ interface ChatMessageProps {
 }
 
 export function ChatMessage({ message, getCatById }: ChatMessageProps) {
+  const router = useRouter();
   const coCreator = useCoCreatorConfig();
   const { state: ttsState, synthesize: ttsSynthesize, activeMessageId } = useTts();
   const currentThreadId = useChatStore((s) => s.currentThreadId);
@@ -299,7 +301,14 @@ export function ChatMessage({ message, getCatById }: ChatMessageProps) {
 
   return (
     <div data-message-id={message.id} className="group flex gap-2 mb-4 items-start">
-      {catData && <CatAvatar catId={message.catId!} size={32} status={message.isStreaming ? 'streaming' : undefined} />}
+      {catData && (
+        <CatAvatar
+          catId={message.catId!}
+          size={32}
+          status={message.isStreaming ? 'streaming' : undefined}
+          onClick={() => router.push(`/settings?s=members&cat=${message.catId}`)}
+        />
+      )}
       <div className="max-w-[85%] md:max-w-[75%] min-w-0">
         {catStyle && (
           <div className="mb-1 flex flex-col gap-1 min-w-0">

--- a/packages/web/src/components/memory/MemoryHub.tsx
+++ b/packages/web/src/components/memory/MemoryHub.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ServiceStatusPanel } from '../settings/ServiceStatusPanel';
 import { KnowledgeFeed } from '../workspace/KnowledgeFeed';
 import { CollectionCatalog } from './CollectionCatalog';
 import { CollectionGraph } from './CollectionGraph';
@@ -34,7 +35,8 @@ export function MemoryHub({ activeTab = 'feed', initialQuery, initialReferrerThr
           </div>
         )}
         {activeTab === 'status' && (
-          <div data-testid="memory-tab-status">
+          <div className="space-y-4" data-testid="memory-tab-status">
+            <ServiceStatusPanel filterFeatures={['memory-semantic-search']} title="语义搜索服务" />
             <IndexStatus />
           </div>
         )}

--- a/packages/web/src/components/settings/SettingsContent.tsx
+++ b/packages/web/src/components/settings/SettingsContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
 import { apiFetch } from '@/utils/api-client';
 import { BrakeSettingsPanel } from '../BrakeSettingsPanel';
@@ -28,9 +28,10 @@ import { SETTINGS_SECTIONS } from './settings-nav-config';
 
 interface SettingsContentProps {
   section: string;
+  initialEditCatId?: string;
 }
 
-export function SettingsContent({ section }: SettingsContentProps) {
+export function SettingsContent({ section, initialEditCatId }: SettingsContentProps) {
   const { cats, refresh } = useCatData();
   const [config, setConfig] = useState<ConfigData | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
@@ -59,6 +60,24 @@ export function SettingsContent({ section }: SettingsContentProps) {
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  const consumedDeepLinkRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      initialEditCatId &&
+      section === 'members' &&
+      cats.length > 0 &&
+      consumedDeepLinkRef.current !== initialEditCatId
+    ) {
+      const cat = cats.find((c) => c.id === initialEditCatId);
+      if (cat) {
+        consumedDeepLinkRef.current = initialEditCatId;
+        setCreateDraft(null);
+        setEditingCat(cat);
+        setEditorOpen(true);
+      }
+    }
+  }, [initialEditCatId, section, cats]);
 
   const handleEditorSaved = useCallback(async () => {
     await Promise.all([fetchData(), refresh()]);

--- a/packages/web/src/components/settings/SettingsShell.tsx
+++ b/packages/web/src/components/settings/SettingsShell.tsx
@@ -10,6 +10,7 @@ function SettingsShellInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const activeSection = searchParams.get('s') ?? DEFAULT_SECTION;
+  const initialEditCatId = searchParams.get('cat') ?? undefined;
   const standalone = searchParams.get('standalone') === '1';
 
   const handleSelect = useCallback(
@@ -26,7 +27,7 @@ function SettingsShellInner() {
       <div className="flex h-full flex-col bg-[var(--console-panel-bg)]">
         <div className="m-3 flex flex-1 flex-col overflow-y-auto rounded-[18px] bg-[var(--console-shell-bg)] px-5 py-6 shadow-[var(--console-shadow-soft)] md:px-9 md:py-8">
           <div className="space-y-5">
-            <SettingsContent section={activeSection} />
+            <SettingsContent section={activeSection} initialEditCatId={initialEditCatId} />
           </div>
         </div>
       </div>
@@ -49,7 +50,7 @@ function SettingsShellInner() {
 
       <div className="min-w-0 flex-1 overflow-y-auto">
         <div className="space-y-5 px-5 py-5 md:px-8 md:py-7">
-          <SettingsContent section={activeSection} />
+          <SettingsContent section={activeSection} initialEditCatId={initialEditCatId} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## What

Synced from cat-cafe PR #1793 — fixes three community-reported functional blockers:

- **P1**: `requireLifecycleOwner()` changed to permissive when `DEFAULT_OWNER_USER_ID` unset (1-char fix)
- **P2**: `MemoryHub` status tab now includes `ServiceStatusPanel` for `memory-semantic-search`
- **P2**: Chat avatar click navigates to `/settings?s=members&cat={catId}` with auto-open editor

## Why

Community-reported in #723. P1 blocks all lifecycle writes (install/start/stop/uninstall) with 403 on fresh/local setups.

Closes #723

## Test Evidence

All changes validated in cat-cafe PR #1793 (pnpm gate passed, local + cloud review).

[布偶猫🐾]