### PR TITLE
fix(security): harden internal admin and debug route gates

### DIFF
--- a/packages/api/src/routes/f163-admin.ts
+++ b/packages/api/src/routes/f163-admin.ts
@@ -10,6 +10,7 @@ import { DuplicateScanner } from '../domains/memory/f163-duplicate-scanner.js';
 import { F163ExperimentLogger } from '../domains/memory/f163-experiment-logger.js';
 import type { F163Authority } from '../domains/memory/f163-types.js';
 import { computeVariantId, freezeFlags } from '../domains/memory/f163-types.js';
+import { requirePrivilegedRouteOwner } from '../utils/privileged-route-guard.js';
 
 const AUTHORITY_LEVELS: F163Authority[] = ['observed', 'candidate', 'validated', 'constitutional'];
 
@@ -49,14 +50,15 @@ const applySchema = z.object({
   rationale: z.string().min(1),
 });
 
+const F163_ADMIN_GATE = {
+  surface: 'F163 admin routes',
+  ownerErrorMessage: 'F163 admin routes can only be accessed by the configured owner',
+};
+
 export const f163AdminRoutes: FastifyPluginAsync<F163AdminRoutesOptions> = async (app, opts) => {
   app.post('/api/f163/promote', async (request, reply) => {
-    // Localhost-only guard
-    const remoteIp = request.ip;
-    if (remoteIp !== '127.0.0.1' && remoteIp !== '::1' && remoteIp !== '::ffff:127.0.0.1') {
-      reply.status(403);
-      return { error: 'promote only allowed from localhost' };
-    }
+    const gate = requirePrivilegedRouteOwner(request, reply, F163_ADMIN_GATE);
+    if (!gate.ok) return gate.response;
 
     const parsed = promoteSchema.safeParse(request.body);
     if (!parsed.success) {
@@ -116,12 +118,8 @@ export const f163AdminRoutes: FastifyPluginAsync<F163AdminRoutesOptions> = async
   // ── Phase B: Compression scan (AC-B1) ──────────────────────────────
 
   app.post('/api/f163/compress/scan', async (request, reply) => {
-    // Localhost-only guard
-    const remoteIp = request.ip;
-    if (remoteIp !== '127.0.0.1' && remoteIp !== '::1' && remoteIp !== '::ffff:127.0.0.1') {
-      reply.status(403);
-      return { error: 'compression scan only allowed from localhost' };
-    }
+    const gate = requirePrivilegedRouteOwner(request, reply, F163_ADMIN_GATE);
+    if (!gate.ok) return gate.response;
 
     // Flag gate: compression must not be 'off'
     const flags = freezeFlags();
@@ -161,12 +159,8 @@ export const f163AdminRoutes: FastifyPluginAsync<F163AdminRoutesOptions> = async
   // ── Phase B: Compression apply (AC-B2) ─────────────────────────────
 
   app.post('/api/f163/compress/apply', async (request, reply) => {
-    // Localhost-only guard
-    const remoteIp = request.ip;
-    if (remoteIp !== '127.0.0.1' && remoteIp !== '::1' && remoteIp !== '::ffff:127.0.0.1') {
-      reply.status(403);
-      return { error: 'compression apply only allowed from localhost' };
-    }
+    const gate = requirePrivilegedRouteOwner(request, reply, F163_ADMIN_GATE);
+    if (!gate.ok) return gate.response;
 
     // Flag gate: compression must be 'apply'
     const flags = freezeFlags();
@@ -211,6 +205,9 @@ export const f163AdminRoutes: FastifyPluginAsync<F163AdminRoutesOptions> = async
   // ── Phase B: Source expansion (AC-B3) ──────────────────────────────
 
   app.get('/api/f163/expand/:anchor', async (request, reply) => {
+    const gate = requirePrivilegedRouteOwner(request, reply, F163_ADMIN_GATE);
+    if (!gate.ok) return gate.response;
+
     const { anchor } = request.params as { anchor: string };
 
     // Look up the doc

--- a/packages/api/src/routes/prompt-captures.ts
+++ b/packages/api/src/routes/prompt-captures.ts
@@ -3,25 +3,24 @@
  * All endpoints require session auth (localhost-only by default).
  */
 
-import type { FastifyPluginAsync } from 'fastify';
+import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { getPromptCaptureStore } from '../infrastructure/debug/prompt-capture-bridge.js';
 import { isPromptCaptureEnabled } from '../infrastructure/debug/prompt-capture-store.js';
+import { requirePrivilegedRouteOwner } from '../utils/privileged-route-guard.js';
 
-function requireSession(
-  request: import('fastify').FastifyRequest,
-  reply: import('fastify').FastifyReply,
-): string | null {
-  const userId = (request as import('fastify').FastifyRequest & { sessionUserId?: string }).sessionUserId;
-  if (!userId) {
-    reply.status(401).send({ error: 'Session required' });
-    return null;
-  }
-  return userId;
+const PROMPT_CAPTURE_GATE = {
+  surface: 'Prompt capture debug routes',
+  ownerErrorMessage: 'Prompt captures can only be accessed by the configured owner',
+};
+
+function requirePromptCaptureOwner(request: FastifyRequest, reply: FastifyReply) {
+  return requirePrivilegedRouteOwner(request, reply, PROMPT_CAPTURE_GATE);
 }
 
 export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
   app.get('/api/debug/prompt-captures/status', async (request, reply) => {
-    if (!requireSession(request, reply)) return;
+    const gate = requirePromptCaptureOwner(request, reply);
+    if (!gate.ok) return gate.response;
     const store = getPromptCaptureStore();
     return {
       enabled: isPromptCaptureEnabled(),
@@ -34,8 +33,9 @@ export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
   app.get<{ Querystring: { threadId?: string; invocationId?: string; limit?: string } }>(
     '/api/debug/prompt-captures',
     async (request, reply) => {
-      const userId = requireSession(request, reply);
-      if (!userId) return;
+      const gate = requirePromptCaptureOwner(request, reply);
+      if (!gate.ok) return gate.response;
+      const { userId } = gate;
       const store = getPromptCaptureStore();
       const limit = Math.min(parseInt(request.query.limit ?? '20', 10) || 20, 100);
 
@@ -50,8 +50,9 @@ export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
   );
 
   app.get<{ Params: { captureId: string } }>('/api/debug/prompt-captures/:captureId', async (request, reply) => {
-    const userId = requireSession(request, reply);
-    if (!userId) return;
+    const gate = requirePromptCaptureOwner(request, reply);
+    if (!gate.ok) return gate.response;
+    const { userId } = gate;
     const { captureId } = request.params;
     if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/.test(captureId)) {
       return reply.status(400).send({ error: 'Invalid captureId format' });
@@ -64,7 +65,8 @@ export const promptCaptureRoutes: FastifyPluginAsync = async (app) => {
   });
 
   app.post('/api/debug/prompt-captures/prune', async (request, reply) => {
-    if (!requireSession(request, reply)) return;
+    const gate = requirePromptCaptureOwner(request, reply);
+    if (!gate.ok) return gate.response;
     const removed = getPromptCaptureStore().prune();
     return { removed };
   });

--- a/packages/api/src/utils/privileged-route-guard.ts
+++ b/packages/api/src/utils/privileged-route-guard.ts
@@ -1,0 +1,45 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { isDirectLoopbackRequest } from './loopback-request.js';
+import { resolveOwnerGate } from './owner-gate.js';
+
+export type PrivilegedRouteGuardResult = { ok: true; userId: string } | { ok: false; response: { error: string } };
+
+export interface PrivilegedRouteGuardOptions {
+  surface: string;
+  ownerErrorMessage?: string;
+}
+
+function resolveSessionUserId(request: FastifyRequest): string | null {
+  const userId = (request as FastifyRequest & { sessionUserId?: string }).sessionUserId;
+  return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+}
+
+export function requirePrivilegedRouteOwner(
+  request: FastifyRequest,
+  reply: FastifyReply,
+  options: PrivilegedRouteGuardOptions,
+): PrivilegedRouteGuardResult {
+  const userId = resolveSessionUserId(request);
+  if (!userId) {
+    reply.status(401);
+    return { ok: false, response: { error: 'Authenticated session required (establish via GET /api/session)' } };
+  }
+
+  if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
+    reply.status(403);
+    return {
+      ok: false,
+      response: { error: `${options.surface} from non-localhost requires DEFAULT_OWNER_USER_ID to be configured` },
+    };
+  }
+
+  const gateResult = resolveOwnerGate(userId, {
+    errorMessage: options.ownerErrorMessage ?? `${options.surface} can only be accessed by the configured owner`,
+  });
+  if (gateResult) {
+    reply.status(gateResult.status);
+    return { ok: false, response: { error: gateResult.error } };
+  }
+
+  return { ok: true, userId };
+}

--- a/packages/api/src/utils/privileged-route-guard.ts
+++ b/packages/api/src/utils/privileged-route-guard.ts
@@ -14,6 +14,11 @@ function resolveSessionUserId(request: FastifyRequest): string | null {
   return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
 }
 
+function resolveConfiguredOwnerUserId(): string | null {
+  const ownerId = process.env.DEFAULT_OWNER_USER_ID?.trim();
+  return ownerId ? ownerId : null;
+}
+
 export function requirePrivilegedRouteOwner(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -25,11 +30,14 @@ export function requirePrivilegedRouteOwner(
     return { ok: false, response: { error: 'Authenticated session required (establish via GET /api/session)' } };
   }
 
-  if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
+  const configuredOwnerId = resolveConfiguredOwnerUserId();
+  if (!isDirectLoopbackRequest(request) && (!configuredOwnerId || configuredOwnerId === 'default-user')) {
     reply.status(403);
     return {
       ok: false,
-      response: { error: `${options.surface} from non-localhost requires DEFAULT_OWNER_USER_ID to be configured` },
+      response: {
+        error: `${options.surface} from non-localhost requires DEFAULT_OWNER_USER_ID to be configured to a non-default owner`,
+      },
     };
   }
 

--- a/packages/api/test/f163-zero-behavior.test.js
+++ b/packages/api/test/f163-zero-behavior.test.js
@@ -8,7 +8,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { afterEach, beforeEach, describe, it } from 'node:test';
+import { afterEach, describe, it } from 'node:test';
 import Database from 'better-sqlite3';
 import Fastify from 'fastify';
 import { computeVariantId, freezeFlags } from '../dist/domains/memory/f163-types.js';
@@ -16,11 +16,28 @@ import { SqliteEvidenceStore } from '../dist/domains/memory/SqliteEvidenceStore.
 import { applyMigrations } from '../dist/domains/memory/schema.js';
 import { evidenceRoutes } from '../dist/routes/evidence.js';
 
+const ORIGINAL_DEFAULT_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
+
+function restoreDefaultOwnerUserId() {
+  if (ORIGINAL_DEFAULT_OWNER_USER_ID === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+  else process.env.DEFAULT_OWNER_USER_ID = ORIGINAL_DEFAULT_OWNER_USER_ID;
+}
+
+function installTestSessionHook(app) {
+  app.addHook('preHandler', async (request) => {
+    const sessionUser = request.headers['x-test-session-user'];
+    if (typeof sessionUser === 'string' && sessionUser.trim()) {
+      request.sessionUserId = sessionUser.trim();
+    }
+  });
+}
+
 describe('F163 Zero-behavior regression', () => {
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('F163_')) delete process.env[key];
     }
+    restoreDefaultOwnerUserId();
   });
 
   it('all flags off = no authority boost applied', async () => {
@@ -188,13 +205,15 @@ describe('F163 Zero-behavior regression', () => {
 
     const { f163AdminRoutes } = await import('../dist/routes/f163-admin.js');
     const app = Fastify();
+    installTestSessionHook(app);
     await app.register(f163AdminRoutes, { evidenceStore: store });
     await app.ready();
 
+    process.env.DEFAULT_OWNER_USER_ID = 'f163-owner';
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: { 'x-test-session-user': 'f163-owner' },
     });
     assert.equal(res.statusCode, 403, 'scan should be blocked when compression=off');
   });
@@ -212,13 +231,15 @@ describe('F163 Zero-behavior regression', () => {
     // But the API level should block it
     const { f163AdminRoutes } = await import('../dist/routes/f163-admin.js');
     const app = Fastify();
+    installTestSessionHook(app);
     await app.register(f163AdminRoutes, { evidenceStore: store });
     await app.ready();
 
+    process.env.DEFAULT_OWNER_USER_ID = 'f163-owner';
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: { 'x-test-session-user': 'f163-owner' },
       payload: {
         sourceAnchors: ['nonexistent'],
         summaryTitle: 'Test',

--- a/packages/api/test/helpers/f163-admin-auth.js
+++ b/packages/api/test/helpers/f163-admin-auth.js
@@ -1,0 +1,23 @@
+export const F163_TEST_OWNER_USER_ID = 'f163-test-owner';
+
+export function installF163AdminTestSessionHook(app) {
+  app.addHook('preHandler', async (request) => {
+    const sessionUser = request.headers['x-test-session-user'];
+    if (typeof sessionUser === 'string' && sessionUser.trim()) {
+      request.sessionUserId = sessionUser.trim();
+    }
+  });
+}
+
+export function useF163TestOwner() {
+  process.env.DEFAULT_OWNER_USER_ID = F163_TEST_OWNER_USER_ID;
+}
+
+export function restoreDefaultOwnerUserId(originalDefaultOwnerUserId) {
+  if (originalDefaultOwnerUserId === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+  else process.env.DEFAULT_OWNER_USER_ID = originalDefaultOwnerUserId;
+}
+
+export function f163OwnerHeaders(extra = {}) {
+  return { 'x-test-session-user': F163_TEST_OWNER_USER_ID, ...extra };
+}

--- a/packages/api/test/memory/f163-compression-api.test.js
+++ b/packages/api/test/memory/f163-compression-api.test.js
@@ -9,16 +9,26 @@ import { afterEach, describe, it } from 'node:test';
 import Fastify from 'fastify';
 import { SqliteEvidenceStore } from '../../dist/domains/memory/SqliteEvidenceStore.js';
 import { f163AdminRoutes } from '../../dist/routes/f163-admin.js';
+import {
+  f163OwnerHeaders,
+  installF163AdminTestSessionHook,
+  restoreDefaultOwnerUserId,
+  useF163TestOwner,
+} from '../helpers/f163-admin-auth.js';
+
+const ORIGINAL_DEFAULT_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
 
 describe('F163 compression scan API (AC-B1)', () => {
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('F163_')) delete process.env[key];
     }
+    restoreDefaultOwnerUserId(ORIGINAL_DEFAULT_OWNER_USER_ID);
   });
 
   async function setup(compressionFlag) {
     if (compressionFlag) process.env.F163_COMPRESSION = compressionFlag;
+    useF163TestOwner();
 
     const store = new SqliteEvidenceStore(':memory:');
     await store.initialize();
@@ -52,6 +62,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     ]);
 
     const app = Fastify();
+    installF163AdminTestSessionHook(app);
     await app.register(f163AdminRoutes, { evidenceStore: store });
     await app.ready();
     return { app, store };
@@ -62,7 +73,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
     });
     assert.equal(res.statusCode, 403);
     const body = res.json();
@@ -74,7 +85,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
     });
     assert.equal(res.statusCode, 403);
   });
@@ -84,7 +95,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: { threshold: 0.2 },
     });
     assert.equal(res.statusCode, 200);
@@ -97,7 +108,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: { threshold: 0.2 },
     });
     assert.equal(res.statusCode, 200);
@@ -107,10 +118,11 @@ describe('F163 compression scan API (AC-B1)', () => {
 
   it('rejects non-localhost requests', async () => {
     const { app } = await setup('suggest');
+    delete process.env.DEFAULT_OWNER_USER_ID;
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '192.168.1.100' },
+      headers: f163OwnerHeaders({ 'x-forwarded-for': '192.168.1.100' }),
       remoteAddress: '192.168.1.100',
     });
     assert.equal(res.statusCode, 403);
@@ -121,7 +133,7 @@ describe('F163 compression scan API (AC-B1)', () => {
     await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: { threshold: 0.3 },
     });
 
@@ -137,13 +149,13 @@ describe('F163 compression scan API (AC-B1)', () => {
     await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: { threshold: 0.3 },
     });
     await app.inject({
       method: 'POST',
       url: '/api/f163/compress/scan',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: { threshold: 0.3 },
     });
 

--- a/packages/api/test/memory/f163-compression-apply.test.js
+++ b/packages/api/test/memory/f163-compression-apply.test.js
@@ -9,16 +9,26 @@ import { afterEach, describe, it } from 'node:test';
 import Fastify from 'fastify';
 import { SqliteEvidenceStore } from '../../dist/domains/memory/SqliteEvidenceStore.js';
 import { f163AdminRoutes } from '../../dist/routes/f163-admin.js';
+import {
+  f163OwnerHeaders,
+  installF163AdminTestSessionHook,
+  restoreDefaultOwnerUserId,
+  useF163TestOwner,
+} from '../helpers/f163-admin-auth.js';
+
+const ORIGINAL_DEFAULT_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
 
 describe('F163 compression apply API (AC-B2)', () => {
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('F163_')) delete process.env[key];
     }
+    restoreDefaultOwnerUserId(ORIGINAL_DEFAULT_OWNER_USER_ID);
   });
 
   async function setup(compressionFlag) {
     if (compressionFlag) process.env.F163_COMPRESSION = compressionFlag;
+    useF163TestOwner();
 
     const store = new SqliteEvidenceStore(':memory:');
     await store.initialize();
@@ -52,6 +62,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     ]);
 
     const app = Fastify();
+    installF163AdminTestSessionHook(app);
     await app.register(f163AdminRoutes, { evidenceStore: store });
     await app.ready();
     return { app, store };
@@ -62,7 +73,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02'],
         summaryTitle: 'Redis keyPrefix scripting summary',
@@ -78,7 +89,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02'],
         summaryTitle: 'Summary',
@@ -94,7 +105,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02', 'LL-A03'],
         summaryTitle: 'Redis keyPrefix scripting behavior',
@@ -131,7 +142,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'NONEXISTENT'],
         summaryTitle: 'Summary',
@@ -149,7 +160,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02'],
         summaryTitle: 'Logging test summary',
@@ -171,7 +182,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02'],
         summaryTitle: 'First apply',
@@ -191,7 +202,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01'],
         summaryTitle: 'Single source summary',
@@ -209,7 +220,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res1 = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-A01', 'LL-A02'],
         summaryTitle: 'First summary',
@@ -224,7 +235,7 @@ describe('F163 compression apply API (AC-B2)', () => {
     const res2 = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: [summaryAnchor, 'LL-A03'],
         summaryTitle: 'Second summary',

--- a/packages/api/test/memory/f163-expand.test.js
+++ b/packages/api/test/memory/f163-expand.test.js
@@ -8,16 +8,26 @@ import { afterEach, describe, it } from 'node:test';
 import Fastify from 'fastify';
 import { SqliteEvidenceStore } from '../../dist/domains/memory/SqliteEvidenceStore.js';
 import { f163AdminRoutes } from '../../dist/routes/f163-admin.js';
+import {
+  f163OwnerHeaders,
+  installF163AdminTestSessionHook,
+  restoreDefaultOwnerUserId,
+  useF163TestOwner,
+} from '../helpers/f163-admin-auth.js';
+
+const ORIGINAL_DEFAULT_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
 
 describe('F163 source expansion API (AC-B3)', () => {
   afterEach(() => {
     for (const key of Object.keys(process.env)) {
       if (key.startsWith('F163_')) delete process.env[key];
     }
+    restoreDefaultOwnerUserId(ORIGINAL_DEFAULT_OWNER_USER_ID);
   });
 
   async function setup() {
     process.env.F163_COMPRESSION = 'apply';
+    useF163TestOwner();
     const store = new SqliteEvidenceStore(':memory:');
     await store.initialize();
 
@@ -43,13 +53,14 @@ describe('F163 source expansion API (AC-B3)', () => {
 
     // Create summary via the API
     const app = Fastify();
+    installF163AdminTestSessionHook(app);
     await app.register(f163AdminRoutes, { evidenceStore: store });
     await app.ready();
 
     const applyRes = await app.inject({
       method: 'POST',
       url: '/api/f163/compress/apply',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
       payload: {
         sourceAnchors: ['LL-E01', 'LL-E02'],
         summaryTitle: 'Combined lesson',
@@ -68,7 +79,7 @@ describe('F163 source expansion API (AC-B3)', () => {
     const res = await app.inject({
       method: 'GET',
       url: `/api/f163/expand/${summaryAnchor}`,
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 200);
@@ -88,7 +99,7 @@ describe('F163 source expansion API (AC-B3)', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/f163/expand/NONEXISTENT',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 404);
@@ -100,7 +111,7 @@ describe('F163 source expansion API (AC-B3)', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/f163/expand/LL-E01',
-      headers: { 'x-forwarded-for': '127.0.0.1' },
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 400);

--- a/packages/api/test/memory/f163-promotion.test.js
+++ b/packages/api/test/memory/f163-promotion.test.js
@@ -3,17 +3,31 @@
  */
 
 import assert from 'node:assert/strict';
-import { beforeEach, describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 import Fastify from 'fastify';
 import { SqliteEvidenceStore } from '../../dist/domains/memory/SqliteEvidenceStore.js';
 import { f163AdminRoutes } from '../../dist/routes/f163-admin.js';
+import {
+  f163OwnerHeaders,
+  installF163AdminTestSessionHook,
+  restoreDefaultOwnerUserId,
+  useF163TestOwner,
+} from '../helpers/f163-admin-auth.js';
+
+const ORIGINAL_DEFAULT_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
 
 describe('POST /api/f163/promote', () => {
   let app;
   let store;
 
+  afterEach(() => {
+    restoreDefaultOwnerUserId(ORIGINAL_DEFAULT_OWNER_USER_ID);
+  });
+
   beforeEach(async () => {
+    useF163TestOwner();
     app = Fastify();
+    installF163AdminTestSessionHook(app);
     store = new SqliteEvidenceStore(':memory:');
     await store.initialize();
 
@@ -44,7 +58,7 @@ describe('POST /api/f163/promote', () => {
         targetAuthority: 'candidate',
         reason: 'Confirmed by review',
       },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 200);
@@ -71,7 +85,7 @@ describe('POST /api/f163/promote', () => {
         targetAuthority: 'validated',
         reason: 'Validated by CVO',
       },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 200);
@@ -91,7 +105,7 @@ describe('POST /api/f163/promote', () => {
         targetAuthority: 'observed',
         reason: 'Trying to demote',
       },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 400);
@@ -111,7 +125,7 @@ describe('POST /api/f163/promote', () => {
         targetAuthority: 'constitutional',
         reason: 'Trying to go constitutional',
       },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 403);
@@ -128,7 +142,7 @@ describe('POST /api/f163/promote', () => {
         targetAuthority: 'candidate',
         reason: 'Test',
       },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 404);
@@ -139,7 +153,7 @@ describe('POST /api/f163/promote', () => {
       method: 'POST',
       url: '/api/f163/promote',
       payload: { anchor: 'test-promote-1' },
-      remoteAddress: '127.0.0.1',
+      headers: f163OwnerHeaders(),
     });
 
     assert.equal(res.statusCode, 400);

--- a/packages/api/test/security-owner-gates.test.js
+++ b/packages/api/test/security-owner-gates.test.js
@@ -116,6 +116,23 @@ describe('security owner/network gates for #835 surfaces', () => {
     await app.close();
   });
 
+  it('rejects proxied privileged routes when owner is the public default session user', async () => {
+    process.env.DEFAULT_OWNER_USER_ID = 'default-user';
+    const app = await buildF163App();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/f163/expand/summary-anchor',
+      headers: {
+        'x-test-session-user': 'default-user',
+        'x-forwarded-for': '192.168.1.23',
+      },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /localhost/i);
+    await app.close();
+  });
+
   it('rejects proxied F163 promote writes when no owner is configured', async () => {
     delete process.env.DEFAULT_OWNER_USER_ID;
     const app = await buildF163App();

--- a/packages/api/test/security-owner-gates.test.js
+++ b/packages/api/test/security-owner-gates.test.js
@@ -1,0 +1,214 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import Fastify from 'fastify';
+
+const { f163AdminRoutes } = await import('../dist/routes/f163-admin.js');
+const { promptCaptureRoutes } = await import('../dist/routes/prompt-captures.js');
+
+const ORIGINAL_OWNER_ID = process.env.DEFAULT_OWNER_USER_ID;
+const ORIGINAL_F163_COMPRESSION = process.env.F163_COMPRESSION;
+
+function restoreEnv() {
+  if (ORIGINAL_OWNER_ID === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+  else process.env.DEFAULT_OWNER_USER_ID = ORIGINAL_OWNER_ID;
+
+  if (ORIGINAL_F163_COMPRESSION === undefined) delete process.env.F163_COMPRESSION;
+  else process.env.F163_COMPRESSION = ORIGINAL_F163_COMPRESSION;
+}
+
+function installTestSessionHook(app) {
+  app.addHook('preHandler', async (request) => {
+    const sessionUser = request.headers['x-test-session-user'];
+    if (typeof sessionUser === 'string' && sessionUser.trim()) {
+      request.sessionUserId = sessionUser.trim();
+    }
+  });
+}
+
+function createEvidenceStore() {
+  const docs = new Map([
+    [
+      'summary-anchor',
+      {
+        anchor: 'summary-anchor',
+        authority: 'validated',
+        title: 'Sensitive summary',
+        summary: 'Summary that expands into source prompt evidence',
+      },
+    ],
+    [
+      'source-a',
+      {
+        anchor: 'source-a',
+        authority: 'observed',
+        title: 'Source A',
+        summary: 'Sensitive source payload',
+      },
+    ],
+    ['promote-anchor', { anchor: 'promote-anchor', authority: 'observed' }],
+  ]);
+
+  const db = {
+    prepare(sql) {
+      return {
+        all() {
+          if (sql.includes('SELECT source_ids, summary_of_anchor')) {
+            return [{ source_ids: JSON.stringify(['source-a']), summary_of_anchor: 'summary-anchor' }];
+          }
+          return [];
+        },
+        run() {
+          return { changes: 1 };
+        },
+      };
+    },
+  };
+
+  return {
+    getByAnchor: async (anchor) => docs.get(anchor) ?? null,
+    getDb: () => db,
+    runExclusive: async (fn) => fn(),
+    createSummary: async () => 'summary-new',
+  };
+}
+
+async function buildF163App() {
+  const app = Fastify({ logger: false });
+  installTestSessionHook(app);
+  await app.register(f163AdminRoutes, { evidenceStore: createEvidenceStore() });
+  await app.ready();
+  return app;
+}
+
+async function buildPromptCaptureApp() {
+  const app = Fastify({ logger: false });
+  installTestSessionHook(app);
+  await app.register(promptCaptureRoutes);
+  await app.ready();
+  return app;
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe('security owner/network gates for #835 surfaces', () => {
+  it('rejects unauthenticated F163 expand reads', async () => {
+    const app = await buildF163App();
+    const res = await app.inject({ method: 'GET', url: '/api/f163/expand/summary-anchor' });
+
+    assert.equal(res.statusCode, 401);
+    assert.match(res.json().error, /session/i);
+    await app.close();
+  });
+
+  it('allows F163 expand for configured owner sessions', async () => {
+    process.env.DEFAULT_OWNER_USER_ID = 'owner-1';
+    const app = await buildF163App();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/f163/expand/summary-anchor',
+      headers: { 'x-test-session-user': 'owner-1' },
+    });
+
+    assert.equal(res.statusCode, 200, res.body);
+    assert.equal(res.json().summary.anchor, 'summary-anchor');
+    await app.close();
+  });
+
+  it('rejects proxied F163 promote writes when no owner is configured', async () => {
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    const app = await buildF163App();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/f163/promote',
+      headers: {
+        'x-test-session-user': 'default-user',
+        'x-forwarded-for': '192.168.1.23',
+      },
+      payload: {
+        anchor: 'promote-anchor',
+        targetAuthority: 'candidate',
+        reason: 'test promotion',
+      },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /DEFAULT_OWNER_USER_ID/);
+    await app.close();
+  });
+
+  it('rejects proxied F163 compression scan when no owner is configured', async () => {
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    process.env.F163_COMPRESSION = 'suggest';
+    const app = await buildF163App();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/f163/compress/scan',
+      headers: {
+        'x-test-session-user': 'default-user',
+        'x-forwarded-for': '192.168.1.23',
+      },
+      payload: { threshold: 0.75 },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /DEFAULT_OWNER_USER_ID/);
+    await app.close();
+  });
+
+  it('rejects proxied F163 compression apply when no owner is configured', async () => {
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    process.env.F163_COMPRESSION = 'apply';
+    const app = await buildF163App();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/f163/compress/apply',
+      headers: {
+        'x-test-session-user': 'default-user',
+        'x-forwarded-for': '192.168.1.23',
+      },
+      payload: {
+        sourceAnchors: ['source-a', 'source-b'],
+        summaryTitle: 'summary',
+        summarySummary: 'summary body',
+        rationale: 'test compression',
+      },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /DEFAULT_OWNER_USER_ID/);
+    await app.close();
+  });
+
+  it('rejects prompt-capture debug reads for non-owner sessions', async () => {
+    process.env.DEFAULT_OWNER_USER_ID = 'owner-1';
+    const app = await buildPromptCaptureApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/debug/prompt-captures/status',
+      headers: { 'x-test-session-user': 'not-owner' },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /owner/i);
+    await app.close();
+  });
+
+  it('rejects proxied prompt-capture debug reads when no owner is configured', async () => {
+    delete process.env.DEFAULT_OWNER_USER_ID;
+    const app = await buildPromptCaptureApp();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/debug/prompt-captures/status',
+      headers: {
+        'x-test-session-user': 'default-user',
+        'x-forwarded-for': '192.168.1.23',
+      },
+    });
+
+    assert.equal(res.statusCode, 403);
+    assert.match(res.json().error, /DEFAULT_OWNER_USER_ID/);
+    await app.close();
+  });
+});


### PR DESCRIPTION
## What

- Applies the existing privileged owner/network gate semantics to internal admin/debug surfaces.
- Adds regression coverage for unauthorized, non-owner, and non-local privileged access paths.
- Ports the scoped source-side hotfix from zts212653/cat-cafe#2077 via the controlled hotfix lane.

## Provenance

- Source merge commit: zts212653/cat-cafe@354a9377cdaf30c7e4aeb09ace330d9493334d9d
- Hotfix base sync tag: sync/2026-06-02-040539
- Source sync commit: 41b0b2e38e6c748ddc8d0cb01f3f0d80b1d6cd39
- Landed target sync commit: d24577a7de52f00b907caea9056655f018d5857b

## Issue

- Refs #835
- Related limited scope: #835
- Keep #835 open after this PR merges

## Scope

This PR accepts only the limited internal admin/debug route hardening scope. It does not accept the full report as-is; remaining lower-severity hardening or policy-mismatch items should be evaluated separately.

## Verification

Dry-run:

```sh
CLOWDER_AI_DIR=/Users/lysander/projects/relay-station/clowder-ai-hotfix-835-target \
  bash scripts/sync-hotfix.sh --dry-run --tag=sync/2026-06-02-040539 fix/835-security-gates \
  packages/api/src/routes/f163-admin.ts \
  packages/api/src/routes/prompt-captures.ts \
  packages/api/src/utils/privileged-route-guard.ts \
  packages/api/test/f163-zero-behavior.test.js \
  packages/api/test/helpers/f163-admin-auth.js \
  packages/api/test/memory/f163-compression-api.test.js \
  packages/api/test/memory/f163-compression-apply.test.js \
  packages/api/test/memory/f163-expand.test.js \
  packages/api/test/memory/f163-promotion.test.js \
  packages/api/test/security-owner-gates.test.js
```

Result: manifest allowlist passed; target drift check passed for all 10 files.

Target verification:

```sh
pnpm --filter @cat-cafe/api run build
CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh \
  node --import $(pwd)/packages/api/test/helpers/setup-cat-registry.js --test \
  packages/api/test/f163-zero-behavior.test.js \
  packages/api/test/security-owner-gates.test.js \
  packages/api/test/memory/f163-promotion.test.js \
  packages/api/test/memory/f163-compression-api.test.js \
  packages/api/test/memory/f163-compression-apply.test.js \
  packages/api/test/memory/f163-expand.test.js
```

Result: build passed; targeted suite 39/39 passed.

[砚砚/GPT-5.5🐾]