### PR TITLE
fix(#813,#814): lazy session handoff + post_message bubble merge

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/InvocationQueue.ts
@@ -641,6 +641,26 @@ export class InvocationQueue {
     return false;
   }
 
+  /** #813: Check if a cat has dispatched (callerCatId) any pending/processing entry
+   *  in this thread, optionally filtered by sourceCategory. Used to detect A2A handoff
+   *  so continuation capsule can be skipped (lazy session handoff). */
+  hasPendingFromCat(
+    threadId: string,
+    callerCatId: string,
+    opts?: { sourceCategories?: NonNullable<QueueEntry['sourceCategory']>[] },
+  ): boolean {
+    for (const q of this.queues.values()) {
+      if (!this.queueMatchesThread(q, threadId)) continue;
+      for (const e of q) {
+        if (e.status !== 'queued' && e.status !== 'processing') continue;
+        if (e.callerCatId !== callerCatId) continue;
+        if (opts?.sourceCategories && !opts.sourceCategories.includes(e.sourceCategory!)) continue;
+        return true;
+      }
+    }
+    return false;
+  }
+
   /** F122B: Mark a specific entry as processing by ID (cross-user). */
   markProcessingById(threadId: string, entryId: string): boolean {
     for (const q of this.queues.values()) {

--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -136,6 +136,7 @@ export type ContinuationEnqueueOutcome =
   | 'skipped_invalid_capsule'
   | 'skipped_existing_entry'
   | 'skipped_rate_limited'
+  | 'skipped_handoff_complete'
   | 'queue_full';
 
 export class QueueProcessor {
@@ -320,6 +321,23 @@ export class QueueProcessor {
         '[QueueProcessor] continuation skipped: capsule target mismatch',
       );
       return { outcome: 'skipped_invalid_capsule' };
+    }
+
+    // #813: Skip continuation when cat has already handed off via A2A.
+    // Session handoff should be passive (lazy) — the new session is created
+    // when the cat is next triggered, not immediately after seal.
+    // Check if this cat already has a pending A2A entry it dispatched FROM itself
+    // (callerCatId = catId), indicating it completed work and handed off.
+    if (
+      capsule.ballState === 'needs_handoff' ||
+      capsule.ballState === 'completed' ||
+      this.deps.queue.hasPendingFromCat(threadId, catId, { sourceCategories: ['a2a'] })
+    ) {
+      this.deps.log.info(
+        { threadId, catId, ballState: capsule.ballState },
+        '[QueueProcessor] continuation skipped: cat already handed off (lazy session handoff)',
+      );
+      return { outcome: 'skipped_handoff_complete' };
     }
 
     const now = Date.now();

--- a/packages/api/src/domains/cats/services/types.ts
+++ b/packages/api/src/domains/cats/services/types.ts
@@ -167,7 +167,12 @@ export interface AgentMessage {
   /** Backend stored-message ID (set for callback post-message, used for rich_block correlation) */
   messageId?: string;
   /** F52: Cross-thread origin metadata (set for cross-thread callback messages) */
-  extra?: { crossPost?: { sourceThreadId: string; sourceInvocationId?: string }; targetCats?: string[] };
+  extra?: {
+    crossPost?: { sourceThreadId: string; sourceInvocationId?: string };
+    targetCats?: string[];
+    /** #814: True when message originated from an explicit post_message callback (not stream duplicate) */
+    isExplicitPost?: boolean;
+  };
   /** F121: ID of the message this message is replying to */
   replyTo?: string;
   /** F121: Hydrated preview of the replied-to message */

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -598,7 +598,8 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
       const richExtra = richBlocks.length > 0 ? { rich: { v: 1 as const, blocks: richBlocks } } : {};
       const targetCatsExtra = validExplicitTargets.length ? { targetCats: validExplicitTargets } : {};
-      const extraParts = { ...richExtra, ...targetCatsExtra };
+      // #814: Mark as explicit post so frontend TD112 dedup skips merge
+      const extraParts = { isExplicitPost: true, ...richExtra, ...targetCatsExtra };
       const extra = Object.keys(extraParts).length > 0 ? extraParts : undefined;
 
       const hasA2AMentions = !!(mentions.length > 0 && router && invocationRecordStore && effectiveThreadId);
@@ -1045,6 +1046,10 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     // identity never falls back to parent (which would collapse multi-turn same-cat).
     const persistedExtra = {
       ...(extra ?? {}),
+      // #814: Mark as explicit post_message so frontend TD112 dedup does not
+      // merge this into the cat's CLI stream bubble. post_message is a cat-initiated
+      // separate communication, not a duplicate of the stream response.
+      isExplicitPost: true,
       stream: {
         invocationId: effectiveInvId,
         turnInvocationId: invocationId ?? effectiveInvId,
@@ -1199,16 +1204,14 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
           // F194 Phase Z9 (砚砚 R1 P1-2): unified visible turn stamp via helper.
           ...stampVisibleTurn(effectiveInvId, invocationId),
           // F52+F098-C1: Include crossPost + targetCats in real-time broadcast
-          ...(isCrossThread || validExplicitTargets.length
-            ? {
-                extra: {
-                  ...(isCrossThread
-                    ? { crossPost: { sourceThreadId: actor.threadId, sourceInvocationId: effectiveInvId } }
-                    : {}),
-                  ...(validExplicitTargets.length ? { targetCats: validExplicitTargets } : {}),
-                },
-              }
-            : {}),
+          // #814: Always include isExplicitPost so frontend TD112 dedup skips merge
+          extra: {
+            isExplicitPost: true,
+            ...(isCrossThread
+              ? { crossPost: { sourceThreadId: actor.threadId, sourceInvocationId: effectiveInvId } }
+              : {}),
+            ...(validExplicitTargets.length ? { targetCats: validExplicitTargets } : {}),
+          },
           ...(mentionsUser ? { mentionsUser } : {}),
           ...(validatedReplyTo ? { replyTo: validatedReplyTo } : {}),
           ...(replyPreview ? { replyPreview } : {}),

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -275,6 +275,8 @@ export interface ChatMessage {
     };
     /** F098-C1: Explicit target cats from post_message API */
     targetCats?: string[];
+    /** #814: True when message originated from an explicit post_message callback (not stream duplicate) */
+    isExplicitPost?: boolean;
     /** Scheduler presentation metadata (hidden trigger / ephemeral lifecycle toast) */
     scheduler?: SchedulerMessageExtra['scheduler'];
     /** F118 AC-C3: Timeout diagnostics for enhanced error display */

--- a/packages/web/src/stores/chatStore.ts
+++ b/packages/web/src/stores/chatStore.ts
@@ -484,6 +484,11 @@ function findAssistantDuplicate(messages: ChatMessage[], incoming: ChatMessage):
 
   const incomingInvId = getBubbleInvocationId(incoming);
 
+  // #814: Explicit post_message callbacks are independent messages — never merge.
+  // post_message is a cat-initiated separate communication (e.g., @mention to another cat),
+  // not a duplicate of the same response arriving via stream+callback paths.
+  if (incoming.origin === 'callback' && incoming.extra?.isExplicitPost) return -1;
+
   // Phase 1: Hard rule — scan ALL same-cat assistants for exact invocationId match.
   // Must run first because bridge/soft rules on a newer message would mis-associate.
   if (incomingInvId) {


### PR DESCRIPTION
## Summary
- **#813**: Session seal after A2A handoff no longer triggers immediate re-invocation. `enqueueContinuation` now checks if the cat has already dispatched an A2A entry (`hasPendingFromCat`) or if `ballState` indicates handoff complete — continuation is skipped. New sessions are created lazily when the cat is next triggered.
- **#814**: `post_message` callbacks are now marked with `isExplicitPost=true`. Frontend TD112 `findAssistantDuplicate` skips merge when this flag is set, preventing explicit cat-initiated messages from being absorbed into stream bubbles.
- **#815**: Issue created for queue cross-source redundancy — requires deeper architectural work, tracked separately.

## Changes
| File | Change |
|------|--------|
| `InvocationQueue.ts` | New `hasPendingFromCat()` method — checks if a cat dispatched any pending A2A entries |
| `QueueProcessor.ts` | `enqueueContinuation` skips enqueue when cat has A2A handoff pending or ballState is completed/needs_handoff |
| `callbacks.ts` | Both post_message handlers (agent-key + invocation-scoped) now set `isExplicitPost: true` in persisted extra and broadcast |
| `chatStore.ts` | `findAssistantDuplicate` returns -1 (no merge) when incoming message has `isExplicitPost` flag |

## Test plan
- [ ] Trigger A2A handoff with context > 85% threshold → verify sealed cat is NOT immediately re-invoked
- [ ] Cat calls `post_message` during invocation → verify separate bubble appears (not merged into stream bubble)
- [ ] Normal stream→callback dedup still works (same response via both paths still merges)
- [ ] Continuation still works for non-handoff seals (e.g., cat sealed mid-work without @mention)

Fixes #813, #814

🤖 Generated with [Claude Code](https://claude.com/claude-code)