### PR TITLE
sync: cat-cafe 8fd75a637307 → clowder-ai

### DIFF
--- a/.sync-provenance.json
+++ b/.sync-provenance.json
@@ -1,6 +1,6 @@
 {
-  "source_commit_sha": "d77767552b45a61308bd3b8d2e13f59f72b5678b",
-  "target_head_sha": "28fc477cbeb225e7abb7d7ea0c6048e396b8b2f7",
+  "source_commit_sha": "8fd75a637307579b7299c07bc6b7bbf3843238ba",
+  "target_head_sha": "0684c7ccde1e12937b68096c727790fa3121bcf5",
   "release_tag": null,
   "source_snapshot_tag": null,
   "manifest_version": 3,
@@ -8,5 +8,5 @@
   "excluded_file_count": 13,
   "transform_count": 34,
   "secret_scan_result": "clean",
-  "synced_at": "2026-05-21T10:39:53Z"
+  "synced_at": "2026-05-21T13:44:14Z"
 }

--- a/docs/features/.export-summary.json
+++ b/docs/features/.export-summary.json
@@ -1,5 +1,5 @@
 {
-  "exportedAt": "2026-05-21T10:39:44.623Z",
+  "exportedAt": "2026-05-21T13:44:06.480Z",
   "minTier": "yellow",
   "exported": 211,
   "skipped": 5,

--- a/docs/features/F206-settings-ui-convergence.md
+++ b/docs/features/F206-settings-ui-convergence.md
@@ -199,6 +199,7 @@ team lead 2026-05-21 截图反馈：Settings 与 Chat/Thread 切换时 rail/cont
 3. **SignalNav tab token parity**：Signal tabs 对齐 MemoryNav/MissionControl 的 `border-strong + card-bg + button-emphasis` active hierarchy
 4. **Memory/Signal visible content carriers**：MemoryHub / SignalInboxView / SignalSourcesView 的主内容区补齐 `rounded-2xl + --console-card-bg + --console-border-soft + soft shadow + 18px padding`，对齐 SettingsSection / Mission panels 的圆角承载层；用 regression test 固定三页必须有可见 carrier
 5. **Single-card content hierarchy**：Memory/Signal 的 title/nav/content 合并进同一张圆角承载卡，删除 MemoryNav/SignalNav 中冗余的“返回对话/返回线程”按钮；线程返回由 ActivityBar chat icon 统一承担
+6. **MissionHub single-card parity**：Mission Hub 的标题、tabs、状态条、内容合并进 `mission-content-surface` 圆角承载卡，删除冗余“返回线程”按钮；`/mission-hub` 入口不再传 `?from=`，线程返回统一走 ActivityBar chat icon
 
 ### Post-close Guardrail: 线条分隔 vs 背景分层
 
@@ -363,6 +364,7 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 | KD-6 | Console shell 容器层级拆成 outer shell + content carrier | Settings/Thread 这类 rail/content 页面用淡边界分隔；Memory/Mission/Signal 这类 console page 外层用 full-height shell，页面级标题/nav/content 归入 content carrier，承载层跟随多数页面的圆角 surface 模式 | 2026-05-21 |
 | KD-7 | 多数页面的圆角承载层优先于无缝少数派 | CVO 2026-05-21 二次验收指出“规则与 SOP 等多数页面是圆角承载层”，Memory/Signal 的无缝主内容是异端；PR #1826 给 Memory/Signal 主内容补 visible carrier，避免 card-bg 与 shell-bg 过近导致“看起来没圆角/没空白” | 2026-05-21 |
 | KD-8 | Memory/Signal 页面承载层必须是一张卡，不拆 title/nav 与 content | CVO 2026-05-21 三次验收指出“原本是一整张，你们分开成两个了”；PR #1827 将 Memory/Signal 的标题、tabs、内容合进同一张 content carrier，并删除重复返回按钮，ActivityBar chat icon 作为统一返回入口 | 2026-05-21 |
+| KD-9 | Mission Hub 也必须跟随同一张圆角承载卡模式 | CVO 2026-05-21 四次验收指出“就差 mission hub 了”，Mission 仍有返回线程按钮且不是圆框；PR #1829 将 Mission 标题/tabs/status/content 合进同一张 `mission-content-surface` carrier，并移除 `?from=`/返回线程路径 | 2026-05-21 |
 
 ## Review Gate
 
@@ -385,3 +387,4 @@ team lead 2026-05-20 追加口径：Thread 栏、对话栏、底部/右侧状态
 - Post-close shell container parity: opus 本地 review → 云端 skip（CVO KD-1 速度优先，纯 CSS shell hierarchy correction）
 - Post-close rounded content carrier follow-up: opus 本地 review → 云端 review clean（纯 CSS carrier visibility fix + regression test）
 - Post-close unified content card follow-up: codex 本地 review + `pnpm gate` → 云端 skip（CVO explicit directive，纯 layout hierarchy fix + test update）
+- Post-close Mission content card follow-up: opus 本地 review + `pnpm gate` → 云端 skip（CVO explicit directive，纯 layout hierarchy fix + test update）

--- a/packages/api/src/domains/cats/services/agents/providers/antigravity/AntigravityAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/antigravity/AntigravityAgentService.ts
@@ -98,6 +98,22 @@ function sanitizeAutoResumeMaxAttempts(value?: number): number {
   return Math.max(0, Math.floor(value));
 }
 
+function hasTerminalPlannerText(steps: readonly TrajectoryStep[]): boolean {
+  return steps.some((step) => {
+    if (step.type !== 'CORTEX_STEP_TYPE_PLANNER_RESPONSE') return false;
+    if (step.status !== 'CORTEX_STEP_STATUS_DONE' && step.status !== 'FINISHED' && step.status !== 'DONE') {
+      return false;
+    }
+    if (step.plannerResponse?.stopReason === 'STOP_REASON_CLIENT_STREAM_ERROR') return false;
+    const text = step.plannerResponse?.modifiedResponse ?? step.plannerResponse?.response;
+    return typeof text === 'string' && text.trim() !== '';
+  });
+}
+
+function isAssistantPrefillTailError(rawError: string): boolean {
+  return /assistant message prefill/i.test(rawError) && /conversation must end with a user message/i.test(rawError);
+}
+
 function isPathInside(childPath: string, parentPath: string): boolean {
   const rel = relative(parentPath, childPath);
   if (rel === '') return true;
@@ -541,6 +557,7 @@ export class AntigravityAgentService implements AgentService {
         }
 
         let hasText = false;
+        let hasTerminalText = false;
         let fatalSeen = false;
         let terminalAbort = false;
         let autoApproveAttempted = false;
@@ -896,6 +913,7 @@ export class AntigravityAgentService implements AgentService {
               }
 
               const messages = transformTrajectorySteps(batch.steps, self.catId, metadata);
+              const batchHasTerminalPlannerText = batch.cursor.terminalSeen && hasTerminalPlannerText(batch.steps);
               for (const p of collectImagePathsFromSteps(batch.steps)) collectedImagePaths.add(p);
               // F172 Phase G: capture DONE GENERATE_IMAGE steps for the post-invocation brain scan
               for (const step of batch.steps) {
@@ -1165,6 +1183,9 @@ export class AntigravityAgentService implements AgentService {
               });
 
               const seenFatalKeys = new Set<string>();
+              const batchHasFatalError = messages.some(
+                (msg) => msg.type === 'error' && msg.errorCode !== undefined && msg.errorCode !== 'tool_error',
+              );
               const batchHasSpecificError = messages.some(
                 (msg) =>
                   msg.type === 'error' &&
@@ -1280,6 +1301,10 @@ export class AntigravityAgentService implements AgentService {
                   }
                   const errorMetadata = msg.metadata ?? metadata;
                   const rawError = msg.metadata?.upstreamError?.rawReason ?? msg.error ?? '';
+                  if (hasTerminalText && isAssistantPrefillTailError(rawError)) {
+                    log.info({ cascadeId }, 'suppressed assistant-prefill upstream_error after terminal planner text');
+                    continue;
+                  }
                   const looksLikeApprovalDenied = /user denied permission/i.test(rawError);
                   const looksLikeApprovalTimeout = /context canceled/i.test(rawError);
                   if (
@@ -1371,6 +1396,8 @@ export class AntigravityAgentService implements AgentService {
                 terminalAbort = true;
                 yield msg;
               }
+
+              if (batchHasTerminalPlannerText && !batchHasFatalError) hasTerminalText = true;
 
               if (modelCapacityRetryDelayMs != null) {
                 log.info(

--- a/packages/api/test/antigravity-agent-service-fatal-errors.test.js
+++ b/packages/api/test/antigravity-agent-service-fatal-errors.test.js
@@ -3628,6 +3628,266 @@ describe('AntigravityAgentService (Bridge) — fatal errors', () => {
     assert.equal(record.journalSummarySnapshot.entries[0].status, 'pending');
   });
 
+  test('suppresses Antigravity assistant-prefill tail error after terminal text', async () => {
+    const supervisorStore = new InMemoryAntigravitySupervisorStore();
+    const bridge = createMockBridge({ cascadeId: 'cascade-f201-terminal-prefill-tail' });
+    bridge.nativeExecuteAndPush = mock.fn(async (step) => step.type === 'CORTEX_STEP_TYPE_RUN_COMMAND');
+    bridge.pollForSteps = async function* () {
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_RUN_COMMAND',
+            status: 'CORTEX_STEP_STATUS_WAITING',
+            metadata: {
+              toolCall: {
+                id: 'toolu_terminal_prefill_tail',
+                name: 'run_command',
+                argumentsJson: JSON.stringify({
+                  CommandLine: 'which rg && echo "---" && rg --version',
+                  Cwd: '/tmp',
+                  SafeToAutoRun: true,
+                }),
+              },
+              sourceTrajectoryStepInfo: {
+                cascadeId: 'cascade-f201-terminal-prefill-tail',
+                trajectoryId: 'traj-f201-terminal-prefill-tail',
+                stepIndex: 1,
+              },
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 0, lastDeliveredStepCount: 1, terminalSeen: false, lastActivityAt: Date.now() },
+      };
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: {
+              modifiedResponse: 'grep_search smoke passed; rg resolved from the bundled binary.',
+              stopReason: 'STOP_REASON_STOP_PATTERN',
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 1, lastDeliveredStepCount: 2, terminalSeen: true, lastActivityAt: Date.now() },
+      };
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: { stopReason: 'STOP_REASON_CLIENT_STREAM_ERROR' },
+          },
+          {
+            type: 'CORTEX_STEP_TYPE_ERROR_MESSAGE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            errorMessage: {
+              error: {
+                modelErrorMessage:
+                  'INVALID_ARGUMENT (code 400): invalid_request_error: This model does not support assistant message prefill. The conversation must end with a user message.',
+              },
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 2, lastDeliveredStepCount: 4, terminalSeen: true, lastActivityAt: Date.now() },
+      };
+    };
+
+    const service = new AntigravityAgentService({
+      catId: 'antigravity',
+      model: 'claude-opus-4-6',
+      bridge,
+      supervisorStore,
+      streamErrorGraceWindowMs: 0,
+      modelCapacityRetryDelaysMs: [0],
+    });
+    const messages = await collect(
+      service.invoke('hello', {
+        auditContext: {
+          threadId: 'thread-f201-terminal-prefill-tail',
+          invocationId: 'inv-f201-terminal-prefill-tail',
+          userId: 'u1',
+          catId: 'antigravity',
+        },
+      }),
+    );
+
+    assert.equal(
+      bridge.nativeExecuteAndPush.mock.calls.filter(
+        (call) => call.arguments[0]?.metadata?.toolCall?.id === 'toolu_terminal_prefill_tail',
+      ).length,
+      1,
+      'native executor still dispatches the read-only run_command once',
+    );
+    assert.deepEqual(
+      messages.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+      ['grep_search smoke passed; rg resolved from the bundled binary.'],
+    );
+    assert.equal(
+      messages.some((msg) => msg.type === 'error' && msg.errorCode === 'upstream_error'),
+      false,
+      'tail assistant-prefill upstream_error should not override an already delivered terminal answer',
+    );
+    assert.equal(
+      messages.some((msg) => msg.type === 'system_info' && msg.content?.includes('"antigravity_recovery"')),
+      false,
+      'tail assistant-prefill error should not produce a resumable recovery card',
+    );
+
+    const record = await supervisorStore.get('inv-f201-terminal-prefill-tail', 'cascade-f201-terminal-prefill-tail');
+    assert.equal(record?.status, 'done');
+    assert.equal(record?.receiptState, 'clean');
+  });
+
+  test('does not suppress assistant-prefill upstream_error after non-terminal text', async () => {
+    const bridge = createMockBridge({ cascadeId: 'cascade-f201-nonterminal-prefill-tail' });
+    bridge.pollForSteps = async function* () {
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: {
+              response: 'I found the first result; continuing with the next check.',
+              stopReason: 'STOP_REASON_STOP_PATTERN',
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 0, lastDeliveredStepCount: 1, terminalSeen: false, lastActivityAt: Date.now() },
+      };
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_ERROR_MESSAGE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            errorMessage: {
+              error: {
+                modelErrorMessage:
+                  'INVALID_ARGUMENT (code 400): invalid_request_error: This model does not support assistant message prefill. The conversation must end with a user message.',
+              },
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 1, lastDeliveredStepCount: 2, terminalSeen: true, lastActivityAt: Date.now() },
+      };
+    };
+
+    const service = new AntigravityAgentService({
+      catId: 'antigravity',
+      model: 'claude-opus-4-6',
+      bridge,
+      streamErrorGraceWindowMs: 0,
+      modelCapacityRetryDelaysMs: [],
+    });
+    const messages = await collect(service.invoke('hello'));
+
+    assert.deepEqual(
+      messages.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+      ['I found the first result; continuing with the next check.'],
+    );
+    assert.equal(
+      messages.filter((msg) => msg.type === 'error' && msg.errorCode === 'upstream_error').length,
+      1,
+      'assistant-prefill upstream_error after non-terminal text must still surface',
+    );
+  });
+
+  test('does not suppress assistant-prefill upstream_error coalesced with terminalSeen text', async () => {
+    const bridge = createMockBridge({ cascadeId: 'cascade-f201-coalesced-prefill-tail' });
+    bridge.pollForSteps = async function* () {
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: {
+              response: 'I found one result; checking the final status next.',
+              stopReason: 'STOP_REASON_STOP_PATTERN',
+            },
+          },
+          {
+            type: 'CORTEX_STEP_TYPE_ERROR_MESSAGE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            errorMessage: {
+              error: {
+                modelErrorMessage:
+                  'INVALID_ARGUMENT (code 400): invalid_request_error: This model does not support assistant message prefill. The conversation must end with a user message.',
+              },
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 0, lastDeliveredStepCount: 2, terminalSeen: true, lastActivityAt: Date.now() },
+      };
+    };
+
+    const service = new AntigravityAgentService({
+      catId: 'antigravity',
+      model: 'claude-opus-4-6',
+      bridge,
+      streamErrorGraceWindowMs: 0,
+      modelCapacityRetryDelaysMs: [],
+    });
+    const messages = await collect(service.invoke('hello'));
+
+    assert.deepEqual(
+      messages.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+      ['I found one result; checking the final status next.'],
+    );
+    assert.equal(
+      messages.filter((msg) => msg.type === 'error' && msg.errorCode === 'upstream_error').length,
+      1,
+      'same-batch assistant-prefill upstream_error must not be hidden by batch-level terminalSeen',
+    );
+  });
+
+  test('does not suppress generic stream_error after terminal text', async () => {
+    const bridge = createMockBridge({ cascadeId: 'cascade-f201-terminal-stream-error' });
+    bridge.pollForSteps = async function* () {
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: {
+              response: 'I have an intermediate result, then I will continue.',
+              stopReason: 'STOP_REASON_STOP_PATTERN',
+            },
+          },
+        ],
+        cursor: { baselineStepCount: 0, lastDeliveredStepCount: 1, terminalSeen: false, lastActivityAt: Date.now() },
+      };
+      yield {
+        steps: [
+          {
+            type: 'CORTEX_STEP_TYPE_PLANNER_RESPONSE',
+            status: 'CORTEX_STEP_STATUS_DONE',
+            plannerResponse: { stopReason: 'STOP_REASON_CLIENT_STREAM_ERROR' },
+          },
+        ],
+        cursor: { baselineStepCount: 1, lastDeliveredStepCount: 2, terminalSeen: true, lastActivityAt: Date.now() },
+      };
+    };
+
+    const service = new AntigravityAgentService({
+      catId: 'antigravity',
+      model: 'claude-opus-4-6',
+      bridge,
+      streamErrorGraceWindowMs: 0,
+      modelCapacityRetryDelaysMs: [],
+    });
+    const messages = await collect(service.invoke('hello'));
+
+    assert.deepEqual(
+      messages.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+      ['I have an intermediate result, then I will continue.'],
+    );
+    assert.equal(
+      messages.filter((msg) => msg.type === 'error' && msg.errorCode === 'stream_error').length,
+      1,
+      'generic stream_error after prior terminal text must still surface',
+    );
+  });
+
   test('AC-G7: YOLO-dispatched approval-gated run_command remains side-effect journal covered', async () => {
     const supervisorStore = new InMemoryAntigravitySupervisorStore();
     const bridge = createMockBridge({ cascadeId: 'cascade-f201-yolo-journal' });

--- a/packages/web/src/app/mission-hub/page.tsx
+++ b/packages/web/src/app/mission-hub/page.tsx
@@ -1,10 +1,5 @@
 import { MissionControlPage } from '@/components/mission-control/MissionControlPage';
 
-export default function MissionHubPage({
-  searchParams,
-}: {
-  searchParams: Record<string, string | string[] | undefined>;
-}) {
-  const from = typeof searchParams.from === 'string' ? searchParams.from : null;
-  return <MissionControlPage initialReferrerThread={from} />;
+export default function MissionHubPage() {
+  return <MissionControlPage />;
 }

--- a/packages/web/src/components/__tests__/console-shell-content-surface.test.ts
+++ b/packages/web/src/components/__tests__/console-shell-content-surface.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -15,6 +17,7 @@ function readComponent(relativePath: string): string {
 describe('console shell content surfaces', () => {
   it.each([
     ['MemoryHub', 'memory/MemoryHub.tsx', 'memory-content-surface'],
+    ['MissionControlPage', 'mission-control/MissionControlPage.tsx', 'mission-content-surface'],
     ['SignalInboxView', 'signals/SignalInboxView.tsx', 'signal-inbox-content-surface'],
     ['SignalSourcesView', 'signals/SignalSourcesView.tsx', 'signal-sources-content-surface'],
   ])('%s uses a visible rounded content carrier', (_name, path, testId) => {

--- a/packages/web/src/components/__tests__/mission-control-page.test.ts
+++ b/packages/web/src/components/__tests__/mission-control-page.test.ts
@@ -3,7 +3,6 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { MissionControlPage } from '@/components/mission-control/MissionControlPage';
-import { useChatStore } from '@/stores/chatStore';
 import { useMissionControlStore } from '@/stores/missionControlStore';
 import {
   createMissionControlMockBackend,
@@ -69,15 +68,14 @@ describe('MissionControlPage', () => {
     delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
   });
 
-  it('renders back-to-chat link with href="/"', async () => {
+  it('renders a single rounded Mission Hub content surface without a redundant back button', async () => {
     await act(async () => {
       root.render(React.createElement(MissionControlPage));
     });
     await flush(act);
 
-    const backLink = container.querySelector('[data-testid="mc-back-to-chat"]') as HTMLAnchorElement | null;
-    expect(backLink).not.toBeNull();
-    expect(backLink?.getAttribute('href')).toBe('/');
+    expect(container.querySelector('[data-testid="mc-back-to-chat"]')).toBeNull();
+    expect(container.querySelector('[data-testid="mission-content-surface"]')).not.toBeNull();
   });
 
   it('does not render the thread sidebar inside mission hub layout', async () => {
@@ -1586,8 +1584,7 @@ describe('MissionControlPage — Tabs + Status bar + Dep graph', () => {
     expect(container.querySelector('[data-testid="mc-dep-node-F001"]')).not.toBeNull();
   });
 
-  it('referrer-based back button links to referrer thread when ?from= present', async () => {
-    // Set up window.location.search with ?from=thread-abc
+  it('ignores ?from= and does not render a Mission Hub back button', async () => {
     const originalSearch = window.location.search;
     Object.defineProperty(window, 'location', {
       writable: true,
@@ -1599,68 +1596,8 @@ describe('MissionControlPage — Tabs + Status bar + Dep graph', () => {
     });
     await flush(act);
 
-    const backLink = container.querySelector('[data-testid="mc-back-to-chat"]') as HTMLAnchorElement;
-    expect(backLink).not.toBeNull();
-    expect(backLink.getAttribute('href')).toBe('/thread/thread-abc');
-
-    // Restore
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, search: originalSearch },
-    });
-  });
-
-  it('back button falls back to store currentThreadId when no ?from= param', async () => {
-    // No ?from= in URL — simulate navigating to /mission-hub directly
-    const originalSearch = window.location.search;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, search: '' },
-    });
-
-    // Set the store's currentThreadId before render (inside act to avoid warning)
-    await act(async () => {
-      useChatStore.setState({ currentThreadId: 'thread-xyz' });
-    });
-
-    await act(async () => {
-      root.render(React.createElement(MissionControlPage));
-    });
-    await flush(act);
-
-    const backLink = container.querySelector('[data-testid="mc-back-to-chat"]') as HTMLAnchorElement;
-    expect(backLink).not.toBeNull();
-    expect(backLink.getAttribute('href')).toBe('/thread/thread-xyz');
-
-    // Restore
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, search: originalSearch },
-    });
-    await act(async () => {
-      useChatStore.setState({ currentThreadId: 'default' });
-    });
-  });
-
-  it('back button goes to / when store has default thread and no ?from= param', async () => {
-    const originalSearch = window.location.search;
-    Object.defineProperty(window, 'location', {
-      writable: true,
-      value: { ...window.location, search: '' },
-    });
-
-    await act(async () => {
-      useChatStore.setState({ currentThreadId: 'default' });
-    });
-
-    await act(async () => {
-      root.render(React.createElement(MissionControlPage));
-    });
-    await flush(act);
-
-    const backLink = container.querySelector('[data-testid="mc-back-to-chat"]') as HTMLAnchorElement;
-    expect(backLink).not.toBeNull();
-    expect(backLink.getAttribute('href')).toBe('/');
+    expect(container.querySelector('[data-testid="mc-back-to-chat"]')).toBeNull();
+    expect(container.querySelector('[data-testid="mission-content-surface"]')).not.toBeNull();
 
     Object.defineProperty(window, 'location', {
       writable: true,

--- a/packages/web/src/components/mission-control/MissionControlPage.tsx
+++ b/packages/web/src/components/mission-control/MissionControlPage.tsx
@@ -2,7 +2,6 @@
 
 import type { BacklogItem, CatId, ExternalProject, MissionHubSelfClaimScope, ThreadPhase } from '@cat-cafe/shared';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useChatStore } from '@/stores/chatStore';
 import { useExternalProjectStore } from '@/stores/externalProjectStore';
 import { useMissionControlStore } from '@/stores/missionControlStore';
 import { apiFetch } from '@/utils/api-client';
@@ -38,6 +37,9 @@ interface ThreadListResponse {
 
 type SelfClaimPolicyBlocker = 'once' | 'thread' | null;
 
+const CONTENT_SURFACE_CLASS =
+  'rounded-2xl border border-[var(--console-border-soft)] bg-[var(--console-card-bg)] p-[18px] shadow-[0_12px_30px_rgba(43,33,26,0.06)]';
+
 function detectSelfClaimPolicyBlocker(rawError: string): SelfClaimPolicyBlocker {
   if (rawError.includes('Self-claim once policy already consumed')) return 'once';
   if (rawError.includes('Self-claim thread policy blocked')) return 'thread';
@@ -64,7 +66,7 @@ async function parseError(response: Response): Promise<string> {
   }
 }
 
-export function MissionControlPage({ initialReferrerThread = null }: { initialReferrerThread?: string | null }) {
+export function MissionControlPage() {
   const threadSituationRequestSeq = useRef(0);
   const [selfClaimScopes, setSelfClaimScopes] = useState<Record<string, MissionHubSelfClaimScope>>({});
   const [selfClaimPolicyBlocker, setSelfClaimPolicyBlocker] = useState<SelfClaimPolicyBlocker>(null);
@@ -433,43 +435,11 @@ export function MissionControlPage({ initialReferrerThread = null }: { initialRe
     setActiveProjectId(activeProject?.id ?? null);
   }, [activeProject, setActiveProjectId]);
 
-  // AC-H2: Referrer-based back button — remember where we came from
-  // Priority: URL ?from= param > store's currentThreadId (last active thread)
-  const storeThreadId = useChatStore((s) => s.currentThreadId);
-  const [mcFromParam, setMcFromParam] = useState<string | null>(initialReferrerThread);
-  useEffect(() => {
-    const nextFromParam = new URLSearchParams(window.location.search).get('from');
-    if (nextFromParam) setMcFromParam(nextFromParam);
-  }, [initialReferrerThread]);
-  const referrerThread = useMemo(() => {
-    if (mcFromParam) return mcFromParam;
-    return storeThreadId && storeThreadId !== 'default' ? storeThreadId : null;
-  }, [mcFromParam, storeThreadId]);
-
   return (
     <div className="flex h-screen bg-[var(--console-shell-bg)]">
-      <main className="flex min-w-0 flex-1 flex-col overflow-hidden">
-        {/* Header */}
-        <header className="flex items-center justify-between border-b border-[var(--console-border-soft)] bg-[var(--console-card-bg)] px-6 py-3">
-          <div className="flex items-center gap-3">
-            <a
-              href={referrerThread && referrerThread !== 'default' ? `/thread/${referrerThread}` : '/'}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-card-bg)] px-3 py-1.5 text-xs font-medium text-[var(--console-button-emphasis)] transition-colors hover:bg-[var(--console-hover-bg)]"
-              data-testid="mc-back-to-chat"
-            >
-              <svg
-                className="h-4 w-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <polyline points="15 18 9 12 15 6" />
-              </svg>
-              返回线程
-            </a>
+      <main className="min-w-0 flex-1 overflow-y-auto p-5">
+        <div className={`${CONTENT_SURFACE_CLASS} flex min-h-full flex-col`} data-testid="mission-content-surface">
+          <header className="flex flex-wrap items-center justify-between gap-3">
             <div className="flex items-center gap-2">
               <svg
                 className="h-5 w-5 text-cafe-muted"
@@ -487,208 +457,197 @@ export function MissionControlPage({ initialReferrerThread = null }: { initialRe
               </svg>
               <h1 className="text-lg font-bold text-cafe">Mission Hub</h1>
             </div>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={() => void handleImportFromDocs()}
-              disabled={submitting}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-card-bg)] px-3 py-1.5 text-xs font-medium text-cafe-secondary transition-colors hover:bg-[var(--console-hover-bg)] disabled:opacity-40"
-              data-testid="mc-import-docs"
-            >
-              导入 Backlog
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowImportModal(true)}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-card-bg)] px-3 py-1.5 text-xs font-medium text-cafe-secondary transition-colors hover:bg-[var(--console-hover-bg)]"
-              data-testid="mc-import-project"
-            >
-              + 导入项目
-            </button>
-          </div>
-        </header>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleImportFromDocs()}
+                disabled={submitting}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-card-bg)] px-3 py-1.5 text-xs font-medium text-cafe-secondary transition-colors hover:bg-[var(--console-hover-bg)] disabled:opacity-40"
+                data-testid="mc-import-docs"
+              >
+                导入 Backlog
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowImportModal(true)}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-[var(--console-border-strong)] bg-[var(--console-card-bg)] px-3 py-1.5 text-xs font-medium text-cafe-secondary transition-colors hover:bg-[var(--console-hover-bg)]"
+                data-testid="mc-import-project"
+              >
+                + 导入项目
+              </button>
+            </div>
+          </header>
 
-        {showImportModal && (
-          <ImportProjectModal
-            onClose={() => setShowImportModal(false)}
-            onImported={() => void loadExternalProjects()}
-          />
-        )}
+          {showImportModal && (
+            <ImportProjectModal
+              onClose={() => setShowImportModal(false)}
+              onImported={() => void loadExternalProjects()}
+            />
+          )}
 
-        {/* Tabs */}
-        <div className="flex border-b border-[var(--console-border-soft)] bg-[var(--console-card-bg)]">
-          <button
-            type="button"
-            onClick={() => setActiveTab('features')}
-            className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
-              activeTab === 'features'
-                ? 'border-b-2 border-[var(--console-button-emphasis)] text-[var(--console-button-emphasis)]'
-                : 'text-cafe-muted hover:text-cafe-secondary'
-            }`}
-            data-testid="mc-tab-features"
-          >
-            功能列表
-          </button>
-          <button
-            type="button"
-            onClick={() => setActiveTab('dependencies')}
-            className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
-              activeTab === 'dependencies'
-                ? 'border-b-2 border-[var(--console-button-emphasis)] text-[var(--console-button-emphasis)]'
-                : 'text-cafe-muted hover:text-cafe-secondary'
-            }`}
-            data-testid="mc-tab-dependencies"
-          >
-            依赖全景
-          </button>
-          {projects.map((p) => (
+          <div className="mt-4 flex border-b border-[var(--console-border-soft)]">
             <button
-              key={p.id}
               type="button"
-              onClick={() => setActiveTab(p.id)}
+              onClick={() => setActiveTab('features')}
               className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
-                activeTab === p.id
+                activeTab === 'features'
                   ? 'border-b-2 border-[var(--console-button-emphasis)] text-[var(--console-button-emphasis)]'
                   : 'text-cafe-muted hover:text-cafe-secondary'
               }`}
+              data-testid="mc-tab-features"
             >
-              {p.name}
+              功能列表
             </button>
-          ))}
-        </div>
-
-        {/* Status summary bar */}
-        <div className="flex items-center gap-5 border-b border-[var(--console-border-soft)] bg-[var(--console-card-bg)] px-6 py-2.5">
-          <StatusDot
-            color="bg-cafe-status-degraded"
-            label={`${pendingCount} 待审批`}
-            textColor="text-[var(--semantic-warning-text)]"
-          />
-          <StatusDot
-            color="bg-cafe-status-active"
-            label={`${activeCount} 执行中`}
-            textColor="text-[var(--semantic-info-text)]"
-          />
-          <StatusDot
-            color="bg-cafe-status-healthy"
-            label={`${doneCount} 已完成`}
-            textColor="text-[var(--semantic-success-text)]"
-          />
-        </div>
-
-        {error && (
-          <div
-            className="mx-6 mt-3 rounded-xl border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-xs text-[var(--semantic-error-text)]"
-            data-testid="mc-error"
-            role="alert"
-          >
-            {error}
+            <button
+              type="button"
+              onClick={() => setActiveTab('dependencies')}
+              className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
+                activeTab === 'dependencies'
+                  ? 'border-b-2 border-[var(--console-button-emphasis)] text-[var(--console-button-emphasis)]'
+                  : 'text-cafe-muted hover:text-cafe-secondary'
+              }`}
+              data-testid="mc-tab-dependencies"
+            >
+              依赖全景
+            </button>
+            {projects.map((p) => (
+              <button
+                key={p.id}
+                type="button"
+                onClick={() => setActiveTab(p.id)}
+                className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
+                  activeTab === p.id
+                    ? 'border-b-2 border-[var(--console-button-emphasis)] text-[var(--console-button-emphasis)]'
+                    : 'text-cafe-muted hover:text-cafe-secondary'
+                }`}
+              >
+                {p.name}
+              </button>
+            ))}
           </div>
-        )}
 
-        {/* Main content area */}
-        <div className="min-h-0 flex-1 overflow-auto">
-          {activeProject ? (
-            <div className="p-6">
-              <ExternalProjectTab project={activeProject} />
-            </div>
-          ) : activeTab === 'features' ? (
-            <div className="grid min-h-0 grid-cols-1 gap-4 p-6 xl:grid-cols-[minmax(0,1fr)_340px]">
-              <div className="space-y-4">
-                {/* Quick create */}
-                <QuickCreateForm disabled={submitting} onCreate={handleCreate} />
+          <div className="flex flex-wrap items-center gap-5 border-b border-[var(--console-border-soft)] py-2.5">
+            <StatusDot
+              color="bg-cafe-status-degraded"
+              label={`${pendingCount} 待审批`}
+              textColor="text-[var(--semantic-warning-text)]"
+            />
+            <StatusDot
+              color="bg-cafe-status-active"
+              label={`${activeCount} 执行中`}
+              textColor="text-[var(--semantic-info-text)]"
+            />
+            <StatusDot
+              color="bg-cafe-status-healthy"
+              label={`${doneCount} 已完成`}
+              textColor="text-[var(--semantic-success-text)]"
+            />
+          </div>
 
-                {/* Feature row list */}
-                <FeatureRowList
-                  items={items}
-                  threadsByBacklogId={threadsByBacklogId}
-                  threadCountByFeature={threadCountByFeature}
-                  threadsByFeatureId={threadsByFeatureId}
-                  selectedItemId={selectedItemId}
-                  onSelectItem={setSelectedItemId}
-                />
-              </div>
-
-              {/* Right panel: tabbed operations */}
-              <div className="flex min-h-0 flex-col">
-                <div className="flex border-b border-[var(--console-border-soft)]">
-                  <button
-                    type="button"
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      rightPanelTab === 'suggestion'
-                        ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
-                        : 'text-cafe-muted hover:text-cafe-secondary'
-                    }`}
-                    onClick={() => setRightPanelTab('suggestion')}
-                    data-testid="mc-right-tab-suggestion"
-                  >
-                    建议详情
-                  </button>
-                  <button
-                    type="button"
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      rightPanelTab === 'sop'
-                        ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
-                        : 'text-cafe-muted hover:text-cafe-secondary'
-                    }`}
-                    onClick={() => setRightPanelTab('sop')}
-                    data-testid="mc-right-tab-sop"
-                  >
-                    SOP
-                  </button>
-                  <button
-                    type="button"
-                    className={`px-3 py-1.5 text-xs font-medium transition-colors ${
-                      rightPanelTab === 'threads'
-                        ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
-                        : 'text-cafe-muted hover:text-cafe-secondary'
-                    }`}
-                    onClick={() => setRightPanelTab('threads')}
-                    data-testid="mc-right-tab-threads"
-                  >
-                    线程态势
-                  </button>
-                </div>
-                <div className="flex-1 overflow-auto">
-                  {rightPanelTab === 'suggestion' && (
-                    <SuggestionDrawer
-                      item={selectedItem}
-                      submitting={submitting}
-                      selectedPhase={selectedPhase}
-                      selfClaimScopes={selfClaimScopes}
-                      selfClaimPolicyBlocker={selfClaimPolicyBlocker}
-                      onChangePhase={setSelectedPhase}
-                      onSuggest={handleSuggest}
-                      onApprove={handleApprove}
-                      onReject={handleReject}
-                      onSelfClaim={handleSelfClaim}
-                      onAcquireLease={handleAcquireLease}
-                      onHeartbeatLease={handleHeartbeatLease}
-                      onReleaseLease={handleReleaseLease}
-                      onReclaimLease={handleReclaimLease}
-                    />
-                  )}
-                  {rightPanelTab === 'sop' && <WorkflowSopPanel backlogItemId={selectedItemId} />}
-                  {rightPanelTab === 'threads' && (
-                    <ThreadSituationPanel
-                      dispatchedItems={dispatchedItems}
-                      loading={threadsLoading}
-                      threadsByBacklogId={threadsByBacklogId}
-                      threadsByFeatureId={threadsByFeatureId}
-                    />
-                  )}
-                </div>
-              </div>
-            </div>
-          ) : (
-            <div className="p-6">
-              <DependencyGraphTab items={items} />
+          {error && (
+            <div
+              className="mt-3 rounded-xl border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-xs text-[var(--semantic-error-text)]"
+              data-testid="mc-error"
+              role="alert"
+            >
+              {error}
             </div>
           )}
-        </div>
 
-        {loading && items.length === 0 && <p className="px-6 py-2 text-xs text-cafe-muted">加载 backlog 中...</p>}
+          <div className="min-h-0 flex-1 pt-4">
+            {activeProject ? (
+              <ExternalProjectTab project={activeProject} />
+            ) : activeTab === 'features' ? (
+              <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
+                <div className="space-y-4">
+                  <QuickCreateForm disabled={submitting} onCreate={handleCreate} />
+                  <FeatureRowList
+                    items={items}
+                    threadsByBacklogId={threadsByBacklogId}
+                    threadCountByFeature={threadCountByFeature}
+                    threadsByFeatureId={threadsByFeatureId}
+                    selectedItemId={selectedItemId}
+                    onSelectItem={setSelectedItemId}
+                  />
+                </div>
+
+                <div className="flex min-h-0 flex-col">
+                  <div className="flex border-b border-[var(--console-border-soft)]">
+                    <button
+                      type="button"
+                      className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                        rightPanelTab === 'suggestion'
+                          ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
+                          : 'text-cafe-muted hover:text-cafe-secondary'
+                      }`}
+                      onClick={() => setRightPanelTab('suggestion')}
+                      data-testid="mc-right-tab-suggestion"
+                    >
+                      建议详情
+                    </button>
+                    <button
+                      type="button"
+                      className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                        rightPanelTab === 'sop'
+                          ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
+                          : 'text-cafe-muted hover:text-cafe-secondary'
+                      }`}
+                      onClick={() => setRightPanelTab('sop')}
+                      data-testid="mc-right-tab-sop"
+                    >
+                      SOP
+                    </button>
+                    <button
+                      type="button"
+                      className={`px-3 py-1.5 text-xs font-medium transition-colors ${
+                        rightPanelTab === 'threads'
+                          ? 'border-b-2 border-[var(--console-button-emphasis)] text-cafe'
+                          : 'text-cafe-muted hover:text-cafe-secondary'
+                      }`}
+                      onClick={() => setRightPanelTab('threads')}
+                      data-testid="mc-right-tab-threads"
+                    >
+                      线程态势
+                    </button>
+                  </div>
+                  <div className="flex-1 overflow-auto">
+                    {rightPanelTab === 'suggestion' && (
+                      <SuggestionDrawer
+                        item={selectedItem}
+                        submitting={submitting}
+                        selectedPhase={selectedPhase}
+                        selfClaimScopes={selfClaimScopes}
+                        selfClaimPolicyBlocker={selfClaimPolicyBlocker}
+                        onChangePhase={setSelectedPhase}
+                        onSuggest={handleSuggest}
+                        onApprove={handleApprove}
+                        onReject={handleReject}
+                        onSelfClaim={handleSelfClaim}
+                        onAcquireLease={handleAcquireLease}
+                        onHeartbeatLease={handleHeartbeatLease}
+                        onReleaseLease={handleReleaseLease}
+                        onReclaimLease={handleReclaimLease}
+                      />
+                    )}
+                    {rightPanelTab === 'sop' && <WorkflowSopPanel backlogItemId={selectedItemId} />}
+                    {rightPanelTab === 'threads' && (
+                      <ThreadSituationPanel
+                        dispatchedItems={dispatchedItems}
+                        loading={threadsLoading}
+                        threadsByBacklogId={threadsByBacklogId}
+                        threadsByFeatureId={threadsByFeatureId}
+                      />
+                    )}
+                  </div>
+                </div>
+              </div>
+            ) : (
+              <DependencyGraphTab items={items} />
+            )}
+          </div>
+
+          {loading && items.length === 0 && <p className="pt-3 text-xs text-cafe-muted">加载 backlog 中...</p>}
+        </div>
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary

Full outbound sync from cat-cafe to clowder-ai.

Source: `8fd75a637307579b7299c07bc6b7bbf3843238ba`
Previous target base: `0684c7ccde1e`
Manifest: v3

Included changes since last sync:
- Mission Hub content carrier follow-up: title/tabs/content unified into one rounded `CONTENT_SURFACE_CLASS` card and redundant back-to-thread wiring removed.
- Antigravity final-text stop hook handling fix from cat-cafe main.
- Public F206 doc/export metadata refresh.

## Gate Evidence

- cat-cafe source baseline: `pnpm test && pnpm check && pnpm lint && pnpm --filter @cat-cafe/shared build && pnpm --filter @cat-cafe/api build` passed.
- `scripts/sync-to-opensource.sh --dry-run` passed.
- Real sync temp target public gate passed before touching clowder-ai:
  - dependency install
  - biome/follow-up check
  - TypeScript lint
  - build
  - F203 native L0 compiler smoke
  - `test:public`
  - startup acceptance on public ports 3003/3004
  - static port verification
- Security scan clean; existing documented endpoint/env warnings only.

## Files Changed

9 files changed, 481 insertions, 297 deletions.