### PR TITLE
fix(scheduler): per-slot dedupe for cron boundary-race double-fire

### DIFF
--- a/packages/api/src/infrastructure/scheduler/TaskRunnerV2.ts
+++ b/packages/api/src/infrastructure/scheduler/TaskRunnerV2.ts
@@ -1,4 +1,4 @@
-import { getNextCronMs } from './cron-utils.js';
+import { computeNextCronSlot } from './cron-utils.js';
 import type { DynamicTaskDef, DynamicTaskStore } from './DynamicTaskStore.js';
 import { executeTaskPipeline } from './execute-pipeline.js';
 import type { RunLedger } from './RunLedger.js';
@@ -86,6 +86,14 @@ export class TaskRunnerV2 {
   private running = new Map<string, boolean>();
   private tickCounts = new Map<string, number>();
   private lastRunAt = new Map<string, number | null>();
+  /**
+   * F167 verdict 2026-05-29 (vhp_eval_a2a_2026_05_29T03_11_28Z_double_cron_fire):
+   * epoch-ms of the most recent cron slot already fired per task. Used by
+   * scheduleCronTick() to skip past slots whose tick was already triggered —
+   * prevents the boundary race where setTimeout drift fires the same cron slot
+   * twice via the `.finally` reschedule path.
+   */
+  private cronSlotFired = new Map<string, number>();
   /** Phase 3A: track dynamic task IDs → DynamicTaskDef.id mapping */
   private dynamicTaskIds = new Map<string, string>();
   /** True after start() has been called — used to auto-schedule late-registered tasks */
@@ -155,6 +163,7 @@ export class TaskRunnerV2 {
     this.running.delete(taskId);
     this.tickCounts.delete(taskId);
     this.lastRunAt.delete(taskId);
+    this.cronSlotFired.delete(taskId);
     this.dynamicTaskIds.delete(taskId);
     return true;
   }
@@ -235,7 +244,21 @@ export class TaskRunnerV2 {
   /** Schedule next cron tick via setTimeout chain */
   private scheduleCronTick(task: AnyTaskSpec): void {
     if (task.trigger.type !== 'cron') return;
-    const ms = getNextCronMs(task.trigger.expression, task.trigger.timezone);
+    // F167 fix (boundary-race guard): compute the next slot strictly after the
+    // last slot we already fired. Without this, when setTimeout drifts a few
+    // ms before its target cron time and executePipeline returns quickly, the
+    // `.finally` reschedule below can recompute the same slot (Date.now() is
+    // still before it) and fire it a second time. Marking the slot as fired
+    // synchronously inside the setTimeout callback below closes the race.
+    const lastFired = this.cronSlotFired.get(task.id);
+    let nextSlotMs: number;
+    try {
+      nextSlotMs = computeNextCronSlot(task.trigger.expression, task.trigger.timezone, Date.now(), lastFired);
+    } catch (err) {
+      this.logger.error(`[scheduler] ${task.id}: cron expression invalid`, err);
+      return;
+    }
+    const ms = Math.max(1, nextSlotMs - Date.now());
     // #605: chunk long delays to avoid Node setTimeout 32-bit overflow
     if (ms > TaskRunnerV2.MAX_TIMER_DELAY) {
       const timer = setTimeout(() => {
@@ -249,6 +272,11 @@ export class TaskRunnerV2 {
       return;
     }
     const timer = setTimeout(() => {
+      // F167 fix: mark this slot fired BEFORE any async work. The `.finally`
+      // reschedule may run while Date.now() is still milliseconds before
+      // nextSlotMs (timer drift); computeNextCronSlot will then advance past
+      // this entry instead of returning the same slot.
+      this.cronSlotFired.set(task.id, nextSlotMs);
       this.executePipeline(task)
         .catch((err) => {
           this.logger.error(`[scheduler] ${task.id}: pipeline error`, err);
@@ -369,6 +397,7 @@ export class TaskRunnerV2 {
       this.logger.info(`[scheduler] ${id}: stopped`);
     }
     this.timers.clear();
+    this.cronSlotFired.clear();
     this.started = false;
   }
 

--- a/packages/api/src/infrastructure/scheduler/cron-utils.ts
+++ b/packages/api/src/infrastructure/scheduler/cron-utils.ts
@@ -14,3 +14,43 @@ export function getNextCronMs(expression: string, timezone?: string): number {
   const next = parsed.next().toDate();
   return Math.max(1, next.getTime() - Date.now());
 }
+
+/**
+ * Compute the absolute epoch-ms timestamp of the next cron occurrence that is
+ * strictly later than `lastFiredSlotMs` (when provided).
+ *
+ * Why this exists — cron boundary race:
+ *   TaskRunnerV2 schedules cron ticks via a setTimeout chain whose `.finally`
+ *   block reschedules the next tick. When `setTimeout` fires slightly **before**
+ *   its target cron time (timer drift / fast `executePipeline`), the
+ *   `.finally` callback may run while `Date.now()` is still earlier than the
+ *   intended cron slot. A plain `parsed.next()` call then returns the **same**
+ *   slot a second time — causing a duplicate fire within the same cron window.
+ *
+ *   By passing the last-fired slot here, we advance past it deterministically
+ *   so the next scheduled fire always lands on a future, never-fired slot.
+ *
+ * @param expression - Standard 5-field cron expression
+ * @param timezone - Optional IANA timezone (passed to cron-parser as `tz`)
+ * @param now - Current epoch ms (injected for testability)
+ * @param lastFiredSlotMs - Epoch ms of the most recent already-fired slot; if
+ *   provided, the returned value is guaranteed `> lastFiredSlotMs`.
+ * @returns Epoch ms of the next valid cron slot strictly after `lastFiredSlotMs`
+ * @throws If the expression is invalid
+ */
+export function computeNextCronSlot(
+  expression: string,
+  timezone: string | undefined,
+  now: number,
+  lastFiredSlotMs: number | undefined,
+): number {
+  const options: Record<string, unknown> = { currentDate: new Date(now) };
+  if (timezone) options.tz = timezone;
+  const parsed = CronExpressionParser.parse(expression, options);
+  let nextMs = parsed.next().toDate().getTime();
+  // Boundary-race guard: advance past any slot already fired.
+  while (lastFiredSlotMs !== undefined && nextMs <= lastFiredSlotMs) {
+    nextMs = parsed.next().toDate().getTime();
+  }
+  return nextMs;
+}

--- a/packages/api/src/infrastructure/scheduler/cron-utils.ts
+++ b/packages/api/src/infrastructure/scheduler/cron-utils.ts
@@ -21,11 +21,13 @@ export function getNextCronMs(expression: string, timezone?: string): number {
  *
  * Why this exists — cron boundary race:
  *   TaskRunnerV2 schedules cron ticks via a setTimeout chain whose `.finally`
- *   block reschedules the next tick. When `setTimeout` fires slightly **before**
- *   its target cron time (timer drift / fast `executePipeline`), the
- *   `.finally` callback may run while `Date.now()` is still earlier than the
- *   intended cron slot. A plain `parsed.next()` call then returns the **same**
- *   slot a second time — causing a duplicate fire within the same cron window.
+ *   block reschedules the next tick. Node's `setTimeout` uses a monotonic clock
+ *   internally, but `getNextCronMs` computes the delay from wall-clock
+ *   `Date.now()`. When the wall clock is adjusted backward during the wait
+ *   window (NTP step-back, VM pause/resume, container clock drift), the
+ *   callback fires at a wall-clock time **before** the target cron slot.
+ *   A plain `parsed.next()` call then returns the **same** slot a second
+ *   time — causing a duplicate fire within the same cron window.
  *
  *   By passing the last-fired slot here, we advance past it deterministically
  *   so the next scheduled fire always lands on a future, never-fired slot.
@@ -49,7 +51,17 @@ export function computeNextCronSlot(
   const parsed = CronExpressionParser.parse(expression, options);
   let nextMs = parsed.next().toDate().getTime();
   // Boundary-race guard: advance past any slot already fired.
+  // Max-iterations cap prevents runaway loops if lastFiredSlotMs is a dirty
+  // far-future value (e.g., clock skew write-back). For per-minute crons,
+  // 1440 iterations = 1 day of slots — well beyond any plausible drift.
+  const MAX_ADVANCE_ITERATIONS = 1440;
+  let iterations = 0;
   while (lastFiredSlotMs !== undefined && nextMs <= lastFiredSlotMs) {
+    if (++iterations >= MAX_ADVANCE_ITERATIONS) {
+      throw new Error(
+        `computeNextCronSlot: exceeded ${MAX_ADVANCE_ITERATIONS} iterations advancing past lastFiredSlotMs=${lastFiredSlotMs} (now=${now}, expression=${expression}). Possible dirty future timestamp.`,
+      );
+    }
     nextMs = parsed.next().toDate().getTime();
   }
   return nextMs;

--- a/packages/api/test/scheduler/cron-utils.test.js
+++ b/packages/api/test/scheduler/cron-utils.test.js
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+describe('cron-utils — getNextCronMs (backward compat)', () => {
+  it('returns positive ms for valid expression', async () => {
+    const { getNextCronMs } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const ms = getNextCronMs('0 9 * * *');
+    assert.ok(typeof ms === 'number');
+    assert.ok(ms > 0, 'next cron occurrence should be in the future');
+    assert.ok(ms <= 24 * 60 * 60 * 1000, 'daily cron should fire within 24h');
+  });
+
+  it('throws for invalid expression', async () => {
+    const { getNextCronMs } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    assert.throws(() => getNextCronMs('not a cron'), /invalid|parse|validation|resolve/i);
+  });
+});
+
+// ─── Cron boundary-race guard (F167 verdict 2026-05-29 fix) ──────────
+//
+// Bug: TaskRunnerV2 fires the same cron slot twice when setTimeout drifts
+//      slightly before the target slot and `.finally` reschedules before the
+//      slot has passed. See vhp_eval_a2a_2026_05_29T03_11_28Z_double_cron_fire.
+//
+// Fix: computeNextCronSlot accepts `lastFiredSlotMs` and advances past it so
+//      the same slot can never be returned twice.
+
+describe('cron-utils — computeNextCronSlot (boundary-race guard)', () => {
+  it('returns next cron slot when no prior fire', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    // 2026-05-29 02:00:00 UTC → next "0 3 * * *" slot = 2026-05-29 03:00:00 UTC
+    const now = Date.UTC(2026, 4, 29, 2, 0, 0, 0);
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, undefined);
+    assert.equal(next, Date.UTC(2026, 4, 29, 3, 0, 0, 0));
+  });
+
+  it('BOUNDARY RACE: now is before slot, lastFired equals that slot → advance to next day', async () => {
+    // Repro the production bug:
+    //   - setTimeout fires at 02:59:59.860 UTC (~140ms early, timer drift)
+    //   - executePipeline marks cronSlotFired = 03:00:00.000
+    //   - executePipeline returns fast (~90ms); .finally runs at 02:59:59.95X
+    //   - Without guard: parsed.next() with currentDate=02:59:59.95X returns
+    //     03:00:00.000 again → second fire in the same slot.
+    //   - With guard: advance past lastFired → next day's 03:00:00.000.
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const now = Date.UTC(2026, 4, 29, 2, 59, 59, 950); // .finally running, still before slot
+    const lastFired = Date.UTC(2026, 4, 29, 3, 0, 0, 0); // today's 03:00 already fired
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, lastFired);
+    assert.equal(
+      next,
+      Date.UTC(2026, 4, 30, 3, 0, 0, 0),
+      'must skip the already-fired slot and land on the next day',
+    );
+  });
+
+  it('returns next slot when lastFired is older than current next (normal case)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    // Now is 04:00 today, yesterday's 03:00 already fired → next is tomorrow 03:00.
+    const now = Date.UTC(2026, 4, 29, 4, 0, 0, 0);
+    const lastFired = Date.UTC(2026, 4, 28, 3, 0, 0, 0); // yesterday's slot
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, lastFired);
+    assert.equal(next, Date.UTC(2026, 4, 30, 3, 0, 0, 0));
+  });
+
+  it('advances multiple slots when lastFired is in the future (defensive against clock skew)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const now = Date.UTC(2026, 4, 29, 2, 0, 0, 0);
+    // Pretend tomorrow's slot was already fired (e.g., manual triggerNow + retroactive marking).
+    const lastFired = Date.UTC(2026, 4, 30, 3, 0, 0, 0);
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, lastFired);
+    assert.equal(next, Date.UTC(2026, 4, 31, 3, 0, 0, 0));
+  });
+
+  it('handles per-minute cron with sub-minute boundary race', async () => {
+    // Same race shape but on a per-minute cron.
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const now = Date.UTC(2026, 4, 29, 12, 0, 59, 980); // 12:00:59.980, before 12:01 slot
+    const lastFired = Date.UTC(2026, 4, 29, 12, 1, 0, 0); // 12:01 already fired
+    const next = computeNextCronSlot('* * * * *', 'UTC', now, lastFired);
+    assert.equal(next, Date.UTC(2026, 4, 29, 12, 2, 0, 0));
+  });
+
+  it('respects timezone option (Asia/Shanghai)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    // Cron "0 11 * * *" in Asia/Shanghai (UTC+8) = 03:00 UTC.
+    // Now is 2026-05-29 02:59:59.950 UTC → next slot today = 03:00 UTC.
+    const now = Date.UTC(2026, 4, 29, 2, 59, 59, 950);
+    const next = computeNextCronSlot('0 11 * * *', 'Asia/Shanghai', now, undefined);
+    assert.equal(next, Date.UTC(2026, 4, 29, 3, 0, 0, 0));
+  });
+
+  it('throws for invalid expression (same contract as getNextCronMs)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    assert.throws(
+      () => computeNextCronSlot('not a cron', 'UTC', Date.UTC(2026, 4, 29, 0, 0, 0, 0), undefined),
+      /invalid|parse|validation|resolve/i,
+    );
+  });
+
+  it('undefined lastFiredSlotMs is treated as no guard (initial scheduling)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const now = Date.UTC(2026, 4, 29, 2, 59, 59, 950);
+    // Without lastFired guard, returns today's 03:00 even though we're milliseconds before it.
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, undefined);
+    assert.equal(next, Date.UTC(2026, 4, 29, 3, 0, 0, 0));
+  });
+});

--- a/packages/api/test/scheduler/cron-utils.test.js
+++ b/packages/api/test/scheduler/cron-utils.test.js
@@ -46,11 +46,7 @@ describe('cron-utils — computeNextCronSlot (boundary-race guard)', () => {
     const now = Date.UTC(2026, 4, 29, 2, 59, 59, 950); // .finally running, still before slot
     const lastFired = Date.UTC(2026, 4, 29, 3, 0, 0, 0); // today's 03:00 already fired
     const next = computeNextCronSlot('0 3 * * *', 'UTC', now, lastFired);
-    assert.equal(
-      next,
-      Date.UTC(2026, 4, 30, 3, 0, 0, 0),
-      'must skip the already-fired slot and land on the next day',
-    );
+    assert.equal(next, Date.UTC(2026, 4, 30, 3, 0, 0, 0), 'must skip the already-fired slot and land on the next day');
   });
 
   it('returns next slot when lastFired is older than current next (normal case)', async () => {

--- a/packages/api/test/scheduler/cron-utils.test.js
+++ b/packages/api/test/scheduler/cron-utils.test.js
@@ -18,9 +18,10 @@ describe('cron-utils — getNextCronMs (backward compat)', () => {
 
 // ─── Cron boundary-race guard (F167 verdict 2026-05-29 fix) ──────────
 //
-// Bug: TaskRunnerV2 fires the same cron slot twice when setTimeout drifts
-//      slightly before the target slot and `.finally` reschedules before the
-//      slot has passed. See vhp_eval_a2a_2026_05_29T03_11_28Z_double_cron_fire.
+// Bug: TaskRunnerV2 fires the same cron slot twice when wall-clock divergence
+//      from the monotonic timer (NTP step-back, VM pause, container clock drift)
+//      causes Date.now() to be before the target slot at callback time, and
+//      `.finally` reschedules the same slot. See vhp_eval_a2a_2026_05_29T03_11_28Z_double_cron_fire.
 //
 // Fix: computeNextCronSlot accepts `lastFiredSlotMs` and advances past it so
 //      the same slot can never be returned twice.
@@ -36,7 +37,7 @@ describe('cron-utils — computeNextCronSlot (boundary-race guard)', () => {
 
   it('BOUNDARY RACE: now is before slot, lastFired equals that slot → advance to next day', async () => {
     // Repro the production bug:
-    //   - setTimeout fires at 02:59:59.860 UTC (~140ms early, timer drift)
+    //   - setTimeout fires at 02:59:59.860 UTC (wall clock behind monotonic due to NTP/clock adjustment)
     //   - executePipeline marks cronSlotFired = 03:00:00.000
     //   - executePipeline returns fast (~90ms); .finally runs at 02:59:59.95X
     //   - Without guard: parsed.next() with currentDate=02:59:59.95X returns
@@ -91,6 +92,29 @@ describe('cron-utils — computeNextCronSlot (boundary-race guard)', () => {
       () => computeNextCronSlot('not a cron', 'UTC', Date.UTC(2026, 4, 29, 0, 0, 0, 0), undefined),
       /invalid|parse|validation|resolve/i,
     );
+  });
+
+  it('severely late trigger (cross-slot): timer lag beyond one full cron period', async () => {
+    // When event-loop lag causes setTimeout to fire well past the target slot,
+    // cronSlotFired records the *expected* slot (nextSlotMs), not the actual
+    // trigger time. The next computeNextCronSlot must still advance correctly.
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    // Target was 03:00 today, but timer fired at 04:30 (1.5h late, past the slot).
+    // lastFired = 03:00 (the expected slot that was marked synchronously).
+    const now = Date.UTC(2026, 4, 29, 4, 30, 0, 0);
+    const lastFired = Date.UTC(2026, 4, 29, 3, 0, 0, 0);
+    const next = computeNextCronSlot('0 3 * * *', 'UTC', now, lastFired);
+    // Next slot is tomorrow 03:00 — same as if the timer had fired on time.
+    assert.equal(next, Date.UTC(2026, 4, 30, 3, 0, 0, 0), 'late trigger must still advance to the next future slot');
+  });
+
+  it('throws when max iterations exceeded (dirty far-future lastFiredSlotMs)', async () => {
+    const { computeNextCronSlot } = await import('../../dist/infrastructure/scheduler/cron-utils.js');
+    const now = Date.UTC(2026, 4, 29, 2, 0, 0, 0);
+    // lastFired set to ~3 years in the future — per-minute cron would need
+    // >1.5M iterations to advance past it, exceeding the 1440 cap.
+    const lastFired = Date.UTC(2029, 4, 29, 3, 0, 0, 0);
+    assert.throws(() => computeNextCronSlot('* * * * *', 'UTC', now, lastFired), /exceeded 1440 iterations/);
   });
 
   it('undefined lastFiredSlotMs is treated as no guard (initial scheduling)', async () => {


### PR DESCRIPTION
Closes #792

## Summary

- `TaskRunnerV2.scheduleCronTick()` double-fires the same cron slot when `setTimeout` drifts early and `.finally` reschedules before the slot boundary passes
- Fix: per-slot idempotency via `computeNextCronSlot()` + synchronous slot marking in the setTimeout callback

## Changes

| File | Change |
|---|---|
| `cron-utils.ts` | + `computeNextCronSlot(expr, tz, now, lastFiredSlotMs)` pure function with `while`-loop guard |
| `TaskRunnerV2.ts` | + `cronSlotFired: Map<taskId, slotMs>`; `scheduleCronTick` uses `computeNextCronSlot`; sync mark in setTimeout cb; cleanup in `unregister`/`stop` |
| `cron-utils.test.js` (new) | 9 tests covering normal path + BOUNDARY RACE + clock skew + tz + invalid expr |

`getNextCronMs` (display-only use in `schedule-notify.ts`) is preserved — backward compat.

## Evidence

| Check | Result |
|---|---|
| `pnpm check` (biome + all linters) | exit 0 |
| `pnpm run build` | exit 0 |
| `test/scheduler/*.test.js` + `test/harness-eval/*.test.js` | 560/560 pass |
| RED → GREEN | Temporarily disabling the `while` guard in `computeNextCronSlot` makes 3 BOUNDARY RACE subtests fail; restoring it makes them pass |

## Test plan

- [x] Unit: `computeNextCronSlot` pure function (`test/scheduler/cron-utils.test.js`)
- [x] Regression: existing scheduler tests stay green
- [x] Build/lint clean
- [ ] Production verification: next daily eval at 03:00 UTC emits exactly 1 tick + 1 delivery (vs 2 in the failing window)