### PR TITLE
fix(#723): avatar in-page modal + ConfirmDialog z-index (outbound sync)

### DIFF
--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -46,6 +46,7 @@ import { syncLocalBootcampState } from './first-run-quest/syncLocalBootcampState
 import { useFirstProjectMistakeTipGate } from './first-run-quest/useFirstProjectMistakeTipGate';
 import { useFirstProjectPreviewAutoOpen } from './first-run-quest/useFirstProjectPreviewAutoOpen';
 import { GameOverlayConnector } from './game/GameOverlayConnector';
+import { HubCatEditor } from './HubCatEditor';
 import { BootcampIcon } from './icons/BootcampIcon';
 import { PawIcon } from './icons/PawIcon';
 import { MessageActions } from './MessageActions';
@@ -131,7 +132,7 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
   // AC-6: research=multi hint from Signal study "多猫研究" button
   const isResearchMode = searchParams?.get('research') === 'multi';
   const { clearTasks } = useTaskStore();
-  const { cats, getCatById, isLoading, hasFetched } = useCatData();
+  const { cats, getCatById, refresh: refreshCats, isLoading, hasFetched } = useCatData();
   const workspaceWorktreeId = useChatStore((s) => s.workspaceWorktreeId);
   usePreviewAutoOpen(workspaceWorktreeId, threadId);
   useWorkspaceNavigate(workspaceWorktreeId, threadId);
@@ -141,6 +142,8 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
   const [showBootcampList, setShowBootcampList] = useState(false);
   const [showFirstRunQuestPrompt, setShowFirstRunQuestPrompt] = useState(false);
   const [showQuestWizard, setShowQuestWizard] = useState(false);
+  const [editingCatId, setEditingCatId] = useState<string | null>(null);
+  const editingCat = editingCatId ? (getCatById(editingCatId) ?? null) : null;
   // F106: fetch bootcamp count independently of sidebar lifecycle
   // refreshKey increments only on modal close → avoids duplicate fetch on open
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -572,13 +575,14 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
     onIndexEvent: handleIndexSocketEvent,
   });
 
+  const handleEditCat = useCallback((catId: string) => setEditingCatId(catId), []);
   const renderSingleMessage = useCallback(
     (msg: ChatMessageData) => (
       <MessageActions key={msg.id} message={msg} threadId={threadId}>
-        <ChatMessage message={msg} getCatById={getCatById} />
+        <ChatMessage message={msg} getCatById={getCatById} onEditCat={handleEditCat} />
       </MessageActions>
     ),
-    [threadId, getCatById],
+    [threadId, getCatById, handleEditCat],
   );
 
   const { cancelInvocation, syncRooms, socketConnected } = useSocket(socketCallbacks, threadId);
@@ -1158,6 +1162,18 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
       />
       <BootcampListModal open={showBootcampList} onClose={handleBootcampModalClose} currentThreadId={threadId} />
       {showVoteModal && <VoteConfigModal onSubmit={handleVoteSubmit} onCancel={() => setShowVoteModal(false)} />}
+      {editingCat && (
+        <HubCatEditor
+          open
+          cat={editingCat}
+          draft={null}
+          onClose={() => setEditingCatId(null)}
+          onSaved={async () => {
+            await refreshCats();
+            setEditingCatId(null);
+          }}
+        />
+      )}
       {/* Bootcamp guide overlay: intro phase tips + lifecycle tips (phase-7.5 uses guide engine) */}
       {(() => {
         if (showFirstRunQuestPrompt || showQuestWizard) return null;

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { type CatData, formatCatName } from '@/hooks/useCatData';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
 import { useTts } from '@/hooks/useTts';
@@ -67,10 +66,10 @@ function isConnectorSystemNotice(message: ChatMessageType): boolean {
 interface ChatMessageProps {
   message: ChatMessageType;
   getCatById: (id: string) => CatData | undefined;
+  onEditCat?: (catId: string) => void;
 }
 
-export function ChatMessage({ message, getCatById }: ChatMessageProps) {
-  const router = useRouter();
+export function ChatMessage({ message, getCatById, onEditCat }: ChatMessageProps) {
   const coCreator = useCoCreatorConfig();
   const { state: ttsState, synthesize: ttsSynthesize, activeMessageId } = useTts();
   const currentThreadId = useChatStore((s) => s.currentThreadId);
@@ -306,7 +305,7 @@ export function ChatMessage({ message, getCatById }: ChatMessageProps) {
           catId={message.catId!}
           size={32}
           status={message.isStreaming ? 'streaming' : undefined}
-          onClick={() => router.push(`/settings?s=members&cat=${message.catId}`)}
+          onClick={onEditCat && message.catId ? () => onEditCat(message.catId!) : undefined}
         />
       )}
       <div className="max-w-[85%] md:max-w-[75%] min-w-0">

--- a/packages/web/src/components/ConfirmDialog.tsx
+++ b/packages/web/src/components/ConfirmDialog.tsx
@@ -54,7 +54,7 @@ export function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 bg-[var(--console-overlay-backdrop)] flex items-center justify-center z-50"
+      className="fixed inset-0 bg-[var(--console-overlay-backdrop)] flex items-center justify-center z-[100]"
       onClick={onCancel}
     >
       <div


### PR DESCRIPTION
## What

Outbound sync from cat-cafe PR #1797 + #1800:
- ChatMessage avatar click opens HubCatEditor as in-page modal instead of navigating to /settings
- ChatContainer hosts editingCatId state + HubCatEditor modal (same pattern as BootcampListModal)
- ConfirmDialog z-index bumped from z-50 to z-[100] to render above HubCatEditor (z-[60])

## Why

Community-reported #723: avatar click should stay on current thread page. ConfirmDialog z-index regression caused unsaved-changes confirmation to render behind the editor modal.

## Test Evidence

Changes are functional parity with cat-cafe main (PR #1797 + #1800, both cloud-reviewed and merged).

---

<!-- 布偶猫/宪宪 (opus) -->