### PR TITLE
feat(#671): unify runtime data directories

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,7 +102,6 @@ LLM_POSTPROCESS_ENABLED=0
 # WHISPER_URL=http://localhost:9876
 # NEXT_PUBLIC_WHISPER_URL=http://localhost:9876
 # TTS_URL=http://localhost:9879
-# TTS_CACHE_DIR=./data/tts-cache
 # NEXT_PUBLIC_LLM_POSTPROCESS_URL=http://localhost:9878
 
 # ── Optional: Semantic Retrieval 语义检索（可选）──────────────

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,0 +1,9 @@
+# OpenCode Runtime Notes
+
+This file is loaded as the project-level OpenCode instruction addendum.
+
+## Interaction Channels
+
+- Do not use the `question` tool for Cat Cafe handoffs; project config sets `permission.question` to `deny`.
+- For structured UI messages, use `cat_cafe_create_rich_block` through the Cat Cafe callback tools instead of prose-only placeholders.
+- Keep route instructions in the native L0 system prompt; this file is only the OpenCode-specific runtime addendum.

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -439,35 +439,62 @@ class ServiceManager {
     }
   }
 
-  _moveLegacyDesktopPath(from, to) {
+  _moveLegacyDesktopPath(from, to, sidecarSuffixes = []) {
     if (!fs.existsSync(from)) return true;
-    if (path.resolve(from) === path.resolve(to)) return true;
-    if (this._isPathPopulated(to)) {
-      log(`Warning: legacy desktop data ${from} not moved; target already populated at ${to}`);
-      return false;
+    const moves = [{ from, to }];
+    for (const suffix of sidecarSuffixes) {
+      const sidecarFrom = `${from}${suffix}`;
+      if (fs.existsSync(sidecarFrom)) {
+        moves.push({ from: sidecarFrom, to: `${to}${suffix}` });
+      }
+    }
+    const pendingMoves = moves.filter((move) => path.resolve(move.from) !== path.resolve(move.to));
+    if (pendingMoves.length === 0) return true;
+    for (const move of pendingMoves) {
+      if (this._isPathPopulated(move.to)) {
+        log(`Warning: legacy desktop data ${move.from} not moved; target already populated at ${move.to}`);
+        return false;
+      }
     }
 
     try {
-      if (fs.existsSync(to)) {
-        fs.rmSync(to, { recursive: true, force: true });
+      for (const move of pendingMoves) {
+        if (fs.existsSync(move.to)) {
+          fs.rmSync(move.to, { recursive: true, force: true });
+        }
+        fs.mkdirSync(path.dirname(move.to), { recursive: true });
       }
-      fs.mkdirSync(path.dirname(to), { recursive: true });
+      const renamed = [];
       try {
-        fs.renameSync(from, to);
+        for (const move of pendingMoves) {
+          fs.renameSync(move.from, move.to);
+          renamed.push(move);
+        }
       } catch (err) {
+        for (const move of renamed.reverse()) {
+          try {
+            fs.renameSync(move.to, move.from);
+          } catch {}
+        }
         if (err?.code !== 'EXDEV') throw err;
         try {
-          const st = fs.lstatSync(from);
-          if (st.isDirectory() && !st.isSymbolicLink()) {
-            fs.cpSync(from, to, { recursive: true, errorOnExist: true, force: false });
-          } else {
-            fs.copyFileSync(from, to);
+          for (const move of pendingMoves) {
+            const st = fs.lstatSync(move.from);
+            if (st.isDirectory() && !st.isSymbolicLink()) {
+              fs.cpSync(move.from, move.to, { recursive: true, errorOnExist: true, force: false });
+            } else {
+              fs.copyFileSync(move.from, move.to);
+            }
           }
         } catch (copyErr) {
-          fs.rmSync(to, { recursive: true, force: true });
+          for (const move of pendingMoves) {
+            fs.rmSync(move.to, { recursive: true, force: true });
+          }
           throw copyErr;
         }
-        fs.rmSync(from, { recursive: true, force: true });
+        for (const move of pendingMoves) {
+          fs.rmSync(move.from, { recursive: true, force: true });
+        }
       }
       log(`Legacy desktop data migrated: ${from} -> ${to}`);
       return true;
@@ -481,14 +508,14 @@ class ServiceManager {
     const dataDir = path.join(baseDir, 'data');
     const cacheDir = path.join(baseDir, 'cache');
     const moves = [
-      [path.join(baseDir, 'evidence.sqlite'), path.join(dataDir, 'evidence.sqlite')],
+      [path.join(baseDir, 'evidence.sqlite'), path.join(dataDir, 'evidence.sqlite'), ['-wal', '-shm', '-journal']],
       [path.join(baseDir, 'uploads'), path.join(dataDir, 'uploads')],
       [path.join(dataDir, 'connector-media'), path.join(cacheDir, 'connector-media')],
       [path.join(dataDir, 'tts-cache'), path.join(cacheDir, 'tts')],
     ];
     const failed = [];
-    for (const [from, to] of moves) {
-      if (!this._moveLegacyDesktopPath(from, to)) failed.push(`${from} -> ${to}`);
+    for (const [from, to, sidecarSuffixes] of moves) {
+      if (!this._moveLegacyDesktopPath(from, to, sidecarSuffixes)) failed.push(`${from} -> ${to}`);
     }
     if (failed.length > 0) {
       throw new Error(

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -204,6 +204,7 @@ class ServiceManager {
         log(`Warning: failed to create directory ${d}: ${err.message}`);
       }
     }
+    this._migrateLegacyDesktopDataDirs(baseDir);
     const projectDir = path.join(baseDir, 'project');
     const marker = path.join(projectDir, 'pnpm-workspace.yaml');
     if (!fs.existsSync(marker)) {
@@ -424,6 +425,75 @@ class ServiceManager {
         // Inno Setup already created the junction during install.
         log(`Warning: scripts/node_modules link: ${err.message}`);
       }
+    }
+  }
+
+  _isPathPopulated(p) {
+    try {
+      const st = fs.lstatSync(p);
+      if (st.isFile() || st.isSymbolicLink()) return true;
+      if (st.isDirectory()) return fs.readdirSync(p).length > 0;
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  _moveLegacyDesktopPath(from, to) {
+    if (!fs.existsSync(from)) return true;
+    if (path.resolve(from) === path.resolve(to)) return true;
+    if (this._isPathPopulated(to)) {
+      log(`Warning: legacy desktop data ${from} not moved; target already populated at ${to}`);
+      return false;
+    }
+
+    try {
+      if (fs.existsSync(to)) {
+        fs.rmSync(to, { recursive: true, force: true });
+      }
+      fs.mkdirSync(path.dirname(to), { recursive: true });
+      try {
+        fs.renameSync(from, to);
+      } catch (err) {
+        if (err?.code !== 'EXDEV') throw err;
+        try {
+          const st = fs.lstatSync(from);
+          if (st.isDirectory() && !st.isSymbolicLink()) {
+            fs.cpSync(from, to, { recursive: true, errorOnExist: true, force: false });
+          } else {
+            fs.copyFileSync(from, to);
+          }
+        } catch (copyErr) {
+          fs.rmSync(to, { recursive: true, force: true });
+          throw copyErr;
+        }
+        fs.rmSync(from, { recursive: true, force: true });
+      }
+      log(`Legacy desktop data migrated: ${from} -> ${to}`);
+      return true;
+    } catch (err) {
+      log(`Warning: failed to migrate legacy desktop data ${from} -> ${to}: ${err.message}`);
+      return false;
+    }
+  }
+
+  _migrateLegacyDesktopDataDirs(baseDir) {
+    const dataDir = path.join(baseDir, 'data');
+    const cacheDir = path.join(baseDir, 'cache');
+    const moves = [
+      [path.join(baseDir, 'evidence.sqlite'), path.join(dataDir, 'evidence.sqlite')],
+      [path.join(baseDir, 'uploads'), path.join(dataDir, 'uploads')],
+      [path.join(dataDir, 'connector-media'), path.join(cacheDir, 'connector-media')],
+      [path.join(dataDir, 'tts-cache'), path.join(cacheDir, 'tts')],
+    ];
+    const failed = [];
+    for (const [from, to] of moves) {
+      if (!this._moveLegacyDesktopPath(from, to)) failed.push(`${from} -> ${to}`);
+    }
+    if (failed.length > 0) {
+      throw new Error(
+        `Legacy desktop data migration failed; refusing to start with hidden legacy data: ${failed.join('; ')}`,
+      );
     }
   }
 

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -417,16 +417,35 @@ class ServiceManager {
           log(`.cat-cafe symlink retargeted: ${projectCatCafeDir} -> ${catCafeStateDir}`);
         }
       } else if (catCafeStat.isDirectory()) {
-        // Real directory with data — move to unified location, replace with
-        // symlink.  Remove the empty mkdir target first to allow rename.
-        try {
-          fs.rmdirSync(catCafeStateDir);
-        } catch {
-          /* non-empty or missing — rename will fail gracefully */
+        // On Windows, NTFS junctions can report as directories via
+        // lstatSync().isSymbolicLink() === false.  Probe with readlinkSync
+        // to detect hidden junctions before treating this as a real dir.
+        let isJunction = false;
+        if (IS_WIN) {
+          try {
+            const jTarget = fs.readlinkSync(projectCatCafeDir);
+            isJunction = true;
+            if (path.resolve(jTarget) !== path.resolve(catCafeStateDir)) {
+              removeLink(projectCatCafeDir);
+              fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+              log(`.cat-cafe junction retargeted: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+            }
+          } catch {
+            // readlinkSync failed (EINVAL) → genuine directory, not a junction
+          }
         }
-        fs.renameSync(projectCatCafeDir, catCafeStateDir);
-        fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
-        log(`.cat-cafe state migrated: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+        if (!isJunction) {
+          // Real directory with data — move to unified location, replace with
+          // symlink.  Remove the empty mkdir target first to allow rename.
+          try {
+            fs.rmdirSync(catCafeStateDir);
+          } catch {
+            /* non-empty or missing — rename will fail gracefully */
+          }
+          fs.renameSync(projectCatCafeDir, catCafeStateDir);
+          fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+          log(`.cat-cafe state migrated: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+        }
       }
     } catch {
       // project/.cat-cafe doesn't exist yet — create symlink to data/cat-cafe

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -176,10 +176,15 @@ class ServiceManager {
   _ensureUserDataDir(baseDir) {
     const dirs = [
       baseDir,
+      path.join(baseDir, 'data'),
       path.join(baseDir, 'data', 'transcripts'),
       path.join(baseDir, 'data', 'logs', 'api'),
-      path.join(baseDir, 'data', 'connector-media'),
-      path.join(baseDir, 'uploads'),
+      path.join(baseDir, 'data', 'audit-logs'),
+      path.join(baseDir, 'data', 'cli-raw-archive'),
+      path.join(baseDir, 'data', 'uploads'),
+      path.join(baseDir, 'cache'),
+      path.join(baseDir, 'cache', 'connector-media'),
+      path.join(baseDir, 'cache', 'tts'),
       // Writable project root for the API. The install dir (Program Files) is
       // read-only for non-admin users, but the API writes many files under
       // {projectRoot}/.cat-cafe/ (cat-catalog.json, governance-registry.json,
@@ -188,8 +193,8 @@ class ServiceManager {
       // no per-path env overrides, so the API cwd must be a writable dir with
       // a pnpm-workspace.yaml marker.
       path.join(baseDir, 'data', 'redis'),
+      path.join(baseDir, 'data', 'cat-cafe'),
       path.join(baseDir, 'project'),
-      path.join(baseDir, 'project', '.cat-cafe'),
     ];
     for (const d of dirs) {
       try {
@@ -210,16 +215,9 @@ class ServiceManager {
       }
     }
 
-    // Mirror read-only install-dir resources into the project dir via symlinks.
-    // Without these, findMonorepoRoot(cwd) resolves to the project dir but
-    // docs/cat-cafe-skills/packages are not under it — so API routes like
-    // /api/docs, capabilities.ts skill listing, and MCP server spawning
-    // (resolve(projectRoot, 'packages/mcp-server/dist/memory.js')) all fail.
     // Windows uses NTFS junctions (no admin needed, absolute paths). macOS
     // uses plain directory symlinks.
     const linkType = IS_WIN ? 'junction' : 'dir';
-    const mirrors = ['.claude', 'assets', 'cat-cafe-skills', 'docs', 'guides', 'packages', 'plugins', 'scripts'];
-
     // Helper: remove a junction or symlink. On Windows, NTFS junctions are
     // directory reparse points — fs.unlinkSync calls DeleteFileW which fails
     // on directory entries (EPERM). fs.rmdirSync calls RemoveDirectoryW which
@@ -235,6 +233,79 @@ class ServiceManager {
         fs.unlinkSync(linkPath);
       }
     };
+
+    const catCafeStateDir = path.join(baseDir, 'data', 'cat-cafe');
+    const projectCatCafeDir = path.join(projectDir, '.cat-cafe');
+    const createCatCafeLink = () => {
+      fs.mkdirSync(catCafeStateDir, { recursive: true });
+      fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+      log(`.cat-cafe state ${linkType} created: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+    };
+    const moveRealCatCafeDir = () => {
+      fs.mkdirSync(path.dirname(catCafeStateDir), { recursive: true });
+      try {
+        fs.renameSync(projectCatCafeDir, catCafeStateDir);
+      } catch {
+        fs.cpSync(projectCatCafeDir, catCafeStateDir, {
+          recursive: true,
+          errorOnExist: true,
+          force: false,
+        });
+        fs.rmSync(projectCatCafeDir, { recursive: true, force: true });
+      }
+      fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+      log(`.cat-cafe state migrated: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+    };
+
+    try {
+      let catCafeStat = null;
+      try {
+        catCafeStat = fs.lstatSync(projectCatCafeDir);
+      } catch {
+        // Path does not exist yet
+      }
+
+      if (!catCafeStat) {
+        createCatCafeLink();
+      } else if (catCafeStat.isSymbolicLink()) {
+        const target = fs.readlinkSync(projectCatCafeDir);
+        if (path.resolve(target) !== path.resolve(catCafeStateDir)) {
+          removeLink(projectCatCafeDir);
+          createCatCafeLink();
+        }
+      } else if (catCafeStat.isDirectory()) {
+        if (IS_WIN) {
+          try {
+            const target = fs.readlinkSync(projectCatCafeDir);
+            if (path.resolve(target) !== path.resolve(catCafeStateDir)) {
+              removeLink(projectCatCafeDir);
+              createCatCafeLink();
+            }
+          } catch {
+            if (!fs.existsSync(catCafeStateDir)) {
+              moveRealCatCafeDir();
+            } else {
+              log(`Warning: both ${projectCatCafeDir} and ${catCafeStateDir} exist; leaving .cat-cafe unmerged`);
+            }
+          }
+        } else if (!fs.existsSync(catCafeStateDir)) {
+          moveRealCatCafeDir();
+        } else {
+          log(`Warning: both ${projectCatCafeDir} and ${catCafeStateDir} exist; leaving .cat-cafe unmerged`);
+        }
+      } else {
+        log(`Warning: ${projectCatCafeDir} exists but is not a directory or link`);
+      }
+    } catch (err) {
+      log(`Warning: failed to prepare .cat-cafe DATA_DIR link: ${err.message}`);
+    }
+
+    // Mirror read-only install-dir resources into the project dir via symlinks.
+    // Without these, findMonorepoRoot(cwd) resolves to the project dir but
+    // docs/cat-cafe-skills/packages are not under it — so API routes like
+    // /api/docs, capabilities.ts skill listing, and MCP server spawning
+    // (resolve(projectRoot, 'packages/mcp-server/dist/memory.js')) all fail.
+    const mirrors = ['.claude', 'assets', 'cat-cafe-skills', 'docs', 'guides', 'packages', 'plugins', 'scripts'];
 
     for (const name of mirrors) {
       const src = path.join(this.root, name);
@@ -330,6 +401,43 @@ class ServiceManager {
       }
     }
 
+    // .cat-cafe writable state: unify under DATA_DIR/cat-cafe/ (#671).
+    // The API resolves .cat-cafe files via resolve(projectRoot, '.cat-cafe', f),
+    // so a symlink from project/.cat-cafe → data/cat-cafe keeps it transparent.
+    const catCafeStateDir = path.join(baseDir, 'data', 'cat-cafe');
+    const projectCatCafeDir = path.join(projectDir, '.cat-cafe');
+    try {
+      const catCafeStat = fs.lstatSync(projectCatCafeDir);
+      if (catCafeStat.isSymbolicLink()) {
+        // Already migrated — verify target points to the right place
+        const target = fs.readlinkSync(projectCatCafeDir);
+        if (path.resolve(target) !== path.resolve(catCafeStateDir)) {
+          removeLink(projectCatCafeDir);
+          fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+          log(`.cat-cafe symlink retargeted: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+        }
+      } else if (catCafeStat.isDirectory()) {
+        // Real directory with data — move to unified location, replace with
+        // symlink.  Remove the empty mkdir target first to allow rename.
+        try {
+          fs.rmdirSync(catCafeStateDir);
+        } catch {
+          /* non-empty or missing — rename will fail gracefully */
+        }
+        fs.renameSync(projectCatCafeDir, catCafeStateDir);
+        fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+        log(`.cat-cafe state migrated: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+      }
+    } catch {
+      // project/.cat-cafe doesn't exist yet — create symlink to data/cat-cafe
+      try {
+        fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
+        log(`.cat-cafe symlink created: ${projectCatCafeDir} -> ${catCafeStateDir}`);
+      } catch (linkErr) {
+        log(`Warning: .cat-cafe symlink failed: ${linkErr.message}`);
+      }
+    }
+
     // scripts/ has no node_modules. compile-system-prompt-l0.mjs uses ESM
     // `import { catRegistry } from '@cat-cafe/shared'` — Node ESM ignores
     // NODE_PATH and only walks the filesystem node_modules chain.
@@ -413,14 +521,9 @@ class ServiceManager {
     const salt = this._getOrCreateTelemetrySalt(userDataDir);
     return {
       TELEMETRY_HMAC_SALT: salt,
-      EVIDENCE_DB: path.join(userDataDir, 'evidence.sqlite'),
-      TRANSCRIPT_DATA_DIR: path.join(userDataDir, 'data', 'transcripts'),
+      DATA_DIR: path.join(userDataDir, 'data'),
+      CACHE_DIR: path.join(userDataDir, 'cache'),
       LOG_DIR: path.join(userDataDir, 'data', 'logs', 'api'),
-      UPLOAD_DIR: path.join(userDataDir, 'uploads'),
-      CONNECTOR_MEDIA_DIR: path.join(userDataDir, 'data', 'connector-media'),
-      TTS_CACHE_DIR: path.join(userDataDir, 'data', 'tts-cache'),
-      AUDIT_LOG_DIR: path.join(userDataDir, 'data', 'audit-logs'),
-      CLI_RAW_ARCHIVE_DIR: path.join(userDataDir, 'data', 'cli-raw-archive'),
     };
   }
 
@@ -614,7 +717,9 @@ class ServiceManager {
     log(`[${name}] spawn: ${cmd} ${args.join(' ')}`);
     log(`[${name}] cwd: ${opts.cwd || this.root}`);
     log(`[${name}] env: MEMORY_STORE=${env.MEMORY_STORE || 'unset'}, REDIS_URL=${env.REDIS_URL || 'unset'}`);
-    log(`[${name}] env: EVIDENCE_DB=${env.EVIDENCE_DB || 'unset'}, LOG_DIR=${env.LOG_DIR || 'unset'}`);
+    log(
+      `[${name}] env: DATA_DIR=${env.DATA_DIR || 'unset'}, CACHE_DIR=${env.CACHE_DIR || 'unset'}, LOG_DIR=${env.LOG_DIR || 'unset'}`,
+    );
 
     const proc = spawn(cmd, args, {
       cwd: opts.cwd || this.root,

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -193,7 +193,6 @@ class ServiceManager {
       // no per-path env overrides, so the API cwd must be a writable dir with
       // a pnpm-workspace.yaml marker.
       path.join(baseDir, 'data', 'redis'),
-      path.join(baseDir, 'data', 'cat-cafe'),
       path.join(baseDir, 'project'),
     ];
     for (const d of dirs) {

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -401,62 +401,6 @@ class ServiceManager {
       }
     }
 
-    // .cat-cafe writable state: unify under DATA_DIR/cat-cafe/ (#671).
-    // The API resolves .cat-cafe files via resolve(projectRoot, '.cat-cafe', f),
-    // so a symlink from project/.cat-cafe → data/cat-cafe keeps it transparent.
-    const catCafeStateDir = path.join(baseDir, 'data', 'cat-cafe');
-    const projectCatCafeDir = path.join(projectDir, '.cat-cafe');
-    try {
-      const catCafeStat = fs.lstatSync(projectCatCafeDir);
-      if (catCafeStat.isSymbolicLink()) {
-        // Already migrated — verify target points to the right place
-        const target = fs.readlinkSync(projectCatCafeDir);
-        if (path.resolve(target) !== path.resolve(catCafeStateDir)) {
-          removeLink(projectCatCafeDir);
-          fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
-          log(`.cat-cafe symlink retargeted: ${projectCatCafeDir} -> ${catCafeStateDir}`);
-        }
-      } else if (catCafeStat.isDirectory()) {
-        // On Windows, NTFS junctions can report as directories via
-        // lstatSync().isSymbolicLink() === false.  Probe with readlinkSync
-        // to detect hidden junctions before treating this as a real dir.
-        let isJunction = false;
-        if (IS_WIN) {
-          try {
-            const jTarget = fs.readlinkSync(projectCatCafeDir);
-            isJunction = true;
-            if (path.resolve(jTarget) !== path.resolve(catCafeStateDir)) {
-              removeLink(projectCatCafeDir);
-              fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
-              log(`.cat-cafe junction retargeted: ${projectCatCafeDir} -> ${catCafeStateDir}`);
-            }
-          } catch {
-            // readlinkSync failed (EINVAL) → genuine directory, not a junction
-          }
-        }
-        if (!isJunction) {
-          // Real directory with data — move to unified location, replace with
-          // symlink.  Remove the empty mkdir target first to allow rename.
-          try {
-            fs.rmdirSync(catCafeStateDir);
-          } catch {
-            /* non-empty or missing — rename will fail gracefully */
-          }
-          fs.renameSync(projectCatCafeDir, catCafeStateDir);
-          fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
-          log(`.cat-cafe state migrated: ${projectCatCafeDir} -> ${catCafeStateDir}`);
-        }
-      }
-    } catch {
-      // project/.cat-cafe doesn't exist yet — create symlink to data/cat-cafe
-      try {
-        fs.symlinkSync(catCafeStateDir, projectCatCafeDir, linkType);
-        log(`.cat-cafe symlink created: ${projectCatCafeDir} -> ${catCafeStateDir}`);
-      } catch (linkErr) {
-        log(`Warning: .cat-cafe symlink failed: ${linkErr.message}`);
-      }
-    }
-
     // scripts/ has no node_modules. compile-system-prompt-l0.mjs uses ESM
     // `import { catRegistry } from '@cat-cafe/shared'` — Node ESM ignores
     // NODE_PATH and only walks the filesystem node_modules chain.

--- a/desktop/service-manager.test.js
+++ b/desktop/service-manager.test.js
@@ -73,6 +73,9 @@ test('migrates legacy desktop override data into DATA_DIR and CACHE_DIR', async 
   const userDataRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-user-'));
   try {
     writeFileSync(path.join(userDataRoot, 'evidence.sqlite'), 'legacy-evidence', 'utf-8');
+    writeFileSync(path.join(userDataRoot, 'evidence.sqlite-wal'), 'legacy-wal', 'utf-8');
+    writeFileSync(path.join(userDataRoot, 'evidence.sqlite-shm'), 'legacy-shm', 'utf-8');
+    writeFileSync(path.join(userDataRoot, 'evidence.sqlite-journal'), 'legacy-journal', 'utf-8');
     mkdirSync(path.join(userDataRoot, 'uploads'), { recursive: true });
     writeFileSync(path.join(userDataRoot, 'uploads', 'image.png'), 'legacy-upload', 'utf-8');
     mkdirSync(path.join(userDataRoot, 'data', 'connector-media'), { recursive: true });
@@ -85,10 +88,16 @@ test('migrates legacy desktop override data into DATA_DIR and CACHE_DIR', async 
     manager._ensureUserDataDir(userDataRoot);
 
     assert.equal(existsSync(path.join(userDataRoot, 'data', 'evidence.sqlite')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'evidence.sqlite-wal')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'evidence.sqlite-shm')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'evidence.sqlite-journal')), true);
     assert.equal(existsSync(path.join(userDataRoot, 'data', 'uploads', 'image.png')), true);
     assert.equal(existsSync(path.join(userDataRoot, 'cache', 'connector-media', 'media.bin')), true);
     assert.equal(existsSync(path.join(userDataRoot, 'cache', 'tts', 'voice.wav')), true);
     assert.equal(existsSync(path.join(userDataRoot, 'evidence.sqlite')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'evidence.sqlite-wal')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'evidence.sqlite-shm')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'evidence.sqlite-journal')), false);
     assert.equal(existsSync(path.join(userDataRoot, 'uploads')), false);
     assert.equal(existsSync(path.join(userDataRoot, 'data', 'connector-media')), false);
     assert.equal(existsSync(path.join(userDataRoot, 'data', 'tts-cache')), false);

--- a/desktop/service-manager.test.js
+++ b/desktop/service-manager.test.js
@@ -68,6 +68,36 @@ test('migrates existing project .cat-cafe into DATA_DIR before linking it back',
   }
 });
 
+test('migrates legacy desktop override data into DATA_DIR and CACHE_DIR', async () => {
+  const installRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-install-'));
+  const userDataRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-user-'));
+  try {
+    writeFileSync(path.join(userDataRoot, 'evidence.sqlite'), 'legacy-evidence', 'utf-8');
+    mkdirSync(path.join(userDataRoot, 'uploads'), { recursive: true });
+    writeFileSync(path.join(userDataRoot, 'uploads', 'image.png'), 'legacy-upload', 'utf-8');
+    mkdirSync(path.join(userDataRoot, 'data', 'connector-media'), { recursive: true });
+    writeFileSync(path.join(userDataRoot, 'data', 'connector-media', 'media.bin'), 'legacy-media', 'utf-8');
+    mkdirSync(path.join(userDataRoot, 'data', 'tts-cache'), { recursive: true });
+    writeFileSync(path.join(userDataRoot, 'data', 'tts-cache', 'voice.wav'), 'legacy-tts', 'utf-8');
+
+    const manager = new ServiceManager(installRoot, { frontendPort: 3003, apiPort: 3004 });
+
+    manager._ensureUserDataDir(userDataRoot);
+
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'evidence.sqlite')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'uploads', 'image.png')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'cache', 'connector-media', 'media.bin')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'cache', 'tts', 'voice.wav')), true);
+    assert.equal(existsSync(path.join(userDataRoot, 'evidence.sqlite')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'uploads')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'connector-media')), false);
+    assert.equal(existsSync(path.join(userDataRoot, 'data', 'tts-cache')), false);
+  } finally {
+    rmSync(installRoot, { recursive: true, force: true });
+    rmSync(userDataRoot, { recursive: true, force: true });
+  }
+});
+
 test('probes bundled plugin mirror and rebuilds it when the first read fails', async () => {
   const installRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-install-'));
   const userDataRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-user-'));

--- a/desktop/service-manager.test.js
+++ b/desktop/service-manager.test.js
@@ -45,6 +45,29 @@ test('mirrors bundled plugins into the writable API project root', async () => {
   }
 });
 
+test('migrates existing project .cat-cafe into DATA_DIR before linking it back', async () => {
+  const installRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-install-'));
+  const userDataRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-user-'));
+  try {
+    const projectCatCafeDir = path.join(userDataRoot, 'project', '.cat-cafe');
+    const stateDir = path.join(userDataRoot, 'data', 'cat-cafe');
+    mkdirSync(projectCatCafeDir, { recursive: true });
+    writeFileSync(path.join(projectCatCafeDir, 'cat-catalog.json'), '{"cats":[]}\n', 'utf-8');
+
+    const manager = new ServiceManager(installRoot, { frontendPort: 3003, apiPort: 3004 });
+
+    manager._ensureUserDataDir(userDataRoot);
+
+    assert.equal(existsSync(path.join(stateDir, 'cat-catalog.json')), true);
+    assert.equal(existsSync(path.join(projectCatCafeDir, 'cat-catalog.json')), true);
+    assert.doesNotThrow(() => fs.readlinkSync(projectCatCafeDir));
+    assert.equal(fs.realpathSync(projectCatCafeDir), fs.realpathSync(stateDir));
+  } finally {
+    rmSync(installRoot, { recursive: true, force: true });
+    rmSync(userDataRoot, { recursive: true, force: true });
+  }
+});
+
 test('probes bundled plugin mirror and rebuilds it when the first read fails', async () => {
   const installRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-install-'));
   const userDataRoot = await mkdtemp(path.join(tmpdir(), 'service-manager-user-'));

--- a/docs/architecture/data-dirs.md
+++ b/docs/architecture/data-dirs.md
@@ -11,7 +11,7 @@ issue: 671
 
 ## 设计
 
-运行时有 11 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
+运行时有 12 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
 
 | 根 | 含义 | 子路径 | 内容 | 不能丢吗？ |
 |----|------|--------|------|------------|
@@ -23,6 +23,7 @@ issue: 671
 | | | `uploads/` | 用户上传文件（头像、附件、参考音频） | ✅ |
 | | | `redis/` | Redis 持久化数据（dump.rdb + AOF） | ✅ |
 | | | `redis-backups/` | Redis 定时备份快照 | ✅ |
+| | | `cat-cafe/` | .cat-cafe 运行时可写状态（账户、凭证、catalog、治理…） | ✅ |
 | `CACHE_DIR` | 可重建缓存 | `tts/` | TTS 音频缓存 | ❌ |
 | | | `connector-media/` | 微信/飞书等下载的临时媒体 | ❌ |
 | `LOG_DIR` | 日志 | — | Pino 滚动日志（直接使用 LOG_DIR，无子目录） | ❌ |
@@ -41,6 +42,7 @@ issue: 671
 - `uploads/` → `packages/api/uploads/`（模块相对，保证 connector outbound delivery 看到同一份）
 - `redis/` → `~/.cat-cafe/redis-{profile}/`（由 `start-dev.sh` 基于 REDIS_PROFILE/PORT 动态推导）
 - `redis-backups/` → `~/.cat-cafe/redis-backups/{profile}/`（同上）
+- `cat-cafe/` → `{projectRoot}/.cat-cafe/`（50+ 消费方通过此路径读写账户、凭证、catalog 等运行时状态）
 - `LOG_DIR` → `{cwd}/data/logs/api`
 
 ### 设置根
@@ -71,7 +73,10 @@ LOG_DIR=/var/log/clowder
 
 `LOG_DIR` 不参与 API 启动迁移：Pino 在 module load 时就绑定了 LOG_DIR，没有 logger restart 流程做不到安全切换。**设置 LOG_DIR 仅影响后续写入；legacy 日志保留在旧路径，需要时由运维手动搬迁。**
 
-`redis/` 和 `redis-backups/` 不参与 API 启动迁移（它们由 `start-dev.sh` / `user-redis.sh` 在 Redis 启动前于 shell 层迁移）。流程：当 `DATA_DIR` 已设且 legacy Redis 目录存在于旧路径时，shell 脚本在启动 `redis-server` 之前将整个目录 `mv` 到 `${DATA_DIR}/redis`。跨设备 fallback 使用 `cp -a` + `rm -rf`。
+`redis/`、`redis-backups/` 和 `cat-cafe/` 不参与 API 启动迁移（它们由 `start-dev.sh` 在服务启动前于 shell 层迁移）。
+
+- **Redis**：当 `DATA_DIR` 已设且 legacy Redis 目录存在于旧路径时，shell 脚本在启动 `redis-server` 之前将整个目录 `mv` 到 `${DATA_DIR}/redis`。跨设备 fallback 使用 `cp -a` + `rm -rf`。
+- **`.cat-cafe/` 状态**：当 `DATA_DIR` 已设时，shell 脚本将 `{projectRoot}/.cat-cafe/` 移动到 `${DATA_DIR}/cat-cafe/`，然后在原位创建指向新路径的 symlink（`ln -sfn`）。这样 50+ 消费方继续用 `resolve(projectRoot, '.cat-cafe', file)` 就透明地读写到新路径。跨设备同样 fallback 到 `cp -a` + `rm -rf`。
 
 ## 运行时迁移
 
@@ -107,7 +112,7 @@ curl -XPOST -H "X-Cat-Cafe-User: $OWNER_ID" \
 ## 相关代码
 
 - `packages/api/src/config/data-dirs.ts` — resolver + introspection
-- `packages/api/src/config/data-dirs-migration.ts` — migration engine（排除 logs/redis — 它们有各自的迁移层）
+- `packages/api/src/config/data-dirs-migration.ts` — migration engine（排除 logs/redis/catCafeState — 它们由 shell 层迁移）
 - `packages/api/src/index.ts` — 启动期接入
 - `packages/api/src/routes/config.ts` — GET / POST 端点
 - `scripts/start-dev.sh` — Redis DATA_DIR 集成 + shell 层迁移

--- a/docs/architecture/data-dirs.md
+++ b/docs/architecture/data-dirs.md
@@ -1,0 +1,108 @@
+---
+topics: [data-dirs, runtime, deployment]
+doc_kind: operations
+created: 2026-05-21
+issue: 671
+---
+
+# 数据目录三根模型 — DATA_DIR / CACHE_DIR / LOG_DIR
+
+> Issue: [#671 — 统一运行时数据路径](https://github.com/zts212653/clowder-ai/issues/671)
+
+## 设计
+
+运行时有 9 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
+
+| 根 | 含义 | 子路径 | 内容 | 不能丢吗？ |
+|----|------|--------|------|------------|
+| `DATA_DIR` | 持久数据 | `evidence.sqlite` | F102 记忆 SQLite | ✅ |
+| | | `world.sqlite` | F093 World Engine SQLite | ✅ |
+| | | `transcripts/` | F24 session transcript | ✅ |
+| | | `audit-logs/` | append-only 审计日志 | ✅ |
+| | | `cli-raw-archive/` | CLI 原始流量归档 | ✅ |
+| | | `uploads/` | 用户上传文件（头像、附件、参考音频） | ✅ |
+| `CACHE_DIR` | 可重建缓存 | `tts/` | TTS 音频缓存 | ❌ |
+| | | `connector-media/` | 微信/飞书等下载的临时媒体 | ❌ |
+| `LOG_DIR` | 日志 | — | Pino 滚动日志（直接使用 LOG_DIR，无子目录） | ❌ |
+
+每个根的语义清晰：备份只需要照顾 `DATA_DIR`；磁盘紧张时可以放心清 `CACHE_DIR`；日志按 `LOG_DIR` 接独立磁盘/集中化平台。
+
+## 行为
+
+### 未设置根
+
+各路径沿用 legacy 默认（保持向后兼容）：
+
+- `evidence.sqlite` / `world.sqlite` → `{repoRoot}/`
+- `transcripts/` → `{monorepoRoot}/data/transcripts`
+- `audit-logs/` / `cli-raw-archive/` / `tts/` / `connector-media/` → `{cwd}/data/{name}`
+- `uploads/` → `packages/api/uploads/`（模块相对，保证 connector outbound delivery 看到同一份）
+- `LOG_DIR` → `{cwd}/data/logs/api`
+
+### 设置根
+
+```bash
+DATA_DIR=/srv/clowder/data
+CACHE_DIR=/srv/clowder/cache
+LOG_DIR=/var/log/clowder
+```
+
+各路径变为 `{root}/{子路径}`（LOG_DIR 直接使用，不加子目录）。三个根独立，可以只设其中一个。
+
+## 启动期自动迁移
+
+服务启动时（Fastify 初始化后、SQLite/TranscriptWriter 等消费方初始化前）会：
+
+1. **侦测**：legacy 路径有数据 + 新根下对应位置为空 → 列为待迁移
+2. **空间预检**：在目标卷上调用 `statfs`，要求可用空间 ≥ 待迁移总量 × 1.5
+3. **迁移**：
+   - 同盘：`fs.rename`（原子）
+   - 跨盘：`fs.copyFile` → `sha256` 校验 → 删除源
+   - SQLite 主文件迁移时一并搬运 `-wal` / `-shm` / `-journal` sidecar
+4. **失败保护**：
+   - 空间不足 → 整体放弃迁移，输出 `abortedReason: insufficient-disk-space: need X bytes at Y, have Z`，所有 legacy 数据保持原位
+   - 单条迁移失败 → 该条 legacy 保持原位、log warning；其他可迁移条目继续
+
+启动迁移成功不需要重启（一切都在消费方初始化之前完成）。
+
+`LOG_DIR` 不参与迁移：Pino 在 module load 时就绑定了 LOG_DIR，没有 logger restart 流程做不到安全切换。**设置 LOG_DIR 仅影响后续写入；legacy 日志保留在旧路径，需要时由运维手动搬迁。**
+
+## 运行时迁移
+
+如果首次启动迁移因磁盘紧张失败，腾出空间后可以不重启就重试：
+
+```bash
+# 只读：看当前布局和待迁移工作
+curl -H "X-Cat-Cafe-User: $OWNER_ID" \
+  http://localhost:3004/api/config/data-dirs
+
+# 写：触发迁移（owner-only）
+curl -XPOST -H "X-Cat-Cafe-User: $OWNER_ID" \
+  http://localhost:3004/api/config/data-dirs/migrate
+```
+
+响应包含 `restartRecommended: true` 时务必重启服务 —— SQLite 等消费方在内存里持有的句柄仍然指向 legacy inode，需要重启才会重新打开到新路径。
+
+## 部署 checklist
+
+1. 确认目标卷有足够空间（建议 ≥ 当前 legacy 数据总量 × 2）
+2. `.env` 加 `DATA_DIR` / `CACHE_DIR` / `LOG_DIR`（按需选择，可只设其中一个）
+3. 重启服务 → 启动日志会输出 `[#671] Data-dirs migration completed`
+4. 日志的 `movedCount` / `skippedCount` / `failedCount` 是迁移结果摘要；`abortedReason` 出现说明空间检查没过
+5. 验证：`GET /api/config/data-dirs` 应该看到 `pendingMigration.hasWork: false`
+
+## 注意
+
+- **uploads 归 DATA_DIR**：虽然名义上像"缓存"，但里面是用户上传的真实文件，丢了就没了。issue 原稿曾把它放在 CACHE_DIR 下，最终决定归 DATA_DIR。
+- **目标已有数据**：如果新根下对应位置已经有非空数据（例如部分迁移过 / 手动复制过），该条会被 `skipReason: target-not-empty` 跳过，避免覆盖。需要重新迁移就先手动清空目标。
+- **环境变量优先级**：相对路径会用 `path.resolve()` 解析（相对 cwd），空字符串/纯空白视为未设置。
+- **测试隔离**：测试代码原本通过 `process.env.AUDIT_LOG_DIR=tempDir` 等 legacy var 隔离写入。Phase 2 后改为 `process.env.DATA_DIR=tempDir`，audit/upload/transcripts 自动落到 `tempDir/{audit-logs,uploads,transcripts}`。读取时拼上子路径。
+
+## 相关代码
+
+- `packages/api/src/config/data-dirs.ts` — resolver + introspection
+- `packages/api/src/config/data-dirs-migration.ts` — migration engine
+- `packages/api/src/index.ts` — 启动期接入
+- `packages/api/src/routes/config.ts` — GET / POST 端点
+- `packages/api/test/data-dirs.test.js` — resolver 单测（27）
+- `packages/api/test/data-dirs-migration.test.js` — migration 单测（14）

--- a/docs/architecture/data-dirs.md
+++ b/docs/architecture/data-dirs.md
@@ -11,7 +11,7 @@ issue: 671
 
 ## 设计
 
-运行时有 9 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
+运行时有 11 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
 
 | 根 | 含义 | 子路径 | 内容 | 不能丢吗？ |
 |----|------|--------|------|------------|
@@ -21,6 +21,8 @@ issue: 671
 | | | `audit-logs/` | append-only 审计日志 | ✅ |
 | | | `cli-raw-archive/` | CLI 原始流量归档 | ✅ |
 | | | `uploads/` | 用户上传文件（头像、附件、参考音频） | ✅ |
+| | | `redis/` | Redis 持久化数据（dump.rdb + AOF） | ✅ |
+| | | `redis-backups/` | Redis 定时备份快照 | ✅ |
 | `CACHE_DIR` | 可重建缓存 | `tts/` | TTS 音频缓存 | ❌ |
 | | | `connector-media/` | 微信/飞书等下载的临时媒体 | ❌ |
 | `LOG_DIR` | 日志 | — | Pino 滚动日志（直接使用 LOG_DIR，无子目录） | ❌ |
@@ -37,6 +39,8 @@ issue: 671
 - `transcripts/` → `{monorepoRoot}/data/transcripts`
 - `audit-logs/` / `cli-raw-archive/` / `tts/` / `connector-media/` → `{cwd}/data/{name}`
 - `uploads/` → `packages/api/uploads/`（模块相对，保证 connector outbound delivery 看到同一份）
+- `redis/` → `~/.cat-cafe/redis-{profile}/`（由 `start-dev.sh` 基于 REDIS_PROFILE/PORT 动态推导）
+- `redis-backups/` → `~/.cat-cafe/redis-backups/{profile}/`（同上）
 - `LOG_DIR` → `{cwd}/data/logs/api`
 
 ### 设置根
@@ -65,7 +69,9 @@ LOG_DIR=/var/log/clowder
 
 启动迁移成功不需要重启（一切都在消费方初始化之前完成）。
 
-`LOG_DIR` 不参与迁移：Pino 在 module load 时就绑定了 LOG_DIR，没有 logger restart 流程做不到安全切换。**设置 LOG_DIR 仅影响后续写入；legacy 日志保留在旧路径，需要时由运维手动搬迁。**
+`LOG_DIR` 不参与 API 启动迁移：Pino 在 module load 时就绑定了 LOG_DIR，没有 logger restart 流程做不到安全切换。**设置 LOG_DIR 仅影响后续写入；legacy 日志保留在旧路径，需要时由运维手动搬迁。**
+
+`redis/` 和 `redis-backups/` 不参与 API 启动迁移（它们由 `start-dev.sh` / `user-redis.sh` 在 Redis 启动前于 shell 层迁移）。流程：当 `DATA_DIR` 已设且 legacy Redis 目录存在于旧路径时，shell 脚本在启动 `redis-server` 之前将整个目录 `mv` 到 `${DATA_DIR}/redis`。跨设备 fallback 使用 `cp -a` + `rm -rf`。
 
 ## 运行时迁移
 
@@ -101,8 +107,10 @@ curl -XPOST -H "X-Cat-Cafe-User: $OWNER_ID" \
 ## 相关代码
 
 - `packages/api/src/config/data-dirs.ts` — resolver + introspection
-- `packages/api/src/config/data-dirs-migration.ts` — migration engine
+- `packages/api/src/config/data-dirs-migration.ts` — migration engine（排除 logs/redis — 它们有各自的迁移层）
 - `packages/api/src/index.ts` — 启动期接入
 - `packages/api/src/routes/config.ts` — GET / POST 端点
-- `packages/api/test/data-dirs.test.js` — resolver 单测（27）
-- `packages/api/test/data-dirs-migration.test.js` — migration 单测（14）
+- `scripts/start-dev.sh` — Redis DATA_DIR 集成 + shell 层迁移
+- `scripts/user-redis.sh` — 个人 Redis DATA_DIR 集成
+- `packages/api/test/data-dirs.test.js` — resolver 单测（34）
+- `packages/api/test/data-dirs-migration.test.js` — migration 单测（19）

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": {
+    "question": "deny"
+  },
+  "plugin": ["oh-my-opencode"],
+  "compaction": {
+    "auto": true
+  }
+}

--- a/packages/api/src/config/cat-voices.ts
+++ b/packages/api/src/config/cat-voices.ts
@@ -60,7 +60,7 @@ function hasParentTraversalSegment(value: string): boolean {
 
 export function resolveRefAudioPath(refAudio: string, characterBaseDir: string): string {
   if (refAudio.startsWith('/uploads/')) {
-    const uploadDir = resolve(getDefaultUploadDir(process.env.UPLOAD_DIR));
+    const uploadDir = resolve(getDefaultUploadDir());
     const uploadKey = refAudio.slice('/uploads/'.length);
     if (hasParentTraversalSegment(uploadKey)) return join(uploadDir, 'invalid-ref');
     const resolved = resolve(uploadDir, uploadKey);

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -412,24 +412,89 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
   };
 }
 
-/** Migrate a single path (file or directory) with SQLite sidecar handling. */
+/**
+ * Migrate a single path (file or directory) with SQLite sidecar handling.
+ *
+ * SQLite DBs are migrated as an atomic bundle: main file + all sidecars
+ * (-wal, -shm, -journal) move together.  If any sidecar move fails the
+ * main file is rolled back so the legacy DB stays intact (P1 review).
+ */
 async function migrateOne(spec: DataPathSpec, isFile: boolean): Promise<void> {
   const target = spec.rootBasedPath!;
   await mkdir(dirname(target), { recursive: true });
 
-  if (isFile) {
-    await moveFile(spec.legacyPath, target);
-    // Move SQLite sidecars alongside
-    for (const suffix of SQLITE_SIDECARS) {
-      const sidecarSrc = `${spec.legacyPath}${suffix}`;
-      if (existsSync(sidecarSrc)) {
-        await moveFile(sidecarSrc, `${target}${suffix}`);
-      }
-    }
+  if (!isFile) {
+    await moveTree(spec.legacyPath, target);
     return;
   }
 
-  await moveTree(spec.legacyPath, target);
+  // Collect main file + any existing sidecars as one migration bundle.
+  const bundle: Array<{ from: string; to: string }> = [{ from: spec.legacyPath, to: target }];
+  for (const suffix of SQLITE_SIDECARS) {
+    const sidecarSrc = `${spec.legacyPath}${suffix}`;
+    if (existsSync(sidecarSrc)) {
+      bundle.push({ from: sidecarSrc, to: `${target}${suffix}` });
+    }
+  }
+
+  // Try same-device rename for the whole bundle (atomic per-file, fast).
+  const renamed: Array<{ from: string; to: string }> = [];
+  let crossDevice = false;
+  for (const move of bundle) {
+    try {
+      await rename(move.from, move.to);
+      renamed.push(move);
+    } catch (err) {
+      if (isCrossDeviceError(err)) {
+        crossDevice = true;
+        break;
+      }
+      // Non-EXDEV error — roll back already-renamed, then rethrow
+      for (const done of renamed.reverse()) {
+        await rename(done.to, done.from).catch(() => {});
+      }
+      throw err;
+    }
+  }
+  if (!crossDevice) return; // all renamed successfully
+
+  // EXDEV: undo any partial renames, then fall back to staged copy-verify-delete
+  for (const done of renamed.reverse()) {
+    await rename(done.to, done.from).catch(() => {});
+  }
+
+  // Phase 1: copy all files to target (sources untouched)
+  const copied: string[] = [];
+  try {
+    for (const move of bundle) {
+      await copyFile(move.from, move.to);
+      copied.push(move.to);
+    }
+  } catch (err) {
+    // Clean up partial copies — sources stay intact
+    for (const dst of copied) {
+      await unlink(dst).catch(() => {});
+    }
+    throw err;
+  }
+
+  // Phase 2: verify all copies
+  for (const move of bundle) {
+    const srcHash = await hashFile(move.from);
+    const dstHash = await hashFile(move.to);
+    if (srcHash !== dstHash) {
+      // Clean up ALL target copies — sources stay intact
+      for (const m of bundle) {
+        await unlink(m.to).catch(() => {});
+      }
+      throw new Error(`Hash mismatch after copy: ${move.from} → ${move.to}`);
+    }
+  }
+
+  // Phase 3: all verified — delete sources
+  for (const move of bundle) {
+    await unlink(move.from);
+  }
 }
 
 async function moveFile(from: string, to: string): Promise<void> {
@@ -479,8 +544,16 @@ async function copyTree(from: string, to: string): Promise<void> {
       await copyTree(src, dst);
     } else if (entry.isFile()) {
       await copyFile(src, dst);
+    } else {
+      // Symlinks, sockets, FIFOs, etc. — abort to avoid silent data loss.
+      // Same-device rename handles these transparently; cross-device copy
+      // cannot safely reproduce them, so fail fast with a clear message.
+      const kind = entry.isSymbolicLink() ? 'symlink' : 'special-file';
+      throw new Error(
+        `Cannot migrate non-regular entry: ${src} (${kind}). ` +
+          'Move the directory manually or remove the entry before retrying.',
+      );
     }
-    // Symlinks/special files: best-effort skip
   }
 }
 

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -35,7 +35,7 @@ export interface MigrationPlanItem {
   readonly spec: DataPathSpec;
   /** Bytes that need to move (legacy path size, including SQLite sidecars). */
   readonly sourceBytes: number;
-  /** True if the source path exists at all. */
+  /** True if the source path exists and is not a placeholder-only upload dir. */
   readonly sourceExists: boolean;
   /** True if the target path is already populated (skip to avoid overwrite). */
   readonly targetPopulated: boolean;
@@ -169,6 +169,7 @@ export interface RunOptions extends PlanOptions {
 }
 
 const DEFAULT_SAFETY_MULTIPLIER = 1.5;
+const UPLOADS_PLACEHOLDER_FILES = new Set(['.gitkeep']);
 
 /** Recursively measure on-disk size of a file or directory. */
 export async function measurePath(path: string): Promise<number> {
@@ -247,7 +248,7 @@ export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPl
       continue;
     }
 
-    const sourceExists = existsSync(spec.legacyPath);
+    const sourceExists = await sourceExistsForMigration(spec);
     const targetPopulated = await isMigrationTargetPopulated(spec);
 
     if (!sourceExists) {
@@ -289,13 +290,24 @@ export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPl
   return { items, totalBytes, hasWork };
 }
 
-async function isPopulated(path: string): Promise<boolean> {
+async function sourceExistsForMigration(spec: DataPathSpec): Promise<boolean> {
+  if (!existsSync(spec.legacyPath)) return false;
+  if (spec.key !== 'uploads') return true;
+  return isPopulated(spec.legacyPath, { ignoreUploadsPlaceholder: true });
+}
+
+async function isPopulated(path: string, opts: { readonly ignoreUploadsPlaceholder?: boolean } = {}): Promise<boolean> {
   try {
     const st = await stat(path);
     if (st.isFile()) return st.size > 0;
     if (st.isDirectory()) {
-      const entries = await readdir(path);
-      return entries.length > 0;
+      const entries = await readdir(path, { withFileTypes: true });
+      return entries.some((entry) => {
+        if (opts.ignoreUploadsPlaceholder === true && entry.isFile() && UPLOADS_PLACEHOLDER_FILES.has(entry.name)) {
+          return false;
+        }
+        return true;
+      });
     }
     return false;
   } catch {

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -25,7 +25,7 @@ import { createHash } from 'node:crypto';
 import { existsSync, statSync } from 'node:fs';
 import { copyFile, mkdir, readdir, rename, rm, stat, unlink } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { describeDataPaths, type DataPathKey, type DataPathSpec } from './data-dirs.js';
+import { type DataPathKey, type DataPathSpec, describeDataPaths } from './data-dirs.js';
 
 /** SQLite sidecar suffixes that must move alongside the main DB file. */
 const SQLITE_SIDECARS = ['-wal', '-shm', '-journal'];
@@ -511,7 +511,9 @@ export const defaultDiskSpaceProbe: MigrationIO['diskFree'] = async (path: strin
   // statfs is available since Node 18.15 — fall back to a generous estimate if missing
   try {
     const fsPromises = await import('node:fs/promises');
-    const statfsFn = (fsPromises as unknown as { statfs?: (p: string) => Promise<{ bavail: bigint; blocks: bigint; bsize: number }> }).statfs;
+    const statfsFn = (
+      fsPromises as unknown as { statfs?: (p: string) => Promise<{ bavail: bigint; blocks: bigint; bsize: number }> }
+    ).statfs;
     if (typeof statfsFn === 'function') {
       const result = await statfsFn(cursor);
       const blockSize = result.bsize;

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -92,14 +92,15 @@ export interface AbortDecision {
  * Returns `{ shouldAbort: true, reason, leftBehind[] }` when:
  *   - The migration aborted at the planning stage (e.g. disk space)
  *   - Any eligible item failed to move
+ *   - A legacy source still exists but its root target is already populated
  *
  * Returns `{ shouldAbort: false }` when:
  *   - No migration was attempted (no root set, or no pending work)
  *   - All eligible items moved successfully
  *
- * Skipped items (target-not-empty, no-source-data) do NOT trigger abort:
- *   their legacyPath is irrelevant (no source) or the operator already moved
- *   data manually.
+ * Skipped items with no source data do NOT trigger abort. Skipped
+ * target-not-empty items do trigger abort because the resolver now points at
+ * the populated target while legacy data still exists at the old path.
  */
 export function shouldAbortStartupOnMigration(result: MigrationResult): AbortDecision {
   if (result.abortedReason) {
@@ -117,6 +118,14 @@ export function shouldAbortStartupOnMigration(result: MigrationResult): AbortDec
       shouldAbort: true,
       reason: `${failed.length} data-dirs path(s) failed to migrate; legacy data still on disk while resolver now points at the new root`,
       leftBehind: failed.map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  const blocked = result.items.filter((i) => i.status === 'skipped' && i.reason === 'target-not-empty');
+  if (blocked.length > 0) {
+    return {
+      shouldAbort: true,
+      reason: `${blocked.length} data-dirs path(s) blocked by target-not-empty; legacy data still on disk while resolver now points at the new root`,
+      leftBehind: blocked.map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
     };
   }
   return { shouldAbort: false, leftBehind: [] };
@@ -302,6 +311,19 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
   const plan = await buildMigrationPlan(opts);
 
   if (!plan.hasWork) {
+    const blocked = plan.items.filter((i) => i.skipReason === 'target-not-empty');
+    if (blocked.length > 0) {
+      log?.warn(
+        { trigger: opts.trigger, blocked: blocked.map((i) => ({ key: i.spec.key, from: i.spec.legacyPath })) },
+        '[#671] Data-dirs migration blocked by populated target',
+      );
+      return {
+        attempted: false,
+        items: blocked.map(planItemToSkippedResult),
+        allSucceeded: false,
+        restartRecommended: false,
+      };
+    }
     log?.info({ trigger: opts.trigger }, '[#671] No data-dirs migration pending');
     return {
       attempted: false,
@@ -350,14 +372,7 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
   const results: MigrationItemResult[] = [];
   for (const item of plan.items) {
     if (!item.eligible) {
-      results.push({
-        key: item.spec.key,
-        fromPath: item.spec.legacyPath,
-        toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
-        bytes: 0,
-        status: 'skipped',
-        reason: item.skipReason,
-      });
+      results.push(planItemToSkippedResult(item));
       continue;
     }
     try {
@@ -402,6 +417,7 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
   }
 
   const movedAny = results.some((r) => r.status === 'moved');
+  const blocked = results.some((r) => r.status === 'skipped' && r.reason === 'target-not-empty');
   const allEligibleSucceeded = eligible.every((item) =>
     results.find((r) => r.key === item.spec.key && r.status === 'moved'),
   );
@@ -409,8 +425,19 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
   return {
     attempted: true,
     items: results,
-    allSucceeded: allEligibleSucceeded,
+    allSucceeded: allEligibleSucceeded && !blocked,
     restartRecommended: opts.trigger === 'runtime' && movedAny,
+  };
+}
+
+function planItemToSkippedResult(item: MigrationPlanItem): MigrationItemResult {
+  return {
+    key: item.spec.key,
+    fromPath: item.spec.legacyPath,
+    toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
+    bytes: 0,
+    status: 'skipped',
+    reason: item.skipReason,
   };
 }
 

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -189,12 +189,17 @@ export async function measurePath(path: string): Promise<number> {
  * Build a migration plan describing what would move and why.
  * Pure — does not touch the filesystem beyond stat/readdir calls.
  *
- * `logs` is intentionally excluded — Pino captures LOG_DIR at module load,
- * so moving logs without a logger restart is unsafe. Setting LOG_DIR only
- * redirects future writes; legacy logs remain at the old path.
+ * Excluded paths:
+ * - `logs`: Pino captures LOG_DIR at module load; moving logs without a
+ *   logger restart is unsafe. Setting LOG_DIR only redirects future writes.
+ * - `redisData` / `redisBackups`: Redis is started by the shell script
+ *   *before* the API server.  The shell layer handles the `--dir` flag
+ *   and pre-start data migration.  Moving Redis data while the server is
+ *   running would corrupt it.
  */
 export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPlan> {
-  const specs = describeDataPaths(opts).filter((s) => s.key !== 'logs');
+  const SHELL_MANAGED: ReadonlySet<string> = new Set(['logs', 'redisData', 'redisBackups']);
+  const specs = describeDataPaths(opts).filter((s) => !SHELL_MANAGED.has(s.key));
   const items: MigrationPlanItem[] = [];
   let totalBytes = 0;
 

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -150,6 +150,8 @@ export interface RunOptions extends PlanOptions {
   readonly io: MigrationIO;
   /** Skip the disk-space pre-flight (useful for tests). */
   readonly skipSpaceCheck?: boolean;
+  /** Test-only: force the cross-device copy fallback path. */
+  readonly forceCrossDeviceForTesting?: boolean;
   /** Multiplier applied to required bytes when checking disk free space. */
   readonly spaceSafetyMultiplier?: number;
 }
@@ -359,7 +361,7 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
       continue;
     }
     try {
-      await migrateOne(item.spec, item.spec.isFile);
+      await migrateOne(item.spec, item.spec.isFile, opts.forceCrossDeviceForTesting === true);
       log?.info(
         {
           key: item.spec.key,
@@ -419,12 +421,12 @@ export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationR
  * (-wal, -shm, -journal) move together.  If any sidecar move fails the
  * main file is rolled back so the legacy DB stays intact (P1 review).
  */
-async function migrateOne(spec: DataPathSpec, isFile: boolean): Promise<void> {
+async function migrateOne(spec: DataPathSpec, isFile: boolean, forceCrossDevice = false): Promise<void> {
   const target = spec.rootBasedPath!;
   await mkdir(dirname(target), { recursive: true });
 
   if (!isFile) {
-    await moveTree(spec.legacyPath, target);
+    await moveTree(spec.legacyPath, target, forceCrossDevice);
     return;
   }
 
@@ -515,21 +517,27 @@ async function moveFile(from: string, to: string): Promise<void> {
   await unlink(from);
 }
 
-async function moveTree(from: string, to: string): Promise<void> {
-  try {
-    await rename(from, to);
-    return;
-  } catch (err) {
-    if (!isCrossDeviceError(err)) throw err;
+async function moveTree(from: string, to: string, forceCrossDevice = false): Promise<void> {
+  if (!forceCrossDevice) {
+    try {
+      await rename(from, to);
+      return;
+    } catch (err) {
+      if (!isCrossDeviceError(err)) throw err;
+    }
   }
   // Cross-device fallback: recursive copy → spot-check sizes → recursive delete
-  await copyTree(from, to);
-  // Best-effort verification: compare total sizes (deep hash would be expensive)
-  const srcSize = await measurePath(from);
-  const dstSize = await measurePath(to);
-  if (srcSize !== dstSize) {
+  try {
+    await copyTree(from, to);
+    // Best-effort verification: compare total sizes (deep hash would be expensive)
+    const srcSize = await measurePath(from);
+    const dstSize = await measurePath(to);
+    if (srcSize !== dstSize) {
+      throw new Error(`Size mismatch after tree copy: ${from} (${srcSize}) → ${to} (${dstSize})`);
+    }
+  } catch (err) {
     await rm(to, { recursive: true, force: true }).catch(() => {});
-    throw new Error(`Size mismatch after tree copy: ${from} (${srcSize}) → ${to} (${dstSize})`);
+    throw err;
   }
   await rm(from, { recursive: true, force: true });
 }

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -1,0 +1,480 @@
+/**
+ * Data directory migration engine — issue #671.
+ *
+ * When the user sets DATA_DIR / CACHE_DIR / LOG_DIR in their .env and
+ * restarts the service, any existing data at the legacy paths must be
+ * relocated to the new root before any consumer (SQLite, logger, etc.)
+ * opens connections to the new path.
+ *
+ * Protocol (铲屎官 spec):
+ *   1. Probe available space on the target volume
+ *   2. Migrate (rename when on the same filesystem; otherwise copy + verify + delete)
+ *   3. Failure → log a warning, leave the legacy path untouched
+ *   4. Success → cleanup of the legacy file/dir is built into the move
+ *      (rename removes the source; cross-volume copy explicitly deletes
+ *      after verification). The next read/write goes to the new path
+ *      naturally because the resolver only returns the new path when
+ *      the root env var is set.
+ *   5. Restart-required: this engine runs *before* DB connections open,
+ *      so startup migration never needs a restart. Runtime migration
+ *      (post-startup, via Settings UI) sets `restartRecommended: true`
+ *      in the result so the caller can surface a notice.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { copyFile, mkdir, readdir, rename, rm, stat, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { describeDataPaths, type DataPathKey, type DataPathSpec } from './data-dirs.js';
+
+/** SQLite sidecar suffixes that must move alongside the main DB file. */
+const SQLITE_SIDECARS = ['-wal', '-shm', '-journal'];
+
+export interface MigrationPlanItem {
+  readonly spec: DataPathSpec;
+  /** Bytes that need to move (legacy path size, including SQLite sidecars). */
+  readonly sourceBytes: number;
+  /** True if the source path exists at all. */
+  readonly sourceExists: boolean;
+  /** True if the target path is already populated (skip to avoid overwrite). */
+  readonly targetPopulated: boolean;
+  /** True if this item is eligible for migration. */
+  readonly eligible: boolean;
+  /** Reason if not eligible. */
+  readonly skipReason?: string;
+}
+
+export interface MigrationPlan {
+  /** All paths in scope — even the ones we won't move. */
+  readonly items: readonly MigrationPlanItem[];
+  /** Total bytes that will move across all eligible items. */
+  readonly totalBytes: number;
+  /** True if any item is eligible for migration. */
+  readonly hasWork: boolean;
+}
+
+export interface MigrationItemResult {
+  readonly key: DataPathKey;
+  readonly fromPath: string;
+  readonly toPath: string;
+  readonly bytes: number;
+  readonly status: 'moved' | 'skipped' | 'failed';
+  readonly reason?: string;
+  readonly error?: string;
+}
+
+export interface MigrationResult {
+  readonly attempted: boolean;
+  readonly items: readonly MigrationItemResult[];
+  /** True if every eligible item moved successfully. */
+  readonly allSucceeded: boolean;
+  /** True if the caller should surface a restart notice (runtime migration only). */
+  readonly restartRecommended: boolean;
+  /** Top-level abort reason, e.g. insufficient disk space. */
+  readonly abortedReason?: string;
+}
+
+export interface DiskSpaceProbe {
+  readonly availableBytes: number;
+  readonly totalBytes: number;
+}
+
+/** Pluggable I/O hooks for testing without touching real FS. */
+export interface MigrationIO {
+  diskFree(path: string): Promise<DiskSpaceProbe>;
+  logger?: {
+    info: (data: object, msg?: string) => void;
+    warn: (data: object, msg?: string) => void;
+    error: (data: object, msg?: string) => void;
+  };
+}
+
+export interface PlanOptions {
+  readonly repoRoot: string;
+  readonly monorepoRoot: string;
+}
+
+export interface RunOptions extends PlanOptions {
+  /** Trigger context — affects restart recommendation in the result. */
+  readonly trigger: 'startup' | 'runtime';
+  readonly io: MigrationIO;
+  /** Skip the disk-space pre-flight (useful for tests). */
+  readonly skipSpaceCheck?: boolean;
+  /** Multiplier applied to required bytes when checking disk free space. */
+  readonly spaceSafetyMultiplier?: number;
+}
+
+const DEFAULT_SAFETY_MULTIPLIER = 1.5;
+
+/** Recursively measure on-disk size of a file or directory. */
+export async function measurePath(path: string): Promise<number> {
+  if (!existsSync(path)) return 0;
+  const st = await stat(path);
+  if (st.isFile()) {
+    let total = st.size;
+    // Include SQLite sidecars if the main file looks like a DB
+    if (path.endsWith('.sqlite')) {
+      for (const suffix of SQLITE_SIDECARS) {
+        const sidecar = `${path}${suffix}`;
+        if (existsSync(sidecar)) {
+          const ss = await stat(sidecar);
+          total += ss.size;
+        }
+      }
+    }
+    return total;
+  }
+  if (st.isDirectory()) {
+    let total = 0;
+    const entries = await readdir(path, { withFileTypes: true });
+    for (const entry of entries) {
+      total += await measurePath(join(path, entry.name));
+    }
+    return total;
+  }
+  return 0;
+}
+
+/**
+ * Build a migration plan describing what would move and why.
+ * Pure — does not touch the filesystem beyond stat/readdir calls.
+ *
+ * `logs` is intentionally excluded — Pino captures LOG_DIR at module load,
+ * so moving logs without a logger restart is unsafe. Setting LOG_DIR only
+ * redirects future writes; legacy logs remain at the old path.
+ */
+export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPlan> {
+  const specs = describeDataPaths(opts).filter((s) => s.key !== 'logs');
+  const items: MigrationPlanItem[] = [];
+  let totalBytes = 0;
+
+  for (const spec of specs) {
+    // Only consider entries where a root is configured and legacy != root path.
+    if (spec.rootBasedPath === null) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated: false,
+        eligible: false,
+        skipReason: 'root-env-not-set',
+      });
+      continue;
+    }
+
+    if (spec.legacyPath === spec.rootBasedPath) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated: false,
+        eligible: false,
+        skipReason: 'legacy-equals-target',
+      });
+      continue;
+    }
+
+    const sourceExists = existsSync(spec.legacyPath);
+    const targetPopulated = existsSync(spec.rootBasedPath) && (await isPopulated(spec.rootBasedPath));
+
+    if (!sourceExists) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated,
+        eligible: false,
+        skipReason: 'no-source-data',
+      });
+      continue;
+    }
+
+    if (targetPopulated) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: true,
+        targetPopulated: true,
+        eligible: false,
+        skipReason: 'target-not-empty',
+      });
+      continue;
+    }
+
+    const sourceBytes = await measurePath(spec.legacyPath);
+    items.push({
+      spec,
+      sourceBytes,
+      sourceExists: true,
+      targetPopulated: false,
+      eligible: true,
+    });
+    totalBytes += sourceBytes;
+  }
+
+  const hasWork = items.some((i) => i.eligible);
+  return { items, totalBytes, hasWork };
+}
+
+async function isPopulated(path: string): Promise<boolean> {
+  try {
+    const st = await stat(path);
+    if (st.isFile()) return st.size > 0;
+    if (st.isDirectory()) {
+      const entries = await readdir(path);
+      return entries.length > 0;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Execute the migration plan with the configured safety guards.
+ * On insufficient disk space, returns `attempted: false` and a reason — no
+ * partial moves happen. On per-item failure, the item is left at the legacy
+ * path and other items continue to migrate independently.
+ */
+export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationResult> {
+  const log = opts.io.logger;
+  const plan = await buildMigrationPlan(opts);
+
+  if (!plan.hasWork) {
+    log?.info({ trigger: opts.trigger }, '[#671] No data-dirs migration pending');
+    return {
+      attempted: false,
+      items: [],
+      allSucceeded: true,
+      restartRecommended: false,
+    };
+  }
+
+  // Group eligible items by their target root mountpoint for space check.
+  const eligible = plan.items.filter((i) => i.eligible);
+
+  if (!opts.skipSpaceCheck) {
+    const safetyMul = opts.spaceSafetyMultiplier ?? DEFAULT_SAFETY_MULTIPLIER;
+    const byTarget = new Map<string, number>();
+    for (const item of eligible) {
+      const targetRoot = item.spec.rootBasedPath!;
+      const bucket = targetMountKey(targetRoot);
+      byTarget.set(bucket, (byTarget.get(bucket) ?? 0) + item.sourceBytes);
+    }
+
+    for (const [bucketPath, requiredBytes] of byTarget) {
+      const probe = await opts.io.diskFree(bucketPath);
+      const need = Math.ceil(requiredBytes * safetyMul);
+      if (probe.availableBytes < need) {
+        log?.warn(
+          {
+            bucket: bucketPath,
+            requiredBytes: need,
+            availableBytes: probe.availableBytes,
+            trigger: opts.trigger,
+          },
+          '[#671] Insufficient disk space for data-dirs migration — aborting',
+        );
+        return {
+          attempted: false,
+          items: [],
+          allSucceeded: false,
+          restartRecommended: false,
+          abortedReason: `insufficient-disk-space: need ${need} bytes at ${bucketPath}, have ${probe.availableBytes}`,
+        };
+      }
+    }
+  }
+
+  const results: MigrationItemResult[] = [];
+  for (const item of plan.items) {
+    if (!item.eligible) {
+      results.push({
+        key: item.spec.key,
+        fromPath: item.spec.legacyPath,
+        toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
+        bytes: 0,
+        status: 'skipped',
+        reason: item.skipReason,
+      });
+      continue;
+    }
+    try {
+      await migrateOne(item.spec, item.spec.isFile);
+      log?.info(
+        {
+          key: item.spec.key,
+          from: item.spec.legacyPath,
+          to: item.spec.rootBasedPath,
+          bytes: item.sourceBytes,
+        },
+        '[#671] Migrated data-dirs entry',
+      );
+      results.push({
+        key: item.spec.key,
+        fromPath: item.spec.legacyPath,
+        toPath: item.spec.rootBasedPath!,
+        bytes: item.sourceBytes,
+        status: 'moved',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log?.warn(
+        {
+          key: item.spec.key,
+          from: item.spec.legacyPath,
+          to: item.spec.rootBasedPath,
+          error: message,
+          trigger: opts.trigger,
+        },
+        '[#671] Migration failed for data-dirs entry — legacy path left intact',
+      );
+      results.push({
+        key: item.spec.key,
+        fromPath: item.spec.legacyPath,
+        toPath: item.spec.rootBasedPath!,
+        bytes: item.sourceBytes,
+        status: 'failed',
+        error: message,
+      });
+    }
+  }
+
+  const movedAny = results.some((r) => r.status === 'moved');
+  const allEligibleSucceeded = eligible.every((item) =>
+    results.find((r) => r.key === item.spec.key && r.status === 'moved'),
+  );
+
+  return {
+    attempted: true,
+    items: results,
+    allSucceeded: allEligibleSucceeded,
+    restartRecommended: opts.trigger === 'runtime' && movedAny,
+  };
+}
+
+/** Migrate a single path (file or directory) with SQLite sidecar handling. */
+async function migrateOne(spec: DataPathSpec, isFile: boolean): Promise<void> {
+  const target = spec.rootBasedPath!;
+  await mkdir(dirname(target), { recursive: true });
+
+  if (isFile) {
+    await moveFile(spec.legacyPath, target);
+    // Move SQLite sidecars alongside
+    for (const suffix of SQLITE_SIDECARS) {
+      const sidecarSrc = `${spec.legacyPath}${suffix}`;
+      if (existsSync(sidecarSrc)) {
+        await moveFile(sidecarSrc, `${target}${suffix}`);
+      }
+    }
+    return;
+  }
+
+  await moveTree(spec.legacyPath, target);
+}
+
+async function moveFile(from: string, to: string): Promise<void> {
+  try {
+    await rename(from, to);
+    return;
+  } catch (err) {
+    if (!isCrossDeviceError(err)) throw err;
+  }
+  // Cross-device fallback: copy → verify hash → delete source
+  await copyFile(from, to);
+  const srcHash = await hashFile(from);
+  const dstHash = await hashFile(to);
+  if (srcHash !== dstHash) {
+    await unlink(to).catch(() => {});
+    throw new Error(`Hash mismatch after copy: ${from} → ${to}`);
+  }
+  await unlink(from);
+}
+
+async function moveTree(from: string, to: string): Promise<void> {
+  try {
+    await rename(from, to);
+    return;
+  } catch (err) {
+    if (!isCrossDeviceError(err)) throw err;
+  }
+  // Cross-device fallback: recursive copy → spot-check sizes → recursive delete
+  await copyTree(from, to);
+  // Best-effort verification: compare total sizes (deep hash would be expensive)
+  const srcSize = await measurePath(from);
+  const dstSize = await measurePath(to);
+  if (srcSize !== dstSize) {
+    await rm(to, { recursive: true, force: true }).catch(() => {});
+    throw new Error(`Size mismatch after tree copy: ${from} (${srcSize}) → ${to} (${dstSize})`);
+  }
+  await rm(from, { recursive: true, force: true });
+}
+
+async function copyTree(from: string, to: string): Promise<void> {
+  await mkdir(to, { recursive: true });
+  const entries = await readdir(from, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = join(from, entry.name);
+    const dst = join(to, entry.name);
+    if (entry.isDirectory()) {
+      await copyTree(src, dst);
+    } else if (entry.isFile()) {
+      await copyFile(src, dst);
+    }
+    // Symlinks/special files: best-effort skip
+  }
+}
+
+async function hashFile(path: string): Promise<string> {
+  const { createReadStream } = await import('node:fs');
+  return new Promise((resolveHash, rejectHash) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(path);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolveHash(hash.digest('hex')));
+    stream.on('error', rejectHash);
+  });
+}
+
+function isCrossDeviceError(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'EXDEV';
+}
+
+/** Choose a stable bucket key for grouping items by target volume. */
+function targetMountKey(targetPath: string): string {
+  // Walk up to find an existing ancestor — that's where free space lives.
+  let cursor = targetPath;
+  while (cursor !== dirname(cursor)) {
+    if (existsSync(cursor)) return cursor;
+    cursor = dirname(cursor);
+  }
+  return cursor;
+}
+
+/** Default disk-free probe using statfs (Node 18.15+). */
+export const defaultDiskSpaceProbe: MigrationIO['diskFree'] = async (path: string) => {
+  // Find a path that exists to call statfs on (statfs fails on missing path)
+  let cursor = path;
+  while (!existsSync(cursor) && cursor !== dirname(cursor)) {
+    cursor = dirname(cursor);
+  }
+  // statfs is available since Node 18.15 — fall back to a generous estimate if missing
+  try {
+    const fsPromises = await import('node:fs/promises');
+    const statfsFn = (fsPromises as unknown as { statfs?: (p: string) => Promise<{ bavail: bigint; blocks: bigint; bsize: number }> }).statfs;
+    if (typeof statfsFn === 'function') {
+      const result = await statfsFn(cursor);
+      const blockSize = result.bsize;
+      return {
+        availableBytes: Number(result.bavail) * blockSize,
+        totalBytes: Number(result.blocks) * blockSize,
+      };
+    }
+  } catch {
+    /* fall through to synchronous statSync — yields no space info */
+  }
+
+  // Last-ditch fallback: pretend we have plenty of space (don't block migration on probe failure)
+  void statSync(cursor); // throw if the path is invalid
+  return { availableBytes: Number.MAX_SAFE_INTEGER, totalBytes: Number.MAX_SAFE_INTEGER };
+};

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -192,13 +192,17 @@ export async function measurePath(path: string): Promise<number> {
  * Excluded paths:
  * - `logs`: Pino captures LOG_DIR at module load; moving logs without a
  *   logger restart is unsafe. Setting LOG_DIR only redirects future writes.
+ * - `catCafeState`: the `.cat-cafe/` directory contains both writable
+ *   state and bundled tools; the shell startup moves the whole dir to
+ *   `DATA_DIR/cat-cafe/` and plants a symlink at the original path so
+ *   all 50+ in-process consumers remain transparent.
  * - `redisData` / `redisBackups`: Redis is started by the shell script
  *   *before* the API server.  The shell layer handles the `--dir` flag
  *   and pre-start data migration.  Moving Redis data while the server is
  *   running would corrupt it.
  */
 export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPlan> {
-  const SHELL_MANAGED: ReadonlySet<string> = new Set(['logs', 'redisData', 'redisBackups']);
+  const SHELL_MANAGED: ReadonlySet<string> = new Set(['logs', 'catCafeState', 'redisData', 'redisBackups']);
   const specs = describeDataPaths(opts).filter((s) => !SHELL_MANAGED.has(s.key));
   const items: MigrationPlanItem[] = [];
   let totalBytes = 0;

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -74,6 +74,54 @@ export interface MigrationResult {
   readonly abortedReason?: string;
 }
 
+export interface AbortDecision {
+  readonly shouldAbort: boolean;
+  readonly reason?: string;
+  /** Per-path details for the error message (key + which side has data). */
+  readonly leftBehind: readonly { readonly key: DataPathKey; readonly fromPath: string; readonly status: string }[];
+}
+
+/**
+ * Decide whether startup must fail-fast.
+ *
+ * The hazard: when a root env var is set, the resolver returns the new path
+ * unconditionally. If the migration aborted (insufficient space) or any item
+ * failed, the legacy data is still at the old path, but consumers will read
+ * the new (empty) path — that looks like silent data loss.
+ *
+ * Returns `{ shouldAbort: true, reason, leftBehind[] }` when:
+ *   - The migration aborted at the planning stage (e.g. disk space)
+ *   - Any eligible item failed to move
+ *
+ * Returns `{ shouldAbort: false }` when:
+ *   - No migration was attempted (no root set, or no pending work)
+ *   - All eligible items moved successfully
+ *
+ * Skipped items (target-not-empty, no-source-data) do NOT trigger abort:
+ *   their legacyPath is irrelevant (no source) or the operator already moved
+ *   data manually.
+ */
+export function shouldAbortStartupOnMigration(result: MigrationResult): AbortDecision {
+  if (result.abortedReason) {
+    return {
+      shouldAbort: true,
+      reason: result.abortedReason,
+      leftBehind: result.items
+        .filter((i) => i.status !== 'moved')
+        .map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  const failed = result.items.filter((i) => i.status === 'failed');
+  if (failed.length > 0) {
+    return {
+      shouldAbort: true,
+      reason: `${failed.length} data-dirs path(s) failed to migrate; legacy data still on disk while resolver now points at the new root`,
+      leftBehind: failed.map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  return { shouldAbort: false, leftBehind: [] };
+}
+
 export interface DiskSpaceProbe {
   readonly availableBytes: number;
   readonly totalBytes: number;
@@ -92,6 +140,8 @@ export interface MigrationIO {
 export interface PlanOptions {
   readonly repoRoot: string;
   readonly monorepoRoot: string;
+  /** See DescribeOptions.uploadsLegacyOverride — test-only injection. */
+  readonly uploadsLegacyOverride?: string;
 }
 
 export interface RunOptions extends PlanOptions {

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -16,9 +16,10 @@
  *      naturally because the resolver only returns the new path when
  *      the root env var is set.
  *   5. Restart-required: this engine runs *before* DB connections open,
- *      so startup migration never needs a restart. Runtime migration
- *      (post-startup, via Settings UI) sets `restartRecommended: true`
- *      in the result so the caller can surface a notice.
+ *      so startup migration never needs a restart. Runtime callers can set
+ *      `blockFileMoves` to require a restart before moving file-backed stores;
+ *      when a runtime-safe migration moves data, the result sets
+ *      `restartRecommended`.
  */
 
 import { createHash } from 'node:crypto';
@@ -157,6 +158,8 @@ export interface RunOptions extends PlanOptions {
   /** Trigger context — affects restart recommendation in the result. */
   readonly trigger: 'startup' | 'runtime';
   readonly io: MigrationIO;
+  /** Refuse to move SQLite/file-backed stores after startup. */
+  readonly blockFileMoves?: boolean;
   /** Skip the disk-space pre-flight (useful for tests). */
   readonly skipSpaceCheck?: boolean;
   /** Test-only: force the cross-device copy fallback path. */
@@ -245,7 +248,7 @@ export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPl
     }
 
     const sourceExists = existsSync(spec.legacyPath);
-    const targetPopulated = existsSync(spec.rootBasedPath) && (await isPopulated(spec.rootBasedPath));
+    const targetPopulated = await isMigrationTargetPopulated(spec);
 
     if (!sourceExists) {
       items.push({
@@ -300,6 +303,19 @@ async function isPopulated(path: string): Promise<boolean> {
   }
 }
 
+async function isMigrationTargetPopulated(spec: DataPathSpec): Promise<boolean> {
+  const target = spec.rootBasedPath;
+  if (target === null) return false;
+  if (existsSync(target) && (await isPopulated(target))) return true;
+  if (!spec.isFile || !target.endsWith('.sqlite')) return false;
+
+  for (const suffix of SQLITE_SIDECARS) {
+    const sidecarTarget = `${target}${suffix}`;
+    if (existsSync(sidecarTarget) && (await isPopulated(sidecarTarget))) return true;
+  }
+  return false;
+}
+
 /**
  * Execute the migration plan with the configured safety guards.
  * On insufficient disk space, returns `attempted: false` and a reason — no
@@ -309,6 +325,23 @@ async function isPopulated(path: string): Promise<boolean> {
 export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationResult> {
   const log = opts.io.logger;
   const plan = await buildMigrationPlan(opts);
+  const blockedFileMoves = opts.blockFileMoves ? plan.items.filter(isFileStoreMigrationCandidate) : [];
+  if (blockedFileMoves.length > 0) {
+    log?.warn(
+      {
+        trigger: opts.trigger,
+        blocked: blockedFileMoves.map((i) => ({ key: i.spec.key, from: i.spec.legacyPath, to: i.spec.rootBasedPath })),
+      },
+      '[#671] Data-dirs migration blocked until restart because file-backed stores may be open',
+    );
+    return {
+      attempted: false,
+      items: blockedFileMoves.map(planItemToRuntimeFileBlockedResult),
+      allSucceeded: false,
+      restartRecommended: true,
+      abortedReason: 'runtime-file-migration-requires-restart: restart before moving file-backed stores',
+    };
+  }
 
   if (!plan.hasWork) {
     const blocked = plan.items.filter((i) => i.skipReason === 'target-not-empty');
@@ -438,6 +471,26 @@ function planItemToSkippedResult(item: MigrationPlanItem): MigrationItemResult {
     bytes: 0,
     status: 'skipped',
     reason: item.skipReason,
+  };
+}
+
+function isFileStoreMigrationCandidate(item: MigrationPlanItem): boolean {
+  return (
+    item.spec.isFile &&
+    item.sourceExists &&
+    item.spec.rootBasedPath !== null &&
+    item.spec.legacyPath !== item.spec.rootBasedPath
+  );
+}
+
+function planItemToRuntimeFileBlockedResult(item: MigrationPlanItem): MigrationItemResult {
+  return {
+    key: item.spec.key,
+    fromPath: item.spec.legacyPath,
+    toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
+    bytes: 0,
+    status: 'skipped',
+    reason: 'runtime-file-migration-requires-restart',
   };
 }
 

--- a/packages/api/src/config/data-dirs.ts
+++ b/packages/api/src/config/data-dirs.ts
@@ -116,12 +116,21 @@ export interface DataPathSpec {
 export interface DescribeOptions {
   readonly repoRoot: string;
   readonly monorepoRoot: string;
+  /**
+   * Override the uploads legacy path. Production code never needs this — it
+   * exists so unit tests can isolate the migration engine from the real
+   * `packages/api/uploads` directory inside the repo (the module-relative
+   * default resolves to that exact path because the module file lives there).
+   * Pass an absolute path that does NOT shadow real data.
+   */
+  readonly uploadsLegacyOverride?: string;
 }
 
 export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[] {
   const dataRoot = readRoot('DATA_DIR');
   const cacheRoot = readRoot('CACHE_DIR');
   const logRoot = readRoot('LOG_DIR');
+  const uploadsLegacy = opts.uploadsLegacyOverride ?? MODULE_DEFAULT_UPLOAD_DIR;
 
   return [
     {
@@ -173,9 +182,11 @@ export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[
       key: 'uploads',
       root: 'DATA_DIR',
       subPath: 'uploads',
-      legacyPath: MODULE_DEFAULT_UPLOAD_DIR,
+      legacyPath: uploadsLegacy,
       rootBasedPath: dataRoot ? joinUnder(dataRoot, 'uploads') : null,
-      currentPath: resolveUploadsDir(),
+      // Note: resolveUploadsDir() always uses MODULE_DEFAULT_UPLOAD_DIR; the
+      // override only affects the legacyPath surfaced for introspection.
+      currentPath: dataRoot ? joinUnder(dataRoot, 'uploads') : uploadsLegacy,
       isFile: false,
     },
     {

--- a/packages/api/src/config/data-dirs.ts
+++ b/packages/api/src/config/data-dirs.ts
@@ -14,6 +14,7 @@
  * CONNECTOR_MEDIA_DIR) are removed — configure via the three roots instead.
  */
 
+import { homedir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -64,6 +65,27 @@ export function resolveUploadsDir(): string {
   return root ? joinUnder(root, 'uploads') : MODULE_DEFAULT_UPLOAD_DIR;
 }
 
+// --- Redis data (lifecycle managed by start-dev.sh / user-redis.sh) ------
+// Redis is started by shell scripts *before* the API server, so the shell
+// layer owns the actual `--dir` flag and pre-start migration.  These
+// resolvers exist for introspection (Settings UI / data-dirs endpoint)
+// and for the shell to stay consistent with the TypeScript world.
+
+export function resolveRedisDataDir(): string {
+  const root = readRoot('DATA_DIR');
+  if (root) return joinUnder(root, 'redis');
+  // Legacy: shell script sets REDIS_DATA_DIR based on profile/port before
+  // launching the API.  Fall back to the default dev path if not in env
+  // (e.g. running `node dist/index.js` directly without start-dev.sh).
+  return process.env.REDIS_DATA_DIR || resolve(homedir(), '.cat-cafe/redis-dev');
+}
+
+export function resolveRedisBackupDir(): string {
+  const root = readRoot('DATA_DIR');
+  if (root) return joinUnder(root, 'redis-backups');
+  return process.env.REDIS_BACKUP_DIR || resolve(homedir(), '.cat-cafe/redis-backups/dev');
+}
+
 // --- CACHE_DIR consumers -------------------------------------------------
 
 export function resolveTtsCacheDir(): string {
@@ -92,6 +114,8 @@ export type DataPathKey =
   | 'auditLogs'
   | 'cliRawArchive'
   | 'uploads'
+  | 'redisData'
+  | 'redisBackups'
   | 'ttsCache'
   | 'connectorMedia'
   | 'logs';
@@ -187,6 +211,24 @@ export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[
       // Note: resolveUploadsDir() always uses MODULE_DEFAULT_UPLOAD_DIR; the
       // override only affects the legacyPath surfaced for introspection.
       currentPath: dataRoot ? joinUnder(dataRoot, 'uploads') : uploadsLegacy,
+      isFile: false,
+    },
+    {
+      key: 'redisData',
+      root: 'DATA_DIR',
+      subPath: 'redis',
+      legacyPath: process.env.REDIS_DATA_DIR || resolve(homedir(), '.cat-cafe/redis-dev'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'redis') : null,
+      currentPath: resolveRedisDataDir(),
+      isFile: false,
+    },
+    {
+      key: 'redisBackups',
+      root: 'DATA_DIR',
+      subPath: 'redis-backups',
+      legacyPath: process.env.REDIS_BACKUP_DIR || resolve(homedir(), '.cat-cafe/redis-backups/dev'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'redis-backups') : null,
+      currentPath: resolveRedisBackupDir(),
       isFile: false,
     },
     {

--- a/packages/api/src/config/data-dirs.ts
+++ b/packages/api/src/config/data-dirs.ts
@@ -1,0 +1,209 @@
+/**
+ * Unified data directory resolver — issue #671.
+ *
+ * Three root env vars control where runtime data is written:
+ * - DATA_DIR  : persistent data (DBs, transcripts, audit logs, uploads, cli archive)
+ * - CACHE_DIR : rebuildable cache (tts audio, connector media)
+ * - LOG_DIR   : log files (used directly, no subdirectory)
+ *
+ * Behavior: if a root is set, the path is `{root}/{subPath}`; otherwise the
+ * legacy default (preserved for backward compatibility) is used.
+ *
+ * Legacy per-path env vars (EVIDENCE_DB, WORLD_DB, TRANSCRIPT_DATA_DIR,
+ * AUDIT_LOG_DIR, CLI_RAW_ARCHIVE_DIR, UPLOAD_DIR, TTS_CACHE_DIR,
+ * CONNECTOR_MEDIA_DIR) are removed — configure via the three roots instead.
+ */
+
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+// packages/api/src/config/ → ../../uploads = packages/api/uploads
+const MODULE_DEFAULT_UPLOAD_DIR = resolve(THIS_DIR, '../../uploads');
+
+export type DataRoot = 'DATA_DIR' | 'CACHE_DIR' | 'LOG_DIR';
+
+function readRoot(name: DataRoot): string | undefined {
+  const raw = process.env[name];
+  return raw && raw.trim() !== '' ? resolve(raw) : undefined;
+}
+
+function joinUnder(root: string, subPath: string): string {
+  return resolve(root, subPath);
+}
+
+// --- DATA_DIR consumers --------------------------------------------------
+
+export function resolveEvidenceDbPath(repoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'evidence.sqlite') : resolve(repoRoot, 'evidence.sqlite');
+}
+
+export function resolveWorldDbPath(repoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'world.sqlite') : resolve(repoRoot, 'world.sqlite');
+}
+
+export function resolveTranscriptsDir(monorepoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'transcripts') : resolve(monorepoRoot, 'data/transcripts');
+}
+
+export function resolveAuditLogsDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'audit-logs') : resolve(process.cwd(), 'data/audit-logs');
+}
+
+export function resolveCliRawArchiveDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'cli-raw-archive') : resolve(process.cwd(), 'data/cli-raw-archive');
+}
+
+export function resolveUploadsDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'uploads') : MODULE_DEFAULT_UPLOAD_DIR;
+}
+
+// --- CACHE_DIR consumers -------------------------------------------------
+
+export function resolveTtsCacheDir(): string {
+  const root = readRoot('CACHE_DIR');
+  return root ? joinUnder(root, 'tts') : resolve(process.cwd(), 'data/tts-cache');
+}
+
+export function resolveConnectorMediaDir(): string {
+  const root = readRoot('CACHE_DIR');
+  return root ? joinUnder(root, 'connector-media') : resolve(process.cwd(), 'data/connector-media');
+}
+
+// --- LOG_DIR (used directly, no subdirectory) ----------------------------
+
+export function resolveLogDir(): string {
+  const root = readRoot('LOG_DIR');
+  return root ?? resolve(process.cwd(), 'data/logs/api');
+}
+
+// --- Introspection (for migration logic + Settings UI) -------------------
+
+export type DataPathKey =
+  | 'evidenceDb'
+  | 'worldDb'
+  | 'transcripts'
+  | 'auditLogs'
+  | 'cliRawArchive'
+  | 'uploads'
+  | 'ttsCache'
+  | 'connectorMedia'
+  | 'logs';
+
+export interface DataPathSpec {
+  /** Stable identifier */
+  readonly key: DataPathKey;
+  /** Which root env var governs this path */
+  readonly root: DataRoot;
+  /** Sub-path under the root (empty for LOG_DIR which uses the root directly) */
+  readonly subPath: string;
+  /** Path that would be used if the root env var is not set */
+  readonly legacyPath: string;
+  /** Path that would be used if the root env var IS set */
+  readonly rootBasedPath: string | null;
+  /** Currently active path (= rootBasedPath if root is set, else legacyPath) */
+  readonly currentPath: string;
+  /** Is the active path file-shaped (true for SQLite DBs) or directory-shaped */
+  readonly isFile: boolean;
+}
+
+export interface DescribeOptions {
+  readonly repoRoot: string;
+  readonly monorepoRoot: string;
+}
+
+export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[] {
+  const dataRoot = readRoot('DATA_DIR');
+  const cacheRoot = readRoot('CACHE_DIR');
+  const logRoot = readRoot('LOG_DIR');
+
+  return [
+    {
+      key: 'evidenceDb',
+      root: 'DATA_DIR',
+      subPath: 'evidence.sqlite',
+      legacyPath: resolve(opts.repoRoot, 'evidence.sqlite'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'evidence.sqlite') : null,
+      currentPath: resolveEvidenceDbPath(opts.repoRoot),
+      isFile: true,
+    },
+    {
+      key: 'worldDb',
+      root: 'DATA_DIR',
+      subPath: 'world.sqlite',
+      legacyPath: resolve(opts.repoRoot, 'world.sqlite'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'world.sqlite') : null,
+      currentPath: resolveWorldDbPath(opts.repoRoot),
+      isFile: true,
+    },
+    {
+      key: 'transcripts',
+      root: 'DATA_DIR',
+      subPath: 'transcripts',
+      legacyPath: resolve(opts.monorepoRoot, 'data/transcripts'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'transcripts') : null,
+      currentPath: resolveTranscriptsDir(opts.monorepoRoot),
+      isFile: false,
+    },
+    {
+      key: 'auditLogs',
+      root: 'DATA_DIR',
+      subPath: 'audit-logs',
+      legacyPath: resolve(process.cwd(), 'data/audit-logs'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'audit-logs') : null,
+      currentPath: resolveAuditLogsDir(),
+      isFile: false,
+    },
+    {
+      key: 'cliRawArchive',
+      root: 'DATA_DIR',
+      subPath: 'cli-raw-archive',
+      legacyPath: resolve(process.cwd(), 'data/cli-raw-archive'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'cli-raw-archive') : null,
+      currentPath: resolveCliRawArchiveDir(),
+      isFile: false,
+    },
+    {
+      key: 'uploads',
+      root: 'DATA_DIR',
+      subPath: 'uploads',
+      legacyPath: MODULE_DEFAULT_UPLOAD_DIR,
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'uploads') : null,
+      currentPath: resolveUploadsDir(),
+      isFile: false,
+    },
+    {
+      key: 'ttsCache',
+      root: 'CACHE_DIR',
+      subPath: 'tts',
+      legacyPath: resolve(process.cwd(), 'data/tts-cache'),
+      rootBasedPath: cacheRoot ? joinUnder(cacheRoot, 'tts') : null,
+      currentPath: resolveTtsCacheDir(),
+      isFile: false,
+    },
+    {
+      key: 'connectorMedia',
+      root: 'CACHE_DIR',
+      subPath: 'connector-media',
+      legacyPath: resolve(process.cwd(), 'data/connector-media'),
+      rootBasedPath: cacheRoot ? joinUnder(cacheRoot, 'connector-media') : null,
+      currentPath: resolveConnectorMediaDir(),
+      isFile: false,
+    },
+    {
+      key: 'logs',
+      root: 'LOG_DIR',
+      subPath: '',
+      legacyPath: resolve(process.cwd(), 'data/logs/api'),
+      rootBasedPath: logRoot ?? null,
+      currentPath: resolveLogDir(),
+      isFile: false,
+    },
+  ];
+}

--- a/packages/api/src/config/data-dirs.ts
+++ b/packages/api/src/config/data-dirs.ts
@@ -65,6 +65,17 @@ export function resolveUploadsDir(): string {
   return root ? joinUnder(root, 'uploads') : MODULE_DEFAULT_UPLOAD_DIR;
 }
 
+// --- .cat-cafe state (writable config/data: accounts, credentials, catalog, governance…)
+// When DATA_DIR is set, the shell startup moves the contents of
+// {projectRoot}/.cat-cafe/ to DATA_DIR/cat-cafe/ and replaces the
+// original with a symlink.  This lets all 50+ consumers keep using
+// `resolve(projectRoot, '.cat-cafe', file)` transparently.
+
+export function resolveCatCafeStateDir(projectRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'cat-cafe') : resolve(projectRoot, '.cat-cafe');
+}
+
 // --- Redis data (lifecycle managed by start-dev.sh / user-redis.sh) ------
 // Redis is started by shell scripts *before* the API server, so the shell
 // layer owns the actual `--dir` flag and pre-start migration.  These
@@ -114,6 +125,7 @@ export type DataPathKey =
   | 'auditLogs'
   | 'cliRawArchive'
   | 'uploads'
+  | 'catCafeState'
   | 'redisData'
   | 'redisBackups'
   | 'ttsCache'
@@ -211,6 +223,15 @@ export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[
       // Note: resolveUploadsDir() always uses MODULE_DEFAULT_UPLOAD_DIR; the
       // override only affects the legacyPath surfaced for introspection.
       currentPath: dataRoot ? joinUnder(dataRoot, 'uploads') : uploadsLegacy,
+      isFile: false,
+    },
+    {
+      key: 'catCafeState',
+      root: 'DATA_DIR',
+      subPath: 'cat-cafe',
+      legacyPath: resolve(opts.repoRoot, '.cat-cafe'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'cat-cafe') : null,
+      currentPath: resolveCatCafeStateDir(opts.repoRoot),
       isFile: false,
     },
     {

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -137,7 +137,6 @@ export const ENV_VARS: EnvDefinition[] = [
     runtimeEditable: false,
     exampleRecommended: true,
   },
-  { name: 'UPLOAD_DIR', defaultValue: './uploads', description: '文件上传目录', category: 'server', sensitive: false },
   {
     name: 'PROJECT_ALLOWED_ROOTS',
     defaultValue: '(未设置 — 使用 denylist 模式，仅拦截系统目录)',
@@ -314,10 +313,11 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'LOG_DIR',
-    defaultValue: './data/logs/api',
-    description: 'API 日志目录（Pino 滚动日志写入路径）',
-    category: 'server',
+    defaultValue: '{cwd}/data/logs/api',
+    description: '日志根目录（issue #671：三根目录模型；Pino 滚动日志直接写入此路径，不再加子目录）',
+    category: 'storage',
     sensitive: false,
+    restartRequired: true,
     exampleRecommended: true,
   },
   {
@@ -488,11 +488,24 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
-    name: 'TRANSCRIPT_DATA_DIR',
-    defaultValue: './data/transcripts',
-    description: 'Session transcript 存储目录',
+    name: 'DATA_DIR',
+    defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
+    description:
+      '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到 ${DATA_DIR}/{子目录}。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
+    restartRequired: true,
+    exampleRecommended: true,
+  },
+  {
+    name: 'CACHE_DIR',
+    defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
+    description:
+      '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到 ${CACHE_DIR}/{子目录}。未设置时各路径沿用旧默认。',
+    category: 'storage',
+    sensitive: false,
+    restartRequired: true,
+    exampleRecommended: true,
   },
   {
     name: 'DOCS_ROOT',
@@ -621,20 +634,6 @@ export const ENV_VARS: EnvDefinition[] = [
     name: 'CAT_CAFE_MCP_SERVER_PATH',
     defaultValue: '(自动检测)',
     description: 'MCP Server 路径',
-    category: 'cli',
-    sensitive: false,
-  },
-  {
-    name: 'AUDIT_LOG_DIR',
-    defaultValue: './data/audit-logs',
-    description: '审计日志目录',
-    category: 'cli',
-    sensitive: false,
-  },
-  {
-    name: 'CLI_RAW_ARCHIVE_DIR',
-    defaultValue: './data/cli-raw-archive',
-    description: 'CLI 原始日志归档目录',
     category: 'cli',
     sensitive: false,
   },
@@ -1209,13 +1208,6 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
-    name: 'TTS_CACHE_DIR',
-    defaultValue: './data/tts-cache',
-    description: 'TTS 音频缓存目录',
-    category: 'tts',
-    sensitive: false,
-  },
-  {
     name: 'GENSHIN_VOICE_DIR',
     defaultValue: '~/projects/.../genshin',
     description: 'GPT-SoVITS 角色模型目录',
@@ -1236,15 +1228,6 @@ export const ENV_VARS: EnvDefinition[] = [
     defaultValue: 'http://localhost:9876',
     description: 'Whisper STT 服务地址（服务端）',
     category: 'stt',
-    sensitive: false,
-  },
-
-  // --- connector media ---
-  {
-    name: 'CONNECTOR_MEDIA_DIR',
-    defaultValue: './data/connector-media',
-    description: '连接器媒体下载目录',
-    category: 'connector',
     sensitive: false,
   },
 
@@ -1504,23 +1487,9 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
-    name: 'EVIDENCE_DB',
-    defaultValue: '{repoRoot}/evidence.sqlite',
-    description: 'F102 SQLite 数据库路径',
-    category: 'evidence',
-    sensitive: false,
-  },
-  {
     name: 'GLOBAL_KNOWLEDGE_DB',
     defaultValue: '~/.cat-cafe/global_knowledge.sqlite',
     description: 'F-4: 全局知识 SQLite 路径（Skills + MEMORY.md 编译产物）',
-    category: 'evidence',
-    sensitive: false,
-  },
-  {
-    name: 'WORLD_DB',
-    defaultValue: '{repoRoot}/world.sqlite',
-    description: 'F093 World Engine SQLite 数据库路径',
     category: 'evidence',
     sensitive: false,
   },

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -491,21 +491,19 @@ export const ENV_VARS: EnvDefinition[] = [
     name: 'DATA_DIR',
     defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
     description:
-      '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到 ${DATA_DIR}/{子目录}。未设置时各路径沿用旧默认。',
+      '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
     restartRequired: true,
-    exampleRecommended: true,
   },
   {
     name: 'CACHE_DIR',
     defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
     description:
-      '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到 ${CACHE_DIR}/{子目录}。未设置时各路径沿用旧默认。',
+      '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
     restartRequired: true,
-    exampleRecommended: true,
   },
   {
     name: 'DOCS_ROOT',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -54,6 +54,8 @@ export interface EnvDefinition {
   hubVisible?: boolean;
   /** If false, value is bootstrap-only and cannot be edited at runtime from Hub */
   runtimeEditable?: boolean;
+  /** If true, runtime writes require session-auth + owner gate even when the value is not secret */
+  writeRequiresOwner?: boolean;
   /** If true, changes take effect only after service restart */
   restartRequired?: boolean;
   /** If true, this var should appear in .env.example (enforced by check:env-example) */
@@ -319,6 +321,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '日志根目录（issue #671：三根目录模型；Pino 滚动日志直接写入此路径，不再加子目录）',
     category: 'storage',
     sensitive: false,
+    writeRequiresOwner: true,
     restartRequired: true,
     exampleRecommended: true,
   },
@@ -496,6 +499,7 @@ export const ENV_VARS: EnvDefinition[] = [
       '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
+    writeRequiresOwner: true,
     restartRequired: true,
   },
   {
@@ -505,6 +509,7 @@ export const ENV_VARS: EnvDefinition[] = [
       '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
+    writeRequiresOwner: true,
     restartRequired: true,
   },
   {
@@ -1794,6 +1799,11 @@ export function isSensitiveEditableEnvVar(def: EnvDefinition): boolean {
   return def.sensitive && def.runtimeEditable === true;
 }
 
+/** True if runtime writes require the privileged owner-gated env route. */
+export function isOwnerGatedEditableEnvVar(def: EnvDefinition): boolean {
+  return isSensitiveEditableEnvVar(def) || def.writeRequiresOwner === true;
+}
+
 export function isEditableEnvVarName(name: string): boolean {
   return ENV_VARS.some((def) => def.name === name && isHubVisibleEnvVar(def) && isEditableEnvVar(def));
 }
@@ -1802,6 +1812,12 @@ export function isEditableEnvVarName(name: string): boolean {
 export function hasSensitiveEditableVars(names: Iterable<string>): boolean {
   const nameSet = new Set(names);
   return ENV_VARS.some((def) => nameSet.has(def.name) && isSensitiveEditableEnvVar(def));
+}
+
+/** Check if any of the given env var names require session-auth + owner gate for writes. */
+export function hasOwnerGatedEditableVars(names: Iterable<string>): boolean {
+  const nameSet = new Set(names);
+  return ENV_VARS.some((def) => nameSet.has(def.name) && isOwnerGatedEditableEnvVar(def));
 }
 
 /** Return only the sensitive-editable keys from the given names (for audit filtering). */

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -321,7 +321,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '日志根目录（issue #671：三根目录模型；Pino 滚动日志直接写入此路径，不再加子目录）',
     category: 'storage',
     sensitive: false,
-    writeRequiresOwner: true,
+    runtimeEditable: false,
     restartRequired: true,
     exampleRecommended: true,
   },
@@ -499,7 +499,7 @@ export const ENV_VARS: EnvDefinition[] = [
       '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
-    writeRequiresOwner: true,
+    runtimeEditable: false,
     restartRequired: true,
   },
   {
@@ -509,7 +509,7 @@ export const ENV_VARS: EnvDefinition[] = [
       '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
-    writeRequiresOwner: true,
+    runtimeEditable: false,
     restartRequired: true,
   },
   {
@@ -1801,7 +1801,7 @@ export function isSensitiveEditableEnvVar(def: EnvDefinition): boolean {
 
 /** True if runtime writes require the privileged owner-gated env route. */
 export function isOwnerGatedEditableEnvVar(def: EnvDefinition): boolean {
-  return isSensitiveEditableEnvVar(def) || def.writeRequiresOwner === true;
+  return isEditableEnvVar(def) && (isSensitiveEditableEnvVar(def) || def.writeRequiresOwner === true);
 }
 
 export function isEditableEnvVarName(name: string): boolean {

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -54,6 +54,8 @@ export interface EnvDefinition {
   hubVisible?: boolean;
   /** If false, value is bootstrap-only and cannot be edited at runtime from Hub */
   runtimeEditable?: boolean;
+  /** If true, changes take effect only after service restart */
+  restartRequired?: boolean;
   /** If true, this var should appear in .env.example (enforced by check:env-example) */
   exampleRecommended?: boolean;
   /** Explicit allowed values for cycle-style toggles (e.g. ['off','shadow','on']) */

--- a/packages/api/src/domains/cats/services/agents/providers/generated-image-publication.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/generated-image-publication.ts
@@ -42,7 +42,7 @@ export interface PublishedGeneratedImage extends SavedImageAsset {
 }
 
 export async function publishGeneratedImage(input: GeneratedImagePublicationInput): Promise<PublishedGeneratedImage> {
-  const resolvedUploadDir = getDefaultUploadDir(input.uploadDir ?? process.env.UPLOAD_DIR);
+  const resolvedUploadDir = getDefaultUploadDir(input.uploadDir);
   const publicationStem = buildPublicationStem(input.publicationKey);
 
   const expectedFilename = `${sanitizeFilenameStem(publicationStem)}${mimeToImageExt(input.mimeType)}`;

--- a/packages/api/src/domains/cats/services/agents/providers/image-paths.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/image-paths.ts
@@ -10,13 +10,13 @@ import { getDefaultUploadDir, resolveInternalRouteUrl } from '../../../../../uti
 /**
  * Extract absolute image file paths from contentBlocks.
  * Converts relative URL paths (/uploads/foo.png) to absolute filesystem paths.
- * @param uploadDir Override for the upload directory (defaults to UPLOAD_DIR env or './uploads')
+ * @param uploadDir Override for the upload directory (defaults to DATA_DIR/uploads or packages/api/uploads)
  */
 export function extractImagePaths(contentBlocks: readonly MessageContent[] | undefined, uploadDir?: string): string[] {
   if (!contentBlocks) return [];
 
   const paths: string[] = [];
-  const resolvedUploadDir = getDefaultUploadDir(uploadDir ?? process.env.UPLOAD_DIR);
+  const resolvedUploadDir = getDefaultUploadDir(uploadDir);
   for (const block of contentBlocks) {
     if (block.type !== 'image') continue;
     const url = block.url;

--- a/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
+++ b/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
@@ -19,6 +19,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, readdir, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { resolveAuditLogsDir } from '../../../../config/data-dirs.js';
 import { createModuleLogger } from '../../../../infrastructure/logger.js';
 
 const log = createModuleLogger('audit');
@@ -35,15 +36,12 @@ export interface AuditEvent {
 
 export type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
 
-/** Default audit log directory */
-const DEFAULT_AUDIT_DIR = './data/audit-logs';
-
 export class EventAuditLog {
   private readonly auditDir: string;
   private initialized = false;
 
   constructor(options?: { auditDir?: string }) {
-    this.auditDir = options?.auditDir ?? process.env.AUDIT_LOG_DIR ?? DEFAULT_AUDIT_DIR;
+    this.auditDir = options?.auditDir ?? resolveAuditLogsDir();
   }
 
   /**

--- a/packages/api/src/domains/cats/services/session/CliRawArchive.ts
+++ b/packages/api/src/domains/cats/services/session/CliRawArchive.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { resolveCliRawArchiveDir } from '../../../../config/data-dirs.js';
 
-const DEFAULT_CLI_RAW_ARCHIVE_DIR = './data/cli-raw-archive';
 const INVOCATION_ID_PATTERN = /^[\w-]+$/;
 
 export interface RawArchiveEntry {
@@ -15,7 +15,7 @@ export class CliRawArchive {
   private readonly initInFlight = new Map<string, Promise<void>>();
 
   constructor(options?: { archiveDir?: string }) {
-    this.archiveDir = options?.archiveDir ?? process.env.CLI_RAW_ARCHIVE_DIR ?? DEFAULT_CLI_RAW_ARCHIVE_DIR;
+    this.archiveDir = options?.archiveDir ?? resolveCliRawArchiveDir();
   }
 
   /** F118: Get the archive file path for a given invocationId (today's date) */

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -238,7 +238,7 @@ import {
   resolveTtsCacheDir,
   resolveWorldDbPath,
 } from './config/data-dirs.js';
-import { defaultDiskSpaceProbe, runDataDirsMigration } from './config/data-dirs-migration.js';
+import { defaultDiskSpaceProbe, runDataDirsMigration, shouldAbortStartupOnMigration } from './config/data-dirs-migration.js';
 import { findMonorepoRoot } from './utils/monorepo-root.js';
 import { resolveUserId } from './utils/request-identity.js';
 import { getDefaultUploadDir } from './utils/upload-paths.js';
@@ -308,6 +308,24 @@ async function main(): Promise<void> {
         },
         '[#671] Data-dirs migration completed',
       );
+    }
+
+    // Fail-fast: if the migration aborted or any item failed, the resolver
+    // now points at the new root but the legacy data is still on disk.
+    // Continuing would let SQLite/transcript/audit-log consumers open empty
+    // files at the new path — silent data loss from the operator's POV.
+    const abort = shouldAbortStartupOnMigration(migrationResult);
+    if (abort.shouldAbort) {
+      app.log.fatal(
+        {
+          reason: abort.reason,
+          leftBehind: abort.leftBehind,
+          DATA_DIR: process.env.DATA_DIR ?? null,
+          CACHE_DIR: process.env.CACHE_DIR ?? null,
+        },
+        '[#671] Data-dirs migration did not complete cleanly — refusing to start to avoid silent data loss. Free space (or restore the legacy paths) and retry, or unset the root env vars to fall back to legacy locations.',
+      );
+      process.exit(1);
     }
   }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,7 +3,8 @@
  * 后端 API 入口
  */
 
-import { join } from 'node:path';
+import { existsSync as fsExistsSync } from 'node:fs';
+import { join, resolve as pathResolve } from 'node:path';
 import { type CatConfig, type CatId, CORE_COMMANDS, catRegistry, type ILimbNode } from '@cat-cafe/shared';
 import type { RedisClient } from '@cat-cafe/shared/utils';
 import { createRedisClient, SessionStore } from '@cat-cafe/shared/utils';
@@ -237,6 +238,7 @@ import {
   resolveTtsCacheDir,
   resolveWorldDbPath,
 } from './config/data-dirs.js';
+import { defaultDiskSpaceProbe, runDataDirsMigration } from './config/data-dirs-migration.js';
 import { findMonorepoRoot } from './utils/monorepo-root.js';
 import { resolveUserId } from './utils/request-identity.js';
 import { getDefaultUploadDir } from './utils/upload-paths.js';
@@ -278,6 +280,35 @@ async function main(): Promise<void> {
 
   if (isDebugMode) {
     app.log.info({ logDir: LOG_DIR_PATH }, '[api] Debug mode enabled (--debug flag)');
+  }
+
+  // #671: Migrate legacy data paths to DATA_DIR/CACHE_DIR before any consumer
+  // opens connections (SQLite, transcript writer, etc.). Logs are excluded.
+  {
+    const cwd = process.cwd();
+    const probeRepoRoot = fsExistsSync(pathResolve(cwd, 'docs', 'features'))
+      ? cwd
+      : fsExistsSync(pathResolve(cwd, '..', '..', 'docs', 'features'))
+        ? pathResolve(cwd, '..', '..')
+        : cwd;
+    const migrationResult = await runDataDirsMigration({
+      repoRoot: probeRepoRoot,
+      monorepoRoot: findMonorepoRoot(cwd),
+      trigger: 'startup',
+      io: { diskFree: defaultDiskSpaceProbe, logger: app.log },
+    });
+    if (migrationResult.attempted) {
+      app.log.info(
+        {
+          movedCount: migrationResult.items.filter((i) => i.status === 'moved').length,
+          skippedCount: migrationResult.items.filter((i) => i.status === 'skipped').length,
+          failedCount: migrationResult.items.filter((i) => i.status === 'failed').length,
+          allSucceeded: migrationResult.allSucceeded,
+          abortedReason: migrationResult.abortedReason,
+        },
+        '[#671] Data-dirs migration completed',
+      );
+    }
   }
 
   // CORS for frontend

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -26,6 +26,18 @@ import {
   toAllCatConfigs,
 } from './config/cat-config-loader.js';
 import { configEventBus } from './config/config-event-bus.js';
+import {
+  resolveConnectorMediaDir,
+  resolveEvidenceDbPath,
+  resolveTranscriptsDir,
+  resolveTtsCacheDir,
+  resolveWorldDbPath,
+} from './config/data-dirs.js';
+import {
+  defaultDiskSpaceProbe,
+  runDataDirsMigration,
+  shouldAbortStartupOnMigration,
+} from './config/data-dirs-migration.js';
 import { resolveFrontendBaseUrl, resolveFrontendCorsOrigins } from './config/frontend-origin.js';
 import { initRuntimeOverrides } from './config/session-strategy-overrides.js';
 import { assertStorageReady } from './config/storage-guard.js';
@@ -231,14 +243,6 @@ import { previewRoutes } from './routes/preview.js';
 import { terminalRoutes } from './routes/terminal.js';
 import { threadExportRoutes } from './routes/thread-export.js';
 import { ApiInstanceLease, type ApiInstanceLeaseInvalidation } from './services/ApiInstanceLease.js';
-import {
-  resolveConnectorMediaDir,
-  resolveEvidenceDbPath,
-  resolveTranscriptsDir,
-  resolveTtsCacheDir,
-  resolveWorldDbPath,
-} from './config/data-dirs.js';
-import { defaultDiskSpaceProbe, runDataDirsMigration, shouldAbortStartupOnMigration } from './config/data-dirs-migration.js';
 import { findMonorepoRoot } from './utils/monorepo-root.js';
 import { resolveUserId } from './utils/request-identity.js';
 import { getDefaultUploadDir } from './utils/upload-paths.js';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -230,6 +230,13 @@ import { previewRoutes } from './routes/preview.js';
 import { terminalRoutes } from './routes/terminal.js';
 import { threadExportRoutes } from './routes/thread-export.js';
 import { ApiInstanceLease, type ApiInstanceLeaseInvalidation } from './services/ApiInstanceLease.js';
+import {
+  resolveConnectorMediaDir,
+  resolveEvidenceDbPath,
+  resolveTranscriptsDir,
+  resolveTtsCacheDir,
+  resolveWorldDbPath,
+} from './config/data-dirs.js';
 import { findMonorepoRoot } from './utils/monorepo-root.js';
 import { resolveUserId } from './utils/request-identity.js';
 import { getDefaultUploadDir } from './utils/upload-paths.js';
@@ -544,8 +551,8 @@ async function main(): Promise<void> {
   const sessionChainStore = createSessionChainStore(redis);
   const runtimeSessionStore = createRuntimeSessionStore(redis);
   // F24: Transcript Writer/Reader for session chain
-  // E7 fix: resolve relative to monorepo root, not CWD (same fix as docsRoot in PR #524)
-  const transcriptDataDir = process.env.TRANSCRIPT_DATA_DIR ?? `${findMonorepoRoot(process.cwd())}/data/transcripts`;
+  // #671: DATA_DIR/transcripts when set; otherwise monorepo-relative legacy default.
+  const transcriptDataDir = resolveTranscriptsDir(findMonorepoRoot(process.cwd()));
   const transcriptWriter = new TranscriptWriter({ dataDir: transcriptDataDir });
   const transcriptReader = new TranscriptReader({ dataDir: transcriptDataDir });
   // F065 Phase C: HandoffConfig for LLM-generated digest on seal
@@ -622,7 +629,7 @@ async function main(): Promise<void> {
   );
   const memoryServices = await createMemoryServices({
     type: 'sqlite',
-    sqlitePath: process.env.EVIDENCE_DB ?? resolve(repoRoot, 'evidence.sqlite'),
+    sqlitePath: resolveEvidenceDbPath(repoRoot),
     docsRoot: process.env.DOCS_ROOT ?? resolve(repoRoot, 'docs'),
     markersDir: resolve(repoRoot, 'docs', 'markers'),
     transcriptDataDir, // reuse the same resolved path as Writer/Reader (line 282)
@@ -1319,7 +1326,7 @@ async function main(): Promise<void> {
   const { WorldRuntimeCoordinator } = await import('./domains/world/WorldRuntimeCoordinator.js');
   const { WorldContextProvider } = await import('./domains/world/WorldContextProvider.js');
   const { WorldKnowledgeAdapter } = await import('./domains/world/WorldKnowledgeAdapter.js');
-  const worldDbPath = process.env.WORLD_DB ?? resolve(repoRoot, 'world.sqlite');
+  const worldDbPath = resolveWorldDbPath(repoRoot);
   const worldStore = new SqliteWorldStore(worldDbPath);
   await worldStore.initialize();
   const worldCoordinator = new WorldRuntimeCoordinator(worldStore);
@@ -2546,12 +2553,12 @@ async function main(): Promise<void> {
   });
 
   // Serve uploaded files (images)
-  const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir();
   await app.register(uploadsRoutes, { uploadDir });
   await app.register(refAudioUploadRoutes);
 
   // F088: Serve downloaded connector media files
-  const connectorMediaDir = process.env.CONNECTOR_MEDIA_DIR ?? './data/connector-media';
+  const connectorMediaDir = resolveConnectorMediaDir();
   await app.register(connectorMediaRoutes, { mediaDir: connectorMediaDir });
 
   // F34: TTS Provider (mlx-audio → Python TTS server)
@@ -2562,7 +2569,7 @@ async function main(): Promise<void> {
   // because resolveServiceEndpoint reads endpointEnvVars first.
   const ttsRegistry = new TtsRegistry();
   ttsRegistry.register(new MlxAudioTtsProvider());
-  const ttsCacheDir = process.env.TTS_CACHE_DIR ?? './data/tts-cache';
+  const ttsCacheDir = resolveTtsCacheDir();
   await app.register(ttsRoutes, { ttsRegistry, cacheDir: ttsCacheDir });
   initVoiceBlockSynthesizer(ttsRegistry, ttsCacheDir);
   initStreamingTtsRegistry(ttsRegistry);

--- a/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
+++ b/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
@@ -16,6 +16,7 @@ import { type CatId, type ConnectorSource, catRegistry } from '@cat-cafe/shared'
 import type { RedisClient } from '@cat-cafe/shared/utils';
 import * as lark from '@larksuiteoapi/node-sdk';
 import type { FastifyBaseLogger } from 'fastify';
+import { resolveConnectorMediaDir, resolveTtsCacheDir } from '../../config/data-dirs.js';
 import { isCatAvailable } from '../../config/cat-config-loader.js';
 import type { ConnectorWebhookHandler, WebhookHandleResult } from '../../routes/connector-webhooks.js';
 import { getDefaultUploadDir } from '../../utils/upload-paths.js';
@@ -259,7 +260,7 @@ export function loadConnectorGatewayConfig(): ConnectorGatewayConfig {
     wecomEncodingAesKey: process.env.WECOM_ENCODING_AES_KEY,
     coCreatorUserId: process.env.DEFAULT_OWNER_USER_ID,
     whisperUrl: process.env.WHISPER_URL,
-    connectorMediaDir: process.env.CONNECTOR_MEDIA_DIR,
+    connectorMediaDir: resolveConnectorMediaDir(),
     xiaoyiAk: process.env.XIAOYI_AK,
     xiaoyiSk: process.env.XIAOYI_SK,
     xiaoyiAgentId: process.env.XIAOYI_AGENT_ID,
@@ -962,8 +963,8 @@ export async function startConnectorGateway(
   stopFns.push(async () => weixin.stopPolling());
 
   // R3-P1: Resolve route URLs to local file paths for real media delivery
-  const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
-  const ttsCacheDir = resolve(process.env.TTS_CACHE_DIR ?? './data/tts-cache');
+  const uploadDir = getDefaultUploadDir();
+  const ttsCacheDir = resolveTtsCacheDir();
   const resolvedMediaDir = resolve(mediaDir);
   const webPublicDir = resolve(process.env.WEB_PUBLIC_DIR ?? '../web/public');
   const mediaPathResolver = (url: string): string | undefined => {

--- a/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
+++ b/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
@@ -16,8 +16,8 @@ import { type CatId, type ConnectorSource, catRegistry } from '@cat-cafe/shared'
 import type { RedisClient } from '@cat-cafe/shared/utils';
 import * as lark from '@larksuiteoapi/node-sdk';
 import type { FastifyBaseLogger } from 'fastify';
-import { resolveConnectorMediaDir, resolveTtsCacheDir } from '../../config/data-dirs.js';
 import { isCatAvailable } from '../../config/cat-config-loader.js';
+import { resolveConnectorMediaDir, resolveTtsCacheDir } from '../../config/data-dirs.js';
 import type { ConnectorWebhookHandler, WebhookHandleResult } from '../../routes/connector-webhooks.js';
 import { getDefaultUploadDir } from '../../utils/upload-paths.js';
 import { deliverConnectorMessage } from '../email/deliver-connector-message.js';

--- a/packages/api/src/infrastructure/logger.ts
+++ b/packages/api/src/infrastructure/logger.ts
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { format as utilFormat } from 'node:util';
 import pino from 'pino';
+import { resolveLogDir } from '../config/data-dirs.js';
 
 /**
  * --debug CLI flag: `node dist/index.js --debug` sets log level to 'debug'.
@@ -20,7 +21,7 @@ import pino from 'pino';
  */
 export const isDebugMode = process.argv.includes('--debug');
 const LOG_LEVEL = (isDebugMode ? 'debug' : (process.env.LOG_LEVEL ?? 'info')) as pino.Level;
-const LOG_DIR = process.env.LOG_DIR ? resolve(process.env.LOG_DIR) : resolve(process.cwd(), 'data', 'logs', 'api');
+const LOG_DIR = resolveLogDir();
 const RETENTION_FILES = 14;
 
 /**

--- a/packages/api/src/routes/avatars.ts
+++ b/packages/api/src/routes/avatars.ts
@@ -129,7 +129,7 @@ export const avatarsRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const ext = extForMime(file.mimetype);
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `avatar-${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`;
     await writeFile(join(uploadDir, filename), buffer);

--- a/packages/api/src/routes/callback-document-routes.ts
+++ b/packages/api/src/routes/callback-document-routes.ts
@@ -62,7 +62,7 @@ export function registerCallbackDocumentRoutes(
     }
 
     // Copy generated file to uploads directory (P1-1: ensure dir exists)
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const uniqueName = `doc-${randomBytes(6).toString('hex')}-${result.fileName}`;
     const destPath = resolve(uploadDir, uniqueName);

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -1996,7 +1996,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       return { error: 'Message not found' };
     }
 
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     const projectMsg = (m: typeof message) => {
       const imagePaths = extractImagePaths(m.contentBlocks, uploadDir);
       const imageUrls = extractImageUrls(m.contentBlocks);

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -1922,7 +1922,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
     // F211 BUG1 fix: resolve /uploads/ relative image URLs to absolute paths
     // so external runtimes (Antigravity/Bengal) can access image files.
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
 
     return {
       // TD091: echo threadId so cats know which thread they're in

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -90,6 +90,34 @@ interface ConfigRoutesOptions {
   projectRoot?: string;
 }
 
+type DataDirsOwnerAuthResult = { ok: true; operator: string } | { ok: false; status: number; error: string };
+
+function resolveSessionOperator(request: FastifyRequest): string | null {
+  const sessionUserId = (request as FastifyRequest & { sessionUserId?: string }).sessionUserId;
+  return typeof sessionUserId === 'string' && sessionUserId.trim() ? sessionUserId.trim() : null;
+}
+
+function requireDataDirsOwnerSession(request: FastifyRequest, label: string): DataDirsOwnerAuthResult {
+  const operator = resolveSessionOperator(request);
+  if (!operator) {
+    return { ok: false, status: 401, error: `${label} requires session authentication` };
+  }
+  if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
+    return {
+      ok: false,
+      status: 403,
+      error: `${label} from non-localhost requires DEFAULT_OWNER_USER_ID to be configured`,
+    };
+  }
+  const gateResult = resolveOwnerGate(operator, {
+    errorMessage: `${label} requires owner identity`,
+  });
+  if (gateResult) {
+    return { ok: false, status: gateResult.status, error: gateResult.error };
+  }
+  return { ok: true, operator };
+}
+
 function getSnapshotValue(snapshot: ConfigSnapshot, key: string): unknown {
   const path = configStore.getSnapshotPath(key);
   if (!path) return undefined;
@@ -295,25 +323,12 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
   });
 
   // #671: Inspect current data-dirs layout + pending migration work.
-  // Exposes absolute paths — owner-only + loopback to avoid leaking filesystem layout.
+  // Exposes absolute paths — require non-forgeable session owner identity.
   app.get('/api/config/data-dirs', async (request, reply) => {
-    const operator = resolveHeaderUserId(request);
-    if (!operator) {
-      reply.status(400);
-      return { error: 'Identity required (X-Cat-Cafe-User header)' };
-    }
-    // Same loopback guard as POST /data-dirs/migrate: remote/proxied
-    // requests without a configured owner are rejected.
-    if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
-      reply.status(403);
-      return { error: 'Data-dirs inspection from non-localhost requires DEFAULT_OWNER_USER_ID to be configured' };
-    }
-    const gateResult = resolveOwnerGate(operator, {
-      errorMessage: 'Data-dirs inspection requires owner identity',
-    });
-    if (gateResult) {
-      reply.status(gateResult.status);
-      return { error: gateResult.error };
+    const auth = requireDataDirsOwnerSession(request, 'Data-dirs inspection');
+    if (!auth.ok) {
+      reply.status(auth.status);
+      return { error: auth.error };
     }
     const cwd = process.cwd();
     const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))
@@ -358,23 +373,10 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
   // SQLite holds open handles to the legacy path until restart, so movedAny + isFile
   // surfaces a restart recommendation in the response.
   app.post('/api/config/data-dirs/migrate', async (request, reply) => {
-    const operator = resolveHeaderUserId(request);
-    if (!operator) {
-      reply.status(400);
-      return { error: 'Identity required (X-Cat-Cafe-User header)' };
-    }
-    // Data migration moves local runtime files. In single-user mode, allow
-    // direct loopback only; remote/proxied requests need an explicit owner.
-    if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
-      reply.status(403);
-      return { error: 'Data-dirs migration from non-localhost requires DEFAULT_OWNER_USER_ID to be configured' };
-    }
-    const gateResult = resolveOwnerGate(operator, {
-      errorMessage: 'Data-dirs migration requires owner identity',
-    });
-    if (gateResult) {
-      reply.status(gateResult.status);
-      return { error: gateResult.error };
+    const auth = requireDataDirsOwnerSession(request, 'Data-dirs migration');
+    if (!auth.ok) {
+      reply.status(auth.status);
+      return { error: auth.error };
     }
     const cwd = process.cwd();
     const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -294,12 +294,18 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
   });
 
   // #671: Inspect current data-dirs layout + pending migration work.
-  // Exposes absolute paths — owner-only to avoid leaking filesystem layout.
+  // Exposes absolute paths — owner-only + loopback to avoid leaking filesystem layout.
   app.get('/api/config/data-dirs', async (request, reply) => {
     const operator = resolveHeaderUserId(request);
     if (!operator) {
       reply.status(400);
       return { error: 'Identity required (X-Cat-Cafe-User header)' };
+    }
+    // Same loopback guard as POST /data-dirs/migrate: remote/proxied
+    // requests without a configured owner are rejected.
+    if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
+      reply.status(403);
+      return { error: 'Data-dirs inspection from non-localhost requires DEFAULT_OWNER_USER_ID to be configured' };
     }
     const gateResult = resolveOwnerGate(operator, {
       errorMessage: 'Data-dirs inspection requires owner identity',

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -22,6 +22,8 @@ import {
 } from '../config/cat-config-loader.js';
 import { configEventBus, createChangeSetId } from '../config/config-event-bus.js';
 import type { ConfigSnapshot } from '../config/config-snapshot.js';
+import { describeDataPaths, resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
+import { buildMigrationPlan, defaultDiskSpaceProbe, runDataDirsMigration } from '../config/data-dirs-migration.js';
 import {
   buildEnvSummary,
   ENV_CATEGORIES,
@@ -29,9 +31,6 @@ import {
   hasSensitiveEditableVars,
   isEditableEnvVarName,
 } from '../config/env-registry.js';
-import { describeDataPaths, resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
-import { buildMigrationPlan, defaultDiskSpaceProbe, runDataDirsMigration } from '../config/data-dirs-migration.js';
-import { findMonorepoRoot } from '../utils/monorepo-root.js';
 import { updateRuntimeCoCreator } from '../config/runtime-cat-catalog.js';
 import { isValidTimeZone } from '../config/time-zone.js';
 import { AuditEventTypes, getEventAuditLog } from '../domains/cats/services/orchestration/EventAuditLog.js';
@@ -42,6 +41,7 @@ import { AuditEventTypes, getEventAuditLog } from '../domains/cats/services/orch
 import { LOG_DIR_PATH } from '../infrastructure/logger.js';
 import { resolveActiveProjectRoot } from '../utils/active-project-root.js';
 import { isDirectLoopbackRequest } from '../utils/loopback-request.js';
+import { findMonorepoRoot } from '../utils/monorepo-root.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 import { getDefaultUploadDir } from '../utils/upload-paths.js';

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -29,7 +29,9 @@ import {
   hasSensitiveEditableVars,
   isEditableEnvVarName,
 } from '../config/env-registry.js';
-import { resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
+import { describeDataPaths, resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
+import { buildMigrationPlan, defaultDiskSpaceProbe, runDataDirsMigration } from '../config/data-dirs-migration.js';
+import { findMonorepoRoot } from '../utils/monorepo-root.js';
 import { updateRuntimeCoCreator } from '../config/runtime-cat-catalog.js';
 import { isValidTimeZone } from '../config/time-zone.js';
 import { AuditEventTypes, getEventAuditLog } from '../domains/cats/services/orchestration/EventAuditLog.js';
@@ -288,6 +290,82 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
           uploads: getDefaultUploadDir(),
         },
       },
+    };
+  });
+
+  // #671: Inspect current data-dirs layout + pending migration work
+  app.get('/api/config/data-dirs', async (request) => {
+    const cwd = process.cwd();
+    const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))
+      ? cwd
+      : existsSync(resolve(cwd, '..', '..', 'docs', 'features'))
+        ? resolve(cwd, '..', '..')
+        : cwd;
+    const opts = { repoRoot: probeRepoRoot, monorepoRoot: findMonorepoRoot(cwd) };
+    const specs = describeDataPaths(opts);
+    const plan = await buildMigrationPlan(opts);
+    return {
+      roots: {
+        DATA_DIR: process.env.DATA_DIR ?? null,
+        CACHE_DIR: process.env.CACHE_DIR ?? null,
+        LOG_DIR: process.env.LOG_DIR ?? null,
+      },
+      paths: specs.map((s) => ({
+        key: s.key,
+        root: s.root,
+        subPath: s.subPath,
+        legacyPath: s.legacyPath,
+        rootBasedPath: s.rootBasedPath,
+        currentPath: s.currentPath,
+        isFile: s.isFile,
+      })),
+      pendingMigration: {
+        hasWork: plan.hasWork,
+        totalBytes: plan.totalBytes,
+        items: plan.items
+          .filter((i) => i.eligible)
+          .map((i) => ({
+            key: i.spec.key,
+            from: i.spec.legacyPath,
+            to: i.spec.rootBasedPath,
+            bytes: i.sourceBytes,
+          })),
+      },
+    };
+  });
+
+  // #671: Trigger a runtime migration (e.g. after a startup retry, or post-Settings update).
+  // SQLite holds open handles to the legacy path until restart, so movedAny + isFile
+  // surfaces a restart recommendation in the response.
+  app.post('/api/config/data-dirs/migrate', async (request, reply) => {
+    const operator = resolveHeaderUserId(request);
+    if (!operator) {
+      reply.status(400);
+      return { error: 'Identity required (X-Cat-Cafe-User header)' };
+    }
+    const ownerId = process.env.DEFAULT_OWNER_USER_ID?.trim();
+    if (!ownerId || operator !== ownerId) {
+      reply.status(403);
+      return { error: 'Data-dirs migration requires owner identity (DEFAULT_OWNER_USER_ID)' };
+    }
+    const cwd = process.cwd();
+    const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))
+      ? cwd
+      : existsSync(resolve(cwd, '..', '..', 'docs', 'features'))
+        ? resolve(cwd, '..', '..')
+        : cwd;
+    const result = await runDataDirsMigration({
+      repoRoot: probeRepoRoot,
+      monorepoRoot: findMonorepoRoot(cwd),
+      trigger: 'runtime',
+      io: { diskFree: defaultDiskSpaceProbe, logger: request.log },
+    });
+    return {
+      attempted: result.attempted,
+      allSucceeded: result.allSucceeded,
+      restartRecommended: result.restartRecommended,
+      abortedReason: result.abortedReason,
+      items: result.items,
     };
   });
 

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -29,6 +29,7 @@ import {
   hasSensitiveEditableVars,
   isEditableEnvVarName,
 } from '../config/env-registry.js';
+import { resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
 import { updateRuntimeCoCreator } from '../config/runtime-cat-catalog.js';
 import { isValidTimeZone } from '../config/time-zone.js';
 import { AuditEventTypes, getEventAuditLog } from '../domains/cats/services/orchestration/EventAuditLog.js';
@@ -266,7 +267,6 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
   });
 
   app.get('/api/config/env-summary', async () => {
-    const apiCwd = process.cwd();
     const home = os.homedir();
     return {
       categories: ENV_CATEGORIES,
@@ -275,7 +275,7 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
         projectRoot,
         homeDir: home,
         dataDirs: {
-          auditLogs: resolve(apiCwd, process.env.AUDIT_LOG_DIR ?? './data/audit-logs'),
+          auditLogs: resolveAuditLogsDir(),
           // F212 Phase F (cloud codex R3 P2 on 3083d7c5f + R4 P2-#2 on fc69597675): use
           // the path the pino destination CAPTURED at logger import. Reading process.env.
           // LOG_DIR directly would let runtime `PATCH /api/config/env` edits change what
@@ -283,9 +283,9 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
           // AC-F5 hint would then point users to a directory that has no current logs.
           // Single source of truth = LOG_DIR_PATH.
           runtimeLogs: LOG_DIR_PATH,
-          cliArchive: resolve(apiCwd, process.env.CLI_RAW_ARCHIVE_DIR ?? './data/cli-raw-archive'),
+          cliArchive: resolveCliRawArchiveDir(),
           redisDevSandbox: resolve(home, '.cat-cafe/redis-dev-sandbox'),
-          uploads: getDefaultUploadDir(process.env.UPLOAD_DIR),
+          uploads: getDefaultUploadDir(),
         },
       },
     };

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -382,12 +382,19 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
       : existsSync(resolve(cwd, '..', '..', 'docs', 'features'))
         ? resolve(cwd, '..', '..')
         : cwd;
-    const result = await runDataDirsMigration({
+    const migrationScope = {
       repoRoot: probeRepoRoot,
       monorepoRoot: findMonorepoRoot(cwd),
+    };
+    const result = await runDataDirsMigration({
+      ...migrationScope,
       trigger: 'runtime',
+      blockFileMoves: true,
       io: { diskFree: defaultDiskSpaceProbe, logger: request.log },
     });
+    if (result.abortedReason?.startsWith('runtime-file-migration-requires-restart')) {
+      reply.status(409);
+    }
     return {
       attempted: result.attempted,
       allSucceeded: result.allSucceeded,

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -28,6 +28,7 @@ import {
   buildEnvSummary,
   ENV_CATEGORIES,
   filterSensitiveEditableKeys,
+  hasOwnerGatedEditableVars,
   hasSensitiveEditableVars,
   isEditableEnvVarName,
 } from '../config/env-registry.js';
@@ -419,14 +420,18 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
       updates.set(update.name, update.value);
     }
 
-    // Sensitive env writes require session-auth (not forgeable header identity)
+    // Protected env writes require session-auth (not forgeable header identity)
     // + loopback guard: non-localhost requests without a configured owner are
     // rejected to prevent LAN/Tailscale write-through in single-user mode.
+    // Some protected values (DATA_DIR/CACHE_DIR) are not secret, so masking and
+    // sensitive-write audit still use the narrower sensitive-editable set.
     const touchesSensitive = hasSensitiveEditableVars(updates.keys());
-    if (touchesSensitive) {
+    const touchesOwnerGated = hasOwnerGatedEditableVars(updates.keys());
+    if (touchesOwnerGated) {
+      const gateLabel = touchesSensitive ? 'Sensitive env' : 'Protected env';
       if (!sessionOperator) {
         reply.status(401);
-        return { error: 'Sensitive env writes require session authentication' };
+        return { error: `${gateLabel} writes require session authentication` };
       }
       // Network guard: when DEFAULT_OWNER_USER_ID is unset, only direct
       // loopback requests (no proxy) are trusted. Proxied or remote requests
@@ -434,11 +439,11 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
       if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
         reply.status(403);
         return {
-          error: 'Sensitive env writes from non-localhost require DEFAULT_OWNER_USER_ID to be configured',
+          error: `${gateLabel} writes from non-localhost require DEFAULT_OWNER_USER_ID to be configured`,
         };
       }
       const gateResult = resolveOwnerGate(sessionOperator, {
-        errorMessage: 'Sensitive env vars can only be modified by the owner',
+        errorMessage: `${gateLabel} vars can only be modified by the owner`,
       });
       if (gateResult) {
         reply.status(gateResult.status);
@@ -475,7 +480,7 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
       });
     }
 
-    const auditOperator = touchesSensitive ? sessionOperator! : (sessionOperator ?? operator);
+    const auditOperator = touchesOwnerGated ? sessionOperator! : (sessionOperator ?? operator);
     try {
       await auditLog.append({
         type: AuditEventTypes.CONFIG_UPDATED,

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -430,7 +430,7 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
     // Protected env writes require session-auth (not forgeable header identity)
     // + loopback guard: non-localhost requests without a configured owner are
     // rejected to prevent LAN/Tailscale write-through in single-user mode.
-    // Some protected values (DATA_DIR/CACHE_DIR) are not secret, so masking and
+    // Some protected runtime-editable values may be non-secret, so masking and
     // sensitive-write audit still use the narrower sensitive-editable set.
     const touchesSensitive = hasSensitiveEditableVars(updates.keys());
     const touchesOwnerGated = hasOwnerGatedEditableVars(updates.keys());

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -343,10 +343,18 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
       reply.status(400);
       return { error: 'Identity required (X-Cat-Cafe-User header)' };
     }
-    const ownerId = process.env.DEFAULT_OWNER_USER_ID?.trim();
-    if (!ownerId || operator !== ownerId) {
+    // Data migration moves local runtime files. In single-user mode, allow
+    // direct loopback only; remote/proxied requests need an explicit owner.
+    if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
       reply.status(403);
-      return { error: 'Data-dirs migration requires owner identity (DEFAULT_OWNER_USER_ID)' };
+      return { error: 'Data-dirs migration from non-localhost requires DEFAULT_OWNER_USER_ID to be configured' };
+    }
+    const gateResult = resolveOwnerGate(operator, {
+      errorMessage: 'Data-dirs migration requires owner identity',
+    });
+    if (gateResult) {
+      reply.status(gateResult.status);
+      return { error: gateResult.error };
     }
     const cwd = process.cwd();
     const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -293,8 +293,21 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
     };
   });
 
-  // #671: Inspect current data-dirs layout + pending migration work
-  app.get('/api/config/data-dirs', async (request) => {
+  // #671: Inspect current data-dirs layout + pending migration work.
+  // Exposes absolute paths — owner-only to avoid leaking filesystem layout.
+  app.get('/api/config/data-dirs', async (request, reply) => {
+    const operator = resolveHeaderUserId(request);
+    if (!operator) {
+      reply.status(400);
+      return { error: 'Identity required (X-Cat-Cafe-User header)' };
+    }
+    const gateResult = resolveOwnerGate(operator, {
+      errorMessage: 'Data-dirs inspection requires owner identity',
+    });
+    if (gateResult) {
+      reply.status(gateResult.status);
+      return { error: gateResult.error };
+    }
     const cwd = process.cwd();
     const probeRepoRoot = existsSync(resolve(cwd, 'docs', 'features'))
       ? cwd

--- a/packages/api/src/routes/invocations.ts
+++ b/packages/api/src/routes/invocations.ts
@@ -36,7 +36,7 @@ export interface InvocationsRoutesOptions {
 }
 
 export const invocationsRoutes: FastifyPluginAsync<InvocationsRoutesOptions> = async (app, opts) => {
-  const uploadDir = getDefaultUploadDir(opts.uploadDir ?? process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir(opts.uploadDir);
 
   // GET /api/invocations/:id — query InvocationRecord state
   app.get<{ Params: { id: string } }>('/api/invocations/:id', async (request, reply) => {

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -270,7 +270,7 @@ export function shouldMarkDecisionNotification(content: string): boolean {
 }
 
 export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (app, opts) => {
-  const uploadDir = getDefaultUploadDir(opts.uploadDir ?? process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir(opts.uploadDir);
 
   // Register multipart parser for image uploads
   await app.register(multipart, {

--- a/packages/api/src/routes/preview.ts
+++ b/packages/api/src/routes/preview.ts
@@ -142,7 +142,7 @@ export const previewRoutes: FastifyPluginAsync<PreviewRouteOpts> = async (app, o
     }
     const ext = match[1] === 'jpeg' ? 'jpg' : match[1]!;
     const buffer = Buffer.from(match[2]!, 'base64');
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `screenshot-${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`;
     await writeFile(join(uploadDir, filename), buffer);

--- a/packages/api/src/routes/ref-audio-upload.ts
+++ b/packages/api/src/routes/ref-audio-upload.ts
@@ -86,7 +86,7 @@ export const refAudioUploadRoutes: FastifyPluginAsync = async (app) => {
       });
     }
 
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `ref-audio-${Date.now()}-${randomUUID().slice(0, 8)}.${detected}`;
     await writeFile(join(uploadDir, filename), buffer, { flag: 'wx' });

--- a/packages/api/src/scripts/rebuild-index.ts
+++ b/packages/api/src/scripts/rebuild-index.ts
@@ -5,8 +5,10 @@
  * Usage: pnpm --filter @cat-cafe/api rebuild-index [--force]
  */
 
-import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolveEvidenceDbPath } from '../config/data-dirs.js';
 import { IndexBuilder } from '../domains/memory/IndexBuilder.js';
 import { SqliteEvidenceStore } from '../domains/memory/SqliteEvidenceStore.js';
 import { createModuleLogger } from '../infrastructure/logger.js';
@@ -19,10 +21,24 @@ interface RebuildIndexArgs {
   dbPath: string;
 }
 
+/**
+ * Resolve repoRoot the same way index.ts main() does — locate the directory
+ * that contains `docs/features` either at cwd or two levels up (monorepo).
+ */
+function detectRepoRoot(cwd: string): string {
+  if (existsSync(resolve(cwd, 'docs', 'features'))) return cwd;
+  if (existsSync(resolve(cwd, '..', '..', 'docs', 'features'))) return resolve(cwd, '..', '..');
+  return cwd;
+}
+
 function parseArgs(argv: string[]): RebuildIndexArgs {
   const force = argv.includes('--force');
-  const docsRoot = join(process.cwd(), 'docs');
-  const dbPath = join(process.cwd(), 'data', 'evidence.sqlite');
+  const repoRoot = detectRepoRoot(process.cwd());
+  // #671: honor DATA_DIR + share the same path the API server uses, instead of
+  // hardcoding `{cwd}/data/evidence.sqlite` (which never matched production
+  // before either — the legacy path is `{repoRoot}/evidence.sqlite`).
+  const dbPath = resolveEvidenceDbPath(repoRoot);
+  const docsRoot = process.env.DOCS_ROOT ? resolve(process.env.DOCS_ROOT) : resolve(repoRoot, 'docs');
   return { force, docsRoot, dbPath };
 }
 

--- a/packages/api/src/utils/upload-paths.ts
+++ b/packages/api/src/utils/upload-paths.ts
@@ -1,17 +1,16 @@
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const THIS_DIR = dirname(fileURLToPath(import.meta.url));
-const MODULE_DEFAULT_UPLOAD_DIR = resolve(THIS_DIR, '../../uploads');
+import { resolve } from 'node:path';
+import { resolveUploadsDir } from '../config/data-dirs.js';
 
 /**
  * Resolve the upload directory.
- * Explicit UPLOAD_DIR keeps the historical cwd-based behavior.
- * Without configuration, default to packages/api/uploads so API routes and
- * connector outbound delivery share the same on-disk truth source.
+ *
+ * An explicit override (e.g. opts.uploadDir for tests / DI) wins. Otherwise
+ * the unified resolver decides: DATA_DIR/uploads if DATA_DIR is set, else
+ * the module-relative packages/api/uploads default (so API routes and
+ * connector outbound delivery share the same on-disk truth source).
  */
-export function getDefaultUploadDir(configuredUploadDir?: string): string {
-  return configuredUploadDir ? resolve(configuredUploadDir) : MODULE_DEFAULT_UPLOAD_DIR;
+export function getDefaultUploadDir(override?: string): string {
+  return override ? resolve(override) : resolveUploadsDir();
 }
 
 const INTERNAL_ROUTE_PREFIXES = ['/uploads/', '/api/connector-media/', '/api/tts/audio/'];

--- a/packages/api/test/anthropic-model-override.test.js
+++ b/packages/api/test/anthropic-model-override.test.js
@@ -25,7 +25,7 @@ let invokeSingleCat;
 describe('anthropic protocol model override from account.models', () => {
   before(async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'anthro-model-audit-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -6,6 +6,7 @@ import test from 'node:test';
 const packageJsonPath = path.resolve(import.meta.dirname, '../package.json');
 const desktopPackageJsonPath = path.resolve(import.meta.dirname, '../../../desktop/package.json');
 const desktopMainPath = path.resolve(import.meta.dirname, '../../../desktop/main.js');
+const desktopServiceManagerPath = path.resolve(import.meta.dirname, '../../../desktop/service-manager.js');
 const desktopBuildScriptPath = path.resolve(import.meta.dirname, '../../../desktop/scripts/build-desktop.ps1');
 const desktopMacBuildScriptPath = path.resolve(import.meta.dirname, '../../../desktop/scripts/build-mac.sh');
 const desktopPostInstallScriptPath = path.resolve(
@@ -39,6 +40,41 @@ test('desktop package includes main process local require dependencies', async (
   }
 
   assert.deepEqual(missing, []);
+});
+
+test('desktop service manager injects #671 root data directories into API env', async () => {
+  const serviceManagerSource = await readFile(desktopServiceManagerPath, 'utf8');
+  const start = serviceManagerSource.indexOf('\n  _buildApiEnv(userDataDir)');
+  const end = serviceManagerSource.indexOf('async _startRedis(userDataDir)');
+  assert.notEqual(start, -1, '_buildApiEnv must exist');
+  assert.notEqual(end, -1, '_startRedis marker must exist after _buildApiEnv');
+
+  const buildApiEnvSource = serviceManagerSource.slice(start, end);
+  assert.match(buildApiEnvSource, /DATA_DIR:\s*path\.join\(userDataDir,\s*'data'\)/);
+  assert.match(buildApiEnvSource, /CACHE_DIR:\s*path\.join\(userDataDir,\s*'cache'\)/);
+  assert.match(buildApiEnvSource, /LOG_DIR:\s*path\.join\(userDataDir,\s*'data',\s*'logs',\s*'api'\)/);
+
+  const removedLegacyVars = [
+    'EVIDENCE_DB',
+    'TRANSCRIPT_DATA_DIR',
+    'UPLOAD_DIR',
+    'CONNECTOR_MEDIA_DIR',
+    'TTS_CACHE_DIR',
+    'AUDIT_LOG_DIR',
+    'CLI_RAW_ARCHIVE_DIR',
+  ];
+  for (const envName of removedLegacyVars) {
+    assert.doesNotMatch(buildApiEnvSource, new RegExp(`\\b${envName}\\s*:`));
+  }
+});
+
+test('desktop service manager links writable .cat-cafe state under DATA_DIR', async () => {
+  const serviceManagerSource = await readFile(desktopServiceManagerPath, 'utf8');
+
+  assert.match(serviceManagerSource, /path\.join\(baseDir,\s*'data',\s*'cat-cafe'\)/);
+  assert.match(serviceManagerSource, /path\.join\(projectDir,\s*'\.cat-cafe'\)/);
+  assert.match(serviceManagerSource, /fs\.renameSync\(projectCatCafeDir,\s*catCafeStateDir\)/);
+  assert.match(serviceManagerSource, /fs\.symlinkSync\(catCafeStateDir,\s*projectCatCafeDir,\s*linkType\)/);
 });
 
 test('windows desktop build script cleans up temporary Defender exclusions', async () => {

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -75,6 +75,8 @@ test('desktop service manager links writable .cat-cafe state under DATA_DIR', as
   assert.match(serviceManagerSource, /path\.join\(projectDir,\s*'\.cat-cafe'\)/);
   assert.match(serviceManagerSource, /fs\.renameSync\(projectCatCafeDir,\s*catCafeStateDir\)/);
   assert.match(serviceManagerSource, /fs\.symlinkSync\(catCafeStateDir,\s*projectCatCafeDir,\s*linkType\)/);
+  // Windows junction detection (P1 review: NTFS junctions can report as directories)
+  assert.match(serviceManagerSource, /readlinkSync\(projectCatCafeDir\)/);
 });
 
 test('windows desktop build script cleans up temporary Defender exclusions', async () => {

--- a/packages/api/test/callback-routes.test.js
+++ b/packages/api/test/callback-routes.test.js
@@ -2486,8 +2486,8 @@ describe('Callback Routes', () => {
   test('#454: generate-document broadcast includes invocationId', async () => {
     const { tmpdir } = await import('node:os');
     const { rm } = await import('node:fs/promises');
-    const uploadDir = `${tmpdir()}/cat-cafe-test-uploads-454`;
-    process.env.UPLOAD_DIR = uploadDir;
+    const dataRoot = `${tmpdir()}/cat-cafe-test-data-454`;
+    process.env.DATA_DIR = dataRoot;
     try {
       const app = await createApp();
       const { invocationId, callbackToken } = await registry.create('user-1', 'opus', 'thread-454-doc');
@@ -2512,8 +2512,8 @@ describe('Callback Routes', () => {
       assert.ok(docMsg, 'generate-document should broadcast system_info with rich_block');
       assert.equal(docMsg.invocationId, invocationId, 'generate-document broadcast must include invocationId');
     } finally {
-      delete process.env.UPLOAD_DIR;
-      await rm(uploadDir, { recursive: true, force: true }).catch(() => {});
+      delete process.env.DATA_DIR;
+      await rm(dataRoot, { recursive: true, force: true }).catch(() => {});
     }
   });
 

--- a/packages/api/test/cat-voices-ref-audio-path.test.js
+++ b/packages/api/test/cat-voices-ref-audio-path.test.js
@@ -8,27 +8,30 @@ import { resolveRefAudioPath } from '../dist/config/cat-voices.js';
 
 describe('resolveRefAudioPath', () => {
   /** @type {string} */
+  let dataRoot;
+  /** @type {string} */
   let uploadDir;
   /** @type {string} */
   let characterDir;
   /** @type {string | undefined} */
-  let prevUploadDir;
+  let prevDataDir;
 
   before(async () => {
-    uploadDir = await mkdtemp(join(tmpdir(), 'cat-cafe-ref-audio-uploads-'));
+    dataRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-ref-audio-data-'));
+    uploadDir = join(dataRoot, 'uploads');
     characterDir = await mkdtemp(join(tmpdir(), 'cat-cafe-character-voices-'));
-    prevUploadDir = process.env.UPLOAD_DIR;
-    process.env.UPLOAD_DIR = uploadDir;
+    prevDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = dataRoot;
   });
 
   after(async () => {
-    if (prevUploadDir === undefined) delete process.env.UPLOAD_DIR;
-    else process.env.UPLOAD_DIR = prevUploadDir;
-    await rm(uploadDir, { recursive: true, force: true });
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
+    await rm(dataRoot, { recursive: true, force: true });
     await rm(characterDir, { recursive: true, force: true });
   });
 
-  it('resolves uploaded refAudio URLs inside UPLOAD_DIR', () => {
+  it('resolves uploaded refAudio URLs inside DATA_DIR/uploads', () => {
     assert.equal(resolveRefAudioPath('/uploads/ref-audio-1.wav', characterDir), join(uploadDir, 'ref-audio-1.wav'));
   });
 
@@ -36,11 +39,11 @@ describe('resolveRefAudioPath', () => {
     assert.equal(resolveRefAudioPath('魈/vo_xiao.wav', characterDir), join(characterDir, '魈/vo_xiao.wav'));
   });
 
-  it('rejects uploaded refAudio traversal outside UPLOAD_DIR', () => {
+  it('rejects uploaded refAudio traversal outside DATA_DIR/uploads', () => {
     assert.equal(resolveRefAudioPath('/uploads/../secret.wav', characterDir), join(uploadDir, 'invalid-ref'));
   });
 
-  it('rejects nested uploaded refAudio traversal even when normalized path stays inside UPLOAD_DIR', () => {
+  it('rejects nested uploaded refAudio traversal even when normalized path stays inside DATA_DIR/uploads', () => {
     assert.equal(resolveRefAudioPath('/uploads/sub/../secret.wav', characterDir), join(uploadDir, 'invalid-ref'));
   });
 

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
-import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { existsSync, symlinkSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, test } from 'node:test';
@@ -365,6 +365,48 @@ describe('data-dirs-migration', () => {
         restartRecommended: false,
       });
       assert.equal(decision.shouldAbort, false);
+    });
+
+    test('cross-device dir migration fails on symlinks instead of silently dropping them', async () => {
+      // Create a data directory containing a symlink
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'real.ndjson'), '{"a":1}\n', 'utf-8');
+      // Create a relative symlink inside the directory (relative so it
+      // survives same-device rename to a different parent directory)
+      await symlink('real.ndjson', join(legacyAudit, 'link.ndjson'));
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+        });
+        // On same device, rename handles symlinks transparently → moved.
+        // The test checks that the migration either succeeds (same device)
+        // or fails with a clear error (cross device), never silently drops.
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        if (audit.status === 'moved') {
+          // Same-device rename succeeded — symlink preserved
+          assert.equal(existsSync(join(dataRoot, 'audit-logs', 'link.ndjson')), true);
+        } else {
+          // Cross-device path hit the symlink guard → failed with message
+          assert.equal(audit.status, 'failed');
+          assert.ok(audit.error.includes('non-regular entry'));
+          // Legacy data stays intact
+          assert.equal(existsSync(join(legacyAudit, 'real.ndjson')), true);
+          assert.equal(existsSync(join(legacyAudit, 'link.ndjson')), true);
+        }
+      } finally {
+        process.chdir(originalCwd);
+      }
     });
 
     test('continues other items when one fails (per-item isolation)', async () => {

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -442,6 +442,37 @@ describe('data-dirs-migration', () => {
       }
     });
 
+    test('cross-device dir migration removes partial target when copy fails', async () => {
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'first.ndjson'), '{"first":true}\n', 'utf-8');
+      await symlink('first.ndjson', join(legacyAudit, 'link.ndjson'));
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+          forceCrossDeviceForTesting: true,
+        });
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        assert.equal(audit.status, 'failed');
+        assert.ok(audit.error.includes('non-regular entry'));
+        assert.equal(existsSync(join(legacyAudit, 'first.ndjson')), true, 'legacy file must remain');
+        assert.equal(existsSync(join(legacyAudit, 'link.ndjson')), true, 'legacy symlink must remain');
+        assert.equal(existsSync(join(dataRoot, 'audit-logs')), false, 'partial target must be removed');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
     test('continues other items when one fails (per-item isolation)', async () => {
       const legacyA = join(workRoot, 'evidence.sqlite');
       const legacyB = join(workRoot, 'world.sqlite');

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, test } from 'node:test';
 
-const { buildMigrationPlan, measurePath, runDataDirsMigration } = await import(
+const { buildMigrationPlan, measurePath, runDataDirsMigration, shouldAbortStartupOnMigration } = await import(
   '../dist/config/data-dirs-migration.js'
 );
 
@@ -59,7 +59,7 @@ describe('data-dirs-migration', () => {
 
   describe('buildMigrationPlan', () => {
     test('reports no work when no root env var is set', async () => {
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
       assert.equal(plan.hasWork, false);
       assert.equal(plan.totalBytes, 0);
       const reasons = new Set(plan.items.map((i) => i.skipReason));
@@ -74,7 +74,7 @@ describe('data-dirs-migration', () => {
       process.chdir(cleanCwd);
       try {
         process.env.DATA_DIR = join(workRoot, 'data');
-        const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+        const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
         assert.equal(plan.hasWork, false);
         for (const item of plan.items) {
           if (item.spec.root === 'DATA_DIR') {
@@ -92,7 +92,7 @@ describe('data-dirs-migration', () => {
       await writeFile(legacyDb, 'fake sqlite content', 'utf-8');
       process.env.DATA_DIR = join(workRoot, 'data');
 
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
       assert.equal(plan.hasWork, true);
       const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
       assert.ok(evidence);
@@ -108,7 +108,7 @@ describe('data-dirs-migration', () => {
       await writeFile(targetDb, 'existing target content', 'utf-8');
 
       process.env.DATA_DIR = join(workRoot, 'data');
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
       const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
       assert.equal(evidence.eligible, false);
       assert.equal(evidence.skipReason, 'target-not-empty');
@@ -148,6 +148,7 @@ describe('data-dirs-migration', () => {
       const result = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'startup',
         io: plentyOfSpaceIO(),
       });
@@ -168,6 +169,7 @@ describe('data-dirs-migration', () => {
       const result = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'startup',
         io: plentyOfSpaceIO(),
       });
@@ -206,6 +208,7 @@ describe('data-dirs-migration', () => {
         const result = await runDataDirsMigration({
           repoRoot: workRoot,
           monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
           trigger: 'startup',
           io: plentyOfSpaceIO(),
         });
@@ -230,6 +233,7 @@ describe('data-dirs-migration', () => {
       const result = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'startup',
         io: squeezedSpaceIO(500), // need ~1500, only have 500
       });
@@ -248,6 +252,7 @@ describe('data-dirs-migration', () => {
       const startup = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'startup',
         io: plentyOfSpaceIO(),
       });
@@ -260,10 +265,76 @@ describe('data-dirs-migration', () => {
       const runtime = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'runtime',
         io: plentyOfSpaceIO(),
       });
       assert.equal(runtime.restartRecommended, true);
+    });
+
+    test('shouldAbortStartupOnMigration: no work → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: false,
+        items: [],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
+    });
+
+    test('shouldAbortStartupOnMigration: all moved → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/new/e', bytes: 10, status: 'moved' },
+          { key: 'worldDb', fromPath: '/old/w', toPath: '/new/w', bytes: 10, status: 'moved' },
+        ],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
+    });
+
+    test('shouldAbortStartupOnMigration: aborted at planning stage → abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: false,
+        items: [],
+        allSucceeded: false,
+        restartRecommended: false,
+        abortedReason: 'insufficient-disk-space: need 1000, have 500',
+      });
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('insufficient-disk-space'));
+    });
+
+    test('shouldAbortStartupOnMigration: per-item failure → abort with leftBehind list', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/new/e', bytes: 10, status: 'moved' },
+          { key: 'worldDb', fromPath: '/old/w', toPath: '/new/w', bytes: 10, status: 'failed', error: 'EACCES' },
+          { key: 'auditLogs', fromPath: '/old/a', toPath: '/new/a', bytes: 0, status: 'skipped', reason: 'no-source-data' },
+        ],
+        allSucceeded: false,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('1 data-dirs path(s) failed'));
+      assert.equal(decision.leftBehind.length, 1);
+      assert.equal(decision.leftBehind[0].key, 'worldDb');
+      assert.equal(decision.leftBehind[0].status, 'failed');
+    });
+
+    test('shouldAbortStartupOnMigration: only skipped items → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/old/e', bytes: 0, status: 'skipped', reason: 'no-source-data' },
+        ],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
     });
 
     test('continues other items when one fails (per-item isolation)', async () => {
@@ -282,6 +353,7 @@ describe('data-dirs-migration', () => {
       const result = await runDataDirsMigration({
         repoRoot: workRoot,
         monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
         trigger: 'startup',
         io: plentyOfSpaceIO(),
       });

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -400,6 +400,36 @@ describe('data-dirs-migration', () => {
       assert.equal(decision.shouldAbort, false);
     });
 
+    test('startup surfaces target-not-empty blocked migrations when no item is eligible', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy evidence', 'utf-8');
+      const dataRoot = join(workRoot, 'newdata');
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite'), 'existing target', 'utf-8');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, false);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'target-not-empty');
+
+      const decision = shouldAbortStartupOnMigration(result);
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('target-not-empty'));
+      assert.equal(decision.leftBehind.length, 1);
+      assert.equal(decision.leftBehind[0].key, 'evidenceDb');
+      assert.equal(decision.leftBehind[0].status, 'skipped');
+    });
+
     test('cross-device dir migration fails on symlinks instead of silently dropping them', async () => {
       // Create a data directory containing a symlink
       const legacyAudit = join(workRoot, 'data', 'audit-logs');

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -129,6 +129,25 @@ describe('data-dirs-migration', () => {
       assert.equal(evidence.eligible, false);
       assert.equal(evidence.skipReason, 'target-not-empty');
     });
+
+    test('treats populated SQLite target sidecars as target-not-empty', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy main', 'utf-8');
+      const dataRoot = join(workRoot, 'data');
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite-wal'), 'target wal', 'utf-8');
+
+      process.env.DATA_DIR = dataRoot;
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.equal(evidence.eligible, false);
+      assert.equal(evidence.targetPopulated, true);
+      assert.equal(evidence.skipReason, 'target-not-empty');
+    });
   });
 
   describe('measurePath', () => {
@@ -319,6 +338,31 @@ describe('data-dirs-migration', () => {
         io: plentyOfSpaceIO(),
       });
       assert.equal(runtime.restartRecommended, true);
+    });
+
+    test('blockFileMoves refuses runtime SQLite moves without touching legacy data', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy evidence', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'newdata');
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'runtime',
+        blockFileMoves: true,
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, false);
+      assert.equal(result.restartRecommended, true);
+      assert.match(result.abortedReason, /restart/i);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'runtime-file-migration-requires-restart');
+      assert.equal(existsSync(legacyDb), true);
+      assert.equal(existsSync(join(workRoot, 'newdata', 'evidence.sqlite')), false);
     });
 
     test('shouldAbortStartupOnMigration: no work → no abort', () => {

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -207,6 +207,39 @@ describe('data-dirs-migration', () => {
       assert.equal(existsSync(`${legacyDb}-shm`), false);
     });
 
+    test('rolls back main SQLite file when sidecar migration fails', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      const legacyWal = `${legacyDb}-wal`;
+      await writeFile(legacyDb, 'main-db-data', 'utf-8');
+      await writeFile(legacyWal, 'wal-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      await mkdir(dataRoot, { recursive: true });
+      // Plant a directory at the WAL target path — rename(file, dir) fails
+      // with EISDIR, triggering the rollback logic in migrateOne.
+      await mkdir(join(dataRoot, 'evidence.sqlite-wal'), { recursive: true });
+
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'failed', 'migration must fail when sidecar target is blocked');
+      // Legacy data must be fully intact (rollback succeeded)
+      assert.equal(existsSync(legacyDb), true, 'legacy main DB must survive rollback');
+      assert.equal(existsSync(legacyWal), true, 'legacy WAL must survive rollback');
+      assert.equal(await readFile(legacyDb, 'utf-8'), 'main-db-data');
+      assert.equal(await readFile(legacyWal, 'utf-8'), 'wal-data');
+      // Target main file must NOT remain (rolled back)
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), false, 'target main DB must be rolled back');
+    });
+
     test('migrates eligible directory paths recursively', async () => {
       // Set up legacy audit-logs dir relative to workRoot (acts as cwd surrogate)
       const legacyAudit = join(workRoot, 'data', 'audit-logs');

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -148,6 +148,27 @@ describe('data-dirs-migration', () => {
       assert.equal(evidence.targetPopulated, true);
       assert.equal(evidence.skipReason, 'target-not-empty');
     });
+
+    test('treats uploads legacy .gitkeep placeholder as no source data', async () => {
+      const legacyUploads = join(workRoot, 'packages', 'api', 'uploads');
+      const dataRoot = join(workRoot, 'data');
+      await mkdir(legacyUploads, { recursive: true });
+      await mkdir(join(dataRoot, 'uploads'), { recursive: true });
+      await writeFile(join(legacyUploads, '.gitkeep'), '', 'utf-8');
+      await writeFile(join(dataRoot, 'uploads', 'real-upload.png'), 'target upload', 'utf-8');
+
+      process.env.DATA_DIR = dataRoot;
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: legacyUploads,
+      });
+
+      const uploads = plan.items.find((i) => i.spec.key === 'uploads');
+      assert.equal(uploads.eligible, false);
+      assert.equal(uploads.sourceExists, false);
+      assert.equal(uploads.skipReason, 'no-source-data');
+    });
   });
 
   describe('measurePath', () => {

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -1,0 +1,300 @@
+import assert from 'node:assert/strict';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+const { buildMigrationPlan, measurePath, runDataDirsMigration } = await import(
+  '../dist/config/data-dirs-migration.js'
+);
+
+function snapshotEnv() {
+  return {
+    DATA_DIR: process.env.DATA_DIR,
+    CACHE_DIR: process.env.CACHE_DIR,
+    LOG_DIR: process.env.LOG_DIR,
+  };
+}
+
+function restoreEnv(snap) {
+  for (const key of Object.keys(snap)) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
+
+function clearRoots() {
+  delete process.env.DATA_DIR;
+  delete process.env.CACHE_DIR;
+  delete process.env.LOG_DIR;
+}
+
+function plentyOfSpaceIO() {
+  return {
+    diskFree: async () => ({ availableBytes: 1_000_000_000_000, totalBytes: 2_000_000_000_000 }),
+  };
+}
+
+function squeezedSpaceIO(availableBytes) {
+  return {
+    diskFree: async () => ({ availableBytes, totalBytes: availableBytes * 2 }),
+  };
+}
+
+describe('data-dirs-migration', () => {
+  let savedEnv;
+  let workRoot;
+
+  beforeEach(async () => {
+    savedEnv = snapshotEnv();
+    clearRoots();
+    workRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-671-mig-'));
+  });
+
+  afterEach(async () => {
+    restoreEnv(savedEnv);
+    if (workRoot) await rm(workRoot, { recursive: true, force: true });
+  });
+
+  describe('buildMigrationPlan', () => {
+    test('reports no work when no root env var is set', async () => {
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      assert.equal(plan.hasWork, false);
+      assert.equal(plan.totalBytes, 0);
+      const reasons = new Set(plan.items.map((i) => i.skipReason));
+      assert.ok(reasons.has('root-env-not-set'));
+    });
+
+    test('skips items with no source data', async () => {
+      // chdir to a clean dir so cwd-relative legacy paths (audit-logs, cli-raw-archive)
+      // don't see leftover data from prior test runs in the project root.
+      const cleanCwd = await mkdtemp(join(tmpdir(), 'cat-cafe-671-cwd-'));
+      const originalCwd = process.cwd();
+      process.chdir(cleanCwd);
+      try {
+        process.env.DATA_DIR = join(workRoot, 'data');
+        const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+        assert.equal(plan.hasWork, false);
+        for (const item of plan.items) {
+          if (item.spec.root === 'DATA_DIR') {
+            assert.ok(['no-source-data', 'legacy-equals-target'].includes(item.skipReason));
+          }
+        }
+      } finally {
+        process.chdir(originalCwd);
+        await rm(cleanCwd, { recursive: true, force: true });
+      }
+    });
+
+    test('detects eligible items with source data + empty target', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'fake sqlite content', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'data');
+
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      assert.equal(plan.hasWork, true);
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.ok(evidence);
+      assert.equal(evidence.eligible, true);
+      assert.ok(evidence.sourceBytes > 0);
+    });
+
+    test('skips items where target is already populated', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'fake', 'utf-8');
+      const targetDb = join(workRoot, 'data', 'evidence.sqlite');
+      await mkdir(join(workRoot, 'data'), { recursive: true });
+      await writeFile(targetDb, 'existing target content', 'utf-8');
+
+      process.env.DATA_DIR = join(workRoot, 'data');
+      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot });
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.equal(evidence.eligible, false);
+      assert.equal(evidence.skipReason, 'target-not-empty');
+    });
+  });
+
+  describe('measurePath', () => {
+    test('returns 0 for missing paths', async () => {
+      assert.equal(await measurePath('/tmp/this-does-not-exist-671'), 0);
+    });
+
+    test('returns file size for plain files', async () => {
+      const file = join(workRoot, 'sample.txt');
+      await writeFile(file, 'abcdef', 'utf-8');
+      assert.equal(await measurePath(file), 6);
+    });
+
+    test('includes SQLite sidecars (-wal, -shm) for *.sqlite files', async () => {
+      const db = join(workRoot, 'evidence.sqlite');
+      await writeFile(db, '1234567890', 'utf-8'); // 10 bytes
+      await writeFile(`${db}-wal`, '12345', 'utf-8'); // 5 bytes
+      await writeFile(`${db}-shm`, 'XX', 'utf-8'); // 2 bytes
+      assert.equal(await measurePath(db), 17);
+    });
+
+    test('recursively sums directory contents', async () => {
+      const dir = join(workRoot, 'tree');
+      await mkdir(join(dir, 'sub'), { recursive: true });
+      await writeFile(join(dir, 'a.txt'), 'hello', 'utf-8'); // 5
+      await writeFile(join(dir, 'sub', 'b.txt'), 'world!', 'utf-8'); // 6
+      assert.equal(await measurePath(dir), 11);
+    });
+  });
+
+  describe('runDataDirsMigration', () => {
+    test('returns attempted=false when no work pending', async () => {
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, true);
+      assert.equal(result.restartRecommended, false);
+    });
+
+    test('migrates eligible file paths and SQLite sidecars', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'evidence-data', 'utf-8');
+      await writeFile(`${legacyDb}-wal`, 'wal-data', 'utf-8');
+      await writeFile(`${legacyDb}-shm`, 'shm-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, true);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.ok(evidence);
+      assert.equal(evidence.status, 'moved');
+
+      // New paths exist with content
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), true);
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite-wal')), true);
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite-shm')), true);
+      assert.equal(await readFile(join(dataRoot, 'evidence.sqlite'), 'utf-8'), 'evidence-data');
+
+      // Legacy paths cleaned up
+      assert.equal(existsSync(legacyDb), false);
+      assert.equal(existsSync(`${legacyDb}-wal`), false);
+      assert.equal(existsSync(`${legacyDb}-shm`), false);
+    });
+
+    test('migrates eligible directory paths recursively', async () => {
+      // Set up legacy audit-logs dir relative to workRoot (acts as cwd surrogate)
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'audit-2026-01-01.ndjson'), '{"a":1}\n', 'utf-8');
+      await writeFile(join(legacyAudit, 'audit-2026-01-02.ndjson'), '{"b":2}\n', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      // Temporarily run from workRoot so cwd-relative legacy resolves correctly
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+        });
+        assert.equal(result.attempted, true);
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        assert.equal(audit.status, 'moved');
+        assert.equal(existsSync(join(dataRoot, 'audit-logs', 'audit-2026-01-01.ndjson')), true);
+        assert.equal(existsSync(join(dataRoot, 'audit-logs', 'audit-2026-01-02.ndjson')), true);
+        assert.equal(existsSync(legacyAudit), false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    test('aborts when disk space is insufficient — no partial moves', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'x'.repeat(1000), 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'startup',
+        io: squeezedSpaceIO(500), // need ~1500, only have 500
+      });
+
+      assert.equal(result.attempted, false);
+      assert.ok(result.abortedReason?.includes('insufficient-disk-space'));
+      assert.equal(existsSync(legacyDb), true, 'legacy file must remain untouched on abort');
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), false);
+    });
+
+    test('recommends restart only for runtime trigger', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'data', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'newdata');
+
+      const startup = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(startup.restartRecommended, false);
+
+      // Reset by moving file back
+      await writeFile(legacyDb, 'data', 'utf-8');
+      await rm(join(workRoot, 'newdata'), { recursive: true, force: true });
+
+      const runtime = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'runtime',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(runtime.restartRecommended, true);
+    });
+
+    test('continues other items when one fails (per-item isolation)', async () => {
+      const legacyA = join(workRoot, 'evidence.sqlite');
+      const legacyB = join(workRoot, 'world.sqlite');
+      await writeFile(legacyA, 'a-data', 'utf-8');
+      await writeFile(legacyB, 'b-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      // Pre-create the evidence target as a populated file → forces target-not-empty
+      // for evidence, world should still migrate.
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite'), 'existing', 'utf-8');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(result.attempted, true);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      const world = result.items.find((i) => i.key === 'worldDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'target-not-empty');
+      assert.equal(world.status, 'moved');
+      assert.equal(existsSync(join(dataRoot, 'world.sqlite')), true);
+      assert.equal(existsSync(legacyB), false);
+      // The pre-existing target evidence stays intact
+      assert.equal(await readFile(join(dataRoot, 'evidence.sqlite'), 'utf-8'), 'existing');
+    });
+  });
+});

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -59,7 +59,11 @@ describe('data-dirs-migration', () => {
 
   describe('buildMigrationPlan', () => {
     test('reports no work when no root env var is set', async () => {
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
       assert.equal(plan.hasWork, false);
       assert.equal(plan.totalBytes, 0);
       const reasons = new Set(plan.items.map((i) => i.skipReason));
@@ -74,7 +78,11 @@ describe('data-dirs-migration', () => {
       process.chdir(cleanCwd);
       try {
         process.env.DATA_DIR = join(workRoot, 'data');
-        const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
+        const plan = await buildMigrationPlan({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        });
         assert.equal(plan.hasWork, false);
         for (const item of plan.items) {
           if (item.spec.root === 'DATA_DIR') {
@@ -92,7 +100,11 @@ describe('data-dirs-migration', () => {
       await writeFile(legacyDb, 'fake sqlite content', 'utf-8');
       process.env.DATA_DIR = join(workRoot, 'data');
 
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
       assert.equal(plan.hasWork, true);
       const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
       assert.ok(evidence);
@@ -108,7 +120,11 @@ describe('data-dirs-migration', () => {
       await writeFile(targetDb, 'existing target content', 'utf-8');
 
       process.env.DATA_DIR = join(workRoot, 'data');
-      const plan = await buildMigrationPlan({ repoRoot: workRoot, monorepoRoot: workRoot, uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy') });
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
       const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
       assert.equal(evidence.eligible, false);
       assert.equal(evidence.skipReason, 'target-not-empty');
@@ -313,7 +329,14 @@ describe('data-dirs-migration', () => {
         items: [
           { key: 'evidenceDb', fromPath: '/old/e', toPath: '/new/e', bytes: 10, status: 'moved' },
           { key: 'worldDb', fromPath: '/old/w', toPath: '/new/w', bytes: 10, status: 'failed', error: 'EACCES' },
-          { key: 'auditLogs', fromPath: '/old/a', toPath: '/new/a', bytes: 0, status: 'skipped', reason: 'no-source-data' },
+          {
+            key: 'auditLogs',
+            fromPath: '/old/a',
+            toPath: '/new/a',
+            bytes: 0,
+            status: 'skipped',
+            reason: 'no-source-data',
+          },
         ],
         allSucceeded: false,
         restartRecommended: false,
@@ -329,7 +352,14 @@ describe('data-dirs-migration', () => {
       const decision = shouldAbortStartupOnMigration({
         attempted: true,
         items: [
-          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/old/e', bytes: 0, status: 'skipped', reason: 'no-source-data' },
+          {
+            key: 'evidenceDb',
+            fromPath: '/old/e',
+            toPath: '/old/e',
+            bytes: 0,
+            status: 'skipped',
+            reason: 'no-source-data',
+          },
         ],
         allSucceeded: true,
         restartRecommended: false,

--- a/packages/api/test/data-dirs.test.js
+++ b/packages/api/test/data-dirs.test.js
@@ -1,0 +1,232 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+const {
+  resolveEvidenceDbPath,
+  resolveWorldDbPath,
+  resolveTranscriptsDir,
+  resolveAuditLogsDir,
+  resolveCliRawArchiveDir,
+  resolveUploadsDir,
+  resolveTtsCacheDir,
+  resolveConnectorMediaDir,
+  resolveLogDir,
+  describeDataPaths,
+} = await import('../dist/config/data-dirs.js');
+
+const REPO_ROOT = '/tmp/issue-671-repo';
+const MONOREPO_ROOT = '/tmp/issue-671-monorepo';
+
+function snapshotEnv() {
+  return {
+    DATA_DIR: process.env.DATA_DIR,
+    CACHE_DIR: process.env.CACHE_DIR,
+    LOG_DIR: process.env.LOG_DIR,
+  };
+}
+
+function restoreEnv(snap) {
+  for (const key of Object.keys(snap)) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
+
+function clearRoots() {
+  delete process.env.DATA_DIR;
+  delete process.env.CACHE_DIR;
+  delete process.env.LOG_DIR;
+}
+
+describe('data-dirs resolver (issue #671)', () => {
+  let savedEnv;
+
+  beforeEach(() => {
+    savedEnv = snapshotEnv();
+    clearRoots();
+  });
+
+  afterEach(() => {
+    restoreEnv(savedEnv);
+  });
+
+  describe('legacy defaults (no root configured)', () => {
+    test('evidence.sqlite falls back to repoRoot', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('world.sqlite falls back to repoRoot', () => {
+      assert.equal(resolveWorldDbPath(REPO_ROOT), resolve(REPO_ROOT, 'world.sqlite'));
+    });
+
+    test('transcripts falls back to monorepoRoot/data/transcripts', () => {
+      assert.equal(resolveTranscriptsDir(MONOREPO_ROOT), resolve(MONOREPO_ROOT, 'data/transcripts'));
+    });
+
+    test('audit-logs falls back to cwd/data/audit-logs', () => {
+      assert.equal(resolveAuditLogsDir(), resolve(process.cwd(), 'data/audit-logs'));
+    });
+
+    test('cli-raw-archive falls back to cwd/data/cli-raw-archive', () => {
+      assert.equal(resolveCliRawArchiveDir(), resolve(process.cwd(), 'data/cli-raw-archive'));
+    });
+
+    test('uploads falls back to module-relative packages/api/uploads', () => {
+      const dir = resolveUploadsDir();
+      // Module default resolves to <pkg>/uploads at runtime (under dist/, two levels up = packages/api)
+      assert.ok(dir.endsWith('/uploads'), `expected to end with /uploads, got ${dir}`);
+      assert.ok(dir.includes('packages/api'), `expected to include packages/api, got ${dir}`);
+    });
+
+    test('tts-cache falls back to cwd/data/tts-cache', () => {
+      assert.equal(resolveTtsCacheDir(), resolve(process.cwd(), 'data/tts-cache'));
+    });
+
+    test('connector-media falls back to cwd/data/connector-media', () => {
+      assert.equal(resolveConnectorMediaDir(), resolve(process.cwd(), 'data/connector-media'));
+    });
+
+    test('logs falls back to cwd/data/logs/api', () => {
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('DATA_DIR root configured', () => {
+    beforeEach(() => {
+      process.env.DATA_DIR = '/tmp/issue-671-data';
+    });
+
+    test('evidence.sqlite goes under DATA_DIR', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), '/tmp/issue-671-data/evidence.sqlite');
+    });
+
+    test('world.sqlite goes under DATA_DIR', () => {
+      assert.equal(resolveWorldDbPath(REPO_ROOT), '/tmp/issue-671-data/world.sqlite');
+    });
+
+    test('transcripts goes under DATA_DIR (overrides monorepoRoot)', () => {
+      assert.equal(resolveTranscriptsDir(MONOREPO_ROOT), '/tmp/issue-671-data/transcripts');
+    });
+
+    test('audit-logs goes under DATA_DIR', () => {
+      assert.equal(resolveAuditLogsDir(), '/tmp/issue-671-data/audit-logs');
+    });
+
+    test('cli-raw-archive goes under DATA_DIR', () => {
+      assert.equal(resolveCliRawArchiveDir(), '/tmp/issue-671-data/cli-raw-archive');
+    });
+
+    test('uploads goes under DATA_DIR (overrides module default)', () => {
+      assert.equal(resolveUploadsDir(), '/tmp/issue-671-data/uploads');
+    });
+
+    test('DATA_DIR does not affect cache or log paths', () => {
+      assert.equal(resolveTtsCacheDir(), resolve(process.cwd(), 'data/tts-cache'));
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('CACHE_DIR root configured', () => {
+    beforeEach(() => {
+      process.env.CACHE_DIR = '/tmp/issue-671-cache';
+    });
+
+    test('tts-cache goes under CACHE_DIR', () => {
+      assert.equal(resolveTtsCacheDir(), '/tmp/issue-671-cache/tts');
+    });
+
+    test('connector-media goes under CACHE_DIR', () => {
+      assert.equal(resolveConnectorMediaDir(), '/tmp/issue-671-cache/connector-media');
+    });
+
+    test('CACHE_DIR does not affect data or log paths', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('LOG_DIR root configured', () => {
+    test('LOG_DIR is used directly without subdirectory', () => {
+      process.env.LOG_DIR = '/tmp/issue-671-logs';
+      assert.equal(resolveLogDir(), '/tmp/issue-671-logs');
+    });
+  });
+
+  describe('empty/whitespace root values are treated as unset', () => {
+    test('DATA_DIR="" falls back to legacy', () => {
+      process.env.DATA_DIR = '';
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('DATA_DIR="   " (whitespace) falls back to legacy', () => {
+      process.env.DATA_DIR = '   ';
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('LOG_DIR="" falls back to default', () => {
+      process.env.LOG_DIR = '';
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('relative root paths are resolved against cwd', () => {
+    test('DATA_DIR=./mydata becomes absolute', () => {
+      process.env.DATA_DIR = './mydata';
+      const expected = resolve(process.cwd(), 'mydata/evidence.sqlite');
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), expected);
+    });
+  });
+
+  describe('describeDataPaths introspection', () => {
+    test('returns 9 specs with correct keys when no root set', () => {
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      assert.equal(specs.length, 9);
+      const keys = specs.map((s) => s.key).sort();
+      assert.deepEqual(keys, [
+        'auditLogs',
+        'cliRawArchive',
+        'connectorMedia',
+        'evidenceDb',
+        'logs',
+        'transcripts',
+        'ttsCache',
+        'uploads',
+        'worldDb',
+      ]);
+      // No root → rootBasedPath is null for all
+      for (const s of specs) {
+        assert.equal(s.rootBasedPath, null, `expected rootBasedPath=null for ${s.key}`);
+        assert.equal(s.currentPath, s.legacyPath, `expected currentPath=legacyPath for ${s.key}`);
+      }
+    });
+
+    test('isFile flag is true only for SQLite DBs', () => {
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      const fileKeys = specs
+        .filter((s) => s.isFile)
+        .map((s) => s.key)
+        .sort();
+      assert.deepEqual(fileKeys, ['evidenceDb', 'worldDb']);
+    });
+
+    test('with all roots set, rootBasedPath equals currentPath', () => {
+      process.env.DATA_DIR = '/tmp/d';
+      process.env.CACHE_DIR = '/tmp/c';
+      process.env.LOG_DIR = '/tmp/l';
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      for (const s of specs) {
+        assert.notEqual(s.rootBasedPath, null, `expected rootBasedPath set for ${s.key}`);
+        assert.equal(s.currentPath, s.rootBasedPath, `mismatch for ${s.key}`);
+      }
+      // Spot check sub-paths
+      const evidence = specs.find((s) => s.key === 'evidenceDb');
+      assert.equal(evidence.currentPath, '/tmp/d/evidence.sqlite');
+      const tts = specs.find((s) => s.key === 'ttsCache');
+      assert.equal(tts.currentPath, '/tmp/c/tts');
+      const logs = specs.find((s) => s.key === 'logs');
+      assert.equal(logs.currentPath, '/tmp/l');
+      assert.equal(logs.subPath, '', 'logs subPath should be empty');
+    });
+  });
+});

--- a/packages/api/test/data-dirs.test.js
+++ b/packages/api/test/data-dirs.test.js
@@ -9,6 +9,7 @@ const {
   resolveAuditLogsDir,
   resolveCliRawArchiveDir,
   resolveUploadsDir,
+  resolveCatCafeStateDir,
   resolveRedisDataDir,
   resolveRedisBackupDir,
   resolveTtsCacheDir,
@@ -100,6 +101,10 @@ describe('data-dirs resolver (issue #671)', () => {
       assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
     });
 
+    test('.cat-cafe state falls back to projectRoot/.cat-cafe', () => {
+      assert.equal(resolveCatCafeStateDir(REPO_ROOT), resolve(REPO_ROOT, '.cat-cafe'));
+    });
+
     test('redis data falls back to REDIS_DATA_DIR env or home default', () => {
       // No REDIS_DATA_DIR in env → homedir-based default
       const dir = resolveRedisDataDir();
@@ -151,6 +156,10 @@ describe('data-dirs resolver (issue #671)', () => {
 
     test('uploads goes under DATA_DIR (overrides module default)', () => {
       assert.equal(resolveUploadsDir(), '/tmp/issue-671-data/uploads');
+    });
+
+    test('.cat-cafe state goes under DATA_DIR', () => {
+      assert.equal(resolveCatCafeStateDir(REPO_ROOT), '/tmp/issue-671-data/cat-cafe');
     });
 
     test('redis data goes under DATA_DIR', () => {
@@ -225,12 +234,13 @@ describe('data-dirs resolver (issue #671)', () => {
   });
 
   describe('describeDataPaths introspection', () => {
-    test('returns 11 specs with correct keys when no root set', () => {
+    test('returns 12 specs with correct keys when no root set', () => {
       const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
-      assert.equal(specs.length, 11);
+      assert.equal(specs.length, 12);
       const keys = specs.map((s) => s.key).sort();
       assert.deepEqual(keys, [
         'auditLogs',
+        'catCafeState',
         'cliRawArchive',
         'connectorMedia',
         'evidenceDb',

--- a/packages/api/test/data-dirs.test.js
+++ b/packages/api/test/data-dirs.test.js
@@ -9,21 +9,29 @@ const {
   resolveAuditLogsDir,
   resolveCliRawArchiveDir,
   resolveUploadsDir,
+  resolveRedisDataDir,
+  resolveRedisBackupDir,
   resolveTtsCacheDir,
   resolveConnectorMediaDir,
   resolveLogDir,
   describeDataPaths,
 } = await import('../dist/config/data-dirs.js');
 
+import { homedir } from 'node:os';
+
 const REPO_ROOT = '/tmp/issue-671-repo';
 const MONOREPO_ROOT = '/tmp/issue-671-monorepo';
 
+const REDIS_ENV_KEYS = ['REDIS_DATA_DIR', 'REDIS_BACKUP_DIR'];
+
 function snapshotEnv() {
-  return {
+  const snap = {
     DATA_DIR: process.env.DATA_DIR,
     CACHE_DIR: process.env.CACHE_DIR,
     LOG_DIR: process.env.LOG_DIR,
   };
+  for (const k of REDIS_ENV_KEYS) snap[k] = process.env[k];
+  return snap;
 }
 
 function restoreEnv(snap) {
@@ -37,6 +45,7 @@ function clearRoots() {
   delete process.env.DATA_DIR;
   delete process.env.CACHE_DIR;
   delete process.env.LOG_DIR;
+  for (const k of REDIS_ENV_KEYS) delete process.env[k];
 }
 
 describe('data-dirs resolver (issue #671)', () => {
@@ -90,6 +99,29 @@ describe('data-dirs resolver (issue #671)', () => {
     test('logs falls back to cwd/data/logs/api', () => {
       assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
     });
+
+    test('redis data falls back to REDIS_DATA_DIR env or home default', () => {
+      // No REDIS_DATA_DIR in env → homedir-based default
+      const dir = resolveRedisDataDir();
+      assert.equal(dir, resolve(homedir(), '.cat-cafe/redis-dev'));
+    });
+
+    test('redis data respects REDIS_DATA_DIR env when set', () => {
+      process.env.REDIS_DATA_DIR = '/tmp/custom-redis';
+      assert.equal(resolveRedisDataDir(), '/tmp/custom-redis');
+      delete process.env.REDIS_DATA_DIR;
+    });
+
+    test('redis backups falls back to REDIS_BACKUP_DIR env or home default', () => {
+      const dir = resolveRedisBackupDir();
+      assert.equal(dir, resolve(homedir(), '.cat-cafe/redis-backups/dev'));
+    });
+
+    test('redis backups respects REDIS_BACKUP_DIR env when set', () => {
+      process.env.REDIS_BACKUP_DIR = '/tmp/custom-redis-backups';
+      assert.equal(resolveRedisBackupDir(), '/tmp/custom-redis-backups');
+      delete process.env.REDIS_BACKUP_DIR;
+    });
   });
 
   describe('DATA_DIR root configured', () => {
@@ -119,6 +151,20 @@ describe('data-dirs resolver (issue #671)', () => {
 
     test('uploads goes under DATA_DIR (overrides module default)', () => {
       assert.equal(resolveUploadsDir(), '/tmp/issue-671-data/uploads');
+    });
+
+    test('redis data goes under DATA_DIR', () => {
+      assert.equal(resolveRedisDataDir(), '/tmp/issue-671-data/redis');
+    });
+
+    test('redis backups goes under DATA_DIR', () => {
+      assert.equal(resolveRedisBackupDir(), '/tmp/issue-671-data/redis-backups');
+    });
+
+    test('DATA_DIR overrides REDIS_DATA_DIR env', () => {
+      process.env.REDIS_DATA_DIR = '/should/be/ignored';
+      assert.equal(resolveRedisDataDir(), '/tmp/issue-671-data/redis');
+      delete process.env.REDIS_DATA_DIR;
     });
 
     test('DATA_DIR does not affect cache or log paths', () => {
@@ -179,9 +225,9 @@ describe('data-dirs resolver (issue #671)', () => {
   });
 
   describe('describeDataPaths introspection', () => {
-    test('returns 9 specs with correct keys when no root set', () => {
+    test('returns 11 specs with correct keys when no root set', () => {
       const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
-      assert.equal(specs.length, 9);
+      assert.equal(specs.length, 11);
       const keys = specs.map((s) => s.key).sort();
       assert.deepEqual(keys, [
         'auditLogs',
@@ -189,6 +235,8 @@ describe('data-dirs resolver (issue #671)', () => {
         'connectorMedia',
         'evidenceDb',
         'logs',
+        'redisBackups',
+        'redisData',
         'transcripts',
         'ttsCache',
         'uploads',

--- a/packages/api/test/domains/preview/preview-routes.test.js
+++ b/packages/api/test/domains/preview/preview-routes.test.js
@@ -315,7 +315,7 @@ describe('POST /api/preview/screenshot', () => {
     assert.equal(res.statusCode, 400);
   });
 
-  it('writes screenshot files to UPLOAD_DIR when customized', async () => {
+  it('writes screenshot files to DATA_DIR/uploads when customized', async () => {
     const dataUrl =
       'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
     const res = await app3.inject({

--- a/packages/api/test/domains/preview/preview-routes.test.js
+++ b/packages/api/test/domains/preview/preview-routes.test.js
@@ -264,14 +264,17 @@ describe('POST /api/preview/auto-open', () => {
 describe('POST /api/preview/screenshot', () => {
   let app3;
   /** @type {string | undefined} */
-  let previousUploadDir;
+  let previousDataDir;
+  /** @type {string} */
+  let dataRoot;
   /** @type {string} */
   let customUploadDir;
 
   before(async () => {
-    customUploadDir = await mkdtemp(join(tmpdir(), 'preview-screenshot-upload-'));
-    previousUploadDir = process.env.UPLOAD_DIR;
-    process.env.UPLOAD_DIR = customUploadDir;
+    dataRoot = await mkdtemp(join(tmpdir(), 'preview-screenshot-upload-'));
+    customUploadDir = join(dataRoot, 'uploads');
+    previousDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = dataRoot;
     app3 = Fastify();
     await app3.register(previewRoutes, {
       portDiscovery: new PortDiscoveryService(),
@@ -282,9 +285,9 @@ describe('POST /api/preview/screenshot', () => {
 
   after(async () => {
     await app3.close();
-    if (previousUploadDir === undefined) delete process.env.UPLOAD_DIR;
-    else process.env.UPLOAD_DIR = previousUploadDir;
-    await rm(customUploadDir, { recursive: true, force: true });
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    await rm(dataRoot, { recursive: true, force: true });
   });
 
   it('accepts a data URL and returns upload path', async () => {

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -4,7 +4,7 @@
 
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
@@ -382,6 +382,57 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
       assert.equal(JSON.parse(res.payload).attempted, false);
     } finally {
       await app.close();
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('refuses runtime migration when file-backed legacy stores would move after startup', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-runtime-migrate-'));
+    const originalCwd = process.cwd();
+    const previous = {
+      DEFAULT_OWNER_USER_ID: process.env.DEFAULT_OWNER_USER_ID,
+      DATA_DIR: process.env.DATA_DIR,
+      CACHE_DIR: process.env.CACHE_DIR,
+      LOG_DIR: process.env.LOG_DIR,
+    };
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DATA_DIR = resolve(tempRoot, 'data');
+    delete process.env.CACHE_DIR;
+    delete process.env.LOG_DIR;
+    mkdirSync(resolve(tempRoot, 'docs', 'features'), { recursive: true });
+    writeFileSync(resolve(tempRoot, 'evidence.sqlite'), 'legacy evidence', 'utf8');
+
+    const app = Fastify({ logger: false });
+    try {
+      process.chdir(tempRoot);
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/config/data-dirs/migrate',
+        headers: { 'x-cat-cafe-user': 'local-user' },
+      });
+
+      assert.equal(res.statusCode, 409);
+      const body = JSON.parse(res.payload);
+      assert.equal(body.attempted, false);
+      assert.equal(body.allSucceeded, false);
+      assert.equal(body.restartRecommended, true);
+      assert.match(body.abortedReason, /restart/i);
+      const evidence = body.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'runtime-file-migration-requires-restart');
+      assert.equal(existsSync(resolve(tempRoot, 'evidence.sqlite')), true);
+      assert.equal(existsSync(resolve(tempRoot, 'data', 'evidence.sqlite')), false);
+    } finally {
+      await app.close();
+      process.chdir(originalCwd);
+      rmSync(tempRoot, { recursive: true, force: true });
       for (const [key, value] of Object.entries(previous)) {
         if (value === undefined) delete process.env[key];
         else process.env[key] = value;

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -13,6 +13,7 @@ import {
   buildEnvSummary,
   ENV_CATEGORIES,
   ENV_VARS,
+  hasOwnerGatedEditableVars,
   hasSensitiveEditableVars,
   isSensitiveEditableEnvVar,
   maskUrlCredentials,
@@ -145,6 +146,21 @@ describe('env-registry', () => {
     assert.ok(hasSensitiveEditableVars(['FRONTEND_URL', 'F102_API_KEY']));
     assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'LOG_DIR']));
     assert.ok(!hasSensitiveEditableVars(['OPENAI_API_KEY']), 'OPENAI_API_KEY is no longer editable (#340 P6)');
+  });
+
+  it('owner-gates root-directory writes without masking their summary values', () => {
+    for (const name of ['DATA_DIR', 'CACHE_DIR', 'LOG_DIR']) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be in registry`);
+      assert.equal(def.sensitive, false, `${name} should remain visible in env-summary`);
+    }
+    assert.ok(hasOwnerGatedEditableVars(['DATA_DIR']));
+    assert.ok(hasOwnerGatedEditableVars(['FRONTEND_URL', 'CACHE_DIR']));
+    assert.ok(hasOwnerGatedEditableVars(['LOG_DIR']));
+    assert.ok(
+      !hasSensitiveEditableVars(['DATA_DIR', 'CACHE_DIR', 'LOG_DIR']),
+      'storage roots are protected but not secret',
+    );
   });
 
   it('marks DEFAULT_OWNER_USER_ID as non-editable (trust anchor)', () => {

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -337,6 +337,69 @@ describe('GET /api/config/env-summary (route)', () => {
   });
 });
 
+describe('POST /api/config/data-dirs/migrate owner gate', () => {
+  it('allows direct-loopback migration in single-user mode when owner is not configured', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const previous = {
+      DEFAULT_OWNER_USER_ID: process.env.DEFAULT_OWNER_USER_ID,
+      DATA_DIR: process.env.DATA_DIR,
+      CACHE_DIR: process.env.CACHE_DIR,
+      LOG_DIR: process.env.LOG_DIR,
+    };
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    delete process.env.DATA_DIR;
+    delete process.env.CACHE_DIR;
+    delete process.env.LOG_DIR;
+
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/config/data-dirs/migrate',
+        headers: { 'x-cat-cafe-user': 'local-user' },
+      });
+
+      assert.equal(res.statusCode, 200);
+      assert.equal(JSON.parse(res.payload).attempted, false);
+    } finally {
+      await app.close();
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it('rejects non-loopback migration in single-user mode when owner is not configured', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const previous = process.env.DEFAULT_OWNER_USER_ID;
+    delete process.env.DEFAULT_OWNER_USER_ID;
+
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/config/data-dirs/migrate',
+        headers: { 'x-cat-cafe-user': 'remote-user' },
+        remoteAddress: '192.168.1.100',
+      });
+
+      assert.equal(res.statusCode, 403);
+      assert.match(JSON.parse(res.payload).error, /non-localhost|DEFAULT_OWNER_USER_ID/i);
+    } finally {
+      await app.close();
+      if (previous === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previous;
+    }
+  });
+});
+
 describe('PATCH /api/config/env (route)', () => {
   afterEach(() => restoreEnv());
 

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -48,6 +48,15 @@ function restoreEnv() {
   }
 }
 
+function addSessionHook(app) {
+  app.addHook('preHandler', async (request) => {
+    const sessionUser = request.headers['x-test-session-user'];
+    if (typeof sessionUser === 'string' && sessionUser.trim()) {
+      request.sessionUserId = sessionUser.trim();
+    }
+  });
+}
+
 describe('env-registry', () => {
   afterEach(() => restoreEnv());
 
@@ -355,8 +364,84 @@ describe('GET /api/config/env-summary (route)', () => {
   });
 });
 
-describe('POST /api/config/data-dirs/migrate owner gate', () => {
-  it('allows direct-loopback migration in single-user mode when owner is not configured', async () => {
+describe('GET/POST /api/config/data-dirs owner gate', () => {
+  it('rejects data-dirs inspection with a spoofed owner header but no session auth', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const previous = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'owner-user';
+
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/config/data-dirs',
+        headers: { 'x-cat-cafe-user': 'owner-user' },
+      });
+
+      assert.equal(res.statusCode, 401);
+      assert.match(JSON.parse(res.payload).error, /session authentication/i);
+    } finally {
+      await app.close();
+      if (previous === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previous;
+    }
+  });
+
+  it('allows data-dirs inspection for an authenticated owner session', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const previous = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'owner-user';
+
+    const app = Fastify({ logger: false });
+    addSessionHook(app);
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/config/data-dirs',
+        headers: { 'x-cat-cafe-user': 'spoofed-user', 'x-test-session-user': 'owner-user' },
+      });
+
+      assert.equal(res.statusCode, 200);
+      assert.ok(Array.isArray(JSON.parse(res.payload).paths));
+    } finally {
+      await app.close();
+      if (previous === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previous;
+    }
+  });
+
+  it('rejects data-dirs migration with a spoofed owner header but no session auth', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const previous = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'owner-user';
+
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/config/data-dirs/migrate',
+        headers: { 'x-cat-cafe-user': 'owner-user' },
+      });
+
+      assert.equal(res.statusCode, 401);
+      assert.match(JSON.parse(res.payload).error, /session authentication/i);
+    } finally {
+      await app.close();
+      if (previous === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previous;
+    }
+  });
+
+  it('allows direct-loopback migration in single-user mode when owner is not configured and session is authenticated', async () => {
     const { configRoutes } = await import('../dist/routes/config.js');
     const previous = {
       DEFAULT_OWNER_USER_ID: process.env.DEFAULT_OWNER_USER_ID,
@@ -370,6 +455,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
     delete process.env.LOG_DIR;
 
     const app = Fastify({ logger: false });
+    addSessionHook(app);
     try {
       await configRoutes(app);
       await app.ready();
@@ -377,7 +463,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/api/config/data-dirs/migrate',
-        headers: { 'x-cat-cafe-user': 'local-user' },
+        headers: { 'x-test-session-user': 'local-user' },
       });
 
       assert.equal(res.statusCode, 200);
@@ -409,6 +495,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
     writeFileSync(resolve(tempRoot, 'evidence.sqlite'), 'legacy evidence', 'utf8');
 
     const app = Fastify({ logger: false });
+    addSessionHook(app);
     try {
       process.chdir(tempRoot);
       await configRoutes(app);
@@ -417,7 +504,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/api/config/data-dirs/migrate',
-        headers: { 'x-cat-cafe-user': 'local-user' },
+        headers: { 'x-test-session-user': 'local-user' },
       });
 
       assert.equal(res.statusCode, 409);
@@ -448,6 +535,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
     delete process.env.DEFAULT_OWNER_USER_ID;
 
     const app = Fastify({ logger: false });
+    addSessionHook(app);
     try {
       await configRoutes(app);
       await app.ready();
@@ -455,7 +543,7 @@ describe('POST /api/config/data-dirs/migrate owner gate', () => {
       const res = await app.inject({
         method: 'POST',
         url: '/api/config/data-dirs/migrate',
-        headers: { 'x-cat-cafe-user': 'remote-user' },
+        headers: { 'x-test-session-user': 'remote-user' },
         remoteAddress: '192.168.1.100',
       });
 

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -15,6 +15,7 @@ import {
   ENV_VARS,
   hasOwnerGatedEditableVars,
   hasSensitiveEditableVars,
+  isEditableEnvVarName,
   isSensitiveEditableEnvVar,
   maskUrlCredentials,
 } from '../dist/config/env-registry.js';
@@ -148,15 +149,16 @@ describe('env-registry', () => {
     assert.ok(!hasSensitiveEditableVars(['OPENAI_API_KEY']), 'OPENAI_API_KEY is no longer editable (#340 P6)');
   });
 
-  it('owner-gates root-directory writes without masking their summary values', () => {
+  it('marks root-directory changes as restart-only and non-runtime-editable without masking values', () => {
     for (const name of ['DATA_DIR', 'CACHE_DIR', 'LOG_DIR']) {
       const def = ENV_VARS.find((v) => v.name === name);
       assert.ok(def, `${name} should be in registry`);
       assert.equal(def.sensitive, false, `${name} should remain visible in env-summary`);
+      assert.equal(def.restartRequired, true, `${name} should require restart`);
+      assert.equal(def.runtimeEditable, false, `${name} must not mutate process.env at runtime`);
+      assert.equal(isEditableEnvVarName(name), false, `${name} should be rejected by PATCH /api/config/env`);
     }
-    assert.ok(hasOwnerGatedEditableVars(['DATA_DIR']));
-    assert.ok(hasOwnerGatedEditableVars(['FRONTEND_URL', 'CACHE_DIR']));
-    assert.ok(hasOwnerGatedEditableVars(['LOG_DIR']));
+    assert.ok(!hasOwnerGatedEditableVars(['DATA_DIR', 'CACHE_DIR', 'LOG_DIR']));
     assert.ok(
       !hasSensitiveEditableVars(['DATA_DIR', 'CACHE_DIR', 'LOG_DIR']),
       'storage roots are protected but not secret',
@@ -779,6 +781,50 @@ describe('PATCH /api/config/env (route)', () => {
       const body = JSON.parse(res.payload);
       assert.match(body.error, /not editable/i);
       assert.equal(readFileSync(envFilePath, 'utf8'), 'REDIS_URL=redis://localhost:6399/15\n');
+    } finally {
+      await app.close();
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects DATA_DIR/CACHE_DIR/LOG_DIR hub writes because root resolvers are restart-bound', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-env-'));
+    const envFilePath = resolve(tempRoot, '.env');
+    writeFileSync(envFilePath, 'DATA_DIR=/old-data\nCACHE_DIR=/old-cache\nLOG_DIR=/old-logs\n', 'utf8');
+    setEnv('DATA_DIR', '/old-data');
+    setEnv('CACHE_DIR', '/old-cache');
+    setEnv('LOG_DIR', '/old-logs');
+
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app, {
+        projectRoot: tempRoot,
+        envFilePath,
+        auditLog: { append: async () => {} },
+      });
+      await app.ready();
+
+      for (const [name, oldValue, newValue] of [
+        ['DATA_DIR', '/old-data', '/new-data'],
+        ['CACHE_DIR', '/old-cache', '/new-cache'],
+        ['LOG_DIR', '/old-logs', '/new-logs'],
+      ]) {
+        const beforeFile = readFileSync(envFilePath, 'utf8');
+        const res = await app.inject({
+          method: 'PATCH',
+          url: '/api/config/env',
+          headers: { 'x-cat-cafe-user': 'codex' },
+          payload: {
+            updates: [{ name, value: newValue }],
+          },
+        });
+
+        assert.equal(res.statusCode, 400, `${name} should be rejected`);
+        assert.match(JSON.parse(res.payload).error, /not editable/i);
+        assert.equal(readFileSync(envFilePath, 'utf8'), beforeFile, `${name} must not rewrite .env`);
+        assert.equal(process.env[name], oldValue, `${name} must not mutate process.env`);
+      }
     } finally {
       await app.close();
       rmSync(tempRoot, { recursive: true, force: true });

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -143,7 +143,7 @@ describe('env-registry', () => {
   it('hasSensitiveEditableVars detects whitelisted sensitive vars', () => {
     assert.ok(hasSensitiveEditableVars(['GITHUB_MCP_PAT']));
     assert.ok(hasSensitiveEditableVars(['FRONTEND_URL', 'F102_API_KEY']));
-    assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'AUDIT_LOG_DIR']));
+    assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'LOG_DIR']));
     assert.ok(!hasSensitiveEditableVars(['OPENAI_API_KEY']), 'OPENAI_API_KEY is no longer editable (#340 P6)');
   });
 

--- a/packages/api/test/generated-image-publication.test.js
+++ b/packages/api/test/generated-image-publication.test.js
@@ -6,20 +6,22 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 describe('publishGeneratedImage', () => {
   let sourceDir;
+  let dataRoot;
   let uploadDir;
-  let previousUploadDir;
+  let previousDataDir;
 
   beforeEach(async () => {
     sourceDir = await mkdtemp(join(tmpdir(), 'cat-cafe-generated-image-source-'));
-    uploadDir = await mkdtemp(join(tmpdir(), 'cat-cafe-generated-image-upload-'));
-    previousUploadDir = process.env.UPLOAD_DIR;
+    dataRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-generated-image-data-'));
+    uploadDir = join(dataRoot, 'uploads');
+    previousDataDir = process.env.DATA_DIR;
   });
 
   afterEach(async () => {
     if (sourceDir) await rm(sourceDir, { recursive: true, force: true });
-    if (uploadDir) await rm(uploadDir, { recursive: true, force: true });
-    if (previousUploadDir === undefined) delete process.env.UPLOAD_DIR;
-    else process.env.UPLOAD_DIR = previousUploadDir;
+    if (dataRoot) await rm(dataRoot, { recursive: true, force: true });
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
   });
 
   it('publishes a generated image as a canonical /uploads artifact with media_gallery block', async () => {
@@ -169,12 +171,12 @@ describe('publishGeneratedImage', () => {
     assert.equal((await readdir(uploadDir)).length, 2);
   });
 
-  it('uses UPLOAD_DIR when uploadDir override is omitted', async () => {
+  it('uses DATA_DIR/uploads when uploadDir override is omitted', async () => {
     const { publishGeneratedImage } = await import(
       '../dist/domains/cats/services/agents/providers/generated-image-publication.js'
     );
 
-    process.env.UPLOAD_DIR = uploadDir;
+    process.env.DATA_DIR = dataRoot;
 
     const sourcePath = join(sourceDir, 'cat.png');
     await writeFile(sourcePath, Buffer.from('fake-png'));

--- a/packages/api/test/invocation-timeout-guard.test.js
+++ b/packages/api/test/invocation-timeout-guard.test.js
@@ -33,10 +33,10 @@ let savedCliTimeoutMs;
 
 describe('invocation-level hard timeout (F089)', () => {
   before(async () => {
-    savedAuditLogDir = process.env.AUDIT_LOG_DIR;
+    savedAuditLogDir = process.env.DATA_DIR;
     savedCliTimeoutMs = process.env.CLI_TIMEOUT_MS;
     const tempDir = await mkdtemp(join(tmpdir(), 'cat-inv-timeout-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     // Override CLI_TIMEOUT_MS to make invocation timeout short for testing.
     // Invocation timeout = CLI_TIMEOUT_MS * 2 = 400ms
     process.env.CLI_TIMEOUT_MS = '200';
@@ -45,8 +45,8 @@ describe('invocation-level hard timeout (F089)', () => {
   });
 
   after(() => {
-    if (savedAuditLogDir === undefined) delete process.env.AUDIT_LOG_DIR;
-    else process.env.AUDIT_LOG_DIR = savedAuditLogDir;
+    if (savedAuditLogDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = savedAuditLogDir;
     if (savedCliTimeoutMs === undefined) delete process.env.CLI_TIMEOUT_MS;
     else process.env.CLI_TIMEOUT_MS = savedCliTimeoutMs;
   });

--- a/packages/api/test/invoke-single-cat-bg-registry.test.js
+++ b/packages/api/test/invoke-single-cat-bg-registry.test.js
@@ -21,16 +21,20 @@ async function collect(iterable) {
 
 let tempDir;
 let invokeSingleCat;
+let prevDataDir;
 
 describe('F198-C P1-1: registerBgCarrier called on claude-bg session_init', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-bg-registry-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    prevDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });
 
   after(async () => {
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
     await rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 

--- a/packages/api/test/invoke-single-cat-bg-status.test.js
+++ b/packages/api/test/invoke-single-cat-bg-status.test.js
@@ -25,16 +25,20 @@ async function collect(iterable) {
 
 let tempDir;
 let invokeSingleCat;
+let prevDataDir;
 
 describe('F198-C P2-1: status messages treated as non-substantive', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-bg-status-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    prevDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });
 
   after(async () => {
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
     await rm(tempDir, { recursive: true, force: true }).catch(() => {});
   });
 

--- a/packages/api/test/invoke-single-cat-breaker-inherit.test.js
+++ b/packages/api/test/invoke-single-cat-breaker-inherit.test.js
@@ -30,7 +30,7 @@ let SessionChainStore;
 describe('F118 D1: failure count inheritance across cli_session_replaced', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-breaker-inherit-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
     const storeMod = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');

--- a/packages/api/test/invoke-single-cat-finally-audit.test.js
+++ b/packages/api/test/invoke-single-cat-finally-audit.test.js
@@ -19,7 +19,7 @@ let invokeSingleCat;
 describe('F118 finally block audit fallback (AC-C5)', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-finally-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/invoke-single-cat-finally-audit.test.js
+++ b/packages/api/test/invoke-single-cat-finally-audit.test.js
@@ -87,10 +87,11 @@ describe('F118 finally block audit fallback (AC-C5)', () => {
     await new Promise((r) => setTimeout(r, 200));
 
     // Read audit log and check for fallback CAT_ERROR
-    const files = await readdir(tempDir);
+    const auditDir = join(tempDir, 'audit-logs');
+    const files = await readdir(auditDir);
     assert.ok(files.length > 0, 'audit log file should exist');
 
-    const auditContent = await readFile(join(tempDir, files[0]), 'utf-8');
+    const auditContent = await readFile(join(auditDir, files[0]), 'utf-8');
     const events = auditContent
       .trim()
       .split('\n')
@@ -133,8 +134,9 @@ describe('F118 finally block audit fallback (AC-C5)', () => {
     // Wait for fire-and-forget audit writes
     await new Promise((r) => setTimeout(r, 200));
 
-    const files = await readdir(tempDir);
-    const auditContent = await readFile(join(tempDir, files[0]), 'utf-8');
+    const auditDir = join(tempDir, 'audit-logs');
+    const files = await readdir(auditDir);
+    const auditContent = await readFile(join(auditDir, files[0]), 'utf-8');
     const events = auditContent
       .trim()
       .split('\n')

--- a/packages/api/test/invoke-single-cat-overflow-breaker.test.js
+++ b/packages/api/test/invoke-single-cat-overflow-breaker.test.js
@@ -24,7 +24,7 @@ let invokeSingleCat;
 describe('F118 overflow circuit breaker (AC-C6)', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-breaker-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/invoke-single-cat-preflight.test.js
+++ b/packages/api/test/invoke-single-cat-preflight.test.js
@@ -76,7 +76,7 @@ describe('invokeSingleCat shared-state preflight', () => {
     delete process.env.CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT;
     const auditDir = mkdtempSync(join(tmpdir(), 'cat-audit-'));
     tempDirs.push(auditDir);
-    process.env.AUDIT_LOG_DIR = auditDir;
+    process.env.DATA_DIR = auditDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/invoke-single-cat-resume-health.test.js
+++ b/packages/api/test/invoke-single-cat-resume-health.test.js
@@ -24,7 +24,7 @@ let invokeSingleCat;
 describe('F118 resume health check (AC-C4 + AC-C6)', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-health-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/invoke-single-cat-timeout-retry.test.js
+++ b/packages/api/test/invoke-single-cat-timeout-retry.test.js
@@ -25,7 +25,7 @@ let invokeSingleCat;
 describe('#774 CLI timeout retry on session resume', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-timeout-retry-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -122,7 +122,7 @@ afterEach(async () => {
 describe('invokeSingleCat audit events (P1 fix)', () => {
   before(async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'cat-audit-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     // Dynamic import AFTER env is set — singleton will use this dir
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -194,8 +194,9 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     // Wait for fire-and-forget audit writes
     await new Promise((r) => setTimeout(r, 150));
 
-    const files = await readdir(tempDir);
-    const auditContent = await readFile(join(tempDir, files[0]), 'utf-8');
+    const auditDir = join(tempDir, 'audit-logs');
+    const files = await readdir(auditDir);
+    const auditContent = await readFile(join(auditDir, files[0]), 'utf-8');
     const events = auditContent
       .trim()
       .split('\n')
@@ -662,8 +663,9 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
 
     await new Promise((r) => setTimeout(r, 150));
 
-    const files = await readdir(tempDir);
-    const auditContent = await readFile(join(tempDir, files[0]), 'utf-8');
+    const auditDir = join(tempDir, 'audit-logs');
+    const files = await readdir(auditDir);
+    const auditContent = await readFile(join(auditDir, files[0]), 'utf-8');
     const events = auditContent
       .trim()
       .split('\n')

--- a/packages/api/test/preflight-race-integration.test.js
+++ b/packages/api/test/preflight-race-integration.test.js
@@ -29,7 +29,7 @@ describe('preflight timeout rescues hung invocation', () => {
     process.env.CAT_CAFE_PREFLIGHT_TIMEOUT_MS = '200';
 
     tempDir = mkdtempSync(join(tmpdir(), 'cat-audit-preflight-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     process.env.CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT = '1';
 
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');

--- a/packages/api/test/proxy-fallback.test.js
+++ b/packages/api/test/proxy-fallback.test.js
@@ -24,7 +24,7 @@ let invokeSingleCat;
 describe('F115 AC-C3: proxy fallback to direct upstream', () => {
   before(async () => {
     const tempDir = await mkdtemp(join(tmpdir(), 'proxy-fallback-audit-'));
-    process.env.AUDIT_LOG_DIR = tempDir;
+    process.env.DATA_DIR = tempDir;
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     invokeSingleCat = mod.invokeSingleCat;
   });

--- a/packages/api/test/ref-audio-upload-route.test.js
+++ b/packages/api/test/ref-audio-upload-route.test.js
@@ -56,16 +56,19 @@ describe('POST /api/uploads/ref-audio', () => {
   /** @type {import('fastify').FastifyInstance} */
   let app;
   /** @type {string} */
+  let dataRoot;
+  /** @type {string} */
   let uploadDir;
   /** @type {string | undefined} */
-  let prevUploadDir;
+  let prevDataDir;
   let trackedFileReads = 0;
   let trackedBufferDrains = 0;
 
   before(async () => {
-    uploadDir = await mkdtemp(join(tmpdir(), 'ref-audio-route-'));
-    prevUploadDir = process.env.UPLOAD_DIR;
-    process.env.UPLOAD_DIR = uploadDir;
+    dataRoot = await mkdtemp(join(tmpdir(), 'ref-audio-route-'));
+    uploadDir = join(dataRoot, 'uploads');
+    prevDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = dataRoot;
     app = Fastify();
     app.addHook('preHandler', async (request) => {
       const sessionUser = request.headers['x-test-session-user'];
@@ -93,9 +96,9 @@ describe('POST /api/uploads/ref-audio', () => {
 
   after(async () => {
     await app.close();
-    if (prevUploadDir === undefined) delete process.env.UPLOAD_DIR;
-    else process.env.UPLOAD_DIR = prevUploadDir;
-    await rm(uploadDir, { recursive: true, force: true });
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
+    await rm(dataRoot, { recursive: true, force: true });
   });
 
   it('rejects trusted Origin fallback without a real session', async () => {
@@ -146,7 +149,7 @@ describe('POST /api/uploads/ref-audio', () => {
     assert.deepEqual(await readdir(uploadDir), filesBefore);
   });
 
-  it('accepts a sniffed WAV reference audio file and persists it under UPLOAD_DIR', async () => {
+  it('accepts a sniffed WAV reference audio file and persists it under DATA_DIR/uploads', async () => {
     const { payload, contentType } = buildMultipartPayload({
       buffer: makeWavBuffer(),
       filename: '../voice.wav',

--- a/packages/api/test/ref-audio-upload-route.test.js
+++ b/packages/api/test/ref-audio-upload-route.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import assert from 'node:assert/strict';
-import { mkdtemp, readdir, rm, stat } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, before, describe, it } from 'node:test';
@@ -67,6 +67,7 @@ describe('POST /api/uploads/ref-audio', () => {
   before(async () => {
     dataRoot = await mkdtemp(join(tmpdir(), 'ref-audio-route-'));
     uploadDir = join(dataRoot, 'uploads');
+    await mkdir(uploadDir, { recursive: true });
     prevDataDir = process.env.DATA_DIR;
     process.env.DATA_DIR = dataRoot;
     app = Fastify();

--- a/packages/api/test/routes/avatars-route.test.js
+++ b/packages/api/test/routes/avatars-route.test.js
@@ -62,7 +62,7 @@ describe('POST /api/uploads/avatar', () => {
     await rm(dataRoot, { recursive: true, force: true });
   });
 
-  it('accepts a 7 MiB PNG and persists it to UPLOAD_DIR', async () => {
+  it('accepts a 7 MiB PNG and persists it to DATA_DIR/uploads', async () => {
     const rawBytes = 7 * 1024 * 1024;
     const buffer = makePngBuffer(rawBytes);
     const { payload, contentType } = buildMultipartPayload({

--- a/packages/api/test/routes/avatars-route.test.js
+++ b/packages/api/test/routes/avatars-route.test.js
@@ -39,14 +39,17 @@ describe('POST /api/uploads/avatar', () => {
   /** @type {import('fastify').FastifyInstance} */
   let app;
   /** @type {string} */
+  let dataRoot;
+  /** @type {string} */
   let uploadDir;
   /** @type {string | undefined} */
-  let prevUploadDir;
+  let prevDataDir;
 
   before(async () => {
-    uploadDir = await mkdtemp(join(tmpdir(), 'avatars-route-'));
-    prevUploadDir = process.env.UPLOAD_DIR;
-    process.env.UPLOAD_DIR = uploadDir;
+    dataRoot = await mkdtemp(join(tmpdir(), 'avatars-route-'));
+    uploadDir = join(dataRoot, 'uploads');
+    prevDataDir = process.env.DATA_DIR;
+    process.env.DATA_DIR = dataRoot;
     app = Fastify();
     await app.register(avatarsRoutes);
     await app.ready();
@@ -54,9 +57,9 @@ describe('POST /api/uploads/avatar', () => {
 
   after(async () => {
     await app.close();
-    if (prevUploadDir === undefined) delete process.env.UPLOAD_DIR;
-    else process.env.UPLOAD_DIR = prevUploadDir;
-    await rm(uploadDir, { recursive: true, force: true });
+    if (prevDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = prevDataDir;
+    await rm(dataRoot, { recursive: true, force: true });
   });
 
   it('accepts a 7 MiB PNG and persists it to UPLOAD_DIR', async () => {

--- a/packages/api/test/security-boundary.test.js
+++ b/packages/api/test/security-boundary.test.js
@@ -131,7 +131,7 @@ test('API binds to 127.0.0.1 by default', async (t) => {
     PREVIEW_GATEWAY_ENABLED: '0',
     PREVIEW_GATEWAY_PORT: '0',
     DOCS_ROOT: tempRoot,
-    EVIDENCE_DB: path.join(tempRoot, 'evidence.sqlite'),
+    DATA_DIR: tempRoot,
   };
   delete childEnv.API_SERVER_HOST;
   delete childEnv.REDIS_URL;

--- a/packages/api/test/sensitive-env-write.test.js
+++ b/packages/api/test/sensitive-env-write.test.js
@@ -101,7 +101,7 @@ describe('PATCH /api/config/env — sensitive env owner gate', () => {
     }
   });
 
-  it('rejects DATA_DIR writes with header-only identity while keeping the value visible', async () => {
+  it('rejects DATA_DIR writes as restart-only while keeping the value visible', async () => {
     const { configRoutes } = await import('../dist/routes/config.js');
     const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-env-'));
     const envFilePath = resolve(tempRoot, '.env');
@@ -126,8 +126,8 @@ describe('PATCH /api/config/env — sensitive env owner gate', () => {
         payload: { updates: [{ name: 'DATA_DIR', value: '/new-data' }] },
       });
 
-      assert.equal(res.statusCode, 401);
-      assert.match(JSON.parse(res.payload).error, /session authentication/);
+      assert.equal(res.statusCode, 400);
+      assert.match(JSON.parse(res.payload).error, /not editable/);
       assert.equal(readFileSync(envFilePath, 'utf8'), 'DATA_DIR=/old-data\n');
       assert.equal(process.env.DATA_DIR, undefined);
     } finally {

--- a/packages/api/test/sensitive-env-write.test.js
+++ b/packages/api/test/sensitive-env-write.test.js
@@ -101,6 +101,41 @@ describe('PATCH /api/config/env — sensitive env owner gate', () => {
     }
   });
 
+  it('rejects DATA_DIR writes with header-only identity while keeping the value visible', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-env-'));
+    const envFilePath = resolve(tempRoot, '.env');
+    writeFileSync(envFilePath, 'DATA_DIR=/old-data\n', 'utf8');
+    setEnv('DEFAULT_OWNER_USER_ID', 'you');
+    setEnv('DATA_DIR', undefined);
+
+    const app = Fastify({ logger: false });
+    addSessionHook(app);
+    try {
+      await configRoutes(app, {
+        projectRoot: tempRoot,
+        envFilePath,
+        auditLog: { append: async () => {} },
+      });
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'PATCH',
+        url: '/api/config/env',
+        headers: { 'x-cat-cafe-user': 'you' },
+        payload: { updates: [{ name: 'DATA_DIR', value: '/new-data' }] },
+      });
+
+      assert.equal(res.statusCode, 401);
+      assert.match(JSON.parse(res.payload).error, /session authentication/);
+      assert.equal(readFileSync(envFilePath, 'utf8'), 'DATA_DIR=/old-data\n');
+      assert.equal(process.env.DATA_DIR, undefined);
+    } finally {
+      await app.close();
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it('allows sensitive env writes in single-user mode when DEFAULT_OWNER_USER_ID is not configured (issue #794)', async () => {
     const { configRoutes } = await import('../dist/routes/config.js');
     const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-env-'));

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -817,6 +817,106 @@ test('redis port override also recomputes isolated redis dirs', () => {
   } finally {
     rmSync(tmp, { recursive: true, force: true });
     rmSync(tempHome, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR Redis migration treats an empty target data dir as unoccupied', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyDir = join(tmp, 'legacy-redis');
+    const dataRoot = join(tmp, 'data-root');
+    const targetDir = join(dataRoot, 'redis');
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'dump.rdb'), 'legacy redis', 'utf8');
+
+    const result = spawnSync(
+      'bash',
+      [
+        '-lc',
+        `set -e\nsource "${scriptPath}" --source-only >/dev/null 2>&1\ntrap - EXIT INT TERM\nprintf '%s|%s|%s' "$REDIS_DATA_DIR" "$(cat "${targetDir}/dump.rdb")" "$([ -d "${legacyDir}" ] && printf legacy || printf moved)"`,
+      ],
+      {
+        encoding: 'utf8',
+        env: baseShellEnv({
+          DATA_DIR: dataRoot,
+          REDIS_DATA_DIR: legacyDir,
+        }),
+      },
+    );
+
+    assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), `${targetDir}|legacy redis|moved`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR Redis migration treats an empty target backup dir as unoccupied', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyBackup = join(tmp, 'legacy-backups');
+    const dataRoot = join(tmp, 'data-root');
+    const targetBackup = join(dataRoot, 'redis-backups');
+    mkdirSync(legacyBackup, { recursive: true });
+    mkdirSync(targetBackup, { recursive: true });
+    writeFileSync(join(legacyBackup, 'snapshot.rdb'), 'legacy backup', 'utf8');
+
+    const result = spawnSync(
+      'bash',
+      [
+        '-lc',
+        `set -e\nsource "${scriptPath}" --source-only >/dev/null 2>&1\ntrap - EXIT INT TERM\nprintf '%s|%s|%s' "$REDIS_BACKUP_DIR" "$(cat "${targetBackup}/snapshot.rdb")" "$([ -d "${legacyBackup}" ] && printf legacy || printf moved)"`,
+      ],
+      {
+        encoding: 'utf8',
+        env: baseShellEnv({
+          DATA_DIR: dataRoot,
+          REDIS_BACKUP_DIR: legacyBackup,
+        }),
+      },
+    );
+
+    assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), `${targetBackup}|legacy backup|moved`);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR Redis migration refuses to hide legacy data behind a populated target', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyDir = join(tmp, 'legacy-redis');
+    const dataRoot = join(tmp, 'data-root');
+    const targetDir = join(dataRoot, 'redis');
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'dump.rdb'), 'legacy redis', 'utf8');
+    writeFileSync(join(targetDir, 'dump.rdb'), 'target redis', 'utf8');
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        DATA_DIR: dataRoot,
+        REDIS_DATA_DIR: legacyDir,
+      }),
+    });
+
+    assert.notEqual(
+      result.status,
+      0,
+      `source should fail closed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /Refusing to switch Redis data to DATA_DIR/);
+    assert.equal(readFileSync(join(legacyDir, 'dump.rdb'), 'utf8'), 'legacy redis');
+    assert.equal(readFileSync(join(targetDir, 'dump.rdb'), 'utf8'), 'target redis');
+    assert.equal(existsSync(legacyDir), true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
   }
 });
 

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -485,6 +485,7 @@ function createTempProject() {
   cpSync(join(realScriptsDir, 'download-source-overrides.sh'), join(scriptsDir, 'download-source-overrides.sh'));
   cpSync(join(realScriptsDir, 'lib', 'node-runtime-guard.sh'), join(scriptsDir, 'lib', 'node-runtime-guard.sh'));
   cpSync(join(realScriptsDir, 'lib', 'redis-rdb-first.sh'), join(scriptsDir, 'lib', 'redis-rdb-first.sh'));
+  cpSync(join(realScriptsDir, 'lib', 'data-root-migration.sh'), join(scriptsDir, 'lib', 'data-root-migration.sh'));
   chmodSync(join(scriptsDir, 'start-dev.sh'), 0o755);
   return tmp;
 }
@@ -500,6 +501,10 @@ function copyStartDevClosure(tempRoot, scriptPath, tempScriptPath, tempOverrides
   cpSync(
     resolve(process.cwd(), '../../scripts/lib/redis-rdb-first.sh'),
     join(tempRoot, 'scripts', 'lib', 'redis-rdb-first.sh'),
+  );
+  cpSync(
+    resolve(process.cwd(), '../../scripts/lib/data-root-migration.sh'),
+    join(tempRoot, 'scripts', 'lib', 'data-root-migration.sh'),
   );
 }
 
@@ -915,6 +920,33 @@ test('DATA_DIR Redis migration refuses to hide legacy data behind a populated ta
     assert.equal(readFileSync(join(legacyDir, 'dump.rdb'), 'utf8'), 'legacy redis');
     assert.equal(readFileSync(join(targetDir, 'dump.rdb'), 'utf8'), 'target redis');
     assert.equal(existsSync(legacyDir), true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR is normalized before deriving Redis paths for API inheritance', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const expectedRoot = join(tmp, 'runtime-data');
+    const result = spawnSync(
+      'bash',
+      [
+        '-lc',
+        `set -e\nsource "${scriptPath}" --source-only >/dev/null 2>&1\ntrap - EXIT INT TERM\nprintf '%s|%s|%s' "$DATA_DIR" "$REDIS_DATA_DIR" "$REDIS_BACKUP_DIR"`,
+      ],
+      {
+        cwd: tmp,
+        encoding: 'utf8',
+        env: baseShellEnv({
+          DATA_DIR: './runtime-data',
+        }),
+      },
+    );
+
+    assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(result.stdout.trim(), `${expectedRoot}|${expectedRoot}/redis|${expectedRoot}/redis-backups`);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -10,6 +10,7 @@ import {
   readFileSync,
   readlinkSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { createServer } from 'node:net';
@@ -997,6 +998,113 @@ test('DATA_DIR .cat-cafe migration replaces empty legacy dir with target symlink
     assert.equal(lstatSync(legacyDir).isSymbolicLink(), true);
     assert.equal(readlinkSync(legacyDir), targetDir);
     assert.equal(readFileSync(join(targetDir, 'accounts.json'), 'utf8'), '{"target":true}');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR .cat-cafe migration moves stale symlink target to the new root', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyDir = join(tmp, '.cat-cafe');
+    const oldTargetDir = join(tmp, 'old-data-root', 'cat-cafe');
+    const newDataRoot = join(tmp, 'new-data-root');
+    const newTargetDir = join(newDataRoot, 'cat-cafe');
+    mkdirSync(oldTargetDir, { recursive: true });
+    writeFileSync(join(oldTargetDir, 'accounts.json'), '{"old":true}', 'utf8');
+    symlinkSync(oldTargetDir, legacyDir);
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: join(tmp, 'home'),
+        DATA_DIR: newDataRoot,
+        REDIS_DATA_DIR: join(tmp, 'redis-empty'),
+        REDIS_BACKUP_DIR: join(tmp, 'redis-backups-empty'),
+      }),
+    });
+
+    assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(lstatSync(legacyDir).isSymbolicLink(), true);
+    assert.equal(readlinkSync(legacyDir), newTargetDir);
+    assert.equal(readFileSync(join(newTargetDir, 'accounts.json'), 'utf8'), '{"old":true}');
+    assert.equal(existsSync(oldTargetDir), false);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR .cat-cafe migration refuses stale symlink split-brain when new target has data', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyDir = join(tmp, '.cat-cafe');
+    const oldTargetDir = join(tmp, 'old-data-root', 'cat-cafe');
+    const newDataRoot = join(tmp, 'new-data-root');
+    const newTargetDir = join(newDataRoot, 'cat-cafe');
+    mkdirSync(oldTargetDir, { recursive: true });
+    mkdirSync(newTargetDir, { recursive: true });
+    writeFileSync(join(oldTargetDir, 'accounts.json'), '{"old":true}', 'utf8');
+    writeFileSync(join(newTargetDir, 'accounts.json'), '{"new":true}', 'utf8');
+    symlinkSync(oldTargetDir, legacyDir);
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: join(tmp, 'home'),
+        DATA_DIR: newDataRoot,
+        REDIS_DATA_DIR: join(tmp, 'redis-empty'),
+        REDIS_BACKUP_DIR: join(tmp, 'redis-backups-empty'),
+      }),
+    });
+
+    assert.notEqual(
+      result.status,
+      0,
+      `source should fail closed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /Refusing to switch \.cat-cafe state to DATA_DIR/);
+    assert.equal(readlinkSync(legacyDir), oldTargetDir);
+    assert.equal(readFileSync(join(oldTargetDir, 'accounts.json'), 'utf8'), '{"old":true}');
+    assert.equal(readFileSync(join(newTargetDir, 'accounts.json'), 'utf8'), '{"new":true}');
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR .cat-cafe migration refuses stale symlink to a non-directory target', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const legacyDir = join(tmp, '.cat-cafe');
+    const oldTargetRoot = join(tmp, 'old-data-root');
+    const oldTargetFile = join(oldTargetRoot, 'cat-cafe');
+    const newDataRoot = join(tmp, 'new-data-root');
+    const newTargetDir = join(newDataRoot, 'cat-cafe');
+    mkdirSync(oldTargetRoot, { recursive: true });
+    writeFileSync(oldTargetFile, 'not a directory', 'utf8');
+    symlinkSync(oldTargetFile, legacyDir);
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: join(tmp, 'home'),
+        DATA_DIR: newDataRoot,
+        REDIS_DATA_DIR: join(tmp, 'redis-empty'),
+        REDIS_BACKUP_DIR: join(tmp, 'redis-backups-empty'),
+      }),
+    });
+
+    assert.notEqual(
+      result.status,
+      0,
+      `source should fail closed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /stale \.cat-cafe symlink target is not a directory/);
+    assert.equal(readlinkSync(legacyDir), oldTargetFile);
+    assert.equal(readFileSync(oldTargetFile, 'utf8'), 'not a directory');
+    assert.equal(existsSync(newTargetDir), false);
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/packages/api/test/start-dev-script.test.js
+++ b/packages/api/test/start-dev-script.test.js
@@ -1,6 +1,17 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -920,6 +931,72 @@ test('DATA_DIR Redis migration refuses to hide legacy data behind a populated ta
     assert.equal(readFileSync(join(legacyDir, 'dump.rdb'), 'utf8'), 'legacy redis');
     assert.equal(readFileSync(join(targetDir, 'dump.rdb'), 'utf8'), 'target redis');
     assert.equal(existsSync(legacyDir), true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR .cat-cafe migration refuses split-brain when legacy and target both contain data', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const dataRoot = join(tmp, 'data-root');
+    const legacyDir = join(tmp, '.cat-cafe');
+    const targetDir = join(dataRoot, 'cat-cafe');
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'accounts.json'), '{"legacy":true}', 'utf8');
+    writeFileSync(join(targetDir, 'accounts.json'), '{"target":true}', 'utf8');
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: join(tmp, 'home'),
+        DATA_DIR: dataRoot,
+        REDIS_DATA_DIR: join(tmp, 'redis-empty'),
+        REDIS_BACKUP_DIR: join(tmp, 'redis-backups-empty'),
+      }),
+    });
+
+    assert.notEqual(
+      result.status,
+      0,
+      `source should fail closed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /Refusing to switch \.cat-cafe state to DATA_DIR/);
+    assert.equal(readFileSync(join(legacyDir, 'accounts.json'), 'utf8'), '{"legacy":true}');
+    assert.equal(readFileSync(join(targetDir, 'accounts.json'), 'utf8'), '{"target":true}');
+    assert.equal(existsSync(legacyDir), true);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('DATA_DIR .cat-cafe migration replaces empty legacy dir with target symlink', () => {
+  const tmp = createTempProject();
+  try {
+    const scriptPath = join(tmp, 'scripts', 'start-dev.sh');
+    const dataRoot = join(tmp, 'data-root');
+    const legacyDir = join(tmp, '.cat-cafe');
+    const targetDir = join(dataRoot, 'cat-cafe');
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(targetDir, 'accounts.json'), '{"target":true}', 'utf8');
+
+    const result = spawnSync('bash', ['-lc', `source "${scriptPath}" --source-only`], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: join(tmp, 'home'),
+        DATA_DIR: dataRoot,
+        REDIS_DATA_DIR: join(tmp, 'redis-empty'),
+        REDIS_BACKUP_DIR: join(tmp, 'redis-backups-empty'),
+      }),
+    });
+
+    assert.equal(result.status, 0, `snippet failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(lstatSync(legacyDir).isSymbolicLink(), true);
+    assert.equal(readlinkSync(legacyDir), targetDir);
+    assert.equal(readFileSync(join(targetDir, 'accounts.json'), 'utf8'), '{"target":true}');
   } finally {
     rmSync(tmp, { recursive: true, force: true });
   }

--- a/packages/api/test/user-redis-script.test.js
+++ b/packages/api/test/user-redis-script.test.js
@@ -29,7 +29,7 @@ test('user-redis DATA_DIR migration moves legacy data into an empty target befor
   const tempHome = join(tempRoot, 'home');
   const dataRoot = join(tempRoot, 'runtime-data');
   const legacyDir = join(tempHome, '.cat-cafe', 'redis-user');
-  const targetDir = join(dataRoot, 'redis');
+  const targetDir = join(dataRoot, 'redis-user');
 
   try {
     mkdirSync(legacyDir, { recursive: true });
@@ -59,7 +59,7 @@ test('user-redis DATA_DIR migration refuses populated target with legacy data pr
   const tempHome = join(tempRoot, 'home');
   const dataRoot = join(tempRoot, 'runtime-data');
   const legacyDir = join(tempHome, '.cat-cafe', 'redis-user');
-  const targetDir = join(dataRoot, 'redis');
+  const targetDir = join(dataRoot, 'redis-user');
 
   try {
     mkdirSync(legacyDir, { recursive: true });
@@ -93,7 +93,7 @@ test('user-redis autobackup normalizes DATA_DIR before deriving local backup dir
   const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-user-redis-autobackup-'));
   const tempHome = join(tempRoot, 'home');
   const binDir = join(tempRoot, 'bin');
-  const expectedBackupDir = join(realpathSync(tempRoot), 'runtime-data', 'redis-backups');
+  const expectedBackupDir = join(realpathSync(tempRoot), 'runtime-data', 'redis-backups', 'user');
 
   try {
     mkdirSync(tempHome, { recursive: true });

--- a/packages/api/test/user-redis-script.test.js
+++ b/packages/api/test/user-redis-script.test.js
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { test } from 'node:test';
+
+function baseShellEnv(overrides = {}) {
+  return {
+    PATH: process.env.PATH ?? '',
+    HOME: process.env.HOME ?? '',
+    TERM: process.env.TERM ?? 'xterm-256color',
+    ...overrides,
+  };
+}
+
+test('user-redis DATA_DIR migration moves legacy data into an empty target before status', () => {
+  const scriptPath = resolve(process.cwd(), '../../scripts/user-redis.sh');
+  const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-user-redis-data-dir-'));
+  const tempHome = join(tempRoot, 'home');
+  const dataRoot = join(tempRoot, 'runtime-data');
+  const legacyDir = join(tempHome, '.cat-cafe', 'redis-user');
+  const targetDir = join(dataRoot, 'redis');
+
+  try {
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'dump.rdb'), 'legacy user redis', 'utf8');
+
+    const result = spawnSync('bash', [scriptPath, 'status'], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: tempHome,
+        DATA_DIR: dataRoot,
+      }),
+    });
+
+    assert.equal(result.status, 0, `status failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.equal(readFileSync(join(targetDir, 'dump.rdb'), 'utf8'), 'legacy user redis');
+    assert.equal(existsSync(legacyDir), false);
+    assert.match(result.stdout, new RegExp(`data dir: ${targetDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('user-redis DATA_DIR migration refuses populated target with legacy data present', () => {
+  const scriptPath = resolve(process.cwd(), '../../scripts/user-redis.sh');
+  const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-user-redis-populated-'));
+  const tempHome = join(tempRoot, 'home');
+  const dataRoot = join(tempRoot, 'runtime-data');
+  const legacyDir = join(tempHome, '.cat-cafe', 'redis-user');
+  const targetDir = join(dataRoot, 'redis');
+
+  try {
+    mkdirSync(legacyDir, { recursive: true });
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'dump.rdb'), 'legacy user redis', 'utf8');
+    writeFileSync(join(targetDir, 'dump.rdb'), 'target user redis', 'utf8');
+
+    const result = spawnSync('bash', [scriptPath, 'status'], {
+      encoding: 'utf8',
+      env: baseShellEnv({
+        HOME: tempHome,
+        DATA_DIR: dataRoot,
+      }),
+    });
+
+    assert.notEqual(
+      result.status,
+      0,
+      `status should fail closed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert.match(`${result.stdout}\n${result.stderr}`, /Refusing to switch user Redis data to DATA_DIR/);
+    assert.equal(readFileSync(join(legacyDir, 'dump.rdb'), 'utf8'), 'legacy user redis');
+    assert.equal(readFileSync(join(targetDir, 'dump.rdb'), 'utf8'), 'target user redis');
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('user-redis autobackup normalizes DATA_DIR before deriving local backup dir', () => {
+  const scriptPath = resolve(process.cwd(), '../../scripts/user-redis-autobackup.sh');
+  const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-user-redis-autobackup-'));
+  const tempHome = join(tempRoot, 'home');
+  const binDir = join(tempRoot, 'bin');
+  const expectedBackupDir = join(realpathSync(tempRoot), 'runtime-data', 'redis-backups');
+
+  try {
+    mkdirSync(tempHome, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, 'launchctl'), '#!/usr/bin/env bash\nexit 1\n', 'utf8');
+    writeFileSync(join(binDir, 'redis-cli'), '#!/usr/bin/env bash\nexit 1\n', 'utf8');
+    chmodSync(join(binDir, 'launchctl'), 0o755);
+    chmodSync(join(binDir, 'redis-cli'), 0o755);
+
+    const result = spawnSync('bash', [scriptPath, 'status'], {
+      cwd: tempRoot,
+      encoding: 'utf8',
+      env: baseShellEnv({
+        PATH: `${binDir}:${process.env.PATH ?? ''}`,
+        HOME: tempHome,
+        DATA_DIR: './runtime-data',
+      }),
+    });
+
+    assert.notEqual(result.status, 127, `status failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert.match(result.stdout, new RegExp(`local:\\s+${expectedBackupDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`));
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/check-env-registry.test.mjs
+++ b/scripts/check-env-registry.test.mjs
@@ -41,6 +41,14 @@ const ALLOWLIST = new Map([
   ['npm_config_user_agent', 'Package-manager metadata injected by npm/pnpm; not user-configurable'],
   ['INIT_CWD', 'Package-manager metadata injected by npm/pnpm; original invocation directory'],
   ['COGVIDEO_API_KEY', 'F139 MediaHub CogVideoX provider — mcp-server-local credential'],
+  [
+    'REDIS_DATA_DIR',
+    '#671 shell-injected: start-dev.sh sets before API launch; not user-facing (derived from DATA_DIR)',
+  ],
+  [
+    'REDIS_BACKUP_DIR',
+    '#671 shell-injected: start-dev.sh sets before API launch; not user-facing (derived from DATA_DIR)',
+  ],
 ]);
 
 // ── Extract registered names from env-registry.ts ──

--- a/scripts/lib/data-root-migration.sh
+++ b/scripts/lib/data-root-migration.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+cat_cafe_absolute_path() {
+    local path="$1"
+    local -a parts
+    local -a normalized=()
+    local part
+
+    case "$path" in
+        /*) ;;
+        *) path="$PWD/$path" ;;
+    esac
+
+    IFS='/' read -r -a parts <<< "$path"
+    for part in "${parts[@]}"; do
+        case "$part" in
+            ""|.) continue ;;
+            ..)
+                if [ "${#normalized[@]}" -gt 0 ]; then
+                    unset "normalized[$((${#normalized[@]} - 1))]"
+                fi
+                ;;
+            *) normalized+=("$part") ;;
+        esac
+    done
+
+    if [ "${#normalized[@]}" -eq 0 ]; then
+        printf '/'
+    else
+        local IFS='/'
+        printf '/%s' "${normalized[*]}"
+    fi
+}
+
+cat_cafe_dir_has_entries() {
+    local dir="$1"
+    [ -d "$dir" ] && find "$dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .
+}
+
+cat_cafe_migrate_data_root_dir_or_abort() {
+    local label="$1"
+    local legacy_dir="$2"
+    local target_dir="$3"
+
+    [ "$legacy_dir" != "$target_dir" ] || return 0
+    cat_cafe_dir_has_entries "$legacy_dir" || return 0
+
+    if [ -d "$target_dir" ]; then
+        if cat_cafe_dir_has_entries "$target_dir"; then
+            echo "  [#671] Refusing to switch ${label} to DATA_DIR because both legacy and target contain data." >&2
+            echo "        legacy: $legacy_dir" >&2
+            echo "        target: $target_dir" >&2
+            exit 1
+        fi
+        rmdir "$target_dir" 2>/dev/null || {
+            echo "  [#671] Refusing to switch ${label} to DATA_DIR because the empty target could not be removed: $target_dir" >&2
+            exit 1
+        }
+    fi
+
+    echo "  [#671] Migrating ${label}: $legacy_dir -> $target_dir"
+    mkdir -p "$(dirname "$target_dir")"
+    mv "$legacy_dir" "$target_dir" 2>/dev/null || {
+        cp -a "$legacy_dir" "$target_dir" && rm -rf "$legacy_dir"
+    } || {
+        echo "  [#671] Failed to migrate ${label}: $legacy_dir -> $target_dir" >&2
+        exit 1
+    }
+}

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -15,6 +15,7 @@ function createSandbox(envFile = '') {
   cpSync(resolve(ROOT, 'scripts/start-dev.sh'), join(dir, 'scripts', 'start-dev.sh'));
   cpSync(resolve(ROOT, 'scripts/lib/node-runtime-guard.sh'), join(dir, 'scripts/lib', 'node-runtime-guard.sh'));
   cpSync(resolve(ROOT, 'scripts/lib/redis-rdb-first.sh'), join(dir, 'scripts/lib', 'redis-rdb-first.sh'));
+  cpSync(resolve(ROOT, 'scripts/lib/data-root-migration.sh'), join(dir, 'scripts/lib', 'data-root-migration.sh'));
 
   const downloadOverrides = resolve(ROOT, 'scripts/download-source-overrides.sh');
   if (existsSync(downloadOverrides)) {

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -480,7 +480,51 @@ if [ -n "${DATA_DIR-}" ]; then
     # (50+ files that do `resolve(projectRoot, '.cat-cafe', file)`) keep working.
     _legacy_catcafe="${PROJECT_DIR}/.cat-cafe"
     _target_catcafe="${DATA_DIR}/cat-cafe"
-    if [ -d "$_legacy_catcafe" ] && [ ! -L "$_legacy_catcafe" ]; then
+    if [ -L "$_legacy_catcafe" ]; then
+        _linked_catcafe="$(readlink "$_legacy_catcafe")"
+        case "$_linked_catcafe" in
+            /*) ;;
+            *) _linked_catcafe="$(cat_cafe_absolute_path "$(dirname "$_legacy_catcafe")/$_linked_catcafe")" ;;
+        esac
+        if [ "$_linked_catcafe" != "$_target_catcafe" ]; then
+            if [ -d "$_linked_catcafe" ]; then
+                if cat_cafe_dir_has_entries "$_linked_catcafe"; then
+                    cat_cafe_migrate_data_root_dir_or_abort ".cat-cafe state" "$_linked_catcafe" "$_target_catcafe"
+                elif [ -d "$_target_catcafe" ]; then
+                    rmdir "$_linked_catcafe" 2>/dev/null || {
+                        echo "  [#671] Refusing to replace stale empty .cat-cafe target because it could not be removed: $_linked_catcafe" >&2
+                        exit 1
+                    }
+                elif [ ! -e "$_target_catcafe" ]; then
+                    echo -e "${YELLOW}  [#671] Migrating .cat-cafe state: $_linked_catcafe → $_target_catcafe${NC}"
+                    mkdir -p "$(dirname "$_target_catcafe")"
+                    mv "$_linked_catcafe" "$_target_catcafe" 2>/dev/null || {
+                        cp -a "$_linked_catcafe" "$_target_catcafe" && rm -rf "$_linked_catcafe"
+                    } || {
+                        echo "  [#671] Failed to migrate .cat-cafe state: $_linked_catcafe -> $_target_catcafe" >&2
+                        exit 1
+                    }
+                else
+                    echo "  [#671] Refusing to switch .cat-cafe state to DATA_DIR because the target path is not a directory: $_target_catcafe" >&2
+                    exit 1
+                fi
+            elif [ -e "$_linked_catcafe" ]; then
+                echo "  [#671] Refusing to switch .cat-cafe state to DATA_DIR because the stale .cat-cafe symlink target is not a directory: $_linked_catcafe" >&2
+                exit 1
+            elif [ ! -d "$_target_catcafe" ]; then
+                if [ -e "$_target_catcafe" ]; then
+                    echo "  [#671] Refusing to switch .cat-cafe state to DATA_DIR because the target path is not a directory: $_target_catcafe" >&2
+                    exit 1
+                fi
+                mkdir -p "$_target_catcafe"
+            fi
+            rm "$_legacy_catcafe" 2>/dev/null || {
+                echo "  [#671] Refusing to replace stale .cat-cafe symlink: $_legacy_catcafe" >&2
+                exit 1
+            }
+            ln -s "$_target_catcafe" "$_legacy_catcafe"
+        fi
+    elif [ -d "$_legacy_catcafe" ]; then
         if cat_cafe_dir_has_entries "$_legacy_catcafe"; then
             cat_cafe_migrate_data_root_dir_or_abort ".cat-cafe state" "$_legacy_catcafe" "$_target_catcafe"
         elif [ -d "$_target_catcafe" ]; then

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -480,14 +480,29 @@ if [ -n "${DATA_DIR-}" ]; then
     # (50+ files that do `resolve(projectRoot, '.cat-cafe', file)`) keep working.
     _legacy_catcafe="${PROJECT_DIR}/.cat-cafe"
     _target_catcafe="${DATA_DIR}/cat-cafe"
-    if [ -d "$_legacy_catcafe" ] && [ ! -L "$_legacy_catcafe" ] && [ ! -d "$_target_catcafe" ]; then
-        echo -e "${YELLOW}  [#671] Migrating .cat-cafe state: $_legacy_catcafe → $_target_catcafe${NC}"
-        mkdir -p "$(dirname "$_target_catcafe")"
-        mv "$_legacy_catcafe" "$_target_catcafe" 2>/dev/null || {
-            cp -a "$_legacy_catcafe" "$_target_catcafe" && rm -rf "$_legacy_catcafe"
-        }
-        ln -sfn "$_target_catcafe" "$_legacy_catcafe"
-    elif [ ! -e "$_legacy_catcafe" ] && [ -d "$_target_catcafe" ]; then
+    if [ -d "$_legacy_catcafe" ] && [ ! -L "$_legacy_catcafe" ]; then
+        if cat_cafe_dir_has_entries "$_legacy_catcafe"; then
+            cat_cafe_migrate_data_root_dir_or_abort ".cat-cafe state" "$_legacy_catcafe" "$_target_catcafe"
+        elif [ -d "$_target_catcafe" ]; then
+            rmdir "$_legacy_catcafe" 2>/dev/null || {
+                echo "  [#671] Refusing to replace empty .cat-cafe with DATA_DIR symlink because it could not be removed: $_legacy_catcafe" >&2
+                exit 1
+            }
+        elif [ ! -e "$_target_catcafe" ]; then
+            echo -e "${YELLOW}  [#671] Migrating .cat-cafe state: $_legacy_catcafe → $_target_catcafe${NC}"
+            mkdir -p "$(dirname "$_target_catcafe")"
+            mv "$_legacy_catcafe" "$_target_catcafe" 2>/dev/null || {
+                cp -a "$_legacy_catcafe" "$_target_catcafe" && rm -rf "$_legacy_catcafe"
+            } || {
+                echo "  [#671] Failed to migrate .cat-cafe state: $_legacy_catcafe -> $_target_catcafe" >&2
+                exit 1
+            }
+        else
+            echo "  [#671] Refusing to switch .cat-cafe state to DATA_DIR because the target path is not a directory: $_target_catcafe" >&2
+            exit 1
+        fi
+    fi
+    if [ ! -e "$_legacy_catcafe" ] && [ -d "$_target_catcafe" ]; then
         # Target exists but no symlink yet (e.g. after manual copy)
         ln -sfn "$_target_catcafe" "$_legacy_catcafe"
     fi

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -435,6 +435,42 @@ default_redis_backup_dir() {
     printf '%s/.cat-cafe/redis-backups/%s' "$HOME" "$key"
 }
 
+dir_has_entries() {
+    local dir="$1"
+    [ -d "$dir" ] && find "$dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .
+}
+
+migrate_data_root_dir_or_abort() {
+    local label="$1"
+    local legacy_dir="$2"
+    local target_dir="$3"
+
+    [ "$legacy_dir" != "$target_dir" ] || return 0
+    dir_has_entries "$legacy_dir" || return 0
+
+    if [ -d "$target_dir" ]; then
+        if dir_has_entries "$target_dir"; then
+            echo -e "${RED}  [#671] Refusing to switch ${label} to DATA_DIR because both legacy and target contain data.${NC}" >&2
+            echo "        legacy: $legacy_dir" >&2
+            echo "        target: $target_dir" >&2
+            exit 1
+        fi
+        rmdir "$target_dir" 2>/dev/null || {
+            echo -e "${RED}  [#671] Refusing to switch ${label} to DATA_DIR because the empty target could not be removed: $target_dir${NC}" >&2
+            exit 1
+        }
+    fi
+
+    echo -e "${YELLOW}  [#671] Migrating ${label}: $legacy_dir → $target_dir${NC}"
+    mkdir -p "$(dirname "$target_dir")"
+    mv "$legacy_dir" "$target_dir" 2>/dev/null || {
+        cp -a "$legacy_dir" "$target_dir" && rm -rf "$legacy_dir"
+    } || {
+        echo -e "${RED}  [#671] Failed to migrate ${label}: $legacy_dir → $target_dir${NC}" >&2
+        exit 1
+    }
+}
+
 REDIS_STORAGE_KEY=$(default_redis_storage_key "$REDIS_PROFILE" "$REDIS_PORT")
 if [ -n "$CLI_REDIS_DATA_DIR_OVERRIDE" ]; then
     REDIS_DATA_DIR="$CLI_REDIS_DATA_DIR_OVERRIDE"
@@ -461,27 +497,14 @@ if [ -n "${DATA_DIR-}" ]; then
     _target_redis_data="${DATA_DIR}/redis"
     if [ "$_legacy_redis_data" != "$_target_redis_data" ]; then
         # Pre-start migration: move legacy Redis data before overriding the path
-        if [ -d "$_legacy_redis_data" ] && [ ! -d "$_target_redis_data" ]; then
-            echo -e "${YELLOW}  [#671] Migrating Redis data: $_legacy_redis_data → $_target_redis_data${NC}"
-            mkdir -p "$(dirname "$_target_redis_data")"
-            mv "$_legacy_redis_data" "$_target_redis_data" 2>/dev/null || {
-                # Cross-device fallback: copy + remove
-                cp -a "$_legacy_redis_data" "$_target_redis_data" && rm -rf "$_legacy_redis_data"
-            }
-        fi
+        migrate_data_root_dir_or_abort "Redis data" "$_legacy_redis_data" "$_target_redis_data"
         REDIS_DATA_DIR="$_target_redis_data"
     fi
 
     _legacy_redis_backup="$REDIS_BACKUP_DIR"
     _target_redis_backup="${DATA_DIR}/redis-backups"
     if [ "$_legacy_redis_backup" != "$_target_redis_backup" ]; then
-        if [ -d "$_legacy_redis_backup" ] && [ ! -d "$_target_redis_backup" ]; then
-            echo -e "${YELLOW}  [#671] Migrating Redis backups: $_legacy_redis_backup → $_target_redis_backup${NC}"
-            mkdir -p "$(dirname "$_target_redis_backup")"
-            mv "$_legacy_redis_backup" "$_target_redis_backup" 2>/dev/null || {
-                cp -a "$_legacy_redis_backup" "$_target_redis_backup" && rm -rf "$_legacy_redis_backup"
-            }
-        fi
+        migrate_data_root_dir_or_abort "Redis backups" "$_legacy_redis_backup" "$_target_redis_backup"
         REDIS_BACKUP_DIR="$_target_redis_backup"
     fi
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -451,6 +451,41 @@ elif [ -n "$CLI_REDIS_PORT_OVERRIDE" ]; then
 else
     REDIS_BACKUP_DIR=${REDIS_BACKUP_DIR:-"$(default_redis_backup_dir "$REDIS_PROFILE" "$REDIS_PORT")"}
 fi
+# --- DATA_DIR → Redis path unification (#671) ---
+# When DATA_DIR is set, all runtime data lives under one root.  Redis data
+# and backups follow the same convention: DATA_DIR/redis, DATA_DIR/redis-backups.
+# This keeps the user-facing config simple (one knob) and makes portable
+# deployment (installer / archive) straightforward.
+if [ -n "${DATA_DIR-}" ]; then
+    _legacy_redis_data="$REDIS_DATA_DIR"
+    _target_redis_data="${DATA_DIR}/redis"
+    if [ "$_legacy_redis_data" != "$_target_redis_data" ]; then
+        # Pre-start migration: move legacy Redis data before overriding the path
+        if [ -d "$_legacy_redis_data" ] && [ ! -d "$_target_redis_data" ]; then
+            echo -e "${YELLOW}  [#671] Migrating Redis data: $_legacy_redis_data → $_target_redis_data${NC}"
+            mkdir -p "$(dirname "$_target_redis_data")"
+            mv "$_legacy_redis_data" "$_target_redis_data" 2>/dev/null || {
+                # Cross-device fallback: copy + remove
+                cp -a "$_legacy_redis_data" "$_target_redis_data" && rm -rf "$_legacy_redis_data"
+            }
+        fi
+        REDIS_DATA_DIR="$_target_redis_data"
+    fi
+
+    _legacy_redis_backup="$REDIS_BACKUP_DIR"
+    _target_redis_backup="${DATA_DIR}/redis-backups"
+    if [ "$_legacy_redis_backup" != "$_target_redis_backup" ]; then
+        if [ -d "$_legacy_redis_backup" ] && [ ! -d "$_target_redis_backup" ]; then
+            echo -e "${YELLOW}  [#671] Migrating Redis backups: $_legacy_redis_backup → $_target_redis_backup${NC}"
+            mkdir -p "$(dirname "$_target_redis_backup")"
+            mv "$_legacy_redis_backup" "$_target_redis_backup" 2>/dev/null || {
+                cp -a "$_legacy_redis_backup" "$_target_redis_backup" && rm -rf "$_legacy_redis_backup"
+            }
+        fi
+        REDIS_BACKUP_DIR="$_target_redis_backup"
+    fi
+fi
+
 REDIS_DBFILE=${REDIS_DBFILE:-dump.rdb}
 REDIS_PIDFILE="${REDIS_DATA_DIR}/redis-${REDIS_PORT}.pid"
 REDIS_LOGFILE="${REDIS_DATA_DIR}/redis-${REDIS_PORT}.log"

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -484,6 +484,23 @@ if [ -n "${DATA_DIR-}" ]; then
         fi
         REDIS_BACKUP_DIR="$_target_redis_backup"
     fi
+
+    # .cat-cafe/ state directory: move writable config/state to DATA_DIR/cat-cafe/
+    # and replace the original with a symlink so all in-process consumers
+    # (50+ files that do `resolve(projectRoot, '.cat-cafe', file)`) keep working.
+    _legacy_catcafe="${PROJECT_DIR}/.cat-cafe"
+    _target_catcafe="${DATA_DIR}/cat-cafe"
+    if [ -d "$_legacy_catcafe" ] && [ ! -L "$_legacy_catcafe" ] && [ ! -d "$_target_catcafe" ]; then
+        echo -e "${YELLOW}  [#671] Migrating .cat-cafe state: $_legacy_catcafe → $_target_catcafe${NC}"
+        mkdir -p "$(dirname "$_target_catcafe")"
+        mv "$_legacy_catcafe" "$_target_catcafe" 2>/dev/null || {
+            cp -a "$_legacy_catcafe" "$_target_catcafe" && rm -rf "$_legacy_catcafe"
+        }
+        ln -sfn "$_target_catcafe" "$_legacy_catcafe"
+    elif [ ! -e "$_legacy_catcafe" ] && [ -d "$_target_catcafe" ]; then
+        # Target exists but no symlink yet (e.g. after manual copy)
+        ln -sfn "$_target_catcafe" "$_legacy_catcafe"
+    fi
 fi
 
 REDIS_DBFILE=${REDIS_DBFILE:-dump.rdb}

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -53,6 +53,7 @@ if [[ "${1:-}" != "--source-only" ]]; then
     ensure_supported_node_runtime "$SCRIPT_DIR/start-dev.sh" "$@"
 fi
 source "$SCRIPT_DIR/lib/redis-rdb-first.sh"
+source "$SCRIPT_DIR/lib/data-root-migration.sh"
 source "$SCRIPT_DIR/download-source-overrides.sh"
 cd "$PROJECT_DIR"
 
@@ -435,42 +436,6 @@ default_redis_backup_dir() {
     printf '%s/.cat-cafe/redis-backups/%s' "$HOME" "$key"
 }
 
-dir_has_entries() {
-    local dir="$1"
-    [ -d "$dir" ] && find "$dir" -mindepth 1 -maxdepth 1 -print -quit 2>/dev/null | grep -q .
-}
-
-migrate_data_root_dir_or_abort() {
-    local label="$1"
-    local legacy_dir="$2"
-    local target_dir="$3"
-
-    [ "$legacy_dir" != "$target_dir" ] || return 0
-    dir_has_entries "$legacy_dir" || return 0
-
-    if [ -d "$target_dir" ]; then
-        if dir_has_entries "$target_dir"; then
-            echo -e "${RED}  [#671] Refusing to switch ${label} to DATA_DIR because both legacy and target contain data.${NC}" >&2
-            echo "        legacy: $legacy_dir" >&2
-            echo "        target: $target_dir" >&2
-            exit 1
-        fi
-        rmdir "$target_dir" 2>/dev/null || {
-            echo -e "${RED}  [#671] Refusing to switch ${label} to DATA_DIR because the empty target could not be removed: $target_dir${NC}" >&2
-            exit 1
-        }
-    fi
-
-    echo -e "${YELLOW}  [#671] Migrating ${label}: $legacy_dir → $target_dir${NC}"
-    mkdir -p "$(dirname "$target_dir")"
-    mv "$legacy_dir" "$target_dir" 2>/dev/null || {
-        cp -a "$legacy_dir" "$target_dir" && rm -rf "$legacy_dir"
-    } || {
-        echo -e "${RED}  [#671] Failed to migrate ${label}: $legacy_dir → $target_dir${NC}" >&2
-        exit 1
-    }
-}
-
 REDIS_STORAGE_KEY=$(default_redis_storage_key "$REDIS_PROFILE" "$REDIS_PORT")
 if [ -n "$CLI_REDIS_DATA_DIR_OVERRIDE" ]; then
     REDIS_DATA_DIR="$CLI_REDIS_DATA_DIR_OVERRIDE"
@@ -493,18 +458,20 @@ fi
 # This keeps the user-facing config simple (one knob) and makes portable
 # deployment (installer / archive) straightforward.
 if [ -n "${DATA_DIR-}" ]; then
+    DATA_DIR="$(cat_cafe_absolute_path "$DATA_DIR")"
+    export DATA_DIR
     _legacy_redis_data="$REDIS_DATA_DIR"
     _target_redis_data="${DATA_DIR}/redis"
     if [ "$_legacy_redis_data" != "$_target_redis_data" ]; then
         # Pre-start migration: move legacy Redis data before overriding the path
-        migrate_data_root_dir_or_abort "Redis data" "$_legacy_redis_data" "$_target_redis_data"
+        cat_cafe_migrate_data_root_dir_or_abort "Redis data" "$_legacy_redis_data" "$_target_redis_data"
         REDIS_DATA_DIR="$_target_redis_data"
     fi
 
     _legacy_redis_backup="$REDIS_BACKUP_DIR"
     _target_redis_backup="${DATA_DIR}/redis-backups"
     if [ "$_legacy_redis_backup" != "$_target_redis_backup" ]; then
-        migrate_data_root_dir_or_abort "Redis backups" "$_legacy_redis_backup" "$_target_redis_backup"
+        cat_cafe_migrate_data_root_dir_or_abort "Redis backups" "$_legacy_redis_backup" "$_target_redis_backup"
         REDIS_BACKUP_DIR="$_target_redis_backup"
     fi
 

--- a/scripts/user-redis-autobackup.sh
+++ b/scripts/user-redis-autobackup.sh
@@ -21,7 +21,7 @@ PROFILE="${USER_REDIS_PROFILE:-user}"
 # #671: When the global DATA_DIR root is set, derive backup dir from it
 if [ -n "${DATA_DIR-}" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
   _GLOBAL_DATA_ROOT="$(cat_cafe_absolute_path "$DATA_DIR")"
-  LOCAL_BACKUP_DIR="${_GLOBAL_DATA_ROOT}/redis-backups"
+  LOCAL_BACKUP_DIR="${_GLOBAL_DATA_ROOT}/redis-backups/${PROFILE}"
 else
   LOCAL_BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
 fi

--- a/scripts/user-redis-autobackup.sh
+++ b/scripts/user-redis-autobackup.sh
@@ -17,7 +17,12 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 USER_REDIS_SCRIPT="${SCRIPT_DIR}/user-redis.sh"
 PORT="${USER_REDIS_PORT:-6401}"
 PROFILE="${USER_REDIS_PROFILE:-user}"
-LOCAL_BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
+# #671: When the global DATA_DIR root is set, derive backup dir from it
+if [ -n "${DATA_DIR-}" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
+  LOCAL_BACKUP_DIR="${DATA_DIR}/redis-backups"
+else
+  LOCAL_BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
+fi
 ICLOUD_ROOT="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
 DEFAULT_OFFSITE_ROOT="$HOME/.cat-cafe/redis-offsite-backups"
 if [[ -d "$ICLOUD_ROOT" ]]; then

--- a/scripts/user-redis-autobackup.sh
+++ b/scripts/user-redis-autobackup.sh
@@ -14,12 +14,14 @@ LAUNCHD_SAFE_PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:
 export PATH="${LAUNCHD_SAFE_PATH}:${PATH:-}"
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/data-root-migration.sh"
 USER_REDIS_SCRIPT="${SCRIPT_DIR}/user-redis.sh"
 PORT="${USER_REDIS_PORT:-6401}"
 PROFILE="${USER_REDIS_PROFILE:-user}"
 # #671: When the global DATA_DIR root is set, derive backup dir from it
 if [ -n "${DATA_DIR-}" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
-  LOCAL_BACKUP_DIR="${DATA_DIR}/redis-backups"
+  _GLOBAL_DATA_ROOT="$(cat_cafe_absolute_path "$DATA_DIR")"
+  LOCAL_BACKUP_DIR="${_GLOBAL_DATA_ROOT}/redis-backups"
 else
   LOCAL_BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
 fi

--- a/scripts/user-redis.sh
+++ b/scripts/user-redis.sh
@@ -23,6 +23,7 @@ if [[ $# -gt 0 ]]; then
 fi
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/redis-rdb-first.sh"
+source "$SCRIPT_DIR/lib/data-root-migration.sh"
 
 PORT="${USER_REDIS_PORT:-6401}"
 PROFILE="${USER_REDIS_PROFILE:-user}"
@@ -32,13 +33,22 @@ PROFILE="${USER_REDIS_PROFILE:-user}"
 # NOTE: we capture the global DATA_DIR *before* overwriting it with the local
 # Redis data directory variable (unfortunately same name for historical reasons).
 _GLOBAL_DATA_ROOT="${DATA_DIR-}"
+if [ -n "$_GLOBAL_DATA_ROOT" ]; then
+  _GLOBAL_DATA_ROOT="$(cat_cafe_absolute_path "$_GLOBAL_DATA_ROOT")"
+fi
 if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_DATA_DIR-}" ]; then
-  DATA_DIR="${_GLOBAL_DATA_ROOT}/redis"
+  _legacy_user_redis_data="$HOME/.cat-cafe/redis-${PROFILE}"
+  _target_user_redis_data="${_GLOBAL_DATA_ROOT}/redis"
+  cat_cafe_migrate_data_root_dir_or_abort "user Redis data" "$_legacy_user_redis_data" "$_target_user_redis_data"
+  DATA_DIR="$_target_user_redis_data"
 else
   DATA_DIR="${USER_REDIS_DATA_DIR:-$HOME/.cat-cafe/redis-${PROFILE}}"
 fi
 if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
-  BACKUP_DIR="${_GLOBAL_DATA_ROOT}/redis-backups"
+  _legacy_user_redis_backup="$HOME/.cat-cafe/redis-backups/${PROFILE}"
+  _target_user_redis_backup="${_GLOBAL_DATA_ROOT}/redis-backups"
+  cat_cafe_migrate_data_root_dir_or_abort "user Redis backups" "$_legacy_user_redis_backup" "$_target_user_redis_backup"
+  BACKUP_DIR="$_target_user_redis_backup"
 else
   BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
 fi

--- a/scripts/user-redis.sh
+++ b/scripts/user-redis.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 #   USER_REDIS_DATA_DIR (default: ~/.cat-cafe/redis-user)
 #   USER_REDIS_BACKUP_DIR (default: ~/.cat-cafe/redis-backups/user)
 #   USER_REDIS_DBFILE (default: dump.rdb)
+#   DATA_DIR (optional global root): DATA_DIR/redis-${USER_REDIS_PROFILE}
+#                                   DATA_DIR/redis-backups/${USER_REDIS_PROFILE}
 
 ACTION="${1:-status}"
 if [[ $# -gt 0 ]]; then
@@ -38,7 +40,7 @@ if [ -n "$_GLOBAL_DATA_ROOT" ]; then
 fi
 if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_DATA_DIR-}" ]; then
   _legacy_user_redis_data="$HOME/.cat-cafe/redis-${PROFILE}"
-  _target_user_redis_data="${_GLOBAL_DATA_ROOT}/redis"
+  _target_user_redis_data="${_GLOBAL_DATA_ROOT}/redis-${PROFILE}"
   cat_cafe_migrate_data_root_dir_or_abort "user Redis data" "$_legacy_user_redis_data" "$_target_user_redis_data"
   DATA_DIR="$_target_user_redis_data"
 else
@@ -46,7 +48,7 @@ else
 fi
 if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
   _legacy_user_redis_backup="$HOME/.cat-cafe/redis-backups/${PROFILE}"
-  _target_user_redis_backup="${_GLOBAL_DATA_ROOT}/redis-backups"
+  _target_user_redis_backup="${_GLOBAL_DATA_ROOT}/redis-backups/${PROFILE}"
   cat_cafe_migrate_data_root_dir_or_abort "user Redis backups" "$_legacy_user_redis_backup" "$_target_user_redis_backup"
   BACKUP_DIR="$_target_user_redis_backup"
 else

--- a/scripts/user-redis.sh
+++ b/scripts/user-redis.sh
@@ -26,8 +26,22 @@ source "$SCRIPT_DIR/lib/redis-rdb-first.sh"
 
 PORT="${USER_REDIS_PORT:-6401}"
 PROFILE="${USER_REDIS_PROFILE:-user}"
-DATA_DIR="${USER_REDIS_DATA_DIR:-$HOME/.cat-cafe/redis-${PROFILE}}"
-BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
+
+# #671: When the global DATA_DIR root is set (unified data directory), derive
+# Redis paths from it — unless the user explicitly overrides via USER_REDIS_*.
+# NOTE: we capture the global DATA_DIR *before* overwriting it with the local
+# Redis data directory variable (unfortunately same name for historical reasons).
+_GLOBAL_DATA_ROOT="${DATA_DIR-}"
+if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_DATA_DIR-}" ]; then
+  DATA_DIR="${_GLOBAL_DATA_ROOT}/redis"
+else
+  DATA_DIR="${USER_REDIS_DATA_DIR:-$HOME/.cat-cafe/redis-${PROFILE}}"
+fi
+if [ -n "$_GLOBAL_DATA_ROOT" ] && [ -z "${USER_REDIS_BACKUP_DIR-}" ]; then
+  BACKUP_DIR="${_GLOBAL_DATA_ROOT}/redis-backups"
+else
+  BACKUP_DIR="${USER_REDIS_BACKUP_DIR:-$HOME/.cat-cafe/redis-backups/${PROFILE}}"
+fi
 DBFILE="${USER_REDIS_DBFILE:-dump.rdb}"
 PIDFILE="${DATA_DIR}/redis-${PORT}.pid"
 LOGFILE="${DATA_DIR}/redis-${PORT}.log"


### PR DESCRIPTION
## Summary

Refs #671.

This draft PR implements the DATA_DIR / CACHE_DIR / LOG_DIR three-root runtime data directory model.

- Add unified data directory resolver and path introspection.
- Route runtime consumers for evidence/world DBs, transcripts, uploads, audit logs, CLI raw archive, connector media, TTS cache, and logs through the resolver.
- Remove the 8 legacy env vars from env-registry and add DATA_DIR / CACHE_DIR.
- Add data directory migration planning/execution, startup wiring, and owner-only runtime migration API.
- Add focused tests and architecture documentation.

## Scope Notes

- Uploads are treated as DATA_DIR because they are user-provided persistent files, not disposable cache.
- LOG_DIR is used directly for future writes and is not migrated automatically because the logger binds during module initialization.
- The only .env.example change is removal of the stale commented TTS_CACHE_DIR entry.

## Verification

- `pnpm --filter @cat-cafe/api build`
- `NODE_ENV=test CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import ./packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/data-dirs.test.js packages/api/test/data-dirs-migration.test.js packages/api/test/env-registry.test.js packages/api/test/ref-audio-upload-route.test.js packages/api/test/cat-voices-ref-audio-path.test.js packages/api/test/invoke-single-cat-bg-registry.test.js packages/api/test/invoke-single-cat-bg-status.test.js packages/api/test/domains/preview/preview-routes.test.js packages/api/test/routes/avatars-route.test.js` — 125/125 passed
- `NODE_ENV=test CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import ./test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/security-boundary.test.js` — 1/1 passed
- legacy env direct-read scan returned no matches
- `git diff --check upstream/main...HEAD`
