### PR TITLE
fix(F192): compute Eval Hub lifecycle.stale from nextEvalAt (closes #790)

### DIFF
--- a/packages/api/src/infrastructure/harness-eval/eval-hub-read-model.ts
+++ b/packages/api/src/infrastructure/harness-eval/eval-hub-read-model.ts
@@ -8,6 +8,12 @@ type CountRecord = Record<string, number | null>;
 
 export interface LoadEvalHubSummaryInput {
   harnessFeedbackRoot: string;
+  /**
+   * Wall-clock reference for staleness checks. Defaults to `new Date()`.
+   * Injectable so date-dependent regression tests don't drift over time.
+   * F192 P2: enables `lifecycle.stale` lifecycle calculation (previously hardcoded false).
+   */
+  now?: Date;
 }
 
 export interface EvalDomainSummary {
@@ -101,11 +107,12 @@ interface ParsedVerdictMarkdown {
 export function loadEvalHubSummary(input: LoadEvalHubSummaryInput): EvalHubSummary {
   const verdictsDir = join(input.harnessFeedbackRoot, 'verdicts');
   const domains = loadDomains(input.harnessFeedbackRoot);
+  const now = input.now ?? new Date();
   const items = readdirSync(verdictsDir, { withFileTypes: true })
     .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
     .map((entry) => parseVerdictMarkdown(join(verdictsDir, entry.name)))
     .filter((verdict) => verdict.frontmatter.feedback_type === 'live-verdict')
-    .map((verdict) => buildEvalHubItem(input.harnessFeedbackRoot, verdict, domains))
+    .map((verdict) => buildEvalHubItem(input.harnessFeedbackRoot, verdict, domains, now))
     .sort((a, b) => b.trend.generatedAt.localeCompare(a.trend.generatedAt));
 
   // F192 livefix OQ-16: Build domain summaries for ALL registered domains,
@@ -142,6 +149,7 @@ function buildEvalHubItem(
   harnessFeedbackRoot: string,
   verdict: ParsedVerdictMarkdown,
   domains: Map<EvalDomainRegistryEntry['domainId'], EvalDomainRegistryEntry>,
+  now: Date,
 ): EvalHubItem {
   const verdictId = verdict.id;
   const bundleDir = join(harnessFeedbackRoot, 'bundles', verdictId);
@@ -187,7 +195,10 @@ function buildEvalHubItem(
     lifecycle: {
       ownerResponseStatus: verdictValue === 'keep_observe' ? 'not_required' : 'not_started',
       closureStatus: verdictValue === 'keep_observe' ? 'observing' : 'open',
-      stale: false,
+      // F192 P2: stale = past the verdict's own re-eval deadline (nextEvalAt).
+      // SLA reevalWithinHours is already absorbed into nextEvalAt at verdict-creation time,
+      // so adding extra grace here would double-discount. A missing nextEvalAt cannot expire.
+      stale: computeStale(nextEvalAt, now),
     },
     evidence,
     trend: {
@@ -317,4 +328,25 @@ function requiredString(value: unknown, field: string): string {
 
 function repoRelative(repoRoot: string, path: string): string {
   return relative(repoRoot, path).replaceAll('\\', '/');
+}
+
+/**
+ * F192 P2 — Eval Hub lifecycle staleness.
+ *
+ * A verdict is `stale` when the wall clock has crossed its declared `nextEvalAt`
+ * without a newer live verdict superseding it. We deliberately do NOT add a
+ * separate SLA grace window here: `nextEvalAt` is computed from
+ * `domain.sla.reevalWithinHours` at verdict-creation time, so any additional
+ * buffer at read time would double-discount the same SLA budget and silently
+ * delay the very signal Eval Hub exists to surface.
+ *
+ * If a verdict happens to omit `nextEvalAt`, we cannot reason about staleness
+ * and return `false` (the absence itself is a data-quality concern that should
+ * be caught upstream by the verdict packet schema, not impersonated here).
+ */
+function computeStale(nextEvalAt: string | undefined, now: Date): boolean {
+  if (!nextEvalAt) return false;
+  const deadlineMs = Date.parse(nextEvalAt);
+  if (Number.isNaN(deadlineMs)) return false;
+  return now.getTime() > deadlineMs;
 }

--- a/packages/api/src/infrastructure/harness-eval/eval-hub-read-model.ts
+++ b/packages/api/src/infrastructure/harness-eval/eval-hub-read-model.ts
@@ -115,6 +115,16 @@ export function loadEvalHubSummary(input: LoadEvalHubSummaryInput): EvalHubSumma
     .map((verdict) => buildEvalHubItem(input.harnessFeedbackRoot, verdict, domains, now))
     .sort((a, b) => b.trend.generatedAt.localeCompare(a.trend.generatedAt));
 
+  // F192 P2 — supersede gating (PR 791 review).
+  // Stale is a *lifecycle state of the active finding per domain*, not a property
+  // every historical verdict carries. After sorting by trend.generatedAt desc, the
+  // first item per domain is the active verdict; the rest have been closed by
+  // re-eval (a newer live verdict landed) and must not count as stale even when
+  // their own nextEvalAt has elapsed — otherwise counts.stale would accumulate
+  // historical overdue verdicts forever and never return to zero, defeating the
+  // re-eval closure loop the Hub exists to surface (AC-E7 / AC-E9).
+  markSupersededAsClosed(items);
+
   // F192 livefix OQ-16: Build domain summaries for ALL registered domains,
   // including those without verdicts (e.g. eval:memory before first eval run).
   const domainSummaries: EvalDomainSummary[] = [...domains.values()].map((domain) => {
@@ -331,14 +341,18 @@ function repoRelative(repoRoot: string, path: string): string {
 }
 
 /**
- * F192 P2 — Eval Hub lifecycle staleness.
+ * F192 P2 — Eval Hub lifecycle staleness (per-verdict deadline check).
  *
- * A verdict is `stale` when the wall clock has crossed its declared `nextEvalAt`
- * without a newer live verdict superseding it. We deliberately do NOT add a
- * separate SLA grace window here: `nextEvalAt` is computed from
- * `domain.sla.reevalWithinHours` at verdict-creation time, so any additional
- * buffer at read time would double-discount the same SLA budget and silently
- * delay the very signal Eval Hub exists to surface.
+ * Reports whether a verdict has crossed its own declared `nextEvalAt`. The
+ * "without a newer live verdict superseding it" half of the stale contract is
+ * applied in a second pass by {@link markSupersededAsClosed} — keeping the
+ * two concerns separated (per-item deadline vs. per-domain supersede) makes
+ * each pure and individually testable.
+ *
+ * We deliberately do NOT add a separate SLA grace window here: `nextEvalAt`
+ * is computed from `domain.sla.reevalWithinHours` at verdict-creation time,
+ * so any additional buffer at read time would double-discount the same SLA
+ * budget and silently delay the very signal Eval Hub exists to surface.
  *
  * If a verdict happens to omit `nextEvalAt`, we cannot reason about staleness
  * and return `false` (the absence itself is a data-quality concern that should
@@ -349,4 +363,30 @@ function computeStale(nextEvalAt: string | undefined, now: Date): boolean {
   const deadlineMs = Date.parse(nextEvalAt);
   if (Number.isNaN(deadlineMs)) return false;
   return now.getTime() > deadlineMs;
+}
+
+/**
+ * F192 P2 — Eval Hub supersede gating (PR 791 review fix).
+ *
+ * Closes the "stale" lifecycle contract: an overdue verdict is only stale if a
+ * newer live verdict has not already superseded it for the same domain. After
+ * a newer verdict lands, the older verdict transitions from "stale" to "closed
+ * by re-eval" (per F192 AC-E7), so its overdue deadline must stop ticking
+ * counts.stale.
+ *
+ * Assumes `items` are already sorted by `trend.generatedAt` desc — the first
+ * item seen per domain is the latest active verdict; every subsequent item in
+ * the same domain has been superseded and has its `lifecycle.stale` forced to
+ * `false`. Mutates `items` in place, consistent with the sibling sort/map style
+ * upstream in `loadEvalHubSummary`.
+ */
+function markSupersededAsClosed(items: EvalHubItem[]): void {
+  const seenDomains = new Set<EvalHubItem['domainId']>();
+  for (const item of items) {
+    if (seenDomains.has(item.domainId)) {
+      item.lifecycle.stale = false;
+    } else {
+      seenDomains.add(item.domainId);
+    }
+  }
 }

--- a/packages/api/test/harness-eval/eval-hub-read-model.test.js
+++ b/packages/api/test/harness-eval/eval-hub-read-model.test.js
@@ -14,14 +14,23 @@ function writeJson(path, value) {
 const repoHarnessFeedbackRoot = fileURLToPath(new URL('../../../../docs/harness-feedback', import.meta.url));
 const apiPackageRoot = fileURLToPath(new URL('../../', import.meta.url));
 
+// Pin staleness reference time so the committed fixture verdict
+// (nextEvalAt = 2026-05-26T03:12:57.174Z) stays "fresh" regardless of wall clock.
+const FIXTURE_NOW_BEFORE_DEADLINE = new Date('2026-05-23T12:00:00.000Z');
+const FIXTURE_NOW_AFTER_DEADLINE = new Date('2026-05-29T00:00:00.000Z');
+
 describe('Eval Hub read model', () => {
   it('loads committed live eval:a2a verdicts with bundle-backed evidence', () => {
-    const summary = loadEvalHubSummary({ harnessFeedbackRoot: repoHarnessFeedbackRoot });
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      now: FIXTURE_NOW_BEFORE_DEADLINE,
+    });
 
     assert.equal(summary.items.length, 1);
     assert.equal(summary.counts.total, 1);
     assert.equal(summary.counts.keepObserve, 1);
     assert.equal(summary.counts.actionable, 0);
+    assert.equal(summary.counts.stale, 0);
 
     const item = summary.items[0];
     assert.equal(item.id, '2026-05-23-eval-a2a-live-verdict');
@@ -63,7 +72,10 @@ describe('Eval Hub read model', () => {
     const originalCwd = cwd();
     try {
       chdir(apiPackageRoot);
-      const summary = loadEvalHubSummary({ harnessFeedbackRoot: repoHarnessFeedbackRoot });
+      const summary = loadEvalHubSummary({
+        harnessFeedbackRoot: repoHarnessFeedbackRoot,
+        now: FIXTURE_NOW_BEFORE_DEADLINE,
+      });
 
       assert.equal(
         summary.items[0].source.verdictPath,
@@ -204,7 +216,12 @@ Evidence:
       sanitizeRulesVersion: 'v1',
     });
 
-    const summary = loadEvalHubSummary({ harnessFeedbackRoot });
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot,
+      // Both synthesized verdicts target 2026-05-27 / 2026-05-31; pin reference
+      // before the earlier deadline so neither flips to stale.
+      now: new Date('2026-05-24T15:00:00.000Z'),
+    });
     assert.equal(summary.items.length, 2);
 
     const a2aItem = summary.items.find((i) => i.domainId === 'eval:a2a');
@@ -218,7 +235,10 @@ Evidence:
 
   // F192 livefix OQ-16: Hub must show ALL registered domains, not just those with verdicts
   it('includes all registered domains in domains[] including those without verdicts', () => {
-    const summary = loadEvalHubSummary({ harnessFeedbackRoot: repoHarnessFeedbackRoot });
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      now: FIXTURE_NOW_BEFORE_DEADLINE,
+    });
 
     assert.ok(summary.domains, 'domains field must exist');
     assert.equal(summary.domains.length, 3, 'should have 3 registered domains (eval:a2a + eval:memory + eval:sop)');
@@ -278,5 +298,117 @@ Evidence:
       () => loadEvalHubSummary({ harnessFeedbackRoot }),
       /failed to resolve evidence bundle for 2026-05-24-bad-live-verdict/,
     );
+  });
+
+  // F192 P2 — eval-hub stale lifecycle calculation regression guard
+  it('marks lifecycle.stale = true and counts.stale = 1 when now is past nextEvalAt', () => {
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      now: FIXTURE_NOW_AFTER_DEADLINE,
+    });
+
+    assert.equal(summary.items.length, 1);
+    assert.equal(summary.counts.stale, 1, 'counts.stale should reflect overdue lifecycle');
+    const item = summary.items[0];
+    assert.equal(item.lifecycle.stale, true, 'verdict past its nextEvalAt must be stale');
+    // Other lifecycle/keep_observe semantics must remain untouched by the stale signal.
+    assert.equal(item.verdict, 'keep_observe');
+    assert.equal(item.lifecycle.closureStatus, 'observing');
+    assert.equal(item.lifecycle.ownerResponseStatus, 'not_required');
+  });
+
+  // F192 P2 — boundary: at-deadline must not flip to stale (strict `>`, not `>=`)
+  it('keeps lifecycle.stale = false when now equals nextEvalAt exactly', () => {
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      // Fixture nextEvalAt = 2026-05-26T03:12:57.174Z
+      now: new Date('2026-05-26T03:12:57.174Z'),
+    });
+
+    assert.equal(summary.items[0].lifecycle.stale, false, 'at-deadline tick is not yet stale');
+    assert.equal(summary.counts.stale, 0);
+  });
+
+  // F192 P2 — defensive: missing nextEvalAt cannot imply staleness
+  it('returns lifecycle.stale = false when the Re-eval bullet lacks an ISO timestamp', () => {
+    const harnessFeedbackRoot = mkdtempSync(join(tmpdir(), 'f192-eval-hub-no-deadline-'));
+    const domainsDir = join(harnessFeedbackRoot, 'eval-domains');
+    const verdictsDir = join(harnessFeedbackRoot, 'verdicts');
+    mkdirSync(domainsDir, { recursive: true });
+    mkdirSync(verdictsDir, { recursive: true });
+
+    const a2aYaml = readFileSync(join(repoHarnessFeedbackRoot, 'eval-domains', 'eval-a2a.yaml'), 'utf8');
+    writeFileSync(join(domainsDir, 'eval-a2a.yaml'), a2aYaml);
+
+    const verdictId = '2026-05-24-eval-a2a-no-deadline';
+    const bundleDir = join(harnessFeedbackRoot, 'bundles', verdictId);
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(
+      join(verdictsDir, `${verdictId}.md`),
+      `---
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: vhp_no_deadline
+---
+
+# Live Verdict — ${verdictId}
+
+- Verdict: \`keep_observe\`
+- Phenomenon: No actionable A2A findings: clean
+- Harness: F167/C1 (hold_ball (MCP tool))
+- Owner ask: No action required; keep observing.
+- Re-eval: window pending; date to be assigned upstream
+
+Evidence:
+- snapshot:bundle/${verdictId}/snapshot
+- attribution:bundle/${verdictId}/eval-F167-2026-05-24:no-finding
+- metric:c1.zombie_hold_count
+`,
+    );
+    writeJson(join(bundleDir, 'snapshot.json'), {
+      verdictId,
+      evalSnapshotId: 'eval-F167-2026-05-24',
+      featureId: 'F167',
+      generatedAt: '2026-05-24T12:00:00.000Z',
+      window: { durationHours: 24 },
+      components: [
+        {
+          id: 'C1',
+          name: 'hold_ball (MCP tool)',
+          activationCounts: { hold_count: 1 },
+          frictionCounts: { 'c1.zombie_hold_count': 0 },
+          confidence: 'medium',
+        },
+      ],
+    });
+    writeJson(join(bundleDir, 'attribution.json'), {
+      verdictId,
+      featureId: 'F167',
+      evalSnapshotId: 'eval-F167-2026-05-24',
+      generatedAt: '2026-05-24T12:01:00.000Z',
+      findings: [],
+      noFindingRecord: { reason: 'clean', evidence: 'within threshold' },
+    });
+    writeJson(join(bundleDir, 'provenance.json'), {
+      verdictId,
+      generatedAt: '2026-05-24T12:02:00.000Z',
+      rawInputs: [{ path: 'raw.yaml', sha256: 'b'.repeat(64) }],
+      generator: { name: 'test', version: '1' },
+      sanitizeRulesVersion: 'v1',
+    });
+
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot,
+      now: new Date('2099-01-01T00:00:00.000Z'),
+    });
+
+    assert.equal(summary.items.length, 1);
+    assert.equal(summary.items[0].reeval.nextEvalAt, undefined, 'fixture should expose missing deadline');
+    assert.equal(
+      summary.items[0].lifecycle.stale,
+      false,
+      'a verdict without a re-eval deadline cannot be classified stale',
+    );
+    assert.equal(summary.counts.stale, 0);
   });
 });

--- a/packages/api/test/harness-eval/eval-hub-read-model.test.js
+++ b/packages/api/test/harness-eval/eval-hub-read-model.test.js
@@ -19,6 +19,77 @@ const apiPackageRoot = fileURLToPath(new URL('../../', import.meta.url));
 const FIXTURE_NOW_BEFORE_DEADLINE = new Date('2026-05-23T12:00:00.000Z');
 const FIXTURE_NOW_AFTER_DEADLINE = new Date('2026-05-29T00:00:00.000Z');
 
+// Shared helper for the per-domain supersede regression cases (PR 791 review feedback).
+// Writes a self-consistent eval:a2a live verdict + bundle triple under harnessFeedbackRoot.
+function writeA2aLiveVerdict(harnessFeedbackRoot, { verdictId, nextEvalAt, generatedAt }) {
+  const verdictsDir = join(harnessFeedbackRoot, 'verdicts');
+  const bundleDir = join(harnessFeedbackRoot, 'bundles', verdictId);
+  mkdirSync(verdictsDir, { recursive: true });
+  mkdirSync(bundleDir, { recursive: true });
+  writeFileSync(
+    join(verdictsDir, `${verdictId}.md`),
+    `---
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: vhp_${verdictId.replace(/-/g, '_')}
+---
+
+# Live Verdict — ${verdictId}
+
+- Verdict: \`keep_observe\`
+- Phenomenon: No actionable A2A findings: clean
+- Harness: F167/C1 (hold_ball (MCP tool))
+- Owner ask: No action required; keep observing.
+- Re-eval: next eval at ${nextEvalAt}
+
+Evidence:
+- snapshot:bundle/${verdictId}/snapshot
+- attribution:bundle/${verdictId}/eval-F167-${verdictId}:no-finding
+- metric:c1.zombie_hold_count
+`,
+  );
+  writeJson(join(bundleDir, 'snapshot.json'), {
+    verdictId,
+    evalSnapshotId: `eval-F167-${verdictId}`,
+    featureId: 'F167',
+    generatedAt,
+    window: { durationHours: 24 },
+    components: [
+      {
+        id: 'C1',
+        name: 'hold_ball (MCP tool)',
+        activationCounts: { hold_count: 1 },
+        frictionCounts: { 'c1.zombie_hold_count': 0 },
+        confidence: 'medium',
+      },
+    ],
+  });
+  writeJson(join(bundleDir, 'attribution.json'), {
+    verdictId,
+    featureId: 'F167',
+    evalSnapshotId: `eval-F167-${verdictId}`,
+    generatedAt,
+    findings: [],
+    noFindingRecord: { reason: 'clean', evidence: 'within threshold' },
+  });
+  writeJson(join(bundleDir, 'provenance.json'), {
+    verdictId,
+    generatedAt,
+    rawInputs: [{ path: 'raw.yaml', sha256: 'a'.repeat(64) }],
+    generator: { name: 'test', version: '1' },
+    sanitizeRulesVersion: 'v1',
+  });
+}
+
+function setupA2aOnlyHarnessFeedbackRoot(label) {
+  const harnessFeedbackRoot = mkdtempSync(join(tmpdir(), `f192-eval-hub-${label}-`));
+  const domainsDir = join(harnessFeedbackRoot, 'eval-domains');
+  mkdirSync(domainsDir, { recursive: true });
+  const a2aYaml = readFileSync(join(repoHarnessFeedbackRoot, 'eval-domains', 'eval-a2a.yaml'), 'utf8');
+  writeFileSync(join(domainsDir, 'eval-a2a.yaml'), a2aYaml);
+  return harnessFeedbackRoot;
+}
+
 describe('Eval Hub read model', () => {
   it('loads committed live eval:a2a verdicts with bundle-backed evidence', () => {
     const summary = loadEvalHubSummary({
@@ -410,5 +481,84 @@ Evidence:
       'a verdict without a re-eval deadline cannot be classified stale',
     );
     assert.equal(summary.counts.stale, 0);
+  });
+
+  // F192 P2 — PR 791 review regression guard.
+  // Stale is a *lifecycle state of the active finding per domain*, not a property of every
+  // historical verdict. When a newer live verdict supersedes an older overdue one, the older
+  // verdict must drop out of counts.stale; otherwise counts.stale stays non-zero forever
+  // after the re-eval window closes, defeating the closure loop the Hub exists to surface.
+  it('does not count an older overdue verdict as stale when a newer fresh verdict supersedes it (same domain)', () => {
+    const harnessFeedbackRoot = setupA2aOnlyHarnessFeedbackRoot('supersede-fresh');
+
+    writeA2aLiveVerdict(harnessFeedbackRoot, {
+      verdictId: '2026-05-20-eval-a2a-older',
+      nextEvalAt: '2026-05-23T00:00:00.000Z', // already past when now = 2026-05-27
+      generatedAt: '2026-05-20T00:00:00.000Z',
+    });
+    writeA2aLiveVerdict(harnessFeedbackRoot, {
+      verdictId: '2026-05-26-eval-a2a-newer',
+      nextEvalAt: '2026-05-30T00:00:00.000Z', // fresh
+      generatedAt: '2026-05-26T00:00:00.000Z',
+    });
+
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot,
+      // Between older deadline (2026-05-23) and newer deadline (2026-05-30).
+      now: new Date('2026-05-27T00:00:00.000Z'),
+    });
+
+    assert.equal(summary.items.length, 2);
+    // Items are sorted by trend.generatedAt desc, so [0] is the newer/latest active verdict.
+    assert.equal(summary.items[0].id, '2026-05-26-eval-a2a-newer');
+    assert.equal(summary.items[1].id, '2026-05-20-eval-a2a-older');
+
+    assert.equal(summary.counts.stale, 0, 'superseded older verdict must not keep counts.stale non-zero');
+    assert.equal(summary.items[0].lifecycle.stale, false, 'newer verdict is fresh (deadline in future)');
+    assert.equal(
+      summary.items[1].lifecycle.stale,
+      false,
+      'older verdict is superseded by the newer one — closed by re-eval, not stale',
+    );
+
+    // Domain summary still surfaces the latest active verdict, regardless of supersede semantics.
+    const a2aDomain = summary.domains.find((d) => d.domainId === 'eval:a2a');
+    assert.equal(a2aDomain.latestVerdictId, '2026-05-26-eval-a2a-newer');
+  });
+
+  // F192 P2 — PR 791 review regression guard (companion case).
+  // When the *latest* verdict itself is overdue, exactly one stale signal must surface per
+  // domain — not one per historical overdue verdict. Without supersede gating, two overdue
+  // verdicts would each tick counts.stale, double-counting a single unresolved finding.
+  it('counts only the latest overdue verdict as stale per domain (not every historical overdue)', () => {
+    const harnessFeedbackRoot = setupA2aOnlyHarnessFeedbackRoot('supersede-both-overdue');
+
+    writeA2aLiveVerdict(harnessFeedbackRoot, {
+      verdictId: '2026-05-15-eval-a2a-older-overdue',
+      nextEvalAt: '2026-05-18T00:00:00.000Z',
+      generatedAt: '2026-05-15T00:00:00.000Z',
+    });
+    writeA2aLiveVerdict(harnessFeedbackRoot, {
+      verdictId: '2026-05-22-eval-a2a-newer-overdue',
+      nextEvalAt: '2026-05-25T00:00:00.000Z',
+      generatedAt: '2026-05-22T00:00:00.000Z',
+    });
+
+    const summary = loadEvalHubSummary({
+      harnessFeedbackRoot,
+      now: new Date('2026-05-29T00:00:00.000Z'), // past both deadlines
+    });
+
+    assert.equal(summary.items.length, 2);
+    assert.equal(summary.counts.stale, 1, 'only the latest active verdict surfaces as stale');
+
+    const latest = summary.items.find((i) => i.id === '2026-05-22-eval-a2a-newer-overdue');
+    const older = summary.items.find((i) => i.id === '2026-05-15-eval-a2a-older-overdue');
+    assert.equal(latest.lifecycle.stale, true, 'latest verdict past its own deadline is stale');
+    assert.equal(
+      older.lifecycle.stale,
+      false,
+      'older verdict is superseded by the newer one — even if both are overdue, only the latest counts',
+    );
   });
 });


### PR DESCRIPTION
Closes #790

## Summary
- Replaces the hardcoded `lifecycle.stale: false` in `eval-hub-read-model.buildEvalHubItem` with a strict `now > nextEvalAt` comparison, restoring F192 AC-E9 (Eval Hub must surface stale findings as part of the harness lifecycle control plane).
- Injects an optional `now: Date` on `LoadEvalHubSummaryInput` so date-dependent tests stay deterministic without monkey-patching `Date`.
- Adds `computeStale` helper with explicit doc on the "no extra SLA grace" decision: `domain.sla.reevalWithinHours` is already absorbed into `nextEvalAt` at verdict-creation time; adding more buffer at read time would double-discount the same SLA budget and silently delay the warning Eval Hub exists to surface.

## Why
Discovered by `@codex` while preparing the 2026-05-29 `eval:a2a` daily verdict packet. The latest committed live verdict declares `nextEvalAt = 2026-05-26T03:12:57.174Z`, but on 2026-05-29 the Hub still reported `counts.stale = 0`, so the overdue re-eval window was invisible to `@opus47` (the domain owner).

## Tradeoff
- **Chose**: strict `now > nextEvalAt`, no read-time grace, missing timestamp → `false`.
- **Rejected**: re-applying `sla.reevalWithinHours` at read time (double-discounting). Rejected: throwing on missing timestamp (data-quality concern owned by verdict-packet schema upstream).
- This is a control-plane livefix only; the 2026-05-23 `eval:a2a` verdict itself remains `keep_observe`, so no A2A harness regression is implied.

## Test plan
- [x] `node --test test/harness-eval/eval-hub-read-model.test.js` → 8/8 pass (5 pinned + 3 new regression guards)
- [x] `node --test test/harness-eval/eval-domain-daily.test.js test/harness-eval/legacy-task-cleanup.test.js` → 24/24 pass (no sibling regression)
- [x] `pnpm --filter @cat-cafe/api lint` (`tsc --noEmit`) clean
- [x] `pnpm check` (biome + features + sop + skills manifest + env + guides + followup-tails + scripts-ascii) clean
- [ ] `@codex` to review the stale-threshold decision (no SLA grace) before merge

## New tests
1. `marks lifecycle.stale = true and counts.stale = 1 when now is past nextEvalAt`
2. `keeps lifecycle.stale = false when now equals nextEvalAt exactly` (boundary, strict `>`)
3. `returns lifecycle.stale = false when the Re-eval bullet lacks an ISO timestamp` (defensive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)