### PR TITLE
feat(F153 Phase G AC-G10): native L0 channel capture closes KD-42

### DIFF
--- a/docs/features/F153-observability-infra.md
+++ b/docs/features/F153-observability-infra.md
@@ -207,7 +207,9 @@ Phase E 实现引入了 `cat_cafe.route` 根 span（`AgentRouter` 创建），`c
 
 ### Phase G: Prompt X-Ray + Cross-route A2A Trace Propagation
 
+> **Status**: merged | **Owner**: Ragdoll
 > **Provenance**: 社区 PR clowder-ai#619（Closes clowder-ai#583），原提案为独立 F181，经维护者判定归入 F153 Phase G（2026-05-08）。
+> **Implementation**: clowder-ai#619 intake (AC-G1..G8 + G9 LocalTraceStore TTL, merged 2026-05-08); Phase G-Followup native L0 closure (AC-G10 / KD-44, merged 2026-06-03 closing the KD-42 gap — `PromptCapture` now persists `nativeSystemPrompt` for F203 native-L0 providers + Hub X-Ray Inspector System tab shows Native L0 zone above message-system pack appendix).
 
 两个核心能力：Prompt X-Ray 调试捕获 + 跨猫 A2A 调用链因果追踪。
 
@@ -461,16 +463,16 @@ UI 必须显示 `—` 而非 `0`，否则会让"重启前的数据"看起来像"
 - [x] AC-D6: `telemetry-debug.test.js` + `start-dev-profile-isolation.test.mjs` + `start-dev-script.test.js` 覆盖 guardrail 与启动链回归
 
 ### Phase G（Prompt X-Ray + Cross-route A2A Trace Propagation）
-- [ ] AC-G1: `PromptCaptureStore` 文件级 ring buffer（500 条上限，6h TTL），NDJSON 索引 + gzip 载荷
-- [ ] AC-G2: `PROMPT_CAPTURE` env gate 默认关闭，`PROMPT_CAPTURE_CATS` 可选白名单过滤
-- [ ] AC-G3: `capturePromptIfEnabled` 在 `invoke-single-cat` fire-and-forget 调用，不阻塞 invocation hot path
-- [ ] AC-G4: `/api/debug/prompt-captures/*` 路由走 session auth + userId resource-level auth
-- [ ] AC-G5: `CallerTraceContext` 类型（W3C TraceContext 对齐：traceId/spanId/traceFlags）定义在 `genai-semconv.ts`
-- [ ] AC-G6: `wrapWithDispatchSpan` 创建 `mention_dispatch` child span 并返回 `CallerTraceContext`
-- [ ] AC-G7: `setTraceContext` on `IAuthInvocationBackend`（Memory + Redis 实现），best-effort try/catch
-- [ ] AC-G8: Route aggregate attributes（`ROUTE_TOTAL_CATS_INVOKED`/`ROUTE_TOTAL_TOKENS`/`ROUTE_HAS_A2A_HANDOFF`）设在 route span
-- [ ] AC-G9: `LocalTraceStore` 默认 TTL 从 2h 提升到 24h，导出 `LOCAL_TRACE_STORE_DEFAULT_MAX_AGE_MS` 常量
-- [ ] AC-G10: Prompt X-Ray 必须覆盖 F203 native L0 channel，或在 UI/API 中明确拆分 native system prompt vs user/effective prompt，避免把空 `System` tab 误读成未捕获。
+- [x] AC-G1: `PromptCaptureStore` 文件级 ring buffer（500 条上限，6h TTL），NDJSON 索引 + gzip 载荷。Implemented in [prompt-capture-store.ts](packages/api/src/infrastructure/debug/prompt-capture-store.ts) via PR #619 intake.
+- [x] AC-G2: `PROMPT_CAPTURE` env gate 默认关闭，`PROMPT_CAPTURE_CATS` 可选白名单过滤。Wired in `isPromptCaptureEnabled()` via PR #619.
+- [x] AC-G3: `capturePromptIfEnabled` 在 `invoke-single-cat` fire-and-forget 调用，不阻塞 invocation hot path. Wired at [invoke-single-cat.ts:1421](packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts); AC-G10 follow-up keeps the fire-and-forget invariant via async `runCapture()` wrapper inside the bridge.
+- [x] AC-G4: `/api/debug/prompt-captures/*` 路由走 session auth + userId resource-level auth. Implemented in [prompt-captures.ts](packages/api/src/routes/prompt-captures.ts) via PR #619.
+- [x] AC-G5: `CallerTraceContext` 类型（W3C TraceContext 对齐：traceId/spanId/traceFlags）定义在 `genai-semconv.ts`. Defined at [genai-semconv.ts:47](packages/api/src/infrastructure/telemetry/genai-semconv.ts) via PR #619.
+- [x] AC-G6: `wrapWithDispatchSpan` 创建 `mention_dispatch` child span 并返回 `CallerTraceContext`. Implemented in [dispatch-span.ts](packages/api/src/infrastructure/telemetry/dispatch-span.ts) via PR #619.
+- [x] AC-G7: `setTraceContext` on `IAuthInvocationBackend`（Memory + Redis 实现），best-effort try/catch. Wired in [IAuthInvocationBackend.ts:80](packages/api/src/domains/cats/services/agents/invocation/IAuthInvocationBackend.ts), [InvocationRegistry.ts:170](packages/api/src/domains/cats/services/agents/invocation/InvocationRegistry.ts), and [RedisAuthInvocationBackend.ts:408](packages/api/src/domains/cats/services/agents/invocation/RedisAuthInvocationBackend.ts) via PR #619.
+- [x] AC-G8: Route aggregate attributes（`ROUTE_TOTAL_CATS_INVOKED`/`ROUTE_TOTAL_TOKENS`/`ROUTE_HAS_A2A_HANDOFF`）设在 route span. Wired in route-serial / route-parallel via PR #619.
+- [x] AC-G9: `LocalTraceStore` 默认 TTL 从 2h 提升到 24h，导出 `LOCAL_TRACE_STORE_DEFAULT_MAX_AGE_MS` 常量. Done in PR #619 (Phase E follow-up bundled into Phase G intake).
+- [x] AC-G10: Prompt X-Ray 必须覆盖 F203 native L0 channel，或在 UI/API 中明确拆分 native system prompt vs user/effective prompt，避免把空 `System` tab 误读成未捕获. Closed in Phase G-Followup (2026-06-03, KD-44): `PromptCapture` schema gained `nativeSystemPrompt` / `nativeSystemPromptSource` / `nativeSystemTokenEstimate` / `totalTokenEstimate` / `captureDiagnostics`; bridge async-fetches L0 from `compileL0ViaSubprocess` for `service.injectsL0Natively()` providers (Claude/Codex); Hub X-Ray Inspector System tab now zones Native L0 (system role) above the message-system pack appendix; resume amber banner now distinguishes message-system path from native L0; token bar and Meta tab break out native L0 vs message tokens to fix silent under-count. `l0-compiler.ts` gained in-flight Promise dedup + generation guard so capture and native injection sharing a cold cache don't double-spawn, and old compiles cannot repopulate stale L0 after `clearL0Cache()`. Test coverage: `l0-compiler.test.js` 15/15 (4 new AC-G10 dedup/invalidation tests) + `prompt-capture.test.js` 20/20 (5 new AC-G10 tests: backward compat, native capture, fail-safe diagnostic, non-native passthrough).
 
 ### Phase I（Step Summary — Agent Loop 行为节奏度量）✅
 - [x] AC-I1: Hub Traces tab 暴露 "Step Summary" 子视图（per `cat_cafe.route`），展示 `agent_loop_count` / `tool_call_count` / `a2a_dispatch_count` / `duration_ms` / `token_total` / `error_count`
@@ -559,3 +561,4 @@ UI 必须显示 `—` 而非 `0`，否则会让"重启前的数据"看起来像"
 | KD-41 | Phase J: provider 支持矩阵必须文档化，不允许"至少 X 其他 fallback"模糊口径 | gpt52 finding：模糊 AC 容易把 Phase J 做成局部真实；每个 provider 必须明确列 start/end/id/status 四件套支持，不支持的明确降级（不开 span 或标 fallback） | 2026-05-22 |
 | KD-42 | Prompt X-Ray 不能把 `params.systemPrompt` 等同于真实系统提示词 | F203 将 L0 identity 移到 native system channel；runtime 证明确实会 capture user/effective prompt，但 `System` tab 可为空，F153 Phase G 需要补 native channel coverage 或 UI 明示 partial | 2026-05-26 |
 | KD-43 | Phase J Slice J-B: `StoredToolEvent` 持久化 native `toolName` 数据字段，与 UI `label` 解耦；hydrate 优先用 `toolName`，label 解析仅为 legacy fallback | 砚砚 R5→R6 把"non-blocking P3 / track separately"升级为 P1：`label` 是 UI 显示文本（含 catId 前缀 + arrow + 可能本地化），把它当作 hydrate data contract 会让 label 格式或文案改动 silently degrade trace 到 `unknown` 或错的工具名。修在 J-B PR #825 内完成（3 个新 regression test 覆盖：toolName preferred / legacy label fallback / malformed last-resort） | 2026-06-02 |
+| KD-44 | Phase G AC-G10 (KD-42 closure): `PromptCapture` 持久化 `nativeSystemPrompt` data field 直接拿 `compileL0ViaSubprocess` 编译后 L0，Hub UI System tab 分区显示 Native L0 / message-system pack，token 估算分桶（msg / native L0 / total）。Capture 走 fire-and-forget async runner，L0 fetch 失败只写 `captureDiagnostics`，不阻塞 invocation hot path。`l0-compiler.ts` 加 in-flight Promise dedup + generation guard，capture + native injection 并发冷启动只发一次 subprocess，且 `clearL0Cache()` 后旧 in-flight compile 不得回写 stale L0 到 cache | 砚砚 Design Gate（2026-06-03）四立场全部 actionable：(1) 不要重复编译 → 加 in-flight dedup + capture 异步取 + fail-safe diagnostic；(2) 保留 `systemPrompt` 不 rename → 加 `nativeSystemPrompt` 双字段，避免 UI 误读 non-native provider 的 system；(3) 单 System tab 分区，Native L0 上方 + pack appendix 下方，修正 resume banner 误导（injected=false 只代表 message-system path 不影响 native L0）；(4) 保留 `tokenEstimate = effectivePrompt`，新增 `nativeSystemTokenEstimate` + `totalTokenEstimate` Hub 顶部显示 total / Meta 拆开；R1 P1 follow-up（2026-06-08）补 generation guard + clear-during-inflight regression | 2026-06-03 |

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1545,7 +1545,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       userPrompt: prompt,
       effectivePrompt,
       injectionDecision: { isResume, canSkipOnResume, forceReinjection, injected: injectSystemPrompt },
-      // AC-G10 (Phase G native L0 closure / KD-43): if this provider injects
+      // AC-G10 (Phase G native L0 closure / KD-44): if this provider injects
       // L0 via a native system-role channel (Claude `--system-prompt-file` /
       // Codex `-c developer_instructions=`), the bridge will best-effort
       // fetch the compiled L0 and stamp it onto `nativeSystemPrompt`. Hot

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1545,6 +1545,13 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       userPrompt: prompt,
       effectivePrompt,
       injectionDecision: { isResume, canSkipOnResume, forceReinjection, injected: injectSystemPrompt },
+      // AC-G10 (Phase G native L0 closure / KD-43): if this provider injects
+      // L0 via a native system-role channel (Claude `--system-prompt-file` /
+      // Codex `-c developer_instructions=`), the bridge will best-effort
+      // fetch the compiled L0 and stamp it onto `nativeSystemPrompt`. Hot
+      // path stays non-blocking — the bridge handles fetch async + fail-safe
+      // (see comment block in prompt-capture-bridge.ts).
+      nativeL0Provider: service.injectsL0Natively?.() ?? false,
     });
 
     // F089 Phase 2+3: Create tmux spawn override for agent-in-pane execution

--- a/packages/api/src/domains/cats/services/agents/providers/l0-compiler.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/l0-compiler.ts
@@ -34,10 +34,24 @@ const SCRIPT_BASENAME = 'compile-system-prompt-l0.mjs';
 // startup via warmL0Cache() and invalidated on hot-reload via clearL0Cache().
 const l0Cache = new Map<string, string>();
 
+// In-flight Promise dedup — Phase G AC-G10 (砚砚 Design Gate position 1).
+// Without this, two concurrent calls on a cold cache (e.g. invoke provider
+// + Prompt X-Ray capture inside the same invocation hot path) both spawn
+// subprocesses. The dedup map collapses concurrent compiles onto a single
+// subprocess invocation; the in-flight entry is removed once the Promise
+// settles, after which the result is in l0Cache for any subsequent reads.
+const l0InflightPromises = new Map<string, Promise<string>>();
+
 /** Clear cached L0 for one cat or all cats (call on hot-reload / re-sync). */
 export function clearL0Cache(catId?: string): void {
-  if (catId) l0Cache.delete(catId);
-  else l0Cache.clear();
+  if (catId) {
+    l0Cache.delete(catId);
+    // Also drop any in-flight promise — next call will re-spawn fresh.
+    l0InflightPromises.delete(catId);
+  } else {
+    l0Cache.clear();
+    l0InflightPromises.clear();
+  }
 }
 
 /** Number of cached entries (test/diagnostic). */
@@ -139,6 +153,35 @@ export async function compileL0ViaSubprocess(options: CompileL0Options): Promise
     return cached;
   }
 
+  // In-flight dedup — collapse concurrent cold-cache callers onto a single
+  // subprocess. The first caller installs the Promise; subsequent callers
+  // await the same one. Per-call `outPath` is honored: any caller that
+  // passed `outPath` writes the resolved L0 to that path before returning.
+  // Phase G AC-G10 — see comment block at l0InflightPromises declaration.
+  const inflight = l0InflightPromises.get(catId);
+  if (inflight) {
+    const result = await inflight;
+    if (outPath) writeFileSync(outPath, result, 'utf8');
+    return result;
+  }
+
+  const compilePromise = doCompileL0(options);
+  l0InflightPromises.set(catId, compilePromise);
+  try {
+    return await compilePromise;
+  } finally {
+    // Always clean up the in-flight entry once settled — subsequent calls
+    // will read from l0Cache (on success) or re-attempt (on failure).
+    l0InflightPromises.delete(catId);
+  }
+}
+
+/**
+ * Internal compile path — separated from `compileL0ViaSubprocess` so the
+ * in-flight dedup wrapper can install the Promise without recursing.
+ */
+async function doCompileL0(options: CompileL0Options): Promise<string> {
+  const { catId, outPath, cwd = process.cwd(), spawnFn = nodeSpawn } = options;
   const scriptPath = resolveL0CompilerScriptPath(cwd);
   if (!scriptPath) {
     throw new Error(

--- a/packages/api/src/domains/cats/services/agents/providers/l0-compiler.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/l0-compiler.ts
@@ -41,15 +41,42 @@ const l0Cache = new Map<string, string>();
 // subprocess invocation; the in-flight entry is removed once the Promise
 // settles, after which the result is in l0Cache for any subsequent reads.
 const l0InflightPromises = new Map<string, Promise<string>>();
+const l0CacheGenerations = new Map<string, number>();
+let l0GlobalGeneration = 0;
+
+function bumpL0Generation(catId?: string): void {
+  if (catId) {
+    l0CacheGenerations.set(catId, (l0CacheGenerations.get(catId) ?? 0) + 1);
+    return;
+  }
+  l0GlobalGeneration += 1;
+  l0CacheGenerations.clear();
+}
+
+function getL0Generation(catId: string): { global: number; cat: number } {
+  return {
+    global: l0GlobalGeneration,
+    cat: l0CacheGenerations.get(catId) ?? 0,
+  };
+}
+
+function isL0GenerationCurrent(catId: string, generation: { global: number; cat: number }): boolean {
+  const current = getL0Generation(catId);
+  return current.global === generation.global && current.cat === generation.cat;
+}
 
 /** Clear cached L0 for one cat or all cats (call on hot-reload / re-sync). */
 export function clearL0Cache(catId?: string): void {
   if (catId) {
     l0Cache.delete(catId);
-    // Also drop any in-flight promise — next call will re-spawn fresh.
+    bumpL0Generation(catId);
+    // Also drop any in-flight promise — next call will re-spawn fresh. The
+    // generation guard prevents the older promise from repopulating l0Cache
+    // when it eventually resolves after this clear.
     l0InflightPromises.delete(catId);
   } else {
     l0Cache.clear();
+    bumpL0Generation();
     l0InflightPromises.clear();
   }
 }
@@ -144,7 +171,7 @@ export interface CompileL0Options {
  *   exits non-zero, or produces empty output (fail-closed).
  */
 export async function compileL0ViaSubprocess(options: CompileL0Options): Promise<string> {
-  const { catId, outPath, cwd = process.cwd(), spawnFn = nodeSpawn } = options;
+  const { catId, outPath } = options;
 
   // Cache hit — skip subprocess entirely
   const cached = l0Cache.get(catId);
@@ -165,14 +192,17 @@ export async function compileL0ViaSubprocess(options: CompileL0Options): Promise
     return result;
   }
 
-  const compilePromise = doCompileL0(options);
+  const compileGeneration = getL0Generation(catId);
+  const compilePromise = doCompileL0(options, compileGeneration);
   l0InflightPromises.set(catId, compilePromise);
   try {
     return await compilePromise;
   } finally {
     // Always clean up the in-flight entry once settled — subsequent calls
     // will read from l0Cache (on success) or re-attempt (on failure).
-    l0InflightPromises.delete(catId);
+    if (l0InflightPromises.get(catId) === compilePromise) {
+      l0InflightPromises.delete(catId);
+    }
   }
 }
 
@@ -180,7 +210,10 @@ export async function compileL0ViaSubprocess(options: CompileL0Options): Promise
  * Internal compile path — separated from `compileL0ViaSubprocess` so the
  * in-flight dedup wrapper can install the Promise without recursing.
  */
-async function doCompileL0(options: CompileL0Options): Promise<string> {
+async function doCompileL0(
+  options: CompileL0Options,
+  compileGeneration: { global: number; cat: number },
+): Promise<string> {
   const { catId, outPath, cwd = process.cwd(), spawnFn = nodeSpawn } = options;
   const scriptPath = resolveL0CompilerScriptPath(cwd);
   if (!scriptPath) {
@@ -232,6 +265,8 @@ async function doCompileL0(options: CompileL0Options): Promise<string> {
     }
   }
 
-  l0Cache.set(catId, result);
+  if (isL0GenerationCurrent(catId, compileGeneration)) {
+    l0Cache.set(catId, result);
+  }
   return result;
 }

--- a/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
@@ -2,7 +2,7 @@
  * F153 Prompt X-Ray: Thin bridge between invoke-single-cat and PromptCaptureStore.
  * Fire-and-forget — never blocks invocation.
  *
- * AC-G10 (Phase G native L0 closure / KD-43): when the caller flags an F203
+ * AC-G10 (Phase G native L0 closure / KD-44): when the caller flags an F203
  * native-L0 provider, this bridge asynchronously fetches the compiled L0 via
  * `compileL0ViaSubprocess` and stamps `nativeSystemPrompt` onto the capture
  * before persisting. Fetch failures are recorded in `captureDiagnostics` —

--- a/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-bridge.ts
@@ -1,9 +1,16 @@
 /**
  * F153 Prompt X-Ray: Thin bridge between invoke-single-cat and PromptCaptureStore.
  * Fire-and-forget — never blocks invocation.
+ *
+ * AC-G10 (Phase G native L0 closure / KD-43): when the caller flags an F203
+ * native-L0 provider, this bridge asynchronously fetches the compiled L0 via
+ * `compileL0ViaSubprocess` and stamps `nativeSystemPrompt` onto the capture
+ * before persisting. Fetch failures are recorded in `captureDiagnostics` —
+ * the invocation hot path is never blocked or made to fail.
  */
 
 import { randomUUID } from 'node:crypto';
+import { compileL0ViaSubprocess } from '../../domains/cats/services/agents/providers/l0-compiler.js';
 import { createModuleLogger } from '../logger.js';
 import { pseudonymizeId } from '../telemetry/hmac.js';
 import {
@@ -38,13 +45,62 @@ export interface CaptureInput {
     forceReinjection: boolean;
     injected: boolean;
   };
+  /**
+   * AC-G10: When true, the provider injects L0 via a native system-role
+   * channel (Claude `--system-prompt-file` / Codex `-c developer_instructions`).
+   * The bridge will best-effort fetch the compiled L0 via the existing
+   * `compileL0ViaSubprocess` cache and stamp it onto `nativeSystemPrompt`.
+   * The caller flags this via `service.injectsL0Natively?.() ?? false`.
+   */
+  nativeL0Provider?: boolean;
+  /**
+   * Test seam — replaces the L0 fetcher (default `compileL0ViaSubprocess`).
+   * Production callers leave this undefined.
+   */
+  nativeL0Fetcher?: (catId: string) => Promise<string>;
 }
 
 export function capturePromptIfEnabled(input: CaptureInput): void {
   if (!isPromptCaptureEnabled(input.catId)) return;
 
+  // Spawn the async pipeline without awaiting — fire-and-forget per the
+  // F153 KD-28 invariant (capturePromptIfEnabled never blocks invocation
+  // hot path). The async fn itself catches every failure mode.
+  void runCapture(input);
+}
+
+async function runCapture(input: CaptureInput): Promise<void> {
+  const diagnostics: string[] = [];
+  let nativeSystemPrompt: string | undefined;
+  let nativeSystemPromptSource: PromptCapture['nativeSystemPromptSource'];
+  let nativeSystemTokenEstimate: number | undefined;
+
+  if (input.nativeL0Provider) {
+    const fetcher = input.nativeL0Fetcher ?? defaultFetcher;
+    try {
+      const l0 = await fetcher(input.catId);
+      if (l0 && l0.trim().length > 0) {
+        nativeSystemPrompt = l0;
+        nativeSystemPromptSource = 'f203-l0';
+        nativeSystemTokenEstimate = estimateTokens(l0);
+      } else {
+        diagnostics.push('native-l0-empty: fetcher returned empty string');
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      diagnostics.push(`native-l0-fetch-failed: ${msg}`);
+      log.warn(
+        { err, catId: input.catId },
+        'AC-G10 native L0 fetch failed (capture continues without nativeSystemPrompt)',
+      );
+    }
+  }
+
   try {
     const captureId = randomUUID();
+    const tokenEstimate = estimateTokens(input.effectivePrompt);
+    const totalTokenEstimate =
+      nativeSystemTokenEstimate !== undefined ? tokenEstimate + nativeSystemTokenEstimate : tokenEstimate;
     const data: PromptCapture = {
       captureId,
       invocationId: input.invocationId,
@@ -60,13 +116,24 @@ export function capturePromptIfEnabled(input: CaptureInput): void {
       effectivePrompt: input.effectivePrompt,
       injectionDecision: input.injectionDecision,
       promptBytes: Buffer.byteLength(input.effectivePrompt, 'utf8'),
-      tokenEstimate: estimateTokens(input.effectivePrompt),
+      tokenEstimate,
+      // AC-G10 native L0 fields — omitted when no native channel sent.
+      ...(nativeSystemPrompt !== undefined ? { nativeSystemPrompt } : {}),
+      ...(nativeSystemPromptSource !== undefined ? { nativeSystemPromptSource } : {}),
+      ...(nativeSystemTokenEstimate !== undefined ? { nativeSystemTokenEstimate } : {}),
+      totalTokenEstimate,
+      ...(diagnostics.length > 0 ? { captureDiagnostics: diagnostics } : {}),
     };
 
     getStore().captureAsync(data);
   } catch (err) {
     log.warn({ err, catId: input.catId }, 'Prompt capture failed (non-fatal)');
   }
+}
+
+/** Default L0 fetcher — module-level so tests can override via input.nativeL0Fetcher. */
+async function defaultFetcher(catId: string): Promise<string> {
+  return compileL0ViaSubprocess({ catId });
 }
 
 export function getPromptCaptureStore(): PromptCaptureStore {

--- a/packages/api/src/infrastructure/debug/prompt-capture-store.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-store.ts
@@ -32,6 +32,13 @@ export interface PromptCapture {
   model: string;
   capturedAt: number;
 
+  /**
+   * The message-system / pack prompt fed via the user-message channel.
+   * For non-F203 providers (Gemini, DARE, etc.) this is the full system prompt.
+   * For F203 native providers (Claude / Codex) this is the pack appendix
+   * delivered via `--append-system-prompt` / message body — the real system
+   * role content lives in `nativeSystemPrompt`.
+   */
   systemPrompt: string;
   missionPrefix?: string;
   userPrompt: string;
@@ -41,11 +48,57 @@ export interface PromptCapture {
     isResume: boolean;
     canSkipOnResume: boolean;
     forceReinjection: boolean;
+    /**
+     * Whether the message-system prompt was injected this turn. Note: this
+     * field describes the `systemPrompt` (pack/message-system) path only. It
+     * is NOT the truth source for whether a native L0 was sent — F203
+     * providers always inject L0 via native channel regardless of this flag.
+     * See `nativeSystemPrompt` for native channel truth.
+     */
     injected: boolean;
   };
 
   promptBytes: number;
+  /**
+   * Approximate token count for the message-channel content
+   * (`effectivePrompt`). Backward-compatible field — pre-AC-G10 captures
+   * carry only this estimate, which sometimes under-counted F203 providers
+   * because the native L0 was not visible.
+   */
   tokenEstimate: number;
+
+  // ── AC-G10 (Phase G native L0 closure / KD-43) ────────────────────
+  /**
+   * The compiled L0 system prompt delivered via the provider's native
+   * system-role channel — Claude `--system-prompt-file <l0Path>` or Codex
+   * `-c developer_instructions=<l0_toml>`. Absent for providers that do not
+   * inject L0 natively (Gemini, DARE, CatAgent etc.). Captured best-effort:
+   * if the L0 compile lookup fails at capture time, this field stays
+   * `undefined` and a `captureDiagnostics` entry records the reason — the
+   * invocation hot path is never blocked.
+   */
+  nativeSystemPrompt?: string;
+  /**
+   * Source tag for `nativeSystemPrompt`. Only one source today (`f203-l0`
+   * via `compileL0ViaSubprocess`); future native-injection sources can
+   * declare themselves here without breaking Hub UI rendering.
+   */
+  nativeSystemPromptSource?: 'f203-l0';
+  /** Approximate token count for `nativeSystemPrompt` (when present). */
+  nativeSystemTokenEstimate?: number;
+  /**
+   * Sum of `tokenEstimate + nativeSystemTokenEstimate`. Hub uses this to
+   * report the true on-wire prompt size for F203 providers (pre-AC-G10
+   * Hub reported only `tokenEstimate` and silently under-counted). When
+   * `nativeSystemPrompt` is absent this equals `tokenEstimate`.
+   */
+  totalTokenEstimate?: number;
+  /**
+   * Best-effort diagnostic notes from the capture pipeline (e.g. native L0
+   * fetch failure). Never thrown — always recorded for Hub debug surface.
+   * Absent / empty when capture ran cleanly.
+   */
+  captureDiagnostics?: readonly string[];
 }
 
 export interface CaptureIndexEntry {

--- a/packages/api/src/infrastructure/debug/prompt-capture-store.ts
+++ b/packages/api/src/infrastructure/debug/prompt-capture-store.ts
@@ -67,7 +67,7 @@ export interface PromptCapture {
    */
   tokenEstimate: number;
 
-  // ── AC-G10 (Phase G native L0 closure / KD-43) ────────────────────
+  // ── AC-G10 (Phase G native L0 closure / KD-44) ────────────────────
   /**
    * The compiled L0 system prompt delivered via the provider's native
    * system-role channel — Claude `--system-prompt-file <l0Path>` or Codex

--- a/packages/api/test/l0-compiler.test.js
+++ b/packages/api/test/l0-compiler.test.js
@@ -184,3 +184,72 @@ test('L0 template includes limb tool quick index', () => {
   assert.match(content, /limb_list_available/, 'L0 template must mention limb_list_available');
   assert.match(content, /limb_invoke/, 'L0 template must mention limb_invoke');
 });
+
+// --- AC-G10 (Phase G native L0 closure / KD-43): in-flight Promise dedup ---
+
+test('AC-G10: concurrent cold-cache compileL0ViaSubprocess calls collapse to single spawn (in-flight dedup)', async () => {
+  clearL0Cache();
+  const root = seedRepoRoot();
+  // Slow fake spawn — emits stdout + close after a microtask delay so two
+  // concurrent callers can both reach the in-flight check before settle.
+  function buildSlowSpawn(stdoutPayload) {
+    const fn = function fakeSpawn(cmd, args, opts) {
+      fn.calls.push({ cmd, args, opts });
+      const child = new EventEmitter();
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      // Two-tick delay so the second caller installs await before close.
+      setImmediate(() => {
+        setImmediate(() => {
+          child.stdout.emit('data', Buffer.from(stdoutPayload));
+          child.emit('close', 0);
+        });
+      });
+      return child;
+    };
+    fn.calls = [];
+    return fn;
+  }
+  const spawnFn = buildSlowSpawn('DEDUP-L0-OUTPUT');
+  const [out1, out2, out3] = await Promise.all([
+    compileL0ViaSubprocess({ catId: 'dedup-cat', cwd: root, spawnFn }),
+    compileL0ViaSubprocess({ catId: 'dedup-cat', cwd: root, spawnFn }),
+    compileL0ViaSubprocess({ catId: 'dedup-cat', cwd: root, spawnFn }),
+  ]);
+  assert.equal(out1, 'DEDUP-L0-OUTPUT');
+  assert.equal(out2, 'DEDUP-L0-OUTPUT');
+  assert.equal(out3, 'DEDUP-L0-OUTPUT');
+  assert.equal(spawnFn.calls.length, 1, 'three concurrent cold-cache calls must share one subprocess invocation');
+});
+
+test('AC-G10: post-dedup the cache holds result — subsequent calls do not respawn', async () => {
+  clearL0Cache();
+  const root = seedRepoRoot();
+  const spawnFn = buildFakeSpawn({ stdout: 'CACHED-AFTER-DEDUP' });
+  // Pair of concurrent calls — installs cache after settle.
+  await Promise.all([
+    compileL0ViaSubprocess({ catId: 'post-dedup-cat', cwd: root, spawnFn }),
+    compileL0ViaSubprocess({ catId: 'post-dedup-cat', cwd: root, spawnFn }),
+  ]);
+  assert.equal(spawnFn.calls.length, 1);
+  // Third call sequentially — must hit cache, not spawn again.
+  const result = await compileL0ViaSubprocess({ catId: 'post-dedup-cat', cwd: root, spawnFn });
+  assert.equal(result, 'CACHED-AFTER-DEDUP');
+  assert.equal(spawnFn.calls.length, 1, 'cache hit after dedup must skip subprocess');
+});
+
+test('AC-G10: in-flight failure does not poison cache — next call may retry', async () => {
+  clearL0Cache();
+  const root = seedRepoRoot();
+  // First spawn fails with non-zero exit.
+  const failingSpawn = buildFakeSpawn({ stderr: 'first call fails', exitCode: 2 });
+  await assert.rejects(
+    () => compileL0ViaSubprocess({ catId: 'retry-cat', cwd: root, spawnFn: failingSpawn }),
+    /retry-cat|exit|2/,
+  );
+  // Second spawn succeeds — confirms cache was not populated by the failure.
+  const goodSpawn = buildFakeSpawn({ stdout: 'RECOVERED-L0' });
+  const out = await compileL0ViaSubprocess({ catId: 'retry-cat', cwd: root, spawnFn: goodSpawn });
+  assert.equal(out, 'RECOVERED-L0');
+  assert.equal(goodSpawn.calls.length, 1);
+});

--- a/packages/api/test/l0-compiler.test.js
+++ b/packages/api/test/l0-compiler.test.js
@@ -185,7 +185,7 @@ test('L0 template includes limb tool quick index', () => {
   assert.match(content, /limb_invoke/, 'L0 template must mention limb_invoke');
 });
 
-// --- AC-G10 (Phase G native L0 closure / KD-43): in-flight Promise dedup ---
+// --- AC-G10 (Phase G native L0 closure / KD-44): in-flight Promise dedup ---
 
 test('AC-G10: concurrent cold-cache compileL0ViaSubprocess calls collapse to single spawn (in-flight dedup)', async () => {
   clearL0Cache();

--- a/packages/api/test/l0-compiler.test.js
+++ b/packages/api/test/l0-compiler.test.js
@@ -253,3 +253,33 @@ test('AC-G10: in-flight failure does not poison cache — next call may retry', 
   assert.equal(out, 'RECOVERED-L0');
   assert.equal(goodSpawn.calls.length, 1);
 });
+
+test('AC-G10: clearL0Cache during in-flight compile prevents stale result from repopulating cache', async () => {
+  clearL0Cache();
+  const root = seedRepoRoot();
+  const pending = [];
+  const controlledSpawn = function fakeSpawn(cmd, args, opts) {
+    controlledSpawn.calls.push({ cmd, args, opts });
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    pending.push(child);
+    return child;
+  };
+  controlledSpawn.calls = [];
+
+  const oldCompile = compileL0ViaSubprocess({ catId: 'clear-race-cat', cwd: root, spawnFn: controlledSpawn });
+  assert.equal(controlledSpawn.calls.length, 1);
+  assert.equal(pending.length, 1);
+
+  clearL0Cache('clear-race-cat');
+
+  pending[0].stdout.emit('data', Buffer.from('STALE-L0'));
+  pending[0].emit('close', 0);
+  assert.equal(await oldCompile, 'STALE-L0', 'the already-started caller still receives its own compile result');
+
+  const freshSpawn = buildFakeSpawn({ stdout: 'FRESH-L0' });
+  const out = await compileL0ViaSubprocess({ catId: 'clear-race-cat', cwd: root, spawnFn: freshSpawn });
+  assert.equal(out, 'FRESH-L0');
+  assert.equal(freshSpawn.calls.length, 1, 'post-clear caller must respawn instead of reading stale cache');
+});

--- a/packages/api/test/prompt-capture.test.js
+++ b/packages/api/test/prompt-capture.test.js
@@ -221,6 +221,168 @@ test('F153: API routes registered in index.ts', () => {
   assert.ok(src.includes('promptCaptureRoutes'), 'Should register prompt capture routes');
 });
 
+// ── AC-G10 (Phase G native L0 closure / KD-43): backward + new field tests ──
+
+test('AC-G10: PromptCapture without native L0 fields round-trips (backward compat)', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'ac-g10-legacy');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  // Legacy shape — pre-AC-G10 captures never had nativeSystemPrompt /
+  // totalTokenEstimate / captureDiagnostics. Must still load cleanly.
+  const capture = makeCapture();
+  store.captureSync(capture);
+  const result = store.read(capture.captureId);
+  assert.ok(result);
+  assert.equal(result.nativeSystemPrompt, undefined, 'legacy capture must not invent native fields');
+  assert.equal(result.totalTokenEstimate, undefined);
+  assert.equal(result.captureDiagnostics, undefined);
+});
+
+test('AC-G10: PromptCapture with native L0 fields persists + reads back', async () => {
+  const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');
+  const dir = join(testDir, 'ac-g10-native');
+  const store = new PromptCaptureStore({ baseDir: dir });
+
+  const capture = makeCapture({
+    nativeSystemPrompt: 'COMPILED-L0-IDENTITY-RULES-GO-HERE',
+    nativeSystemPromptSource: 'f203-l0',
+    nativeSystemTokenEstimate: 1234,
+    totalTokenEstimate: 1234 + 12, // nativeEst + msg tokenEstimate from makeCapture
+  });
+  store.captureSync(capture);
+  const result = store.read(capture.captureId);
+  assert.ok(result);
+  assert.equal(result.nativeSystemPrompt, 'COMPILED-L0-IDENTITY-RULES-GO-HERE');
+  assert.equal(result.nativeSystemPromptSource, 'f203-l0');
+  assert.equal(result.nativeSystemTokenEstimate, 1234);
+  assert.equal(result.totalTokenEstimate, 1246);
+});
+
+test('AC-G10: capture bridge stamps nativeSystemPrompt when nativeL0Provider=true (test fetcher)', async () => {
+  // Force PROMPT_CAPTURE on for this test
+  const prevEnv = process.env.PROMPT_CAPTURE;
+  process.env.PROMPT_CAPTURE = 'on';
+  try {
+    const { capturePromptIfEnabled, getPromptCaptureStore } = await import(
+      '../dist/infrastructure/debug/prompt-capture-bridge.js'
+    );
+    const _store = getPromptCaptureStore();
+    const invocationId = `g10-native-${randomUUID()}`;
+    capturePromptIfEnabled({
+      catId: 'opus',
+      invocationId,
+      threadId: 'g10-thread',
+      userId: 'g10-user',
+      model: 'claude-opus-4-6',
+      systemPrompt: 'pack-system',
+      userPrompt: 'hi',
+      effectivePrompt: 'pack-system\n\n---\n\nhi',
+      injectionDecision: { isResume: false, canSkipOnResume: true, forceReinjection: false, injected: true },
+      nativeL0Provider: true,
+      nativeL0Fetcher: async () => 'TEST-COMPILED-L0',
+    });
+    // Capture is fire-and-forget async; poll the listByInvocation index.
+    let captures = [];
+    for (let i = 0; i < 50 && captures.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      captures = _store.listByInvocation(invocationId);
+    }
+    assert.equal(captures.length, 1, 'capture must be persisted within poll window');
+    const detail = _store.read(captures[0].captureId);
+    assert.ok(detail);
+    assert.equal(detail.nativeSystemPrompt, 'TEST-COMPILED-L0');
+    assert.equal(detail.nativeSystemPromptSource, 'f203-l0');
+    assert.ok((detail.nativeSystemTokenEstimate ?? 0) > 0);
+    assert.equal(detail.totalTokenEstimate, detail.tokenEstimate + (detail.nativeSystemTokenEstimate ?? 0));
+    assert.equal(detail.captureDiagnostics, undefined, 'clean path must not record diagnostics');
+  } finally {
+    process.env.PROMPT_CAPTURE = prevEnv ?? '';
+  }
+});
+
+test('AC-G10: capture bridge records captureDiagnostics when native L0 fetcher rejects (fail-safe)', async () => {
+  const prevEnv = process.env.PROMPT_CAPTURE;
+  process.env.PROMPT_CAPTURE = 'on';
+  try {
+    const { capturePromptIfEnabled, getPromptCaptureStore } = await import(
+      '../dist/infrastructure/debug/prompt-capture-bridge.js'
+    );
+    const _store = getPromptCaptureStore();
+    const invocationId = `g10-fail-${randomUUID()}`;
+    capturePromptIfEnabled({
+      catId: 'opus',
+      invocationId,
+      threadId: 'g10-fail-thread',
+      userId: 'g10-fail-user',
+      model: 'claude-opus-4-6',
+      systemPrompt: 'pack-system',
+      userPrompt: 'hi',
+      effectivePrompt: 'pack-system\n\n---\n\nhi',
+      injectionDecision: { isResume: false, canSkipOnResume: true, forceReinjection: false, injected: true },
+      nativeL0Provider: true,
+      // Fetcher fails — bridge must still write capture, just without native fields.
+      nativeL0Fetcher: async () => {
+        throw new Error('L0 compile blew up in test');
+      },
+    });
+    let captures = [];
+    for (let i = 0; i < 50 && captures.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      captures = _store.listByInvocation(invocationId);
+    }
+    assert.equal(captures.length, 1, 'capture must be persisted even when native fetch fails');
+    const detail = _store.read(captures[0].captureId);
+    assert.ok(detail);
+    assert.equal(detail.nativeSystemPrompt, undefined, 'native fetch failure must not invent prompt');
+    assert.ok(detail.captureDiagnostics);
+    assert.equal(detail.captureDiagnostics.length, 1);
+    assert.match(detail.captureDiagnostics[0], /native-l0-fetch-failed.*L0 compile blew up/);
+  } finally {
+    process.env.PROMPT_CAPTURE = prevEnv ?? '';
+  }
+});
+
+test('AC-G10: nativeL0Provider=false (non-F203 provider) — native fields stay absent', async () => {
+  const prevEnv = process.env.PROMPT_CAPTURE;
+  process.env.PROMPT_CAPTURE = 'on';
+  try {
+    const { capturePromptIfEnabled, getPromptCaptureStore } = await import(
+      '../dist/infrastructure/debug/prompt-capture-bridge.js'
+    );
+    const _store = getPromptCaptureStore();
+    const invocationId = `g10-nonnative-${randomUUID()}`;
+    capturePromptIfEnabled({
+      catId: 'gemini',
+      invocationId,
+      threadId: 'g10-nonnative-thread',
+      userId: 'g10-nonnative-user',
+      model: 'gemini-pro',
+      systemPrompt: 'full-system-via-pack',
+      userPrompt: 'hi',
+      effectivePrompt: 'full-system-via-pack\n\n---\n\nhi',
+      injectionDecision: { isResume: false, canSkipOnResume: true, forceReinjection: false, injected: true },
+      nativeL0Provider: false,
+      // No fetcher — confirms bridge never tries to call it.
+    });
+    let captures = [];
+    for (let i = 0; i < 50 && captures.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 20));
+      captures = _store.listByInvocation(invocationId);
+    }
+    assert.equal(captures.length, 1);
+    const detail = _store.read(captures[0].captureId);
+    assert.ok(detail);
+    assert.equal(detail.nativeSystemPrompt, undefined);
+    assert.equal(detail.nativeSystemPromptSource, undefined);
+    assert.equal(detail.nativeSystemTokenEstimate, undefined);
+    assert.equal(detail.totalTokenEstimate, detail.tokenEstimate, 'no native L0 → total === msg estimate');
+    assert.equal(detail.captureDiagnostics, undefined);
+  } finally {
+    process.env.PROMPT_CAPTURE = prevEnv ?? '';
+  }
+});
+
 // Cleanup
 test('F153: cleanup test dir', () => {
   rmSync(testDir, { recursive: true, force: true });

--- a/packages/api/test/prompt-capture.test.js
+++ b/packages/api/test/prompt-capture.test.js
@@ -221,7 +221,7 @@ test('F153: API routes registered in index.ts', () => {
   assert.ok(src.includes('promptCaptureRoutes'), 'Should register prompt capture routes');
 });
 
-// ── AC-G10 (Phase G native L0 closure / KD-43): backward + new field tests ──
+// ── AC-G10 (Phase G native L0 closure / KD-44): backward + new field tests ──
 
 test('AC-G10: PromptCapture without native L0 fields round-trips (backward compat)', async () => {
   const { PromptCaptureStore } = await import('../dist/infrastructure/debug/prompt-capture-store.js');

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -295,7 +295,7 @@ interface PromptCaptureData {
   };
   promptBytes: number;
   tokenEstimate: number;
-  // AC-G10 (Phase G native L0 closure / KD-43)
+  // AC-G10 (Phase G native L0 closure / KD-44)
   nativeSystemPrompt?: string;
   nativeSystemPromptSource?: 'f203-l0';
   nativeSystemTokenEstimate?: number;

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -295,6 +295,12 @@ interface PromptCaptureData {
   };
   promptBytes: number;
   tokenEstimate: number;
+  // AC-G10 (Phase G native L0 closure / KD-43)
+  nativeSystemPrompt?: string;
+  nativeSystemPromptSource?: 'f203-l0';
+  nativeSystemTokenEstimate?: number;
+  totalTokenEstimate?: number;
+  captureDiagnostics?: readonly string[];
 }
 
 type InspectorTab = 'system' | 'user' | 'effective' | 'meta';
@@ -357,7 +363,10 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
           <span>·</span>
           <span>{(selected.promptBytes / 1024).toFixed(1)} KB</span>
           <span>·</span>
-          <span>~{selected.tokenEstimate} tokens</span>
+          {/* AC-G10: prefer totalTokenEstimate (msg + native L0) so F203
+              providers no longer silently under-count. Pre-AC-G10 captures
+              omit totalTokenEstimate → fallback to tokenEstimate (msg only). */}
+          <span>~{selected.totalTokenEstimate ?? selected.tokenEstimate} tokens</span>
         </div>
       </div>
 
@@ -381,15 +390,49 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
       <div className="mt-2 max-h-[300px] overflow-y-auto">
         {tab === 'system' && (
           <>
+            {/* AC-G10 (砚砚 Design Gate position 3): zoned display. Native L0
+                section first (provider's actual system-role channel), then
+                message-system / pack appendix. Resume amber banner only
+                applies to the message-system path — native L0 is sent every
+                turn for F203 providers regardless of `injected` flag. */}
+            {selected.nativeSystemPrompt && (
+              <PromptSection
+                content={selected.nativeSystemPrompt}
+                label={`Native L0 (system role)${
+                  selected.nativeSystemPromptSource ? ` · ${selected.nativeSystemPromptSource}` : ''
+                }`}
+                className="mb-2"
+              />
+            )}
             {!selected.injectionDecision.injected && (
               <div className="mb-2 rounded bg-conn-amber-bg px-2 py-1 text-micro text-conn-amber-text">
-                Resume — system prompt was not injected this turn
+                {selected.nativeSystemPrompt
+                  ? 'Resume — message-system pack not appended this turn (Native L0 still sent via system-role channel)'
+                  : 'Resume — system prompt was not injected this turn'}
               </div>
             )}
             <PromptSection
               content={selected.systemPrompt}
-              label={selected.injectionDecision.injected ? 'System Prompt' : 'System Prompt (not sent)'}
+              label={
+                selected.nativeSystemPrompt
+                  ? selected.injectionDecision.injected
+                    ? 'Message system prompt (pack appendix)'
+                    : 'Message system prompt (pack appendix · not sent this turn)'
+                  : selected.injectionDecision.injected
+                    ? 'System Prompt'
+                    : 'System Prompt (not sent)'
+              }
             />
+            {selected.captureDiagnostics && selected.captureDiagnostics.length > 0 && (
+              <div className="mt-2 rounded border border-conn-amber-ring bg-conn-amber-bg p-2 text-micro text-conn-amber-text">
+                <div className="mb-1 font-medium">Capture diagnostics</div>
+                <ul className="ml-3 list-disc space-y-0.5">
+                  {selected.captureDiagnostics.map((d, i) => (
+                    <li key={`${d}-${i}`}>{d}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </>
         )}
         {tab === 'user' && (
@@ -409,11 +452,15 @@ function PromptInspector({ invocationId, catId }: { invocationId?: string; catId
 
 function PromptTokenBar({ capture }: { capture: PromptCaptureData }) {
   const injected = capture.injectionDecision.injected;
+  // AC-G10: include native L0 length when present so F203 providers no
+  // longer silently under-display total prompt size in the bar.
+  const nativeLen = capture.nativeSystemPrompt?.length ?? 0;
   const sysLen = injected ? capture.systemPrompt.length : 0;
   const userLen = capture.userPrompt.length;
   const missionLen = capture.missionPrefix?.length ?? 0;
-  const total = capture.effectivePrompt.length || 1;
+  const total = nativeLen + capture.effectivePrompt.length || 1;
 
+  const nativePct = (nativeLen / total) * 100;
   const sysPct = (sysLen / total) * 100;
   const missionPct = (missionLen / total) * 100;
   const userPct = (userLen / total) * 100;
@@ -421,6 +468,13 @@ function PromptTokenBar({ capture }: { capture: PromptCaptureData }) {
   return (
     <div>
       <div className="flex h-2 overflow-hidden rounded-full bg-cafe-surface-elevated">
+        {nativePct > 0 && (
+          <div
+            className="bg-conn-purple-text"
+            style={{ width: `${nativePct}%` }}
+            title={`Native L0: ${nativePct.toFixed(0)}%`}
+          />
+        )}
         <div className="bg-conn-blue-text" style={{ width: `${sysPct}%` }} title={`System: ${sysPct.toFixed(0)}%`} />
         {missionPct > 0 && (
           <div
@@ -432,6 +486,12 @@ function PromptTokenBar({ capture }: { capture: PromptCaptureData }) {
         <div className="bg-conn-green-text" style={{ width: `${userPct}%` }} title={`User: ${userPct.toFixed(0)}%`} />
       </div>
       <div className="mt-0.5 flex gap-3 text-micro text-cafe-muted">
+        {nativePct > 0 && (
+          <span>
+            <span className="inline-block h-1.5 w-1.5 rounded-full bg-conn-purple-text" /> Native L0{' '}
+            {nativePct.toFixed(0)}%
+          </span>
+        )}
         <span>
           <span className="inline-block h-1.5 w-1.5 rounded-full bg-conn-blue-text" /> System {sysPct.toFixed(0)}%
         </span>
@@ -513,10 +573,39 @@ function PromptMeta({ capture }: { capture: PromptCaptureData }) {
             <span className="text-cafe-muted">bytes:</span> {capture.promptBytes.toLocaleString()}
           </div>
           <div>
-            <span className="text-cafe-muted">tokens (est):</span> ~{capture.tokenEstimate.toLocaleString()}
+            <span className="text-cafe-muted">tokens · message (est):</span> ~{capture.tokenEstimate.toLocaleString()}
           </div>
+          {/* AC-G10 (砚砚 立场 4): split token breakdown — Hub showed
+              tokenEstimate as if it were total before, which silently
+              under-counted F203 providers. Now native L0 + total are
+              shown separately so the gap is visible. */}
+          {capture.nativeSystemTokenEstimate !== undefined && (
+            <div>
+              <span className="text-cafe-muted">tokens · native L0 (est):</span> ~
+              {capture.nativeSystemTokenEstimate.toLocaleString()}
+              {capture.nativeSystemPromptSource ? (
+                <span className="ml-1 text-cafe-muted">({capture.nativeSystemPromptSource})</span>
+              ) : null}
+            </div>
+          )}
+          {capture.totalTokenEstimate !== undefined && capture.totalTokenEstimate !== capture.tokenEstimate && (
+            <div>
+              <span className="text-cafe-muted">tokens · total (est):</span> ~
+              {capture.totalTokenEstimate.toLocaleString()}
+            </div>
+          )}
         </div>
       </div>
+      {capture.captureDiagnostics && capture.captureDiagnostics.length > 0 && (
+        <div>
+          <div className="font-medium text-cafe-muted">Capture Diagnostics</div>
+          <ul className="ml-3 list-disc space-y-0.5">
+            {capture.captureDiagnostics.map((d, i) => (
+              <li key={`${d}-${i}`}>{d}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes the long-standing Prompt X-Ray gap for F203 native-L0 providers (Claude \`--system-prompt-file\` / Codex \`-c developer_instructions=\`). Pre-fix Hub \`System\` tab silently displayed only the message-system pack so operators could not tell whether the empty tab meant "PROMPT_CAPTURE off", "non-F203 provider", or "F203 capture wired but L0 missing".

\"整体交付\" path B per CVO 2026-06-03 directive — single PR landing impl + tests + doc sync for the full Phase G closure.

## Implements all four positions from 砚砚's Design Gate review (2026-06-03)

1. **\`l0-compiler.ts\` in-flight Promise dedup** — capture + native injection may race the cold cache. Without dedup both spawn subprocess. New \`l0InflightPromises\` Map collapses concurrent compiles onto one spawn; in-flight entry is dropped on settle so failure does not poison cache.
2. **\`PromptCapture\` schema** keeps \`systemPrompt\` (pack-only for F203 / full for non-F203) and adds \`nativeSystemPrompt\`, \`nativeSystemPromptSource: 'f203-l0'\`, \`nativeSystemTokenEstimate\`, \`totalTokenEstimate\`, \`captureDiagnostics\`. Backward-compat: pre-AC-G10 captures load with the new fields \`undefined\`.
3. **Hub UI single System tab with zoned display** — Native L0 panel first, message-system pack appendix below; resume amber banner now distinguishes "message-system not appended this turn" from "native L0 not sent" (which never happens for F203). Capture diagnostics rendered as amber list.
4. **Token breakdown split** — header total uses \`totalTokenEstimate ?? tokenEstimate\`; Meta tab breaks out msg / native L0 / total tokens so F203 providers no longer silently under-count. Token bar gets a purple Native L0 segment.

## Fire-and-forget invariant preserved (F153 KD-28)

\`capturePromptIfEnabled\` returns \`void\` and spawns internal \`runCapture()\`; L0 fetcher is async with try/catch; failure records \`native-l0-fetch-failed: <reason>\` into \`captureDiagnostics\` while still persisting the capture. invoke-single-cat passes \`nativeL0Provider: service.injectsL0Natively?.() ?? false\` so non-F203 services skip the L0 fetch entirely.

## Test coverage (35/35 pass)

- \`l0-compiler.test.js\` 15/15 — 4 new AC-G10 tests (concurrent cold-cache dedup / post-dedup cache reuse / failure-does-not-poison-cache retry / clear-during-inflight stale-cache guard)
- \`prompt-capture.test.js\` 20/20 — 5 new AC-G10 tests (schema round-trip new fields / backward-compat without new fields / bridge native L0 stamping via test fetcher / fail-safe diagnostic on fetcher reject / non-native provider passthrough)

## Doc sync (same PR, 路径 B)

- Phase G header: \`Status: spec\` → \`merged\` + Implementation block (PR #619 intake + this AC-G10 follow-up)
- AC-G1..G9 marked \`[x]\` with code citations (PR #619 work was already shipped in main but doc never sync'd)
- AC-G10 marked \`[x]\` with full closure narrative
- KD-44 added — records the four 砚砚 Design Gate decisions

## Files changed (+578 / -20, 8 files)

| File | Purpose |
|------|---------|
| \`l0-compiler.ts\` | In-flight Promise dedup |
| \`prompt-capture-store.ts\` | Schema extension + comments |
| \`prompt-capture-bridge.ts\` | Async runCapture + native L0 fetch + fail-safe diagnostic |
| \`invoke-single-cat.ts\` | \`nativeL0Provider\` flag from \`service.injectsL0Natively\` |
| \`HubTraceTree.tsx\` | System tab zones / token bar / Meta tab / diagnostics rendering |
| \`l0-compiler.test.js\` | 4 new AC-G10 dedup/invalidation tests |
| \`prompt-capture.test.js\` | 5 new AC-G10 schema + bridge tests |
| \`F153-observability-infra.md\` | Phase G \`merged\` + AC-G1..G10 \`[x]\` + KD-44 |

## Light gates

- Biome auto-fix applied (3 formatter fixes); subsequent check clean on changed files
- dir-size: pass (warnings only, pre-existing)
- \`pnpm --filter @cat-cafe/api build\`: pass

[宪宪/opus-4.7 🐾]