### PR TITLE
feat(F153 Phase J Slice J-A foundation): ToolSpanTracker + call site

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -54,6 +54,7 @@ import {
   recordLlmCallSpan,
   recordToolUseSpan,
 } from '../../../../../infrastructure/telemetry/span-helpers.js';
+import { ToolSpanTracker } from '../../../../../infrastructure/telemetry/tool-span-tracker.js';
 import { resolveActiveProjectRoot } from '../../../../../utils/active-project-root.js';
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
@@ -598,6 +599,10 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     { attributes: { [AGENT_ID]: catId, [OPERATION_NAME]: 'invoke', invocationId } },
     parentCtx,
   );
+
+  // F153 Phase J AC-J3: per-invocation tool span tracker (real-duration MCP tool spans).
+  // Used when provider emits toolUseId; falls back to legacy recordToolUseSpan when not.
+  const toolSpanTracker = new ToolSpanTracker(invocationSpan, catId as string);
 
   // F153: Expose invocation span to caller + persist trace context for A2A propagation
   if (params.invocationSpanRef) params.invocationSpanRef.current = invocationSpan;
@@ -1845,9 +1850,18 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         }
         outputs.push(attachInvocationIdToTaskProgress(msg));
 
-        // F153 Phase E: Record tool_use as child span (zero-duration; shows in trace tree with tool name + category)
+        // F153 Phase J AC-J2/J3: real-duration MCP tool spans when provider injects toolUseId,
+        // legacy zero-duration fallback otherwise (provider not yet wired per KD-41).
         if (msg.type === 'tool_use' && msg.toolName && invocationSpan) {
-          recordToolUseSpan(invocationSpan, catId, msg.toolName, msg.toolInput as Record<string, unknown>);
+          if (msg.toolUseId) {
+            toolSpanTracker.start(msg.toolName, msg.toolUseId, msg.toolInput as Record<string, unknown>);
+          } else {
+            recordToolUseSpan(invocationSpan, catId, msg.toolName, msg.toolInput as Record<string, unknown>);
+          }
+        }
+        // F153 Phase J AC-J2: pair tool_result with matching tool_use span; close with status.
+        if (msg.type === 'tool_result' && msg.toolUseId) {
+          toolSpanTracker.end(msg.toolUseId, msg.toolResultStatus ?? 'unknown');
         }
 
         // F26: Detect task management tools and emit task_progress for frontend
@@ -2300,6 +2314,10 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       tracing: { traceId: sc.traceId, spanId: sc.spanId, ...(parentSid ? { parentSpanId: parentSid } : {}) },
     };
   } finally {
+    // F153 Phase J AC-J4: drain any open tool spans whose tool_result never arrived
+    // (abort / error / timeout). Mirrors PR #732 mention_dispatch abort-safety pattern.
+    toolSpanTracker.endAllOrphans('aborted');
+
     // F089: Clear invocation hard timeout
     if (invocationTimer) clearTimeout(invocationTimer);
 

--- a/packages/api/src/domains/cats/services/tool-usage/classify.ts
+++ b/packages/api/src/domains/cats/services/tool-usage/classify.ts
@@ -52,3 +52,27 @@ export function classifyTool(toolName: string, toolInput: Record<string, unknown
   // Everything else is a native tool
   return { category: 'native', toolName };
 }
+
+/**
+ * F153 Phase J (KD-40): single source of truth for "is this an MCP tool name?".
+ *
+ * Recognizes 4 patterns:
+ * - `mcp__{server}__{tool}` — Claude Code wrapping
+ * - `mcp:{server}/{tool}`   — Codex wrapping
+ * - `cat_cafe_*`            — bare cat-cafe MCP tool (emitted by some providers without wrapping)
+ * - `signal_*`              — bare signal MCP tool
+ *
+ * Used by `span-helpers.ts` to decide whether to create a child `cat_cafe.tool_use` span.
+ *
+ * NOTE: This is intentionally wider than `classifyTool()` for span-emission purposes.
+ * `classifyTool()` returns `native` for bare prefixes, which is a F150 design choice;
+ * this helper does not change F150 behavior.
+ */
+export function isMcpToolName(toolName: string): boolean {
+  return (
+    toolName.startsWith('mcp__') ||
+    toolName.startsWith('mcp:') ||
+    toolName.startsWith('cat_cafe_') ||
+    toolName.startsWith('signal_')
+  );
+}

--- a/packages/api/src/domains/cats/services/types.ts
+++ b/packages/api/src/domains/cats/services/types.ts
@@ -143,10 +143,19 @@ export interface AgentMessage {
   ephemeralSession?: boolean;
   /** F211 A2: provider runtime lifecycle facts used by invocation to seal/create SessionRecords. */
   sessionLifecycle?: AntigravitySessionLifecycle;
-  /** Tool name (for 'tool_use' type) */
+  /** Tool name (for 'tool_use' and 'tool_result' types; required by F153 Phase J AC-J1) */
   toolName?: string;
   /** Tool input parameters (for 'tool_use' type) */
   toolInput?: Record<string, unknown>;
+  /** F153 Phase J AC-J1: native provider tool call id; used to pair tool_use ↔ tool_result for real-duration spans.
+   *  Provider transformers MUST inject this from raw payload when available (Claude tool_use.id, DARE tool_call_id,
+   *  CatAgent tool_use_id, Codex item.id, etc). Providers without native id may omit; ToolSpanTracker treats
+   *  missing id as fallback (no span open, no fake duration) per KD-41. */
+  toolUseId?: string;
+  /** F153 Phase J AC-J1: structured tool execution outcome (for 'tool_result' type).
+   *  Provider transformers MUST map from raw payload (is_error / success / exitCode / status) instead of
+   *  letting downstream guess from content string. Use 'unknown' when raw signal is genuinely absent. */
+  toolResultStatus?: 'ok' | 'error' | 'unknown';
   /** Error message (for 'error' type) */
   error?: string;
   /** Whether this is the final 'done' in a multi-cat invocation (for 'done' type) */

--- a/packages/api/src/infrastructure/telemetry/span-helpers.ts
+++ b/packages/api/src/infrastructure/telemetry/span-helpers.ts
@@ -6,6 +6,7 @@
  */
 
 import { context, type Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import { isMcpToolName } from '../../domains/cats/services/tool-usage/classify.js';
 import {
   AGENT_ID,
   GENAI_MODEL,
@@ -74,14 +75,14 @@ function classifyToolCategory(toolName: string): string | undefined {
   return undefined;
 }
 
-function isMcpTool(toolName: string): boolean {
-  return toolName.startsWith('cat_cafe_') || toolName.startsWith('mcp__') || toolName.startsWith('signal_');
-}
-
 /**
  * Record a tool_use. MCP/business tools get their own child span;
  * basic tools (Bash/Read/Write/…) only increment a counter attribute
  * on the invocation span to avoid flooding the trace tree.
+ *
+ * F153 Phase J KD-40: uses `isMcpToolName` from `tool-usage/classify.ts` instead
+ * of the previous local `isMcpTool`, which recognized only `cat_cafe_` / `mcp__` /
+ * `signal_` but missed Codex `mcp:` prefix.
  */
 export function recordToolUseSpan(
   invocationSpan: Span,
@@ -89,7 +90,7 @@ export function recordToolUseSpan(
   toolName: string,
   toolInput?: Record<string, unknown>,
 ): void {
-  if (!isMcpTool(toolName)) {
+  if (!isMcpToolName(toolName)) {
     const prev = (toolCallCounts.get(invocationSpan) ?? 0) + 1;
     toolCallCounts.set(invocationSpan, prev);
     invocationSpan.setAttribute('tool.basic_call_count', prev);

--- a/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
+++ b/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
@@ -22,6 +22,7 @@
 import { context, type Span, SpanStatusCode, trace } from '@opentelemetry/api';
 import { isMcpToolName } from '../../domains/cats/services/tool-usage/classify.js';
 import { AGENT_ID, TOOL_CATEGORY, TOOL_INPUT_KEYS, TOOL_NAME } from './genai-semconv.js';
+import { recordToolUseSpan } from './span-helpers.js';
 
 const tracer = trace.getTracer('cat-cafe-api', '0.1.0');
 
@@ -37,8 +38,6 @@ function classifyToolCategory(toolName: string): string | undefined {
   return undefined;
 }
 
-const basicToolCallCounts = new WeakMap<Span, number>();
-
 export type ToolResultStatus = 'ok' | 'error' | 'unknown';
 
 export class ToolSpanTracker {
@@ -53,13 +52,18 @@ export class ToolSpanTracker {
    * Start a tool_use span. Returns the span for advanced callers, or `undefined`
    * for basic tools (which bump the invocation-span counter and emit no child span).
    *
+   * Basic-tool path delegates to `recordToolUseSpan` from `span-helpers.ts` so
+   * the `tool.basic_call_count` WeakMap state is shared with the legacy fallback
+   * call site (KD-40 + R1 fix per cloud Codex: prevents undercount during the
+   * partial-wiring migration window when some msg path goes through tracker and
+   * some through legacy).
+   *
    * Duplicate `start(toolUseId)` is a no-op (re-emitted event); returns existing span.
    */
   start(toolName: string, toolUseId: string, toolInput?: Record<string, unknown>): Span | undefined {
     if (!isMcpToolName(toolName)) {
-      const prev = (basicToolCallCounts.get(this.invocationSpan) ?? 0) + 1;
-      basicToolCallCounts.set(this.invocationSpan, prev);
-      this.invocationSpan.setAttribute('tool.basic_call_count', prev);
+      // Delegate to shared WeakMap in span-helpers.ts (counter state unified)
+      recordToolUseSpan(this.invocationSpan, this.catId, toolName, toolInput);
       return undefined;
     }
 
@@ -89,8 +93,12 @@ export class ToolSpanTracker {
    * Close a tool_use span with the given status. No-op when toolUseId is
    * unknown (either a basic tool that bypassed span creation, or a `tool_result`
    * without a matching `tool_use`).
+   *
+   * Per Phase J spec "Out of scope: Tool input/result body 写入 span attr — 保持
+   * 低敏，只存 keys + status, 不存正文" — does NOT accept a resultMeta blob.
+   * Only the structured `status` is attached as an attribute.
    */
-  end(toolUseId: string, status: ToolResultStatus, resultMeta?: Record<string, unknown>): void {
+  end(toolUseId: string, status: ToolResultStatus): void {
     const span = this.spans.get(toolUseId);
     if (!span) return;
 
@@ -99,13 +107,6 @@ export class ToolSpanTracker {
       span.setStatus({ code: SpanStatusCode.OK });
     } else if (status === 'error') {
       span.setStatus({ code: SpanStatusCode.ERROR });
-    }
-    if (resultMeta) {
-      for (const [k, v] of Object.entries(resultMeta)) {
-        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
-          span.setAttribute(`tool.result.${k}`, v);
-        }
-      }
     }
     span.end();
     this.spans.delete(toolUseId);

--- a/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
+++ b/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
@@ -12,8 +12,10 @@
  * - `start(toolName, toolUseId, input)` → creates an open child span on the
  *   invocation span. Basic (non-MCP) tools bypass span creation and bump the
  *   `tool.basic_call_count` counter on the invocation span instead.
- * - `end(toolUseId, status, resultMeta?)` → closes the span with status from
+ * - `end(toolUseId, status)` → closes the span with status from
  *   `toolResultStatus` (KD-38). No-op when toolUseId is unknown.
+ *   Deliberately does NOT accept a result body / metadata parameter —
+ *   keeps tool result bodies out of span attrs (Phase J Out-of-scope boundary).
  * - `endAllOrphans(reason)` → AC-J4 finally cleanup. Called from invocation
  *   lifecycle finally block to drain spans whose `tool_result` never arrived
  *   (abort/error/timeout).

--- a/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
+++ b/packages/api/src/infrastructure/telemetry/tool-span-tracker.ts
@@ -1,0 +1,131 @@
+/**
+ * F153 Phase J Slice J-A AC-J3: ToolSpanTracker per-invocation.
+ *
+ * Replaces the zero-duration point-marker behavior of `recordToolUseSpan`
+ * with real-duration spans bounded by `tool_use` start and `tool_result` end.
+ *
+ * Scope (KD-37): one tracker per (invocation, cat). Internal map keyed by
+ * `toolUseId`; the tracker instance scope naturally prevents cross-invocation
+ * provider-raw-id collisions.
+ *
+ * Lifecycle:
+ * - `start(toolName, toolUseId, input)` → creates an open child span on the
+ *   invocation span. Basic (non-MCP) tools bypass span creation and bump the
+ *   `tool.basic_call_count` counter on the invocation span instead.
+ * - `end(toolUseId, status, resultMeta?)` → closes the span with status from
+ *   `toolResultStatus` (KD-38). No-op when toolUseId is unknown.
+ * - `endAllOrphans(reason)` → AC-J4 finally cleanup. Called from invocation
+ *   lifecycle finally block to drain spans whose `tool_result` never arrived
+ *   (abort/error/timeout).
+ */
+
+import { context, type Span, SpanStatusCode, trace } from '@opentelemetry/api';
+import { isMcpToolName } from '../../domains/cats/services/tool-usage/classify.js';
+import { AGENT_ID, TOOL_CATEGORY, TOOL_INPUT_KEYS, TOOL_NAME } from './genai-semconv.js';
+
+const tracer = trace.getTracer('cat-cafe-api', '0.1.0');
+
+const MEMORY_TOOL_PREFIXES = [
+  'cat_cafe_search_evidence',
+  'cat_cafe_read_session',
+  'cat_cafe_read_invocation',
+  'cat_cafe_review_distillation',
+];
+
+function classifyToolCategory(toolName: string): string | undefined {
+  if (MEMORY_TOOL_PREFIXES.some((p) => toolName.startsWith(p))) return 'memory';
+  return undefined;
+}
+
+const basicToolCallCounts = new WeakMap<Span, number>();
+
+export type ToolResultStatus = 'ok' | 'error' | 'unknown';
+
+export class ToolSpanTracker {
+  private spans = new Map<string, Span>();
+
+  constructor(
+    private readonly invocationSpan: Span,
+    private readonly catId: string,
+  ) {}
+
+  /**
+   * Start a tool_use span. Returns the span for advanced callers, or `undefined`
+   * for basic tools (which bump the invocation-span counter and emit no child span).
+   *
+   * Duplicate `start(toolUseId)` is a no-op (re-emitted event); returns existing span.
+   */
+  start(toolName: string, toolUseId: string, toolInput?: Record<string, unknown>): Span | undefined {
+    if (!isMcpToolName(toolName)) {
+      const prev = (basicToolCallCounts.get(this.invocationSpan) ?? 0) + 1;
+      basicToolCallCounts.set(this.invocationSpan, prev);
+      this.invocationSpan.setAttribute('tool.basic_call_count', prev);
+      return undefined;
+    }
+
+    const existing = this.spans.get(toolUseId);
+    if (existing) return existing;
+
+    const parentCtx = trace.setSpan(context.active(), this.invocationSpan);
+    const category = classifyToolCategory(toolName);
+    const span = tracer.startSpan(
+      `cat_cafe.tool_use ${toolName}`,
+      {
+        attributes: {
+          [AGENT_ID]: this.catId,
+          [TOOL_NAME]: toolName,
+          ...(toolInput ? { [TOOL_INPUT_KEYS]: Object.keys(toolInput).join(',') } : {}),
+          ...(category ? { [TOOL_CATEGORY]: category } : {}),
+          'tool.use_id': toolUseId,
+        },
+      },
+      parentCtx,
+    );
+    this.spans.set(toolUseId, span);
+    return span;
+  }
+
+  /**
+   * Close a tool_use span with the given status. No-op when toolUseId is
+   * unknown (either a basic tool that bypassed span creation, or a `tool_result`
+   * without a matching `tool_use`).
+   */
+  end(toolUseId: string, status: ToolResultStatus, resultMeta?: Record<string, unknown>): void {
+    const span = this.spans.get(toolUseId);
+    if (!span) return;
+
+    span.setAttribute('tool.result.status', status);
+    if (status === 'ok') {
+      span.setStatus({ code: SpanStatusCode.OK });
+    } else if (status === 'error') {
+      span.setStatus({ code: SpanStatusCode.ERROR });
+    }
+    if (resultMeta) {
+      for (const [k, v] of Object.entries(resultMeta)) {
+        if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') {
+          span.setAttribute(`tool.result.${k}`, v);
+        }
+      }
+    }
+    span.end();
+    this.spans.delete(toolUseId);
+  }
+
+  /**
+   * AC-J4: end all currently-open spans, marking them with the given lifecycle reason.
+   * Called from invocation lifecycle finally block on abort/error/timeout to
+   * prevent orphan spans (mirrors PR #732 mention_dispatch abort-safety pattern).
+   */
+  endAllOrphans(reason: 'aborted' | 'completed' = 'aborted'): void {
+    for (const span of this.spans.values()) {
+      span.setAttribute('tool.lifecycle', reason);
+      span.end();
+    }
+    this.spans.clear();
+  }
+
+  /** Number of currently-open tool spans (for diagnostics / tests). */
+  size(): number {
+    return this.spans.size;
+  }
+}

--- a/packages/api/test/telemetry/tool-span-tracker.test.js
+++ b/packages/api/test/telemetry/tool-span-tracker.test.js
@@ -35,8 +35,8 @@ test('F153 Phase J AC-J3: tool-span-tracker.ts exports ToolSpanTracker class', (
     'should have start(toolName, toolUseId, ...) API',
   );
   assert.ok(
-    src.includes('end(toolUseId: string, status: ToolResultStatus'),
-    'should have end(toolUseId, status, ...) API',
+    src.includes('end(toolUseId: string, status: ToolResultStatus)'),
+    'should have end(toolUseId, status) API — no result body parameter (砚砚 R1 P2)',
   );
   assert.ok(src.includes('endAllOrphans('), 'should have endAllOrphans for AC-J4');
 });
@@ -146,14 +146,43 @@ test('F153 Phase J AC-J6(c): error result sets span status ERROR + tool.result.s
   const tracker = new ToolSpanTracker(invocationSpan, 'opus');
 
   tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-err', {});
-  tracker.end('use-err', 'error', { errorMessage: 'timeout' });
+  tracker.end('use-err', 'error');
   invocationSpan.end();
 
   const spans = otelExporter.getFinishedSpans();
   const toolSpan = spans.find((s) => s.attributes['tool.use_id'] === 'use-err');
   assert.equal(toolSpan.status.code, 2, 'OTel status ERROR (code=2)');
   assert.equal(toolSpan.attributes['tool.result.status'], 'error', 'tool.result.status=error attribute');
-  assert.equal(toolSpan.attributes['tool.result.errorMessage'], 'timeout', 'resultMeta scalar copied to attribute');
+  // 砚砚 R1 P2: tracker.end deliberately does NOT accept result body / resultMeta.
+  // Per spec "Out of scope: Tool input/result body 写入 span attr — 保持低敏".
+  // Only the structured status is attached; freeform fields would bypass redactor coverage.
+  assert.equal(toolSpan.attributes['tool.result.errorMessage'], undefined, 'no freeform result body in span attrs');
+});
+
+test('F153 Phase J AC-J3 (砚砚 R1 P3): tool_use span is child of invocation span (parent-child wiring)', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-parent-check', {});
+  tracker.end('use-parent-check', 'ok');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpan = spans.find((s) => s.attributes['tool.use_id'] === 'use-parent-check');
+  assert.ok(toolSpan, 'tool span should be present');
+  // Hub trace tree relies on parentSpanId pointing at invocation span — this is the
+  // contract that makes the tool show up as a child node, not as an orphan trace.
+  assert.equal(
+    toolSpan.parentSpanContext?.spanId ?? toolSpan.parentSpanId,
+    invocationSpan.spanContext().spanId,
+    'tool span parent must be invocation span (Hub trace tree contract)',
+  );
+  assert.equal(
+    toolSpan.spanContext().traceId,
+    invocationSpan.spanContext().traceId,
+    'tool span shares invocation trace id',
+  );
 });
 
 test('F153 Phase J AC-J6(d) / AC-J4: endAllOrphans marks unresolved spans as aborted', () => {

--- a/packages/api/test/telemetry/tool-span-tracker.test.js
+++ b/packages/api/test/telemetry/tool-span-tracker.test.js
@@ -71,7 +71,6 @@ test('F153 Phase J AC-J5: isMcpToolName recognizes all 4 patterns (mcp__ / mcp: 
 
 // ── Behavioral: ToolSpanTracker lifecycle (real OTel exporter) ──────
 
-const { trace: traceApi } = await import('@opentelemetry/api');
 const { InMemorySpanExporter, SimpleSpanProcessor, NodeTracerProvider } = await import('@opentelemetry/sdk-trace-node');
 
 const otelExporter = new InMemorySpanExporter();

--- a/packages/api/test/telemetry/tool-span-tracker.test.js
+++ b/packages/api/test/telemetry/tool-span-tracker.test.js
@@ -1,0 +1,235 @@
+/**
+ * F153 Phase J Slice J-A AC-J6: behavioral tests for ToolSpanTracker.
+ *
+ * Coverage matrix (from spec):
+ * (a) Two same-name tools in parallel — Map<toolUseId> keeps them separate
+ * (b) Result arrives out-of-order — span correctly paired by toolUseId
+ * (c) Error result → span status ERROR + tool.result.status='error'
+ * (d) Abort orphan cleanup → endAllOrphans marks tool.lifecycle='aborted'
+ * (e) Codex mcp: classification correct — span emitted (not basic counter)
+ *
+ * Plus edge cases:
+ * - Basic tool bumps tool.basic_call_count, no span
+ * - end() no-op for unknown toolUseId
+ * - Duplicate start returns existing span (no double-create)
+ * - isMcpToolName covers all 4 patterns
+ */
+
+if (!process.env.NODE_ENV) process.env.NODE_ENV = 'test';
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ── Source-string sanity: spec implementation contract ─────────────
+
+test('F153 Phase J AC-J3: tool-span-tracker.ts exports ToolSpanTracker class', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/infrastructure/telemetry/tool-span-tracker.ts'), 'utf8');
+  assert.ok(src.includes('export class ToolSpanTracker'), 'should export ToolSpanTracker class');
+  assert.ok(
+    src.includes('start(toolName: string, toolUseId: string'),
+    'should have start(toolName, toolUseId, ...) API',
+  );
+  assert.ok(
+    src.includes('end(toolUseId: string, status: ToolResultStatus'),
+    'should have end(toolUseId, status, ...) API',
+  );
+  assert.ok(src.includes('endAllOrphans('), 'should have endAllOrphans for AC-J4');
+});
+
+test('F153 Phase J AC-J5: span-helpers uses isMcpToolName from classify.ts', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/infrastructure/telemetry/span-helpers.ts'), 'utf8');
+  assert.ok(
+    src.includes("import { isMcpToolName } from '../../domains/cats/services/tool-usage/classify.js'"),
+    'span-helpers should import isMcpToolName',
+  );
+  assert.ok(!src.includes('function isMcpTool('), 'local isMcpTool function should be removed');
+});
+
+test('F153 Phase J AC-J1: AgentMessage has toolUseId + toolResultStatus fields', () => {
+  const src = readFileSync(resolve(__dirname, '../../src/domains/cats/services/types.ts'), 'utf8');
+  assert.ok(src.includes('toolUseId?: string'), 'AgentMessage should declare toolUseId optional field');
+  assert.ok(
+    src.includes("toolResultStatus?: 'ok' | 'error' | 'unknown'"),
+    'AgentMessage should declare toolResultStatus with 3-value union',
+  );
+});
+
+test('F153 Phase J AC-J5: isMcpToolName recognizes all 4 patterns (mcp__ / mcp: / cat_cafe_ / signal_)', async () => {
+  const { isMcpToolName } = await import('../../dist/domains/cats/services/tool-usage/classify.js');
+  assert.equal(isMcpToolName('mcp__cat-cafe__cat_cafe_post_message'), true, 'Claude wrapping');
+  assert.equal(isMcpToolName('mcp:cat-cafe/post_message'), true, 'Codex wrapping (the gap fix)');
+  assert.equal(isMcpToolName('cat_cafe_search_evidence'), true, 'bare cat_cafe_');
+  assert.equal(isMcpToolName('signal_search'), true, 'bare signal_');
+  assert.equal(isMcpToolName('Bash'), false, 'basic tool');
+  assert.equal(isMcpToolName('Read'), false, 'basic tool');
+});
+
+// ── Behavioral: ToolSpanTracker lifecycle (real OTel exporter) ──────
+
+const { trace: traceApi } = await import('@opentelemetry/api');
+const { InMemorySpanExporter, SimpleSpanProcessor, NodeTracerProvider } = await import('@opentelemetry/sdk-trace-node');
+
+const otelExporter = new InMemorySpanExporter();
+const otelProvider = new NodeTracerProvider({
+  spanProcessors: [new SimpleSpanProcessor(otelExporter)],
+});
+otelProvider.register();
+const otelTracer = otelProvider.getTracer('tool-span-tracker-test');
+
+const { ToolSpanTracker } = await import('../../dist/infrastructure/telemetry/tool-span-tracker.js');
+
+test('F153 Phase J AC-J3 behavioral: tracker creates real-duration span paired by toolUseId', async () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-1', { content: 'hi' });
+  await new Promise((r) => setTimeout(r, 10));
+  tracker.end('use-1', 'ok');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpan = spans.find((s) => s.name === 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_post_message');
+  assert.ok(toolSpan, 'tool_use span should be present');
+  assert.ok(toolSpan.duration[1] > 0 || toolSpan.duration[0] > 0, 'span should have non-zero duration');
+  assert.equal(toolSpan.attributes['tool.use_id'], 'use-1', 'tool.use_id attribute set');
+  assert.equal(toolSpan.attributes['tool.result.status'], 'ok', 'tool.result.status set');
+  assert.equal(toolSpan.status.code, 1, 'span status OK');
+});
+
+test('F153 Phase J AC-J6(a): two same-name tools in parallel — both tracked separately', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp:cat-cafe/post_message', 'use-A', {});
+  tracker.start('mcp:cat-cafe/post_message', 'use-B', {});
+  assert.equal(tracker.size(), 2, 'two spans open with same tool name, different ids');
+
+  tracker.end('use-A', 'ok');
+  tracker.end('use-B', 'ok');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpans = spans.filter((s) => s.name.includes('post_message'));
+  assert.equal(toolSpans.length, 2, 'both tool spans flushed');
+  const ids = new Set(toolSpans.map((s) => s.attributes['tool.use_id']));
+  assert.deepEqual([...ids].sort(), ['use-A', 'use-B'], 'distinct tool.use_id attributes');
+});
+
+test('F153 Phase J AC-J6(b): result arrives out-of-order — correct span paired by toolUseId', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'first', {});
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'second', {});
+  tracker.end('second', 'error'); // out of order: second result before first
+  tracker.end('first', 'ok');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const firstSpan = spans.find((s) => s.attributes['tool.use_id'] === 'first');
+  const secondSpan = spans.find((s) => s.attributes['tool.use_id'] === 'second');
+  assert.equal(firstSpan.attributes['tool.result.status'], 'ok', 'first paired with ok');
+  assert.equal(secondSpan.attributes['tool.result.status'], 'error', 'second paired with error');
+});
+
+test('F153 Phase J AC-J6(c): error result sets span status ERROR + tool.result.status=error', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-err', {});
+  tracker.end('use-err', 'error', { errorMessage: 'timeout' });
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpan = spans.find((s) => s.attributes['tool.use_id'] === 'use-err');
+  assert.equal(toolSpan.status.code, 2, 'OTel status ERROR (code=2)');
+  assert.equal(toolSpan.attributes['tool.result.status'], 'error', 'tool.result.status=error attribute');
+  assert.equal(toolSpan.attributes['tool.result.errorMessage'], 'timeout', 'resultMeta scalar copied to attribute');
+});
+
+test('F153 Phase J AC-J6(d) / AC-J4: endAllOrphans marks unresolved spans as aborted', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-1', {});
+  tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'use-2', {});
+  tracker.end('use-1', 'ok');
+  // use-2 result never arrives
+  tracker.endAllOrphans('aborted');
+  assert.equal(tracker.size(), 0, 'all spans cleaned up');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const orphan = spans.find((s) => s.attributes['tool.use_id'] === 'use-2');
+  assert.equal(orphan.attributes['tool.lifecycle'], 'aborted', 'orphan marked aborted');
+});
+
+test('F153 Phase J AC-J6(e): Codex mcp: classified as MCP (span emitted, not basic counter)', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'codex');
+
+  tracker.start('mcp:cat-cafe/post_message', 'use-codex', { content: 'hello' });
+  tracker.end('use-codex', 'ok');
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const codexSpan = spans.find((s) => s.attributes['tool.use_id'] === 'use-codex');
+  assert.ok(codexSpan, 'mcp: tool MUST emit a child span (KD-40 fix)');
+  assert.equal(codexSpan.name, 'cat_cafe.tool_use mcp:cat-cafe/post_message');
+});
+
+test('F153 Phase J: basic tool bumps tool.basic_call_count, no child span', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  tracker.start('Bash', 'use-bash-1', { command: 'ls' });
+  tracker.start('Read', 'use-read-1', { path: '/tmp' });
+  tracker.start('Bash', 'use-bash-2', { command: 'pwd' });
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpans = spans.filter((s) => s.name.startsWith('cat_cafe.tool_use '));
+  assert.equal(toolSpans.length, 0, 'no child spans for basic tools');
+  assert.equal(invocationSpan.attributes['tool.basic_call_count'], 3, 'counter bumped 3 times');
+});
+
+test('F153 Phase J: end() no-op for unknown toolUseId (basic tool or unmatched result)', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  // Never started — end is silent no-op
+  tracker.end('never-started', 'ok');
+  assert.equal(tracker.size(), 0);
+  invocationSpan.end();
+
+  const spans = otelExporter.getFinishedSpans();
+  const toolSpans = spans.filter((s) => s.name.startsWith('cat_cafe.tool_use '));
+  assert.equal(toolSpans.length, 0, 'no spurious span created');
+});
+
+test('F153 Phase J: duplicate start returns existing span (no double-create)', () => {
+  otelExporter.reset();
+  const invocationSpan = otelTracer.startSpan('cat_cafe.invocation');
+  const tracker = new ToolSpanTracker(invocationSpan, 'opus');
+
+  const span1 = tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'dup', {});
+  const span2 = tracker.start('mcp__cat-cafe__cat_cafe_post_message', 'dup', {});
+  assert.strictEqual(span1, span2, 'duplicate start returns existing span');
+  assert.equal(tracker.size(), 1, 'only one span open');
+
+  tracker.end('dup', 'ok');
+  invocationSpan.end();
+});


### PR DESCRIPTION
Refs #762

## Summary

Implements F153 Phase J Slice J-A foundation per [spec PR #755](https://github.com/zts212653/clowder-ai/pull/755) (merged \`798c3527\`). 5 of 6 ACs covered. Provider transformer wiring (AC-J2 native id pass-through) deferred to follow-up PRs to keep this focused.

## ACs covered

| AC | Description | Files |
|----|-------------|-------|
| **J1** | \`AgentMessage\` schema — \`toolUseId\` + \`toolResultStatus\` + \`toolName\` for \`tool_result\` | \`types.ts\` |
| **J3** | \`ToolSpanTracker\` class — start/end/endAllOrphans, per-invocation scope (invocation+cat), \`Map<toolUseId, Span>\` internal | \`tool-span-tracker.ts\` (new) |
| **J4** | \`invoke-single-cat\` finally drains orphan spans via \`tracker.endAllOrphans('aborted')\` — PR #732 pattern | \`invoke-single-cat.ts\` |
| **J5** (KD-40) | \`isMcpToolName\` in \`classify.ts\` replaces local \`isMcpTool\` — handles all 4 patterns (\`mcp__\` / \`mcp:\` / \`cat_cafe_\` / \`signal_\`), fixes Codex \`mcp:\` gap | \`classify.ts\`, \`span-helpers.ts\` |
| **J6** | 13 behavioral tests via \`InMemorySpanExporter\` covering all 5 required cases (same-name parallel, out-of-order, error, abort cleanup, Codex \`mcp:\`) + edge cases | \`tool-span-tracker.test.js\` (new) |

## AC deferred to follow-up

- **AC-J2** (provider transformer native id pass-through for 7 providers): Without this wiring, the new tracker stays dormant in production — call site falls back to legacy \`recordToolUseSpan\` when \`msg.toolUseId\` absent. Foundation is independently tested.

Splitting rationale: foundation review (tracker design, schema, tests) is orthogonal to provider-specific transformer changes; this allows clean review of the architectural boundary before provider-by-provider wiring lands.

## Key design adherence

- **KD-36** (native ID only): Tracker API requires \`toolUseId\` — no \`Map<toolName>\` or stack model possible
- **KD-37** (per-invocation scope): Tracker constructed inside invocation scope; \`toolUseId\` collision-free within same invocation
- **KD-38** (structured result status): \`toolResultStatus\` field, no content-string parsing
- **KD-40** (classify.ts reuse): \`isMcpToolName\` is the single source of truth; \`classifyTool()\` itself unchanged to avoid F150 cross-feature impact
- **KD-41** (no fake duration for ID-less providers): Once providers wired (AC-J2), legacy fallback path naturally degrades to "no span" for providers that don't emit \`toolUseId\`

## Call site behavior

\`\`\`ts
// invoke-single-cat.ts (after invocationSpan creation)
const toolSpanTracker = new ToolSpanTracker(invocationSpan, catId as string);

// In stream loop:
if (msg.type === 'tool_use' && msg.toolName && invocationSpan) {
  if (msg.toolUseId) {
    toolSpanTracker.start(msg.toolName, msg.toolUseId, msg.toolInput);  // new real-duration
  } else {
    recordToolUseSpan(invocationSpan, catId, msg.toolName, msg.toolInput);  // legacy zero-duration
  }
}
if (msg.type === 'tool_result' && msg.toolUseId) {
  toolSpanTracker.end(msg.toolUseId, msg.toolResultStatus ?? 'unknown');
}

// In finally:
toolSpanTracker.endAllOrphans('aborted');
\`\`\`

## Test plan

- [x] 13/13 new tests in \`tool-span-tracker.test.js\` pass (real OTel via \`InMemorySpanExporter\`)
- [x] Existing tests not regressed (mention-dispatch-trace.test.js etc.)
- [x] tsc clean for changed files (only pre-existing better-sqlite3 / web-push type warnings)
- [x] biome clean
- [x] Foundation safe to land — production traffic unchanged until AC-J2 wires providers (call site backward-compat fallback)

@codex spec-aligned review request. Focus areas:
1. \`ToolSpanTracker\` API shape — does it match KD-36..41 boundaries?
2. Call site logic — is the conditional \`toolUseId\` path correct for backward compat?
3. AC-J6 test coverage — are 5 spec cases + edges all hit by behavioral tests?
4. Scope split decision (defer AC-J2 to follow-up) — acceptable?

🤖 Generated with [Claude Code](https://claude.com/claude-code)