### PR TITLE
feat(F192): Phase G-A — semantic interface contracts + friction classification + degrade verdict

### DIFF
--- a/docs/features/F192-socio-technical-harness-eval.md
+++ b/docs/features/F192-socio-technical-harness-eval.md
@@ -1,6 +1,6 @@
 ---
 feature_ids: [F192]
-related_features: [F167, F153, F086, F188, F200]
+related_features: [F167, F153, F086, F188, F200, F208]
 topics: [harness-engineering, eval, socio-technical, observability, cat-user-feedback]
 doc_kind: spec
 created: 2026-05-07
@@ -8,7 +8,7 @@ created: 2026-05-07
 
 # F192: Socio-Technical Harness Eval — harness 共创评估体系
 
-> **Status**: in-progress (reopened 2026-05-27 for Phase F `eval:capability-wakeup`) | **Owner**: Ragdoll | **Phases A-E completed**: 2026-05-27
+> **Status**: in-progress (Phase G `semantic-interface-contracts`) | **Owner**: Ragdoll | **Phases A-E completed**: 2026-05-27 | **Phase G-A completed**: 2026-05-29
 
 ## Architecture Ownership
 
@@ -234,6 +234,43 @@ Phase E 将 F192 从单域试点提升为横切的 Harness Eval Control Plane：
 4. First weekly verdict cycle（real data 第一刀）
 5. L0 §8 v2 数据驱动 iterate（去掉低 miss-rate 条目 / 加新发现的高 miss-rate 场景）
 
+### Phase G: Semantic Interface Contracts + Friction Classification（来源 F208-HCP 设计 + 社区讨论）
+
+来源 2026-05-29 CVO 与社区讨论收敛：auto harness 流程应明确分为 **tracing → eval → decision → governance** 四步。F192 Phase E 已实现 runtime eval + verdict handoff + re-eval closure，但缺少三个关键能力：
+
+1. **Friction Type Classification**：eval 能检测 friction（ratio > threshold），但不能区分 _为什么_ friction 发生——是 harness 本身设计问题（harness_gap）还是猫/用户对 harness 缺乏信任而主动绕过（trust_gap）。区分这两类的依据是 hold_ball 的 cancel_reason 信号（F208-HCP Phase B instruments.ts 已在 develop_base 定义 OTel counters）。
+2. **Degrade Decision Path**：verdict 只有 delete_sunset / build / fix / keep_observe 四个，缺少"不删除但降级为按需模式"的渐进响应。添加 `degrade` verdict + `degradePlan`（targetMode + rollbackCondition）。
+3. **Typed Semantic Interface Contracts**：eval domain registry 只描述调度元数据（evalCat / frequency / SLA），不声明四步流程各步的 contract（tracing 观测什么？eval 量化什么指标？decision 支持哪些 verdict？governance 用什么执行模式？）。
+
+**Build sequence**：
+1. **G-A**（已完成）：Contract schemas + frictionType + degrade verdict
+2. **G-B**：Thread-segment observation unit（eval-a2a tracingContract 从 time-window 扩展支持 thread-segment）
+3. **G-C**：Governance execution（auto-PR / local-overlay / change trail tracking）
+
+#### G-A: Contract Schemas + Friction Type + Degrade Verdict ✅
+
+- [x] AC-G1: `EvalDomainRegistryEntry` 含 4 个 optional typed contract（tracingContract / evalContract / decisionContract / governanceContract），现有 YAML fixtures 不含 contract 时正常 parse（backward compatible）
+- [x] AC-G2: `ComponentHealth` 含 optional `frictionType: 'harness_gap' | 'trust_gap' | 'unknown'`
+- [x] AC-G3: `buildC1()` 从 `hold_cancel_harness_gap` / `hold_cancel_trust_gap` OTel counters 分类 frictionType；counters 不存在时 graceful fallback（friction 存在但无 breakdown → `unknown`；无 friction → `undefined`）
+- [x] AC-G4: Verdict enum 含 `'degrade'`，governance 含 optional `degradePlan { targetMode, rollbackCondition }`；superRefine 校验 degrade 必带 degradePlan
+- [x] AC-G5: `eval-a2a.yaml` 含 `tracingContract { observationUnit: time-window, requiredSources: [F153 endpoints] }`
+- [x] AC-G6: `community-issue-packet.ts` verdict enum 同步更新
+- [x] AC-G7: 327 tests 全绿，零 regression
+
+#### G-B: Thread-Segment Observation（待实施）
+
+- [ ] AC-G8: Eval pipeline 支持 `observationUnit: thread-segment`——从按时间窗口聚合扩展到可按 thread 段分析单个 harness unit 的行为
+- [ ] AC-G9: `eval-a2a.yaml` 可在 tracingContract 切换 `thread-segment` 模式并产出等价 snapshot
+- [ ] AC-G10: Thread-segment mode 的 telemetry adapter 能从 F153 traces 按 threadId 过滤 spans
+
+#### G-C: Governance Execution（待实施）
+
+- [ ] AC-G11: Verdict `degrade` / `fix` / `build` 的 governance execution 支持 `auto-pr` 模式——自动生成 harness 调整 PR（code / config / SOP）
+- [ ] AC-G12: Governance execution 支持 `local-overlay` 模式——通过 `.local` 覆盖机制应用 harness 参数调整
+- [ ] AC-G13: Change trail——每次 governance execution 记录 before/after diff，可在 Console 观测 harness 版本变化历史
+
+依赖：G-B 依赖 F153 trace 按 threadId 查询能力（当前 API 支持 catId 过滤但不支持 threadId）；G-C 依赖 governance 执行工具的实现（PR creation / local overlay write）。G-A 已独立完成，不阻塞 G-B/G-C。
+
 ## 需求点 Checklist
 
 | ID | 需求点（team experience/转述） | AC 编号 | 验证方式 | 状态 |
@@ -246,6 +283,10 @@ Phase E 将 F192 从单域试点提升为横切的 Harness Eval Control Plane：
 | R6 | "诊断 / eval 结果需要一个看板，叫 Eval Hub" | AC-E9, AC-E10 | Eval Hub screenshot / API response | [x] |
 | R7 | "接入完成得清理遗留定时任务，避免双触发" | AC-E6, AC-E13 | scheduled task inventory + dry-run migration report | [x] |
 | R8 | "社区小伙伴发现自己的场景有掉球，也能提 issue / 接自己的项目 eval" | AC-E14, AC-E15 | sanitized issue packet fixture + custom domain fixture | [x] |
+| R9 | "应该是 tracing/eval/决策/治理；eval 给出可量化指标和结论" | AC-G1, AC-G5 | 4 typed contracts in registry schema + eval-a2a.yaml tracingContract | [x] |
+| R10 | "取消持球的原因可能是状态不对...需要结合完整 thread 来看" | AC-G2, AC-G3 | frictionType classification from cancel_reason counters | [x] |
+| R11 | "决策可以自动也可以人介入来控制是不是需要迭代和优化" | AC-G4, AC-G11 | degrade verdict + autoVerdictEnabled toggle + governance execution modes | [ ] |
+| R12 | "治理的版本内容变化，console 上可以观测到" | AC-G12, AC-G13 | local-overlay + change trail in Console | [ ] |
 
 ### 覆盖检查
 - [x] 每个需求点都能映射到至少一个 AC
@@ -270,7 +311,8 @@ Verdict 不是自由文案。每个 verdict 都必须满足对应证据门槛、
 | `fix` | 已有 harness 目标正确，但实现 / prompt / workflow 没做到位；出现 regression、false positive、bypass 或 owner friction | phenomenon、affected harness、metric refs、day-over-day trend、root-cause hypothesis、counterarguments | 请 feature owner 修正现有 harness 或其接线 | 后续 eval 对同一 failure pattern 复验通过；owner 不能自报 resolved | 默认 eval owner + feature owner 闭环；高影响行为变更走 Design Gate |
 | `build` | 反复出现的 failure pattern 没有现有 harness 覆盖，或现有 harness 边界外出现新场景 | missing-coverage evidence、candidate harness scope、expected activation signal、success metric、counterarguments | 请 feature owner 设计 / 扩展 harness，并补 Eval Contract | 新 harness 有 Eval Contract + 首次 eval snapshot；未接入前不得标 resolved | 新增规则 / SOP / MCP 行为变化必须过 Design Gate |
 | `delete_sunset` | harness 的边际效果低或成本高，且可能已被模型 / 猫猫能力内化；**不能仅因最近没触发就判 sunset** | cost/effect trend、activation history、原始 failure pattern refs、Sunset Trial Plan、counterarguments | 请 owner 启动 sunset trial；verdict 本身不执行删除 | trial 满足 criteria 后进入 `dormant`；真正 `retired` 需额外 CVO accept | `toDormant` 可按 criteria 自动；`toRetired` 必须 CVO accept |
-| `keep_observe` | 当前证据不足以改变 harness，或 harness 仍健康；不是“什么都不做”的永久终态 | current metric refs、why-no-action、next observation window、known blind spots | 继续观察 / 补 instrumentation / 等下一窗口 | 到期必须重新 eval；若无 next window 则不合法 | 可由 eval owner 自决；不能用来掩盖缺数据 |
+| `keep_observe` | 当前证据不足以改变 harness，或 harness 仍健康；不是”什么都不做”的永久终态 | current metric refs、why-no-action、next observation window、known blind spots | 继续观察 / 补 instrumentation / 等下一窗口 | 到期必须重新 eval；若无 next window 则不合法 | 可由 eval owner 自决；不能用来掩盖缺数据 |
+| `degrade` | harness 导致的 friction 已被确认，但完全删除风险过高；适合从 always-on 降级为 on-demand | phenomenon、frictionType classification（harness_gap / trust_gap）、degradePlan（targetMode + rollbackCondition）、counterarguments | 请 owner 实施 degrade plan，把 harness 从主动路径切到按需触发 | rollbackCondition 满足后自动回复 active 或升级 delete_sunset；未满足前保持 degraded | governance 必含 degradePlan；degraded 模式需可观测（activation count 在按需触发时仍有计数） |
 
 不变式：
 
@@ -278,6 +320,7 @@ Verdict 不是自由文案。每个 verdict 都必须满足对应证据门槛、
 2. `delete_sunset` verdict 只能触发 Sunset Trial，不能直接关闭或删除 harness。
 3. `keep_observe` 必须带 next observation window；否则就是把未知包装成结论。
 4. `build` 必须补 Eval Contract；没有可观测 success metric 的新 harness 不得进入 active。
+5. `degrade` 必须带 `degradePlan`（targetMode + rollbackCondition）；没有回滚条件的降级 = 变相关闭。
 
 ### Phase E Sunset Trial Contract（`delete_sunset` 展开）
 
@@ -432,6 +475,9 @@ Based on the first micro fit digest (2026-05-11):
 | KD-14 | Eval Hub 是 daily workflow surface，不是 Settings 配置页；F188 Health Dashboard 与 Eval Hub 互链不互替 | Settings 只承载 domain registry / frequency / owner / export policy 等配置。Hub 承载 verdict lifecycle、trend、handoff、closure；F188 承载现场 health repair controls。互链按钮是验收要求，避免用户在两个 surface 间手动找入口；若实用性差，后续调整 IA / 跳转位置属于低风险 UI 改动 | 2026-05-23 |
 | KD-15 | System Thread / System Workspace 基座归一：IM Hub 与 eval domain thread 共享系统线程模型，但按 `kind` 区分 | IM Hub（`connector_hub`）和 Eval domain（`eval_domain`）都是 system-managed thread / workspace；归一的是 thread 基础模型、系统分区、删除保护、跳转和管理方式，不归一业务语义。Eval Hub 是工作面，不另造割裂前端；IM Hub 与 Eval Hub 互链，不互替 | 2026-05-23 |
 | KD-16 | Phase E 剩余交付按 4 个功能块 PR 收敛：E-hub / E-scale / E-sop / E-community，不按 AC 粒度拆 | PR 边界应对应可独立验收的用户/系统能力，而不是单条 AC。E-hub 由Maine Coon接，E-scale 由Ragdoll接；E-sop 依赖已由 F203 #1868 满足但排在 Hub/Scale 后；E-community 最后基于稳定 contract 输出社区 packet | 2026-05-24 |
+| KD-17 | Phase G 语义接口刷新归入 F192（不是 F208-HCP） | F208 ID 在上游已被 Capability Profile Routing 占用；F208-HCP 仅 fork 概念；代码在 F192 architecture cell harness-eval 内；CVO + 社区讨论（tracing→eval→决策→治理）自然延伸 Phase E contract | 2026-05-29 |
+| KD-18 | `degrade` 填补 keep_observe 和 delete_sunset 之间的决策空白 | 现有 4 个 verdict 缺渐进响应——要么继续观察要么准备删除。degrade = "降级为按需模式"，保留 harness 但减少主动干预频率，配合 rollbackCondition 自动回升 | 2026-05-29 |
+| KD-19 | frictionType 分类基于 cancel_reason 而非纯 ratio 推断 | ratio 只说明 friction 多不多，说不清 _为什么_。cancel_reason 区分 harness_gap（harness 设计问题导致取消）vs trust_gap（猫不信任 harness 主动绕过）；两类的修复路径完全不同——前者改 harness，后者改信任 | 2026-05-29 |
 
 ## Review Gate
 
@@ -440,3 +486,4 @@ Based on the first micro fit digest (2026-05-11):
 - Phase C: spec 更新需跨家族 review；实现需跨家族 review
 - Phase D: digest 结论需team lead确认
 - Phase E: 架构级 Design Gate 由 F192 owner + 跨族 reviewer 收敛；E-pilot 先行（无 UI）；Eval Hub UI 需等 E-pilot 真实 verdict 后再 design-in-context + team lead验收；legacy scheduled-task cleanup 需 dry-run report
+- Phase G: 跨族 review（schema 扩展 + verdict 新增影响多 domain consumer）

--- a/docs/features/index.json
+++ b/docs/features/index.json
@@ -1179,7 +1179,7 @@
     {
       "id": "F192",
       "name": "Socio-Technical Harness Eval — harness 共创评估体系",
-      "status": "in-progress (reopened 2026-05-27 for Phase F `eval:capability-wakeup`) | **Owner**: Ragdoll | **Phases A-E completed**: 2026-05-27",
+      "status": "in-progress (Phase G `semantic-interface-contracts`) | **Owner**: Ragdoll | **Phases A-E completed**: 2026-05-27 | **Phase G-A completed**: 2026-05-29",
       "file": "F192-socio-technical-harness-eval.md"
     },
     {

--- a/docs/harness-feedback/eval-domains/eval-a2a.yaml
+++ b/docs/harness-feedback/eval-domains/eval-a2a.yaml
@@ -24,3 +24,9 @@ handoffTargetResolver:
 sla:
   acknowledgeHours: 24
   reevalWithinHours: 72
+tracingContract:
+  observationUnit: time-window
+  requiredSources:
+    - "F153 /api/telemetry/traces"
+    - "F153 /api/telemetry/metrics"
+    - "F153 /api/telemetry/traces/stats"

--- a/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
+++ b/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
@@ -13,69 +13,79 @@ import type { VerdictHandoffPacket } from './verdict-handoff.js';
 
 // ---- Schema ----
 
-const sanitizedIssuePacketSchema = z.object({
-  /** Opaque packet ID (may be derived from internal verdict ID). */
-  id: z.string().min(1),
+const sanitizedIssuePacketSchema = z
+  .object({
+    /** Opaque packet ID (may be derived from internal verdict ID). */
+    id: z.string().min(1),
 
-  /** Domain identifier — must match eval:<lowercase-slug> (not restricted to internal enum). */
-  domainId: z.string().regex(/^eval:[a-z][a-z0-9_-]*$/, 'domainId must match eval:<lowercase-slug>'),
+    /** Domain identifier — must match eval:<lowercase-slug> (not restricted to internal enum). */
+    domainId: z.string().regex(/^eval:[a-z][a-z0-9_-]*$/, 'domainId must match eval:<lowercase-slug>'),
 
-  /** ISO 8601 timestamp when the packet was exported. */
-  exportedAt: z.string().datetime({ offset: true }),
+    /** ISO 8601 timestamp when the packet was exported. */
+    exportedAt: z.string().datetime({ offset: true }),
 
-  /** Identifies the Cat Cafe instance that produced this packet. */
-  sourceInstanceId: z.string().min(1),
+    /** Identifies the Cat Cafe instance that produced this packet. */
+    sourceInstanceId: z.string().min(1),
 
-  /** What happened — the core eval observation. */
-  phenomenon: z.string().min(1),
+    /** What happened — the core eval observation. */
+    phenomenon: z.string().min(1),
 
-  /** Harness component being evaluated (generic names, no internal feature IDs). */
-  harnessComponent: z.object({
-    componentId: z.string().min(1),
-    name: z.string().min(1),
-  }),
+    /** Harness component being evaluated (generic names, no internal feature IDs). */
+    harnessComponent: z.object({
+      componentId: z.string().min(1),
+      name: z.string().min(1),
+    }),
 
-  /** Evidence counts (original refs redacted). */
-  evidenceSummary: z.object({
-    snapshotCount: z.number().int().nonnegative(),
-    attributionCount: z.number().int().nonnegative(),
-    metricCount: z.number().int().nonnegative(),
-    traceCount: z.number().int().nonnegative(),
-  }),
+    /** Evidence counts (original refs redacted). */
+    evidenceSummary: z.object({
+      snapshotCount: z.number().int().nonnegative(),
+      attributionCount: z.number().int().nonnegative(),
+      metricCount: z.number().int().nonnegative(),
+      traceCount: z.number().int().nonnegative(),
+    }),
 
-  /** Day-over-day trend (numeric, no PII). */
-  dailyTrend: z.object({
-    window: z.string().min(1),
-    current: z.record(z.number()),
-    baseline: z.record(z.number()),
-    threshold: z.record(z.number()),
-    direction: z.enum(['improved', 'regressed', 'flat', 'unknown']),
-  }),
+    /** Day-over-day trend (numeric, no PII). */
+    dailyTrend: z.object({
+      window: z.string().min(1),
+      current: z.record(z.number()),
+      baseline: z.record(z.number()),
+      threshold: z.record(z.number()),
+      direction: z.enum(['improved', 'regressed', 'flat', 'unknown']),
+    }),
 
-  /** Root cause hypothesis (analytical text). */
-  rootCauseHypothesis: z.object({
-    summary: z.string().min(1),
-    confidence: z.enum(['low', 'medium', 'high']),
-    alternatives: z.array(z.string().min(1)).min(1),
-  }),
+    /** Root cause hypothesis (analytical text). */
+    rootCauseHypothesis: z.object({
+      summary: z.string().min(1),
+      confidence: z.enum(['low', 'medium', 'high']),
+      alternatives: z.array(z.string().min(1)).min(1),
+    }),
 
-  /** Verdict: delete_sunset / build / fix / keep_observe / degrade. */
-  verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']),
+    /** Verdict: delete_sunset / build / fix / keep_observe / degrade. */
+    verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']),
 
-  /** Degrade execution plan — present only when verdict is 'degrade'. */
-  degradePlan: z
-    .object({
-      targetMode: z.string().min(1),
-      rollbackCondition: z.string().min(1),
-    })
-    .optional(),
+    /** Degrade execution plan — present only when verdict is 'degrade'. */
+    degradePlan: z
+      .object({
+        targetMode: z.string().min(1),
+        rollbackCondition: z.string().min(1),
+      })
+      .optional(),
 
-  /** What the exporting instance recommends the community do. */
-  requestedAction: z.string().min(1),
+    /** What the exporting instance recommends the community do. */
+    requestedAction: z.string().min(1),
 
-  /** Devil's advocate — why the verdict might be wrong. */
-  counterarguments: z.array(z.string().min(1)).min(1),
-});
+    /** Devil's advocate — why the verdict might be wrong. */
+    counterarguments: z.array(z.string().min(1)).min(1),
+  })
+  .superRefine((packet, ctx) => {
+    if (packet.verdict === 'degrade' && !packet.degradePlan) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'degrade verdict requires a degradePlan',
+        path: ['degradePlan'],
+      });
+    }
+  });
 
 export type SanitizedIssuePacket = z.infer<typeof sanitizedIssuePacketSchema>;
 

--- a/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
+++ b/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
@@ -62,6 +62,14 @@ const sanitizedIssuePacketSchema = z.object({
   /** Verdict: delete_sunset / build / fix / keep_observe / degrade. */
   verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']),
 
+  /** Degrade execution plan — present only when verdict is 'degrade'. */
+  degradePlan: z
+    .object({
+      targetMode: z.string().min(1),
+      rollbackCondition: z.string().min(1),
+    })
+    .optional(),
+
   /** What the exporting instance recommends the community do. */
   requestedAction: z.string().min(1),
 
@@ -224,6 +232,14 @@ export function sanitizeVerdictForExport(packet: VerdictHandoffPacket, sourceIns
       alternatives: packet.rootCauseHypothesis.alternatives.map(scrub),
     },
     verdict: packet.verdict,
+    ...(packet.verdict === 'degrade' && packet.governance?.degradePlan
+      ? {
+          degradePlan: {
+            targetMode: packet.governance.degradePlan.targetMode,
+            rollbackCondition: scrub(packet.governance.degradePlan.rollbackCondition),
+          },
+        }
+      : {}),
     requestedAction: scrub(packet.ownerAsk.requestedAction),
     counterarguments: packet.counterarguments.map(scrub),
   };

--- a/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
+++ b/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
@@ -245,7 +245,7 @@ export function sanitizeVerdictForExport(packet: VerdictHandoffPacket, sourceIns
     ...(packet.verdict === 'degrade' && packet.governance?.degradePlan
       ? {
           degradePlan: {
-            targetMode: packet.governance.degradePlan.targetMode,
+            targetMode: scrub(packet.governance.degradePlan.targetMode),
             rollbackCondition: scrub(packet.governance.degradePlan.rollbackCondition),
           },
         }

--- a/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
+++ b/packages/api/src/infrastructure/harness-eval/community-issue-packet.ts
@@ -59,8 +59,8 @@ const sanitizedIssuePacketSchema = z.object({
     alternatives: z.array(z.string().min(1)).min(1),
   }),
 
-  /** Verdict: delete_sunset / build / fix / keep_observe. */
-  verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe']),
+  /** Verdict: delete_sunset / build / fix / keep_observe / degrade. */
+  verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']),
 
   /** What the exporting instance recommends the community do. */
   requestedAction: z.string().min(1),

--- a/packages/api/src/infrastructure/harness-eval/eval-domain-registry.ts
+++ b/packages/api/src/infrastructure/harness-eval/eval-domain-registry.ts
@@ -1,5 +1,25 @@
 import { z } from 'zod';
 
+const tracingContractSchema = z.object({
+  observationUnit: z.enum(['time-window', 'thread-segment']),
+  requiredSources: z.array(z.string().min(1)).min(1),
+});
+
+const evalContractSchema = z.object({
+  metrics: z.array(z.string().min(1)).min(1),
+  thresholds: z.record(z.number()),
+});
+
+const decisionContractSchema = z.object({
+  verdictSet: z.array(z.string().min(1)).min(1),
+  autoVerdictEnabled: z.boolean(),
+});
+
+const governanceContractSchema = z.object({
+  executionModes: z.array(z.enum(['auto-pr', 'local-overlay', 'manual'])).min(1),
+  changeTrail: z.boolean(),
+});
+
 const evalDomainRegistryEntrySchema = z.object({
   domainId: z.enum(['eval:a2a', 'eval:memory', 'eval:sop', 'eval:capability-wakeup']),
   displayName: z.string().min(1),
@@ -26,6 +46,10 @@ const evalDomainRegistryEntrySchema = z.object({
     acknowledgeHours: z.number().int().positive('acknowledgeHours must be positive'),
     reevalWithinHours: z.number().int().positive('reevalWithinHours must be positive'),
   }),
+  tracingContract: tracingContractSchema.optional(),
+  evalContract: evalContractSchema.optional(),
+  decisionContract: decisionContractSchema.optional(),
+  governanceContract: governanceContractSchema.optional(),
 });
 
 export type EvalDomainRegistryEntry = z.infer<typeof evalDomainRegistryEntrySchema>;

--- a/packages/api/src/infrastructure/harness-eval/eval-domain-registry.ts
+++ b/packages/api/src/infrastructure/harness-eval/eval-domain-registry.ts
@@ -10,8 +10,10 @@ const evalContractSchema = z.object({
   thresholds: z.record(z.number()),
 });
 
+const verdictEnum = z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']);
+
 const decisionContractSchema = z.object({
-  verdictSet: z.array(z.string().min(1)).min(1),
+  verdictSet: z.array(verdictEnum).min(1),
   autoVerdictEnabled: z.boolean(),
 });
 

--- a/packages/api/src/infrastructure/harness-eval/f167-eval.ts
+++ b/packages/api/src/infrastructure/harness-eval/f167-eval.ts
@@ -148,19 +148,22 @@ function classifyFrictionType(metrics: Record<string, number>): ComponentHealth[
   const harnessGap = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_harness_gap');
   const trustGap = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_trust_gap');
 
-  if (harnessGap == null && trustGap == null) {
-    const cancelCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_count');
-    const zombieCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_zombie_hold_count');
-    if ((cancelCount != null && cancelCount > 0) || (zombieCount != null && zombieCount > 0)) {
-      return 'unknown';
-    }
-    return undefined;
-  }
-
   const hg = harnessGap ?? 0;
   const tg = trustGap ?? 0;
-  if (hg === 0 && tg === 0) return undefined;
-  return hg >= tg ? 'harness_gap' : 'trust_gap';
+
+  // Positive breakdown → classify directly
+  if (hg > 0 || tg > 0) {
+    return hg >= tg ? 'harness_gap' : 'trust_gap';
+  }
+
+  // No usable breakdown — check if base friction exists
+  const cancelCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_count');
+  const zombieCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_zombie_hold_count');
+  if ((cancelCount != null && cancelCount > 0) || (zombieCount != null && zombieCount > 0)) {
+    return 'unknown';
+  }
+
+  return undefined;
 }
 
 function buildC1(spans: EvalTraceSpan[], metrics: Record<string, number>): ComponentHealth {

--- a/packages/api/src/infrastructure/harness-eval/f167-eval.ts
+++ b/packages/api/src/infrastructure/harness-eval/f167-eval.ts
@@ -22,6 +22,7 @@ export interface ComponentHealth {
   componentName: string;
   activationCounts: Record<string, number | null>;
   frictionCounts: Record<string, number | null>;
+  frictionType?: 'harness_gap' | 'trust_gap' | 'unknown';
   falsePositiveCandidates: string[];
   bypassCandidates: string[];
   confidence: 'high' | 'medium' | 'low' | 'no-data';
@@ -143,6 +144,25 @@ function buildL1(metrics: Record<string, number>): ComponentHealth {
   };
 }
 
+function classifyFrictionType(metrics: Record<string, number>): ComponentHealth['frictionType'] | undefined {
+  const harnessGap = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_harness_gap');
+  const trustGap = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_trust_gap');
+
+  if (harnessGap == null && trustGap == null) {
+    const cancelCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_hold_cancel_count');
+    const zombieCount = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_zombie_hold_count');
+    if ((cancelCount != null && cancelCount > 0) || (zombieCount != null && zombieCount > 0)) {
+      return 'unknown';
+    }
+    return undefined;
+  }
+
+  const hg = harnessGap ?? 0;
+  const tg = trustGap ?? 0;
+  if (hg === 0 && tg === 0) return undefined;
+  return hg >= tg ? 'harness_gap' : 'trust_gap';
+}
+
 function buildC1(spans: EvalTraceSpan[], metrics: Record<string, number>): ComponentHealth {
   const holdBallCalls = countHoldBallFromTraces(spans);
   const zombieHold = sumMetricByPrefix(metrics, 'cat_cafe_a2a_c1_zombie_hold_count');
@@ -156,11 +176,14 @@ function buildC1(spans: EvalTraceSpan[], metrics: Record<string, number>): Compo
     frictionCounts['c1.hold_cancel_count'] = holdCancel ?? 0;
   }
 
+  const frictionType = classifyFrictionType(metrics);
+
   return {
     componentId: 'C1',
     componentName: 'hold_ball (MCP tool)',
     activationCounts: { hold_ball_calls: holdBallCalls },
     frictionCounts,
+    ...(frictionType != null ? { frictionType } : {}),
     falsePositiveCandidates: [],
     bypassCandidates: [],
     confidence: hasData ? (hasCounters ? 'medium' : 'low') : 'no-data',

--- a/packages/api/src/infrastructure/harness-eval/verdict-handoff.ts
+++ b/packages/api/src/infrastructure/harness-eval/verdict-handoff.ts
@@ -41,7 +41,7 @@ const verdictHandoffPacketSchema = z
     }),
     governance: z
       .object({
-        cvoAcceptRequired: z.boolean(),
+        cvoAcceptRequired: z.boolean().optional(),
         degradePlan: z
           .object({
             targetMode: z.string().min(1),

--- a/packages/api/src/infrastructure/harness-eval/verdict-handoff.ts
+++ b/packages/api/src/infrastructure/harness-eval/verdict-handoff.ts
@@ -33,7 +33,7 @@ const verdictHandoffPacketSchema = z
       confidence: z.enum(['low', 'medium', 'high']),
       alternatives: nonEmptyStringArray,
     }),
-    verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe']),
+    verdict: z.enum(['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade']),
     ownerAsk: z.object({
       targetFeatureId: z.string().min(1),
       targetOwnerCatId: z.string().min(1),
@@ -42,6 +42,12 @@ const verdictHandoffPacketSchema = z
     governance: z
       .object({
         cvoAcceptRequired: z.boolean(),
+        degradePlan: z
+          .object({
+            targetMode: z.string().min(1),
+            rollbackCondition: z.string().min(1),
+          })
+          .optional(),
       })
       .optional(),
     acceptanceReevalPlan: z.object({
@@ -51,13 +57,23 @@ const verdictHandoffPacketSchema = z
     counterarguments: nonEmptyStringArray,
   })
   .superRefine((packet, ctx) => {
-    if (packet.verdict !== 'delete_sunset') return;
-    if (packet.governance?.cvoAcceptRequired !== true) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'delete_sunset verdict requires structured CVO accept gate',
-        path: ['governance', 'cvoAcceptRequired'],
-      });
+    if (packet.verdict === 'delete_sunset') {
+      if (packet.governance?.cvoAcceptRequired !== true) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'delete_sunset verdict requires structured CVO accept gate',
+          path: ['governance', 'cvoAcceptRequired'],
+        });
+      }
+    }
+    if (packet.verdict === 'degrade') {
+      if (!packet.governance?.degradePlan) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'degrade verdict requires a degradePlan in governance',
+          path: ['governance', 'degradePlan'],
+        });
+      }
     }
   });
 

--- a/packages/api/test/harness-eval/community-issue-packet.test.js
+++ b/packages/api/test/harness-eval/community-issue-packet.test.js
@@ -95,6 +95,33 @@ describe('SanitizedIssuePacket', () => {
       assert.throws(() => parseSanitizedIssuePacket({ id: 'bad' }), /domainId|exportedAt|phenomenon/i);
     });
 
+    it('rejects degrade verdict without degradePlan', () => {
+      assert.throws(
+        () =>
+          parseSanitizedIssuePacket({
+            id: 'sip-d1',
+            domainId: 'eval:test',
+            exportedAt: '2026-05-30T10:00:00+08:00',
+            sourceInstanceId: 'test',
+            phenomenon: 'test',
+            harnessComponent: { componentId: 'c1', name: 'Test' },
+            evidenceSummary: { snapshotCount: 1, attributionCount: 1, metricCount: 1, traceCount: 1 },
+            dailyTrend: {
+              window: '7d',
+              current: { x: 1 },
+              baseline: { x: 0 },
+              threshold: { x: 0.5 },
+              direction: 'regressed',
+            },
+            rootCauseHypothesis: { summary: 'test', confidence: 'low', alternatives: ['alt'] },
+            verdict: 'degrade',
+            requestedAction: 'Degrade',
+            counterarguments: ['Insufficient data'],
+          }),
+        /degradePlan/,
+      );
+    });
+
     it('accepts any eval: domain prefix (not restricted to internal enum)', () => {
       const packet = {
         id: 'sip-002',

--- a/packages/api/test/harness-eval/community-issue-packet.test.js
+++ b/packages/api/test/harness-eval/community-issue-packet.test.js
@@ -201,14 +201,14 @@ describe('SanitizedIssuePacket', () => {
 
     // ---- degrade verdict: degradePlan export (Codex P2-1 fix) ----
 
-    it('exports degradePlan when verdict is degrade', () => {
+    it('exports degradePlan when verdict is degrade, scrubbing both fields', () => {
       const verdict = parseVerdictHandoffPacket(
         makeVerdict({
           verdict: 'degrade',
           governance: {
             cvoAcceptRequired: false,
             degradePlan: {
-              targetMode: 'local-overlay',
+              targetMode: 'F167 codex-only overlay',
               rollbackCondition: 'F167 ball_drop_rate < 0.05 for 7 days',
             },
           },
@@ -217,7 +217,9 @@ describe('SanitizedIssuePacket', () => {
       const sanitized = sanitizeVerdictForExport(verdict, 'my-instance');
       assert.equal(sanitized.verdict, 'degrade');
       assert.ok(sanitized.degradePlan, 'degradePlan should be present for degrade verdict');
-      assert.equal(sanitized.degradePlan.targetMode, 'local-overlay');
+      // targetMode should be scrubbed (F167 → [feature], codex → [agent])
+      assert.ok(!sanitized.degradePlan.targetMode.includes('F167'), 'targetMode should scrub feature IDs');
+      assert.ok(!sanitized.degradePlan.targetMode.includes('codex'), 'targetMode should scrub cat identities');
       // rollbackCondition should be scrubbed (F167 → [feature])
       assert.ok(!sanitized.degradePlan.rollbackCondition.includes('F167'), 'should scrub feature IDs');
       assert.ok(sanitized.degradePlan.rollbackCondition.includes('[feature]'), 'should replace with [feature]');

--- a/packages/api/test/harness-eval/community-issue-packet.test.js
+++ b/packages/api/test/harness-eval/community-issue-packet.test.js
@@ -172,6 +172,36 @@ describe('SanitizedIssuePacket', () => {
       assert.equal(reparsed.id, sanitized.id);
     });
 
+    // ---- degrade verdict: degradePlan export (Codex P2-1 fix) ----
+
+    it('exports degradePlan when verdict is degrade', () => {
+      const verdict = parseVerdictHandoffPacket(
+        makeVerdict({
+          verdict: 'degrade',
+          governance: {
+            cvoAcceptRequired: false,
+            degradePlan: {
+              targetMode: 'local-overlay',
+              rollbackCondition: 'F167 ball_drop_rate < 0.05 for 7 days',
+            },
+          },
+        }),
+      );
+      const sanitized = sanitizeVerdictForExport(verdict, 'my-instance');
+      assert.equal(sanitized.verdict, 'degrade');
+      assert.ok(sanitized.degradePlan, 'degradePlan should be present for degrade verdict');
+      assert.equal(sanitized.degradePlan.targetMode, 'local-overlay');
+      // rollbackCondition should be scrubbed (F167 → [feature])
+      assert.ok(!sanitized.degradePlan.rollbackCondition.includes('F167'), 'should scrub feature IDs');
+      assert.ok(sanitized.degradePlan.rollbackCondition.includes('[feature]'), 'should replace with [feature]');
+    });
+
+    it('omits degradePlan for non-degrade verdicts', () => {
+      const verdict = parseVerdictHandoffPacket(makeVerdict({ verdict: 'fix' }));
+      const sanitized = sanitizeVerdictForExport(verdict, 'my-instance');
+      assert.equal(sanitized.degradePlan, undefined);
+    });
+
     // ---- P1 fixes: free-text scrubbing + opaque ID ----
 
     it('scrubs internal feature IDs (F\\d{3}) from free-text fields', () => {

--- a/packages/api/test/harness-eval/eval-domain-registry.test.js
+++ b/packages/api/test/harness-eval/eval-domain-registry.test.js
@@ -239,4 +239,75 @@ describe('Eval Domain Registry v0', () => {
     assert.equal(entry.frequency, 'weekly');
     assert.equal(entry.handoffTargetResolver.featureId, 'F203');
   });
+
+  // --- semantic interface contracts (F208 refresh) ---
+
+  it('accepts entry with tracingContract', () => {
+    const entry = parseEvalDomainRegistryEntry({
+      ...validEntry,
+      tracingContract: {
+        observationUnit: 'time-window',
+        requiredSources: ['F153 /api/telemetry/traces', 'F153 /api/telemetry/metrics'],
+      },
+    });
+    assert.equal(entry.tracingContract.observationUnit, 'time-window');
+    assert.equal(entry.tracingContract.requiredSources.length, 2);
+  });
+
+  it('accepts entry with all four contracts', () => {
+    const entry = parseEvalDomainRegistryEntry({
+      ...validEntry,
+      tracingContract: {
+        observationUnit: 'time-window',
+        requiredSources: ['F153 /api/telemetry/traces'],
+      },
+      evalContract: {
+        metrics: ['frictionRatio', 'activationCount'],
+        thresholds: { frictionRatio: 0.05 },
+      },
+      decisionContract: {
+        verdictSet: ['delete_sunset', 'build', 'fix', 'keep_observe', 'degrade'],
+        autoVerdictEnabled: false,
+      },
+      governanceContract: {
+        executionModes: ['auto-pr', 'local-overlay'],
+        changeTrail: true,
+      },
+    });
+    assert.equal(entry.tracingContract.observationUnit, 'time-window');
+    assert.equal(entry.evalContract.metrics.length, 2);
+    assert.equal(entry.decisionContract.autoVerdictEnabled, false);
+    assert.deepEqual(entry.governanceContract.executionModes, ['auto-pr', 'local-overlay']);
+  });
+
+  it('accepts entry without any contracts (backward compatible)', () => {
+    const entry = parseEvalDomainRegistryEntry(validEntry);
+    assert.equal(entry.tracingContract, undefined);
+    assert.equal(entry.evalContract, undefined);
+    assert.equal(entry.decisionContract, undefined);
+    assert.equal(entry.governanceContract, undefined);
+  });
+
+  it('rejects tracingContract with invalid observationUnit', () => {
+    assert.throws(() =>
+      parseEvalDomainRegistryEntry({
+        ...validEntry,
+        tracingContract: {
+          observationUnit: 'invalid-unit',
+          requiredSources: ['something'],
+        },
+      }),
+    );
+  });
+
+  it('loads eval-a2a.yaml with tracingContract', async () => {
+    const raw = await readFile(
+      new URL('../../../../docs/harness-feedback/eval-domains/eval-a2a.yaml', import.meta.url),
+      'utf8',
+    );
+    const parsed = parse(raw);
+    const entry = parseEvalDomainRegistryFile(parsed);
+    assert.equal(entry.tracingContract.observationUnit, 'time-window');
+    assert.ok(entry.tracingContract.requiredSources.length > 0);
+  });
 });

--- a/packages/api/test/harness-eval/eval-domain-registry.test.js
+++ b/packages/api/test/harness-eval/eval-domain-registry.test.js
@@ -300,6 +300,18 @@ describe('Eval Domain Registry v0', () => {
     );
   });
 
+  it('rejects unsupported verdict in decisionContract verdictSet', () => {
+    assert.throws(() =>
+      parseEvalDomainRegistryEntry({
+        ...validEntry,
+        decisionContract: {
+          verdictSet: ['remove'],
+          autoVerdictEnabled: false,
+        },
+      }),
+    );
+  });
+
   it('loads eval-a2a.yaml with tracingContract', async () => {
     const raw = await readFile(
       new URL('../../../../docs/harness-feedback/eval-domains/eval-a2a.yaml', import.meta.url),

--- a/packages/api/test/harness-eval/f167-eval.test.js
+++ b/packages/api/test/harness-eval/f167-eval.test.js
@@ -127,7 +127,7 @@ describe('F167 Runtime Eval Snapshot', () => {
       },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');
-    assert.equal(c1.activationCounts['hold_ball_calls'], 1);
+    assert.equal(c1.activationCounts.hold_ball_calls, 1);
   });
 
   it('counts multiple hold_ball events across spans', () => {
@@ -163,7 +163,7 @@ describe('F167 Runtime Eval Snapshot', () => {
       },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');
-    assert.equal(c1.activationCounts['hold_ball_calls'], 2);
+    assert.equal(c1.activationCounts.hold_ball_calls, 2);
   });
 
   it('does not count tools with similar suffix as hold_ball', () => {
@@ -190,7 +190,7 @@ describe('F167 Runtime Eval Snapshot', () => {
       traceStats: { spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000, oldestStoredAt: now, newestStoredAt: now },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');
-    assert.equal(c1.activationCounts['hold_ball_calls'], 0);
+    assert.equal(c1.activationCounts.hold_ball_calls, 0);
   });
 
   it('L1/C1/C2 report no gaps when counters exist at zero (warmup)', () => {
@@ -360,14 +360,19 @@ describe('F167 Runtime Eval Snapshot', () => {
     const snapshot = generateF167Snapshot({
       ...emptyInput,
       traces: {
-        spans: [{
-          traceId: 'abc', spanId: 's1',
-          name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
-          startTimeMs: now - 1000, endTimeMs: now, durationMs: 1000,
-          status: { code: 0 },
-          attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
-          events: [],
-        }],
+        spans: [
+          {
+            traceId: 'abc',
+            spanId: 's1',
+            name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
+            startTimeMs: now - 1000,
+            endTimeMs: now,
+            durationMs: 1000,
+            status: { code: 0 },
+            attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
+            events: [],
+          },
+        ],
         count: 1,
       },
       metrics: {
@@ -377,8 +382,11 @@ describe('F167 Runtime Eval Snapshot', () => {
         cat_cafe_a2a_c1_hold_cancel_trust_gap: 1,
       },
       traceStats: {
-        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
-        oldestStoredAt: now - 3600000, newestStoredAt: now,
+        spanCount: 1,
+        maxSpans: 10000,
+        maxAgeMs: 86400000,
+        oldestStoredAt: now - 3600000,
+        newestStoredAt: now,
       },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');
@@ -390,14 +398,19 @@ describe('F167 Runtime Eval Snapshot', () => {
     const snapshot = generateF167Snapshot({
       ...emptyInput,
       traces: {
-        spans: [{
-          traceId: 'abc', spanId: 's1',
-          name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
-          startTimeMs: now - 1000, endTimeMs: now, durationMs: 1000,
-          status: { code: 0 },
-          attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
-          events: [],
-        }],
+        spans: [
+          {
+            traceId: 'abc',
+            spanId: 's1',
+            name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
+            startTimeMs: now - 1000,
+            endTimeMs: now,
+            durationMs: 1000,
+            status: { code: 0 },
+            attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
+            events: [],
+          },
+        ],
         count: 1,
       },
       metrics: {
@@ -407,8 +420,11 @@ describe('F167 Runtime Eval Snapshot', () => {
         cat_cafe_a2a_c1_hold_cancel_trust_gap: 4,
       },
       traceStats: {
-        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
-        oldestStoredAt: now - 3600000, newestStoredAt: now,
+        spanCount: 1,
+        maxSpans: 10000,
+        maxAgeMs: 86400000,
+        oldestStoredAt: now - 3600000,
+        newestStoredAt: now,
       },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');
@@ -423,8 +439,11 @@ describe('F167 Runtime Eval Snapshot', () => {
         cat_cafe_a2a_c1_zombie_hold_count: 2,
       },
       traceStats: {
-        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
-        oldestStoredAt: Date.now() - 3600000, newestStoredAt: Date.now(),
+        spanCount: 1,
+        maxSpans: 10000,
+        maxAgeMs: 86400000,
+        oldestStoredAt: Date.now() - 3600000,
+        newestStoredAt: Date.now(),
       },
     });
     const c1 = snapshot.components.find((c) => c.componentId === 'C1');

--- a/packages/api/test/harness-eval/f167-eval.test.js
+++ b/packages/api/test/harness-eval/f167-eval.test.js
@@ -450,6 +450,27 @@ describe('F167 Runtime Eval Snapshot', () => {
     assert.equal(c1.frictionType, 'unknown');
   });
 
+  it('C1 frictionType is unknown when breakdown counters are zero but base friction exists', () => {
+    const snapshot = generateF167Snapshot({
+      ...emptyInput,
+      metrics: {
+        cat_cafe_a2a_c1_hold_cancel_count: 5,
+        cat_cafe_a2a_c1_zombie_hold_count: 0,
+        cat_cafe_a2a_c1_hold_cancel_harness_gap: 0,
+        cat_cafe_a2a_c1_hold_cancel_trust_gap: 0,
+      },
+      traceStats: {
+        spanCount: 1,
+        maxSpans: 10000,
+        maxAgeMs: 86400000,
+        oldestStoredAt: Date.now() - 3600000,
+        newestStoredAt: Date.now(),
+      },
+    });
+    const c1 = snapshot.components.find((c) => c.componentId === 'C1');
+    assert.equal(c1.frictionType, 'unknown');
+  });
+
   it('non-C1 components do not have frictionType', () => {
     const snapshot = generateF167Snapshot(emptyInput);
     for (const comp of snapshot.components) {

--- a/packages/api/test/harness-eval/f167-eval.test.js
+++ b/packages/api/test/harness-eval/f167-eval.test.js
@@ -346,4 +346,97 @@ describe('F167 Runtime Eval Snapshot', () => {
     assert.equal(c2.frictionCounts['c2.verdict_without_pass_count'], 9);
     assert.equal(c2.frictionCounts['c2.void_hold_hint_emitted'], 4);
   });
+
+  // --- frictionType classification (F208 semantic interface refresh) ---
+
+  it('C1 frictionType is undefined when no cancel counters exist', () => {
+    const snapshot = generateF167Snapshot(emptyInput);
+    const c1 = snapshot.components.find((c) => c.componentId === 'C1');
+    assert.equal(c1.frictionType, undefined);
+  });
+
+  it('C1 frictionType is harness_gap when harness cancels dominate', () => {
+    const now = Date.now();
+    const snapshot = generateF167Snapshot({
+      ...emptyInput,
+      traces: {
+        spans: [{
+          traceId: 'abc', spanId: 's1',
+          name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
+          startTimeMs: now - 1000, endTimeMs: now, durationMs: 1000,
+          status: { code: 0 },
+          attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
+          events: [],
+        }],
+        count: 1,
+      },
+      metrics: {
+        cat_cafe_a2a_c1_hold_cancel_count: 5,
+        cat_cafe_a2a_c1_zombie_hold_count: 0,
+        cat_cafe_a2a_c1_hold_cancel_harness_gap: 4,
+        cat_cafe_a2a_c1_hold_cancel_trust_gap: 1,
+      },
+      traceStats: {
+        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
+        oldestStoredAt: now - 3600000, newestStoredAt: now,
+      },
+    });
+    const c1 = snapshot.components.find((c) => c.componentId === 'C1');
+    assert.equal(c1.frictionType, 'harness_gap');
+  });
+
+  it('C1 frictionType is trust_gap when trust cancels dominate', () => {
+    const now = Date.now();
+    const snapshot = generateF167Snapshot({
+      ...emptyInput,
+      traces: {
+        spans: [{
+          traceId: 'abc', spanId: 's1',
+          name: 'cat_cafe.tool_use mcp__cat-cafe__cat_cafe_hold_ball',
+          startTimeMs: now - 1000, endTimeMs: now, durationMs: 1000,
+          status: { code: 0 },
+          attributes: { 'tool.name': 'mcp__cat-cafe__cat_cafe_hold_ball' },
+          events: [],
+        }],
+        count: 1,
+      },
+      metrics: {
+        cat_cafe_a2a_c1_hold_cancel_count: 5,
+        cat_cafe_a2a_c1_zombie_hold_count: 0,
+        cat_cafe_a2a_c1_hold_cancel_harness_gap: 1,
+        cat_cafe_a2a_c1_hold_cancel_trust_gap: 4,
+      },
+      traceStats: {
+        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
+        oldestStoredAt: now - 3600000, newestStoredAt: now,
+      },
+    });
+    const c1 = snapshot.components.find((c) => c.componentId === 'C1');
+    assert.equal(c1.frictionType, 'trust_gap');
+  });
+
+  it('C1 frictionType is unknown when cancel counters exist but no reason breakdown', () => {
+    const snapshot = generateF167Snapshot({
+      ...emptyInput,
+      metrics: {
+        cat_cafe_a2a_c1_hold_cancel_count: 5,
+        cat_cafe_a2a_c1_zombie_hold_count: 2,
+      },
+      traceStats: {
+        spanCount: 1, maxSpans: 10000, maxAgeMs: 86400000,
+        oldestStoredAt: Date.now() - 3600000, newestStoredAt: Date.now(),
+      },
+    });
+    const c1 = snapshot.components.find((c) => c.componentId === 'C1');
+    assert.equal(c1.frictionType, 'unknown');
+  });
+
+  it('non-C1 components do not have frictionType', () => {
+    const snapshot = generateF167Snapshot(emptyInput);
+    for (const comp of snapshot.components) {
+      if (comp.componentId !== 'C1') {
+        assert.equal(comp.frictionType, undefined, `${comp.componentId} should not have frictionType`);
+      }
+    }
+  });
 });

--- a/packages/api/test/harness-eval/verdict-handoff.test.js
+++ b/packages/api/test/harness-eval/verdict-handoff.test.js
@@ -182,6 +182,22 @@ describe('Verdict Handoff Packet contract', () => {
     assert.equal(packet.governance.degradePlan.targetMode, 'on-demand');
   });
 
+  it('accepts degrade verdict without cvoAcceptRequired (CVO gate is optional for degrade)', () => {
+    const packet = parseVerdictHandoffPacket({
+      ...basePacket,
+      verdict: 'degrade',
+      governance: {
+        degradePlan: {
+          targetMode: 'shadow-only',
+          rollbackCondition: 'friction ratio stable below 3% for 72h',
+        },
+      },
+    });
+    assert.equal(packet.verdict, 'degrade');
+    assert.equal(packet.governance.cvoAcceptRequired, undefined);
+    assert.equal(packet.governance.degradePlan.targetMode, 'shadow-only');
+  });
+
   it('rejects degrade verdict with empty degrade plan fields', () => {
     assert.throws(() =>
       parseVerdictHandoffPacket({

--- a/packages/api/test/harness-eval/verdict-handoff.test.js
+++ b/packages/api/test/harness-eval/verdict-handoff.test.js
@@ -183,19 +183,18 @@ describe('Verdict Handoff Packet contract', () => {
   });
 
   it('rejects degrade verdict with empty degrade plan fields', () => {
-    assert.throws(
-      () =>
-        parseVerdictHandoffPacket({
-          ...basePacket,
-          verdict: 'degrade',
-          governance: {
-            cvoAcceptRequired: false,
-            degradePlan: {
-              targetMode: '',
-              rollbackCondition: '',
-            },
+    assert.throws(() =>
+      parseVerdictHandoffPacket({
+        ...basePacket,
+        verdict: 'degrade',
+        governance: {
+          cvoAcceptRequired: false,
+          degradePlan: {
+            targetMode: '',
+            rollbackCondition: '',
           },
-        }),
+        },
+      }),
     );
   });
 });

--- a/packages/api/test/harness-eval/verdict-handoff.test.js
+++ b/packages/api/test/harness-eval/verdict-handoff.test.js
@@ -152,4 +152,50 @@ describe('Verdict Handoff Packet contract', () => {
 
     assert.equal(packet.verdict, 'delete_sunset');
   });
+
+  // --- degrade verdict (F208 semantic interface refresh) ---
+
+  it('rejects degrade verdict without a degrade plan', () => {
+    assert.throws(
+      () =>
+        parseVerdictHandoffPacket({
+          ...basePacket,
+          verdict: 'degrade',
+        }),
+      /degradePlan/,
+    );
+  });
+
+  it('accepts degrade verdict with a valid degrade plan', () => {
+    const packet = parseVerdictHandoffPacket({
+      ...basePacket,
+      verdict: 'degrade',
+      governance: {
+        cvoAcceptRequired: false,
+        degradePlan: {
+          targetMode: 'on-demand',
+          rollbackCondition: 'friction ratio drops below 5% for 48h',
+        },
+      },
+    });
+    assert.equal(packet.verdict, 'degrade');
+    assert.equal(packet.governance.degradePlan.targetMode, 'on-demand');
+  });
+
+  it('rejects degrade verdict with empty degrade plan fields', () => {
+    assert.throws(
+      () =>
+        parseVerdictHandoffPacket({
+          ...basePacket,
+          verdict: 'degrade',
+          governance: {
+            cvoAcceptRequired: false,
+            degradePlan: {
+              targetMode: '',
+              rollbackCondition: '',
+            },
+          },
+        }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

F192 Phase G-A: Extends the harness eval pipeline with semantic interface contracts, friction type classification, and a graduated degrade decision path.

- **Semantic Interface Contracts**: `EvalDomainRegistryEntry` gains 4 optional typed contract fields (`tracingContract` / `evalContract` / `decisionContract` / `governanceContract`) — backward compatible, existing YAML fixtures parse unchanged
- **Friction Type Classification**: `ComponentHealth.frictionType` distinguishes `harness_gap` (harness design issue) vs `trust_gap` (user bypasses harness) vs `unknown` (friction exists but no cancel_reason breakdown) — based on hold_ball cancel_reason OTel counters
- **Degrade Verdict**: Fills the decision gap between `keep_observe` and `delete_sunset` — `degrade` requires a `degradePlan` with `targetMode` + `rollbackCondition`, validated by Zod superRefine
- **Feat file refresh**: F192 spec updated with Phase G description, AC G1-G7, Verdict Matrix `degrade` row, KD-17/18/19, R9-R12

**Origin**: CVO + community discussion on tracing → eval → decision → governance model; F208-HCP (fork) design concepts implemented as F192 Phase G (KD-17: F208 ID taken by Capability Profile Routing on upstream).

## Changed files

| File | Change |
|------|--------|
| `verdict-handoff.ts` | `degrade` in verdict enum + `degradePlan` in governance + superRefine |
| `community-issue-packet.ts` | Sync verdict enum |
| `f167-eval.ts` | `frictionType` on `ComponentHealth` + `classifyFrictionType()` in `buildC1()` |
| `eval-domain-registry.ts` | 4 contract sub-schemas (tracing/eval/decision/governance) as optional fields |
| `eval-a2a.yaml` | `tracingContract` declaration (time-window + F153 sources) |
| `F192 spec` | Phase G section, Verdict Matrix, KD-17/18/19, R9-R12, Review Gate |

## Test plan

- [x] 332 harness-eval tests pass (13 new + 319 existing), 0 regressions
- [x] `pnpm lint` (tsc --noEmit) passes
- [x] Biome check on changed files passes (1 pre-existing warning in untouched code)
- [x] File sizes: verdict-handoff 103L, f167-eval 328L, registry 63L (all under limits)
- [ ] Cross-family review

🤖 Generated with [Claude Code](https://claude.com/claude-code)