### PR TITLE
fix(desktop): Windows startup crash, process leak, stale AppData junctions

### DIFF
--- a/desktop/afterPack.js
+++ b/desktop/afterPack.js
@@ -7,12 +7,22 @@ const path = require('path');
 const fs = require('fs');
 
 exports.default = async function afterPack(context) {
-  if (context.electronPlatformName !== 'darwin') {
+  const platform = context.electronPlatformName;
+
+  // Resolve the resources directory where extraResources are placed.
+  // macOS: {appOutDir}/{ProductName}.app/Contents/Resources/
+  // Windows: {appOutDir}/resources/
+  let resourcesDir;
+  if (platform === 'darwin') {
+    const productFilename = context.packager.appInfo.productFilename;
+    resourcesDir = path.join(context.appOutDir, `${productFilename}.app`, 'Contents', 'Resources');
+  } else if (platform === 'win32') {
+    resourcesDir = path.join(context.appOutDir, 'resources');
+  } else {
+    // Linux or unknown — skip for now
     return;
   }
 
-  const productFilename = context.packager.appInfo.productFilename;
-  const resourcesDir = path.join(context.appOutDir, `${productFilename}.app`, 'Contents', 'Resources');
   const projectRoot = path.resolve(__dirname, '..');
   const deployRoot = path.join(projectRoot, 'bundled', 'deploy');
 

--- a/desktop/installer/cat-cafe.iss
+++ b/desktop/installer/cat-cafe.iss
@@ -96,6 +96,13 @@ Source: "..\..\bundled\node\*";                  DestDir: "{app}\node"; \
 Source: "..\scripts\post-install-offline.ps1";   DestDir: "{app}\scripts"; Components: core
 Source: "..\scripts\generate-desktop-config.ps1"; DestDir: "{app}\scripts"; Components: core
 Source: "..\scripts\sync-agent-hooks-offline.mjs"; DestDir: "{app}\scripts"; Components: core
+; Project-level scripts — needed by the API at runtime (e.g. recommendation-matrix.yaml,
+; service install/uninstall scripts). Without these, the API crashes on startup because
+; recommendation-matrix-data.ts resolves REPO_ROOT from import.meta.url → {app}\ and
+; looks for scripts/services/ there, not inside desktop-dist/resources/.
+Source: "..\..\scripts\*";                       DestDir: "{app}\scripts"; \
+  Excludes: "*.test.*,__pycache__"; \
+  Flags: recursesubdirs createallsubdirs; Components: core
 ; User-level Agent CLI hook truth source used by F180 health/sync.
 Source: "..\..\.claude\hooks\user-level\*";      DestDir: "{app}\.claude\hooks\user-level"; \
   Flags: recursesubdirs createallsubdirs; Components: core

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -164,6 +164,15 @@ app.on('window-all-closed', () => {
   if (process.platform !== 'win32') quitApp();
 });
 
-app.on('before-quit', async () => {
-  if (services) await services.stopAll();
+app.on('before-quit', (e) => {
+  // Electron does NOT await async event handlers. Without blocking here,
+  // the app exits before stopAll() finishes → orphaned node/redis processes.
+  // Prevent default, run cleanup, then quit when done.
+  if (services) {
+    e.preventDefault();
+    services.stopAll().finally(() => {
+      services = null; // prevent re-entry
+      app.quit();
+    });
+  }
 });

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -209,7 +209,7 @@ class ServiceManager {
     // Windows uses NTFS junctions (no admin needed, absolute paths). macOS
     // uses plain directory symlinks.
     const linkType = IS_WIN ? 'junction' : 'dir';
-    const mirrors = ['.claude', 'cat-cafe-skills', 'docs', 'packages'];
+    const mirrors = ['.claude', 'cat-cafe-skills', 'docs', 'packages', 'scripts'];
     for (const name of mirrors) {
       const src = path.join(this.root, name);
       const dst = path.join(projectDir, name);
@@ -219,7 +219,27 @@ class ServiceManager {
       }
       try {
         const dstStat = fs.existsSync(dst) ? fs.lstatSync(dst) : null;
-        if (dstStat?.isSymbolicLink() || dstStat?.isDirectory()) continue;
+        if (dstStat?.isSymbolicLink()) {
+          // Verify the symlink/junction target still exists and points to
+          // the current install dir. Stale junctions from previous installs
+          // must be removed and recreated — otherwise old data breaks new
+          // installs (the junction target may no longer exist or may point
+          // to a different version's layout).
+          try {
+            fs.statSync(dst); // follows symlink — throws if target is gone
+            const target = fs.readlinkSync(dst);
+            if (path.resolve(target) === path.resolve(src)) continue; // valid & correct
+            log(`Stale ${linkType} ${dst} points to ${target}, expected ${src} — recreating`);
+          } catch {
+            log(`Broken ${linkType} ${dst} — target missing, recreating`);
+          }
+          try { fs.unlinkSync(dst); } catch (e2) {
+            log(`Warning: failed to remove stale ${linkType} ${dst}: ${e2.message}`);
+            continue;
+          }
+        } else if (dstStat?.isDirectory()) {
+          continue; // real directory (not a symlink), leave it alone
+        }
         fs.symlinkSync(src, dst, linkType);
         log(`Mirror ${linkType} created: ${dst} -> ${src}`);
       } catch (err) {
@@ -563,13 +583,65 @@ class ServiceManager {
   }
 
   async stopAll() {
+    const KILL_TIMEOUT_MS = 5000;
+    const killPromises = [];
+
     for (const [name, proc] of Object.entries(this.procs)) {
-      if (proc && !proc.killed) {
-        console.log(`[desktop] stopping ${name}...`);
-        proc.kill('SIGTERM');
-      }
+      if (!proc || proc.killed) continue;
+      log(`[desktop] stopping ${name} (pid=${proc.pid})...`);
+
+      killPromises.push(
+        this._killProcessTree(name, proc, KILL_TIMEOUT_MS),
+      );
     }
+
+    await Promise.allSettled(killPromises);
     this.procs = {};
+  }
+
+  async _killProcessTree(name, proc, timeoutMs) {
+    if (!proc.pid) {
+      log(`[${name}] no pid — skipping`);
+      return;
+    }
+
+    if (IS_WIN) {
+      // On Windows, proc.kill('SIGTERM') only kills the direct child process.
+      // Child processes spawned by it (e.g., cmd.exe → node, or node → workers)
+      // become orphans. Use taskkill /T (tree) /F (force) to kill the entire
+      // process tree rooted at the PID.
+      try {
+        execSync(`taskkill /PID ${proc.pid} /T /F`, {
+          timeout: timeoutMs,
+          windowsHide: true,
+          stdio: 'ignore',
+        });
+        log(`[${name}] process tree killed via taskkill`);
+      } catch (err) {
+        // taskkill exits non-zero if the process is already gone — that's fine
+        log(`[${name}] taskkill: ${err.message}`);
+      }
+      return;
+    }
+
+    // macOS/Linux: SIGTERM first, then SIGKILL after timeout
+    proc.kill('SIGTERM');
+
+    const exited = await new Promise((resolve) => {
+      if (proc.exitCode !== null) return resolve(true);
+      const timer = setTimeout(() => resolve(false), timeoutMs);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve(true);
+      });
+    });
+
+    if (!exited) {
+      log(`[${name}] did not exit after SIGTERM, sending SIGKILL`);
+      try {
+        proc.kill('SIGKILL');
+      } catch {}
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #811 — Three related Windows desktop bugs that cause:
1. **Startup crash**: `no such file or directory: scripts/services/recommendation-matrix.yaml`
2. **Process leak**: node processes persist after quitting
3. **Stale data**: old AppData junctions break new installs

## Root cause analysis

### Bug 1: afterPack.js macOS-only → PROJECT_ROOT misresolution

**Chain**: `afterPack.js` returns early for non-darwin → electron-builder skips `node_modules` in extraResources → `resources/packages/api/` has no `node_modules/` → `project-root.js` `hasCompleteRuntime()` fails at `resources/` → falls through to Inno Setup root `{app}\` → `{app}\scripts\` only has 3 desktop scripts (no `services/recommendation-matrix.yaml`) → API crash.

```
resolveProjectRootFromDir(D:\CatCafe\desktop-dist\resources\app)
  ├─ resources\app         → no packages/       → skip
  ├─ resources             → has packages/api/dist/index.js ✓
  │                          but NO node_modules ✗ (afterPack skipped!)  → skip
  ├─ desktop-dist          → no packages/       → skip
  └─ D:\CatCafe\           → has packages/ + node_modules  → MATCH (wrong!)
```

**Fix**: `afterPack.js` now handles `win32` (resources dir = `appOutDir/resources/`). Also added project scripts to Inno Setup `[Files]` and `scripts` to the AppData mirror list as defense-in-depth.

### Bug 2: Process tree not killed on Windows

- `proc.kill('SIGTERM')` on Windows only kills the direct child, not its sub-processes
- Web service spawns via `cmd.exe /c next.cmd` → inner node becomes orphan
- `before-quit` handler was `async` but Electron doesn't await → cleanup incomplete

**Fix**: `taskkill /PID <pid> /T /F` for Windows process tree kill. `before-quit` uses `preventDefault()` + `.finally()` to ensure cleanup completes. macOS gets SIGKILL fallback after 5s timeout.

### Bug 3: Stale AppData junctions

`_ensureUserDataDir` checked `isSymbolicLink()` and skipped without verifying the target exists. Old junctions from deleted install dirs persisted → API followed dead paths.

**Fix**: Verify junction target validity + target path match. Recreate if stale or pointing to wrong install dir.

## Changes

| File | Lines | What |
|------|-------|------|
| `desktop/afterPack.js` | +12/-4 | Support `win32` platform alongside `darwin` |
| `desktop/installer/cat-cafe.iss` | +7 | Add project `scripts/` to Inno Setup install root |
| `desktop/service-manager.js` | +72/-5 | Stale junction fix + `scripts` mirror + `taskkill /T /F` + `_killProcessTree()` |
| `desktop/main.js` | +11/-2 | `before-quit` sync cleanup pattern |

## Test plan

- [ ] Windows installer: verify `{app}\scripts\services\recommendation-matrix.yaml` exists after install
- [ ] Windows: launch app → verify no `recommendation-matrix` error in `cat-cafe-desktop.log`
- [ ] Windows: quit app → verify no orphaned node processes in Task Manager
- [ ] Windows: install v1 → uninstall → install v2 to different dir → verify app starts (stale junction test)
- [ ] macOS: verify `afterPack.js` still works for darwin (no regression)
- [ ] macOS: verify quit kills all processes within 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)