### PR TITLE
sync: cat-cafe 96bf733a -> clowder-ai

### DIFF
--- a/.sync-provenance.json
+++ b/.sync-provenance.json
@@ -1,12 +1,12 @@
 {
-  "source_commit_sha": "fca77edc085455be678fd2554ec461efe0a872e2",
-  "target_head_sha": "c4a81a8ed26ea205050532266fc43cd8bf52365d",
+  "source_commit_sha": "96bf733a9ad4e2902861d5cba25def6ff59ff674",
+  "target_head_sha": "632263259fe36dfac8b1b0c7928cc64c59624117",
   "release_tag": null,
   "source_snapshot_tag": null,
   "manifest_version": 3,
-  "included_file_count": 3543,
+  "included_file_count": 3544,
   "excluded_file_count": 13,
   "transform_count": 34,
   "secret_scan_result": "clean",
-  "synced_at": "2026-05-21T07:23:25Z"
+  "synced_at": "2026-05-21T09:41:18Z"
 }

--- a/docs/features/.export-summary.json
+++ b/docs/features/.export-summary.json
@@ -1,5 +1,5 @@
 {
-  "exportedAt": "2026-05-21T07:23:16.847Z",
+  "exportedAt": "2026-05-21T09:41:10.634Z",
   "minTier": "yellow",
   "exported": 211,
   "skipped": 5,

--- a/docs/features/F206-settings-ui-convergence.md
+++ b/docs/features/F206-settings-ui-convergence.md
@@ -192,11 +192,12 @@ Phase O post-merge audit（Maine Coon）识别 5 个 Settings/Voice 文件仍有
 
 ### Post-close shell container parity ✅
 
-team lead 2026-05-21 截图反馈：Settings 与 Chat/Thread 切换时 rail/content 边界感不一致；Signal 与 Memory/Mission 的页面承载形态不一致。
+team lead 2026-05-21 截图反馈：Settings 与 Chat/Thread 切换时 rail/content 边界感不一致；Signal 与 Memory/Mission 的页面承载形态不一致。后续二次反馈确认方向应以多数页面的“圆角承载层”对齐，而不是把 Signal 拉到无缝 shell 少数派。
 
 1. **SettingsShell rail separator**：Settings 左侧 rail 增加 `border-r border-[var(--console-border-soft)]`，对齐 ThreadSidebar 的 rail/content 分隔模式
-2. **Signal full-height shell**：SignalInboxView / SignalSourcesView 移除旧 `max-w` 圆角外壳，改为 full-height console shell + header/content 分层
+2. **Signal outer shell normalization**：SignalInboxView / SignalSourcesView 移除旧 `max-w` 圆角外壳，外层改为 full-height console shell + header/content 分层
 3. **SignalNav tab token parity**：Signal tabs 对齐 MemoryNav/MissionControl 的 `border-strong + card-bg + button-emphasis` active hierarchy
+4. **Memory/Signal visible content carriers**：MemoryHub / SignalInboxView / SignalSourcesView 的主内容区补齐 `rounded-2xl + --console-card-bg + --console-border-soft + soft shadow + 18px padding`，对齐 SettingsSection / Mission panels 的圆角承载层；用 regression test 固定三页必须有可见 carrier
 
 ### Post-close Guardrail: 线条分隔 vs 背景分层
 
@@ -209,6 +210,7 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 3. 线条是“结构边界”，不是“卡片轮廓”。除了对话主区域的必要框架线，状态栏、统计块、消息统计、Session Chain、Memory/Signals/Settings 内部模块等能不用卡片外框就不用外框，优先用背景、间距、分组标题、轻量 divider。
 4. Review 时不要一刀切套 CDS §1.1：先判断区域角色。框架边界可用线；内容卡片/统计卡/列表项不应回到四周包边。
 5. 视觉验收要看“线条强度”：如果截图里边框先于内容被看见，视为过强，需要降到更淡 token 或改为背景/间距分隔。
+6. 页面级承载层（SettingsSection / Mission panels / Memory/Signal content surface）可以用圆角卡片；“避免四周包边”约束的是承载层内部的二级内容块，不是页面主容器。
 
 ## Acceptance Criteria
 
@@ -327,9 +329,11 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 
 ### Post-close shell container parity
 - [x] AC-S1: SettingsShell rail/content separator matches ThreadSidebar (`border-r` + `--console-border-soft`)
-- [x] AC-S2: SignalInboxView / SignalSourcesView use full-height console shell instead of rounded standalone carrier
+- [x] AC-S2: SignalInboxView / SignalSourcesView use full-height console outer shell instead of legacy max-width standalone shell
 - [x] AC-S3: SignalNav active tab tokens match MemoryNav/MissionControl hierarchy
 - [x] AC-S4: `pnpm gate` 全绿
+- [x] AC-S5: MemoryHub / SignalInboxView / SignalSourcesView main content areas use visible rounded carriers (`rounded-2xl`, `--console-border-soft`, soft shadow, 18px padding)
+- [x] AC-S6: Regression test pins the rounded content surface pattern for all three pages
 
 ## Dependencies
 
@@ -353,7 +357,8 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 | KD-3 | 先归一再 outbound sync | 同步出去的代码是社区二次参考点，混乱版污染下游 | 2026-05-18 |
 | KD-4 | 框架边界可用极淡统一线条，内容卡片避免四周包边 | team lead 2026-05-20 明确：Thread 栏/对话栏/状态栏可统一底色 + 淡线分隔；状态栏等内容块仍应”能不要框线就不要框线”，避免改着改着忘回卡片包边 | 2026-05-20 |
 | KD-5 | 红区文件纯 CSS token 迁移豁免 + reopen anchor CVO 追认 | Phase L/N 触碰 ChatContainer.tsx/ChatMessage.tsx（F183/F184/F194 红区），diff 实证纯 className 视觉 token 迁移（零行为风险）。CVO 2026-05-21 追认豁免。同时追认 F206 reopen 承载 Phase D-P（原 close `8891cd400` → reopen `675a7c104`，anchor 归属 CVO 事后 signoff） | 2026-05-21 |
-| KD-6 | Console shell 容器层级优先统一页面承载形态 | Settings/Thread 这类 rail/content 页面用淡边界分隔；Memory/Mission/Signal 这类 console page 用 full-height shell + header/content 分层，避免一边无缝、一边圆角外壳的跨页面冲突 | 2026-05-21 |
+| KD-6 | Console shell 容器层级拆成 outer shell + content carrier | Settings/Thread 这类 rail/content 页面用淡边界分隔；Memory/Mission/Signal 这类 console page 外层用 full-height shell + header/content 分层，内层主内容承载层跟随多数页面的圆角 surface 模式 | 2026-05-21 |
+| KD-7 | 多数页面的圆角承载层优先于无缝少数派 | CVO 2026-05-21 二次验收指出“规则与 SOP 等多数页面是圆角承载层”，Memory/Signal 的无缝主内容是异端；PR #1826 给 Memory/Signal 主内容补 visible carrier，避免 card-bg 与 shell-bg 过近导致“看起来没圆角/没空白” | 2026-05-21 |
 
 ## Review Gate
 
@@ -374,3 +379,4 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 - Phase O: codex 本地 review → 云端 skip（CVO KD-1 速度优先，纯 CSS token migration for inner controls）
 - Phase P: codex 本地 review → 云端 skip（CVO KD-1 速度优先，纯 CSS token migration for settings/voice residuals）
 - Post-close shell container parity: opus 本地 review → 云端 skip（CVO KD-1 速度优先，纯 CSS shell hierarchy correction）
+- Post-close rounded content carrier follow-up: opus 本地 review → 云端 review clean（纯 CSS carrier visibility fix + regression test）

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -43,6 +43,7 @@
     "@opentelemetry/sdk-node": "^0.214.0",
     "@opentelemetry/sdk-trace-node": "^2.6.1",
     "@opentelemetry/semantic-conventions": "^1.40.0",
+    "@vscode/ripgrep": "1.18.0",
     "@wecom/aibot-node-sdk": "1.0.4",
     "better-sqlite3": "^12.6.2",
     "cheerio": "^1.1.2",

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1625,6 +1625,14 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
+    name: 'CAT_CAFE_RIPGREP_PATH',
+    defaultValue: '(未设置 → 使用内置 @vscode/ripgrep，失败时回落 PATH rg)',
+    description: 'Antigravity grep_search native executor 的 ripgrep 二进制路径覆盖（异常部署/调试用）',
+    category: 'antigravity',
+    sensitive: false,
+    runtimeEditable: false,
+  },
+  {
     name: 'CAT_CAFE_READONLY',
     defaultValue: '(未设置 → 全量注册)',
     description: 'MCP Server 只读模式：跳过 post_message 等写操作工具注册（Antigravity 持久 MCP 用）',

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/executors/IdeReadToolExecutor.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/executors/IdeReadToolExecutor.ts
@@ -20,6 +20,7 @@ const SEARCH_RESULT_SENTINEL = MAX_SEARCH_RESULTS + 1;
 const RG_TIMEOUT_MS = 10_000;
 const STDERR_CAPTURE_BYTES = 32_768;
 const RG_DENYLIST_GLOBS = ['!.env*', '!*.pem', '!*.key', '!id_rsa*', '!.git', '!secrets'];
+let ripgrepBinaryPromise: Promise<string> | undefined;
 
 function durationSince(startedAt: number): number {
   return Math.max(0, Date.now() - startedAt);
@@ -119,9 +120,26 @@ function filterAndTruncateRipgrepJson(stdout: string): string {
 
 export const filterAndTruncateRipgrepJsonForTest = filterAndTruncateRipgrepJson;
 
+async function resolveRipgrepBinary(): Promise<string> {
+  const configured = process.env.CAT_CAFE_RIPGREP_PATH?.trim();
+  if (configured) return configured;
+
+  try {
+    const { rgPath } = await import('@vscode/ripgrep');
+    if (typeof rgPath === 'string' && rgPath.length > 0) return rgPath;
+  } catch {
+    // Fall through to PATH lookup for development shells and system installs.
+  }
+
+  return 'rg';
+}
+
 async function executeRipgrepJson(args: string[], cwd: string): Promise<string> {
+  ripgrepBinaryPromise ??= resolveRipgrepBinary();
+  const ripgrepBinary = await ripgrepBinaryPromise;
+
   return new Promise((resolve, reject) => {
-    const child = spawn('rg', args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+    const child = spawn(ripgrepBinary, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
     const lines: string[] = [];
     let stdoutRemainder = '';
     let stderr = '';

--- a/packages/api/test/antigravity-ide-read-tool-executor.test.js
+++ b/packages/api/test/antigravity-ide-read-tool-executor.test.js
@@ -64,6 +64,30 @@ describe('AntigravityIdeReadToolExecutor', () => {
     assert.equal(entries[0].result.status, 'success');
   });
 
+  test('grep_search works when rg is not discoverable on PATH', async () => {
+    const root = makeWorkspace();
+    const emptyPath = fs.mkdtempSync(path.join(os.tmpdir(), 'antigravity-ide-read-tools-empty-path-'));
+    cleanupDirs.push(emptyPath);
+    const originalPath = process.env.PATH;
+    process.env.PATH = emptyPath;
+
+    try {
+      const executor = new AntigravityIdeReadToolExecutor('grep_search');
+      const { ctx } = makeContext(root);
+
+      const result = await executor.execute({ Pattern: 'needle', Path: 'src' }, ctx);
+
+      assert.equal(result.status, 'success');
+      assert.match(result.stdout, /src\/index\.ts:1:const needle = true;/);
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+    }
+  });
+
   test('grep_search honors canonical SearchPath instead of defaulting to workspace root', async () => {
     const root = makeWorkspace();
     fs.mkdirSync(path.join(root, 'docs'), { recursive: true });

--- a/packages/web/src/components/__tests__/console-shell-content-surface.test.ts
+++ b/packages/web/src/components/__tests__/console-shell-content-surface.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const componentsRoot = resolve(testDir, '..');
+
+const surfaceRequirements = ['rounded-2xl', 'border-[var(--console-border-soft)]', 'shadow-[0_12px_30px'];
+
+function readComponent(relativePath: string): string {
+  return readFileSync(resolve(componentsRoot, relativePath), 'utf8');
+}
+
+describe('console shell content surfaces', () => {
+  it.each([
+    ['MemoryHub', 'memory/MemoryHub.tsx', 'memory-content-surface'],
+    ['SignalInboxView', 'signals/SignalInboxView.tsx', 'signal-inbox-content-surface'],
+    ['SignalSourcesView', 'signals/SignalSourcesView.tsx', 'signal-sources-content-surface'],
+  ])('%s uses a visible rounded content carrier', (_name, path, testId) => {
+    const src = readComponent(path);
+
+    expect(src).toContain(`data-testid="${testId}"`);
+    for (const className of surfaceRequirements) {
+      expect(src).toContain(className);
+    }
+  });
+});

--- a/packages/web/src/components/memory/MemoryHub.tsx
+++ b/packages/web/src/components/memory/MemoryHub.tsx
@@ -16,6 +16,9 @@ interface MemoryHubProps {
   readonly initialReferrerThread?: string | null;
 }
 
+const CONTENT_SURFACE_CLASS =
+  'rounded-2xl border border-[var(--console-border-soft)] bg-[var(--console-card-bg)] p-[18px] shadow-[0_12px_30px_rgba(43,33,26,0.06)]';
+
 export function MemoryHub({ activeTab = 'feed', initialQuery, initialReferrerThread = null }: MemoryHubProps) {
   return (
     <div className="flex h-full flex-col bg-[var(--console-shell-bg)]" data-testid="memory-hub">
@@ -23,40 +26,42 @@ export function MemoryHub({ activeTab = 'feed', initialQuery, initialReferrerThr
         <MemoryNav active={activeTab} initialReferrerThread={initialReferrerThread} />
       </header>
 
-      <main className="flex-1 overflow-y-auto p-4">
-        {activeTab === 'feed' && (
-          <div data-testid="memory-tab-feed">
-            <KnowledgeFeed />
-          </div>
-        )}
-        {activeTab === 'search' && (
-          <div data-testid="memory-tab-search">
-            <EvidenceSearch initialQuery={initialQuery} />
-          </div>
-        )}
-        {activeTab === 'status' && (
-          <div className="space-y-4" data-testid="memory-tab-status">
-            <ServiceStatusPanel filterFeatures={['memory-semantic-search']} title="语义搜索服务" />
-            <IndexStatus />
-          </div>
-        )}
-        {activeTab === 'health' && (
-          <div className="space-y-4" data-testid="memory-tab-health">
-            <MemoryFlagPanel />
-            <HealthReport />
-            <ToolUsageMetricsPanel />
-          </div>
-        )}
-        {activeTab === 'catalog' && (
-          <div data-testid="memory-tab-catalog">
-            <CollectionCatalog />
-          </div>
-        )}
-        {activeTab === 'graph' && (
-          <div data-testid="memory-tab-graph">
-            <CollectionGraph />
-          </div>
-        )}
+      <main className="flex-1 overflow-y-auto p-5">
+        <div className={CONTENT_SURFACE_CLASS} data-testid="memory-content-surface">
+          {activeTab === 'feed' && (
+            <div data-testid="memory-tab-feed">
+              <KnowledgeFeed />
+            </div>
+          )}
+          {activeTab === 'search' && (
+            <div data-testid="memory-tab-search">
+              <EvidenceSearch initialQuery={initialQuery} />
+            </div>
+          )}
+          {activeTab === 'status' && (
+            <div className="space-y-4" data-testid="memory-tab-status">
+              <ServiceStatusPanel filterFeatures={['memory-semantic-search']} title="语义搜索服务" />
+              <IndexStatus />
+            </div>
+          )}
+          {activeTab === 'health' && (
+            <div className="space-y-4" data-testid="memory-tab-health">
+              <MemoryFlagPanel />
+              <HealthReport />
+              <ToolUsageMetricsPanel />
+            </div>
+          )}
+          {activeTab === 'catalog' && (
+            <div data-testid="memory-tab-catalog">
+              <CollectionCatalog />
+            </div>
+          )}
+          {activeTab === 'graph' && (
+            <div data-testid="memory-tab-graph">
+              <CollectionGraph />
+            </div>
+          )}
+        </div>
       </main>
     </div>
   );

--- a/packages/web/src/components/signals/SignalInboxView.tsx
+++ b/packages/web/src/components/signals/SignalInboxView.tsx
@@ -35,6 +35,9 @@ const initialFilters: SignalArticleFilters = {
   tier: 'all',
 };
 
+const CONTENT_SURFACE_CLASS =
+  'rounded-2xl border border-[var(--console-border-soft)] bg-[var(--console-card-bg)] p-[18px] shadow-[0_12px_30px_rgba(43,33,26,0.06)]';
+
 function uniqueSources(items: readonly SignalArticle[]): readonly string[] {
   return Array.from(new Set(items.map((item) => item.source))).sort();
 }
@@ -286,57 +289,62 @@ export function SignalInboxView({ initialReferrerThread = null }: { initialRefer
         <SignalNav active="signals" initialReferrerThread={initialReferrerThread} />
       </header>
 
-      <main className="flex min-h-0 flex-1 flex-col gap-4 overflow-hidden p-6">
-        <SignalStatsCards stats={stats} />
+      <main className="flex min-h-0 flex-1 p-5">
+        <div
+          className={`flex min-h-0 flex-1 flex-col gap-4 overflow-hidden ${CONTENT_SURFACE_CLASS}`}
+          data-testid="signal-inbox-content-surface"
+        >
+          <SignalStatsCards stats={stats} />
 
-        {error && (
-          <div className="rounded-lg bg-conn-red-bg px-3 py-2 text-sm text-red-700 shadow-[0_1px_3px_rgba(43,33,26,0.06)]">
-            请求失败: {error}
-          </div>
-        )}
+          {error && (
+            <div className="rounded-lg bg-conn-red-bg px-3 py-2 text-sm text-red-700 shadow-[0_1px_3px_rgba(43,33,26,0.06)]">
+              请求失败: {error}
+            </div>
+          )}
 
-        <div className="flex min-h-0 flex-1 gap-4">
-          <div className="flex w-[420px] shrink-0 flex-col gap-1 overflow-y-auto border-r border-[var(--console-border-soft)] pr-4">
-            <SignalFilterBar
-              filters={filters}
-              onFilterChange={(patch) => setFilters((cur) => ({ ...cur, ...patch }))}
-              onStatusTab={handleStatusTab}
-              onSubmit={handleSearchSubmit}
-              sources={sources}
-              ime={ime}
-            />
-            <div className="flex items-center justify-between px-2 pb-1">
-              <p className="text-xs font-semibold text-cafe-muted">
-                {loading ? '加载中...' : `共 ${filteredItems.length} 篇`}
-              </p>
-              <BatchActionBar
+          <div className="flex min-h-0 flex-1 gap-4">
+            <div className="flex w-[420px] shrink-0 flex-col gap-1 overflow-y-auto border-r border-[var(--console-border-soft)] pr-4">
+              <SignalFilterBar
+                filters={filters}
+                onFilterChange={(patch) => setFilters((cur) => ({ ...cur, ...patch }))}
+                onStatusTab={handleStatusTab}
+                onSubmit={handleSearchSubmit}
+                sources={sources}
+                ime={ime}
+              />
+              <div className="flex items-center justify-between px-2 pb-1">
+                <p className="text-xs font-semibold text-cafe-muted">
+                  {loading ? '加载中...' : `共 ${filteredItems.length} 篇`}
+                </p>
+                <BatchActionBar
+                  selectedIds={batchSelected}
+                  onClear={() => setBatchSelected(new Set())}
+                  onComplete={() => void refreshInbox()}
+                />
+              </div>
+              <SignalArticleList
+                items={filteredItems}
+                selectedArticleId={selectedArticleId}
+                onSelect={handleSelectArticle}
+                onStatusChange={handleStatusChange}
                 selectedIds={batchSelected}
-                onClear={() => setBatchSelected(new Set())}
-                onComplete={() => void refreshInbox()}
+                onToggleSelect={toggleBatchSelect}
               />
             </div>
-            <SignalArticleList
-              items={filteredItems}
-              selectedArticleId={selectedArticleId}
-              onSelect={handleSelectArticle}
-              onStatusChange={handleStatusChange}
-              selectedIds={batchSelected}
-              onToggleSelect={toggleBatchSelect}
-            />
-          </div>
-          <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto">
-            <SignalArticleDetailPanel
-              article={selectedArticle}
-              isLoading={detailLoading}
-              onStatusChange={handleStatusChange}
-              onTagsChange={handleTagsChange}
-              onNoteChange={handleNoteChange}
-              onDelete={handleDelete}
-              collections={collections}
-              onAddToCollection={handleAddToCollection}
-              onCreateCollection={handleCreateCollection}
-            />
-            <StudyTimeline />
+            <div className="flex min-w-0 flex-1 flex-col gap-4 overflow-y-auto">
+              <SignalArticleDetailPanel
+                article={selectedArticle}
+                isLoading={detailLoading}
+                onStatusChange={handleStatusChange}
+                onTagsChange={handleTagsChange}
+                onNoteChange={handleNoteChange}
+                onDelete={handleDelete}
+                collections={collections}
+                onAddToCollection={handleAddToCollection}
+                onCreateCollection={handleCreateCollection}
+              />
+              <StudyTimeline />
+            </div>
           </div>
         </div>
       </main>

--- a/packages/web/src/components/signals/SignalSourcesView.tsx
+++ b/packages/web/src/components/signals/SignalSourcesView.tsx
@@ -7,6 +7,9 @@ import { groupSignalSourcesByTierAndCategory } from '@/utils/signals-view';
 import { SignalNav } from './SignalNav';
 import { SignalTierBadge } from './SignalTierBadge';
 
+const CONTENT_SURFACE_CLASS =
+  'rounded-2xl border border-[var(--console-border-soft)] bg-[var(--console-card-bg)] p-[18px] shadow-[0_12px_30px_rgba(43,33,26,0.06)]';
+
 export function SignalSourcesView({ initialReferrerThread = null }: { initialReferrerThread?: string | null }) {
   const [sources, setSources] = useState<readonly SignalSource[]>([]);
   const [loading, setLoading] = useState(true);
@@ -94,119 +97,121 @@ export function SignalSourcesView({ initialReferrerThread = null }: { initialRef
         <SignalNav active="sources" initialReferrerThread={initialReferrerThread} />
       </header>
 
-      <main className="flex-1 space-y-4 overflow-y-auto px-6 py-5">
-        <section className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => void setAllEnabled(true)}
-            className="rounded-lg border border-codex-light px-3 py-2 text-sm text-codex-dark hover:bg-codex-bg"
-          >
-            全部开启
-          </button>
-          <button
-            type="button"
-            onClick={() => void setAllEnabled(false)}
-            className="rounded-lg border border-[var(--console-border-soft)] px-3 py-2 text-sm text-cafe-secondary hover:bg-[var(--console-hover-bg)]"
-          >
-            全部关闭
-          </button>
-          <button
-            type="button"
-            onClick={() => void reloadSources()}
-            className="rounded-lg border border-[var(--console-border-soft)] px-3 py-2 text-sm text-cafe-secondary hover:bg-[var(--console-hover-bg)]"
-          >
-            刷新
-          </button>
-        </section>
-
-        {error && (
-          <div className="rounded-lg border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-sm text-[var(--semantic-error-text)]">
-            请求失败: {error}
-          </div>
-        )}
-        {fetchResult && (
-          <div
-            className={[
-              'rounded-lg border px-3 py-2 text-sm',
-              fetchResult.ok
-                ? 'border-conn-green-ring bg-conn-green-bg text-conn-green-text'
-                : 'border-conn-red-ring bg-conn-red-bg text-[var(--semantic-error-text)]',
-            ].join(' ')}
-          >
-            <span className="font-semibold">{fetchResult.sourceId}</span>: {fetchResult.message}
-          </div>
-        )}
-        {loading && <p className="text-sm text-cafe-secondary">加载中...</p>}
-
-        <section className="space-y-4">
-          {groupedSources.map((group) => (
-            <div
-              key={`${group.tier}-${group.category}`}
-              className="rounded-2xl bg-[var(--console-card-bg)] p-4 shadow-sm"
+      <main className="flex-1 overflow-y-auto p-5">
+        <div className={`${CONTENT_SURFACE_CLASS} space-y-4`} data-testid="signal-sources-content-surface">
+          <section className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void setAllEnabled(true)}
+              className="rounded-lg border border-codex-light px-3 py-2 text-sm text-codex-dark hover:bg-codex-bg"
             >
-              <div className="mb-3 flex items-center gap-2">
-                <SignalTierBadge tier={group.tier} />
-                <h2 className="text-sm font-semibold text-cafe-black">{group.category}</h2>
-                <span className="text-xs text-cafe-secondary">({group.sources.length})</span>
-              </div>
-              <ul className="space-y-2">
-                {group.sources.map((source) => (
-                  <li key={source.id} className="rounded-xl bg-[var(--console-field-bg)] p-3">
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div className="min-w-0">
-                        <p className="text-sm font-semibold text-cafe-black">{source.name}</p>
-                        <div className="mt-0.5 flex flex-wrap items-center gap-2">
-                          <a
-                            href={source.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="break-all text-xs text-cafe-interactive hover:underline"
-                          >
-                            {source.url}
-                          </a>
-                          <a
-                            href={source.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="rounded-md border border-opus-light px-2 py-0.5 text-xs text-opus-dark hover:bg-opus-bg"
-                          >
-                            访问 ↗
-                          </a>
-                        </div>
-                        <p className="mt-1 text-xs text-cafe-secondary">
-                          {source.fetch.method} · {source.schedule.frequency}
-                        </p>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <button
-                          type="button"
-                          disabled={fetchingIds.has(source.id)}
-                          onClick={() => void doFetch(source.id)}
-                          className="rounded-full border border-opus-light px-3 py-1 text-xs font-semibold text-opus-dark transition-colors hover:bg-opus-bg disabled:opacity-50"
-                        >
-                          {fetchingIds.has(source.id) ? '抓取中...' : '抓取'}
-                        </button>
-                        <button
-                          type="button"
-                          disabled={updatingId === source.id}
-                          onClick={() => void setEnabled(source.id, !source.enabled)}
-                          className={[
-                            'rounded-full border px-3 py-1 text-xs font-semibold transition-colors',
-                            source.enabled
-                              ? 'border-codex-light bg-codex-bg text-codex-dark'
-                              : 'border-[var(--console-border-soft)] bg-[var(--console-field-bg)] text-cafe-secondary',
-                          ].join(' ')}
-                        >
-                          {updatingId === source.id ? '更新中...' : source.enabled ? '开启' : '关闭'}
-                        </button>
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+              全部开启
+            </button>
+            <button
+              type="button"
+              onClick={() => void setAllEnabled(false)}
+              className="rounded-lg border border-[var(--console-border-soft)] px-3 py-2 text-sm text-cafe-secondary hover:bg-[var(--console-hover-bg)]"
+            >
+              全部关闭
+            </button>
+            <button
+              type="button"
+              onClick={() => void reloadSources()}
+              className="rounded-lg border border-[var(--console-border-soft)] px-3 py-2 text-sm text-cafe-secondary hover:bg-[var(--console-hover-bg)]"
+            >
+              刷新
+            </button>
+          </section>
+
+          {error && (
+            <div className="rounded-lg border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-sm text-[var(--semantic-error-text)]">
+              请求失败: {error}
             </div>
-          ))}
-        </section>
+          )}
+          {fetchResult && (
+            <div
+              className={[
+                'rounded-lg border px-3 py-2 text-sm',
+                fetchResult.ok
+                  ? 'border-conn-green-ring bg-conn-green-bg text-conn-green-text'
+                  : 'border-conn-red-ring bg-conn-red-bg text-[var(--semantic-error-text)]',
+              ].join(' ')}
+            >
+              <span className="font-semibold">{fetchResult.sourceId}</span>: {fetchResult.message}
+            </div>
+          )}
+          {loading && <p className="text-sm text-cafe-secondary">加载中...</p>}
+
+          <section className="space-y-4">
+            {groupedSources.map((group) => (
+              <div
+                key={`${group.tier}-${group.category}`}
+                className="rounded-2xl bg-[var(--console-card-bg)] p-4 shadow-sm"
+              >
+                <div className="mb-3 flex items-center gap-2">
+                  <SignalTierBadge tier={group.tier} />
+                  <h2 className="text-sm font-semibold text-cafe-black">{group.category}</h2>
+                  <span className="text-xs text-cafe-secondary">({group.sources.length})</span>
+                </div>
+                <ul className="space-y-2">
+                  {group.sources.map((source) => (
+                    <li key={source.id} className="rounded-xl bg-[var(--console-field-bg)] p-3">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-cafe-black">{source.name}</p>
+                          <div className="mt-0.5 flex flex-wrap items-center gap-2">
+                            <a
+                              href={source.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="break-all text-xs text-cafe-interactive hover:underline"
+                            >
+                              {source.url}
+                            </a>
+                            <a
+                              href={source.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="rounded-md border border-opus-light px-2 py-0.5 text-xs text-opus-dark hover:bg-opus-bg"
+                            >
+                              访问 ↗
+                            </a>
+                          </div>
+                          <p className="mt-1 text-xs text-cafe-secondary">
+                            {source.fetch.method} · {source.schedule.frequency}
+                          </p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            disabled={fetchingIds.has(source.id)}
+                            onClick={() => void doFetch(source.id)}
+                            className="rounded-full border border-opus-light px-3 py-1 text-xs font-semibold text-opus-dark transition-colors hover:bg-opus-bg disabled:opacity-50"
+                          >
+                            {fetchingIds.has(source.id) ? '抓取中...' : '抓取'}
+                          </button>
+                          <button
+                            type="button"
+                            disabled={updatingId === source.id}
+                            onClick={() => void setEnabled(source.id, !source.enabled)}
+                            className={[
+                              'rounded-full border px-3 py-1 text-xs font-semibold transition-colors',
+                              source.enabled
+                                ? 'border-codex-light bg-codex-bg text-codex-dark'
+                                : 'border-[var(--console-border-soft)] bg-[var(--console-field-bg)] text-cafe-secondary',
+                            ].join(' ')}
+                          >
+                            {updatingId === source.id ? '更新中...' : source.enabled ? '开启' : '关闭'}
+                          </button>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </section>
+        </div>
       </main>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.40.0
         version: 1.40.0
+      '@vscode/ripgrep':
+        specifier: 1.18.0
+        version: 1.18.0
       '@wecom/aibot-node-sdk':
         specifier: 1.0.4
         version: 1.0.4
@@ -2479,6 +2482,69 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -8942,6 +9008,57 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:


### PR DESCRIPTION
## Sync: cat-cafe -> clowder-ai

Source snapshot: `96bf733a9ad4e2902861d5cba25def6ff59ff674`
Target sync commit: `0471555d9f4c63e8a59d97cd61c249df94e94947`
Manifest: v3

### Included Changes
- F206 follow-up: visible rounded content carriers for Memory and Signal pages, with regression coverage for `memory-content-surface`, `signal-inbox-content-surface`, and `signal-sources-content-surface`.
- F206 doc sync: records the CVO correction that page-level content carriers should follow the majority rounded-surface pattern.
- Antigravity IDE search hardening: bundles `ripgrep` path support and related executor test coverage from cat-cafe main.
- Public export refresh: feature export summary, provenance, lockfile/dependency metadata, and generated public docs from the latest cat-cafe main.

### Validation
- `sync-to-opensource.sh --dry-run` passed.
- `sync-to-opensource.sh` source-owned public gate passed before touching real `clowder-ai`.
- Temp target validation covered dependency install, `pnpm check`, `pnpm lint`, build, `test:public`, startup acceptance, and static port verification.
- Security scan clean; warnings were expected env/doc localhost references.

### Notes
- Protected target-owned files were backed up and restored by the sync script.
- No incomplete absorbed records or unreviewed community commits blocked the sync.
