### PR TITLE
fix(#870, #854): OpenCode OAuth MCP config + Windows false-stall suppression

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -87,7 +87,25 @@ const log = createModuleLogger('invoke');
 const tracer = trace.getTracer('cat-cafe-api', '0.1.0');
 const TRANSCRIPT_DIR =
   process.env.TRANSCRIPT_DIR ?? resolve(findMonorepoRoot(), 'scripts', 'meeting-copilot', 'transcripts');
-const CAT_INVOCATION_STALL_AUTO_KILL_MS = 7 * 60_000;
+/**
+ * #854: Stall auto-kill threshold (milliseconds of idle-silent before kill).
+ * Configurable via CLI_STALL_WARNING_MS env var. Default 7 minutes.
+ * Minimum 60_000 (1 min) to prevent disabling stuck-process cleanup.
+ */
+const DEFAULT_STALL_AUTO_KILL_MS = 7 * 60_000;
+const MIN_STALL_AUTO_KILL_MS = 60_000;
+
+export function resolveStallAutoKillMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.CLI_STALL_WARNING_MS;
+  if (raw != null) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed >= MIN_STALL_AUTO_KILL_MS) return parsed;
+    if (raw === '0') return 0; // explicit 0 = disable stall auto-kill
+  }
+  return DEFAULT_STALL_AUTO_KILL_MS;
+}
+
+const CAT_INVOCATION_STALL_AUTO_KILL_MS = resolveStallAutoKillMs();
 const ANTIGRAVITY_AUTOMATIC_RETRY_FRAGMENT_REASONS = new Set([
   'model_capacity',
   'empty_response',
@@ -1583,8 +1601,11 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       ...(sessionId ? { cliSessionId: sessionId } : {}),
       // F118 Phase B: Enable liveness probe for all CLI providers.
       // #774: stallAutoKill clears truly stuck idle-silent CLIs before F216's 10m stale-processing guard.
-      // Leave room for async ps sampling + deferred kill probes, while avoiding the 5m slow-API false kills.
-      livenessProbe: { stallAutoKill: true, stallWarningMs: CAT_INVOCATION_STALL_AUTO_KILL_MS },
+      // #854: stallWarningMs is now configurable via CLI_STALL_WARNING_MS env var (default 7m).
+      //       0 = disable stallAutoKill (probe still runs for diagnostics, no auto-kill).
+      livenessProbe: CAT_INVOCATION_STALL_AUTO_KILL_MS > 0
+        ? { stallAutoKill: true, stallWarningMs: CAT_INVOCATION_STALL_AUTO_KILL_MS }
+        : { stallAutoKill: false },
       ...(catConfig?.cliConfigArgs?.length ? { cliConfigArgs: catConfig.cliConfigArgs } : {}),
       parentSpan: invocationSpan,
     };

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -87,25 +87,7 @@ const log = createModuleLogger('invoke');
 const tracer = trace.getTracer('cat-cafe-api', '0.1.0');
 const TRANSCRIPT_DIR =
   process.env.TRANSCRIPT_DIR ?? resolve(findMonorepoRoot(), 'scripts', 'meeting-copilot', 'transcripts');
-/**
- * #854: Stall auto-kill threshold (milliseconds of idle-silent before kill).
- * Configurable via CLI_STALL_WARNING_MS env var. Default 7 minutes.
- * Minimum 60_000 (1 min) to prevent disabling stuck-process cleanup.
- */
-const DEFAULT_STALL_AUTO_KILL_MS = 7 * 60_000;
-const MIN_STALL_AUTO_KILL_MS = 60_000;
-
-export function resolveStallAutoKillMs(env: NodeJS.ProcessEnv = process.env): number {
-  const raw = env.CLI_STALL_WARNING_MS;
-  if (raw != null) {
-    const parsed = Number(raw);
-    if (Number.isFinite(parsed) && parsed >= MIN_STALL_AUTO_KILL_MS) return parsed;
-    if (raw === '0') return 0; // explicit 0 = disable stall auto-kill
-  }
-  return DEFAULT_STALL_AUTO_KILL_MS;
-}
-
-const CAT_INVOCATION_STALL_AUTO_KILL_MS = resolveStallAutoKillMs();
+const CAT_INVOCATION_STALL_AUTO_KILL_MS = 7 * 60_000;
 const ANTIGRAVITY_AUTOMATIC_RETRY_FRAGMENT_REASONS = new Set([
   'model_capacity',
   'empty_response',
@@ -1601,11 +1583,8 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       ...(sessionId ? { cliSessionId: sessionId } : {}),
       // F118 Phase B: Enable liveness probe for all CLI providers.
       // #774: stallAutoKill clears truly stuck idle-silent CLIs before F216's 10m stale-processing guard.
-      // #854: stallWarningMs is now configurable via CLI_STALL_WARNING_MS env var (default 7m).
-      //       0 = disable stallAutoKill (probe still runs for diagnostics, no auto-kill).
-      livenessProbe: CAT_INVOCATION_STALL_AUTO_KILL_MS > 0
-        ? { stallAutoKill: true, stallWarningMs: CAT_INVOCATION_STALL_AUTO_KILL_MS }
-        : { stallAutoKill: false },
+      // #854: Windows probe now assumes busy (cpuGrowing=true) so CLI_TIMEOUT_MS is the binding constraint there.
+      livenessProbe: { stallAutoKill: true, stallWarningMs: CAT_INVOCATION_STALL_AUTO_KILL_MS },
       ...(catConfig?.cliConfigArgs?.length ? { cliConfigArgs: catConfig.cliConfigArgs } : {}),
       parentSpan: invocationSpan,
     };

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1405,10 +1405,12 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       }
     }
 
+    // authType is either 'api_key' or 'oauth' — both need runtime config (MCP +
+    // L0 + model routing). The only difference is credential injection below.
+    const isApiKey = resolvedAccount?.authType === 'api_key';
     if (
       provider === 'opencode' &&
       resolvedAccount != null &&
-      resolvedAccount.authType === 'api_key' &&
       effectiveModel &&
       effectiveProviderName &&
       (hasExplicitOcProvider || !getOpenCodeKnownModels().has(effectiveModel) || mcpServerPath)
@@ -1441,8 +1443,12 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         runtimeConfigOptions,
       );
       callbackEnv.OPENCODE_CONFIG = openCodeRuntimeConfigPath;
-      if (resolvedAccount.apiKey) callbackEnv[OC_API_KEY_ENV] = resolvedAccount.apiKey;
-      if (resolvedAccount.baseUrl) callbackEnv[OC_BASE_URL_ENV] = resolvedAccount.baseUrl;
+      // Credentials: only for api_key auth.
+      // OAuth users authenticate through OpenCode's native flow.
+      if (isApiKey) {
+        if (resolvedAccount.apiKey) callbackEnv[OC_API_KEY_ENV] = resolvedAccount.apiKey;
+        if (resolvedAccount.baseUrl) callbackEnv[OC_BASE_URL_ENV] = resolvedAccount.baseUrl;
+      }
       log.debug(
         {
           catId,

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1432,6 +1432,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         defaultModel: effectiveModel,
         apiType,
         hasBaseUrl: Boolean(resolvedAccount.baseUrl),
+        omitProviderAuth: !isApiKey,
         mcpServerPath,
         // F203 Phase I: inject compiled L0 + OPENCODE.md into instructions.
         instructions: openCodeL0InstructionPaths,
@@ -1444,9 +1445,9 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       );
       callbackEnv.OPENCODE_CONFIG = openCodeRuntimeConfigPath;
       // Credentials: only for api_key auth.
-      // OAuth users authenticate through OpenCode's native flow — signal
-      // OC_INSTRUCTIONS_ONLY_ENV so buildEnv preserves native auth instead
-      // of clearing it for the custom provider config path.
+      // OAuth users authenticate through OpenCode's native flow; their runtime
+      // config omits provider auth placeholders and signals buildEnv to preserve
+      // native auth instead of clearing it for the custom provider config path.
       if (isApiKey) {
         if (resolvedAccount.apiKey) callbackEnv[OC_API_KEY_ENV] = resolvedAccount.apiKey;
         if (resolvedAccount.baseUrl) callbackEnv[OC_BASE_URL_ENV] = resolvedAccount.baseUrl;

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1444,10 +1444,14 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       );
       callbackEnv.OPENCODE_CONFIG = openCodeRuntimeConfigPath;
       // Credentials: only for api_key auth.
-      // OAuth users authenticate through OpenCode's native flow.
+      // OAuth users authenticate through OpenCode's native flow — signal
+      // OC_INSTRUCTIONS_ONLY_ENV so buildEnv preserves native auth instead
+      // of clearing it for the custom provider config path.
       if (isApiKey) {
         if (resolvedAccount.apiKey) callbackEnv[OC_API_KEY_ENV] = resolvedAccount.apiKey;
         if (resolvedAccount.baseUrl) callbackEnv[OC_BASE_URL_ENV] = resolvedAccount.baseUrl;
+      } else {
+        callbackEnv[OC_INSTRUCTIONS_ONLY_ENV] = '1';
       }
       log.debug(
         {

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1584,7 +1584,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       ...(sessionId ? { cliSessionId: sessionId } : {}),
       // F118 Phase B: Enable liveness probe for all CLI providers.
       // #774: stallAutoKill clears truly stuck idle-silent CLIs before F216's 10m stale-processing guard.
-      // #854: Windows probe now assumes busy (cpuGrowing=true) so CLI_TIMEOUT_MS is the binding constraint there.
+      // #854: Windows cannot sample CPU; suppress suspected_stall there so CLI_TIMEOUT_MS stays binding.
       livenessProbe: { stallAutoKill: true, stallWarningMs: CAT_INVOCATION_STALL_AUTO_KILL_MS },
       ...(catConfig?.cliConfigArgs?.length ? { cliConfigArgs: catConfig.cliConfigArgs } : {}),
       parentSpan: invocationSpan,

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -104,6 +104,11 @@ export interface OpenCodeRuntimeConfigOptions {
   defaultModel?: string;
   apiType?: OpenCodeApiType;
   hasBaseUrl?: boolean;
+  /**
+   * Native-auth OpenCode accounts (OAuth/subscription) must not receive
+   * provider auth placeholders that point at unset CAT_CAFE_OC_* env vars.
+   */
+  omitProviderAuth?: boolean;
   /** Absolute path to Clowder AI MCP server entry (packages/mcp-server/dist/index.js). */
   mcpServerPath?: string;
   /**
@@ -166,6 +171,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
     defaultModel,
     apiType = 'openai',
     hasBaseUrl = false,
+    omitProviderAuth = false,
     mcpServerPath,
     instructions,
   } = options;
@@ -192,8 +198,8 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
         npm: NPM_ADAPTER_FOR_API_TYPE[apiType] ?? NPM_ADAPTER_FOR_API_TYPE.openai,
         models: modelsMap,
         options: {
-          ...(hasBaseUrl ? { baseURL: `{env:${OC_BASE_URL_ENV}}` } : {}),
-          apiKey: `{env:${OC_API_KEY_ENV}}`,
+          ...(!omitProviderAuth && hasBaseUrl ? { baseURL: `{env:${OC_BASE_URL_ENV}}` } : {}),
+          ...(!omitProviderAuth ? { apiKey: `{env:${OC_API_KEY_ENV}}` } : {}),
         },
       },
     },

--- a/packages/api/src/utils/ProcessLivenessProbe.ts
+++ b/packages/api/src/utils/ProcessLivenessProbe.ts
@@ -213,11 +213,7 @@ export class ProcessLivenessProbe {
     // #854: Only emit suspected_stall when CPU sampling is available.
     // On Windows we can't distinguish idle from busy, so we can't "suspect"
     // a stall — CLI_TIMEOUT_MS is the binding constraint instead.
-    if (
-      silenceMs >= this.config.stallWarningMs &&
-      !this.stallWarningEmitted &&
-      this.cpuSamplingAvailable
-    ) {
+    if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted && this.cpuSamplingAvailable) {
       this.stallWarningEmitted = true;
       this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
     } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {

--- a/packages/api/src/utils/ProcessLivenessProbe.ts
+++ b/packages/api/src/utils/ProcessLivenessProbe.ts
@@ -60,6 +60,8 @@ export function parseCpuTime(raw: string): number {
 export class ProcessLivenessProbe {
   readonly config: ProbeConfig;
   private readonly pid: number;
+  /** Whether CPU sampling is available (false on Windows — no `ps`). */
+  readonly cpuSamplingAvailable: boolean;
   private timer: ReturnType<typeof setInterval> | null = null;
   private lastActivityAt: number;
   private prevCpuTimeMs = 0;
@@ -75,6 +77,7 @@ export class ProcessLivenessProbe {
     this.pid = pid;
     this.config = { ...DEFAULT_CONFIG, ...config };
     this.lastActivityAt = Date.now();
+    this.cpuSamplingAvailable = process.platform !== 'win32';
   }
 
   /** Notify that output was received — resets silence tracking */
@@ -154,11 +157,11 @@ export class ProcessLivenessProbe {
     }
 
     // Windows: `ps` is not available. Use process.kill(pid, 0) for liveness
-    // and skip CPU sampling. Assume busy (cpuGrowing = true) so the process
-    // gets the benefit of the doubt — stall auto-kill won't fire, and
-    // CLI_TIMEOUT_MS becomes the binding constraint (#854).
+    // and skip CPU sampling. cpuGrowing stays false (idle-silent state).
+    // #854: emitSilenceWarnings skips suspected_stall when !cpuSamplingAvailable,
+    // so stall auto-kill won't fire and CLI_TIMEOUT_MS is the binding constraint.
     if (process.platform === 'win32') {
-      this.cpuGrowing = true;
+      this.cpuGrowing = false;
       this.emitSilenceWarnings();
       this.sampling = false;
       return;
@@ -207,7 +210,14 @@ export class ProcessLivenessProbe {
   /** Emit soft/stall warnings based on silence duration (shared by Windows and Unix paths) */
   private emitSilenceWarnings(): void {
     const silenceMs = Date.now() - this.lastActivityAt;
-    if (silenceMs >= this.config.stallWarningMs && !this.stallWarningEmitted) {
+    // #854: Only emit suspected_stall when CPU sampling is available.
+    // On Windows we can't distinguish idle from busy, so we can't "suspect"
+    // a stall — CLI_TIMEOUT_MS is the binding constraint instead.
+    if (
+      silenceMs >= this.config.stallWarningMs &&
+      !this.stallWarningEmitted &&
+      this.cpuSamplingAvailable
+    ) {
       this.stallWarningEmitted = true;
       this.warningQueue.push(this.makeWarning('suspected_stall', silenceMs));
     } else if (silenceMs >= this.config.softWarningMs && !this.softWarningEmitted) {

--- a/packages/api/src/utils/ProcessLivenessProbe.ts
+++ b/packages/api/src/utils/ProcessLivenessProbe.ts
@@ -154,10 +154,11 @@ export class ProcessLivenessProbe {
     }
 
     // Windows: `ps` is not available. Use process.kill(pid, 0) for liveness
-    // and skip CPU sampling. Conservative: assume idle (cpuGrowing = false)
-    // so that idle-silent → stall detection still works on Windows.
+    // and skip CPU sampling. Assume busy (cpuGrowing = true) so the process
+    // gets the benefit of the doubt — stall auto-kill won't fire, and
+    // CLI_TIMEOUT_MS becomes the binding constraint (#854).
     if (process.platform === 'win32') {
-      this.cpuGrowing = false;
+      this.cpuGrowing = true;
       this.emitSilenceWarnings();
       this.sampling = false;
       return;

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6109,32 +6109,6 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     );
   });
 
-  // #854: resolveStallAutoKillMs unit tests — env var configurability
-  it('#854: resolveStallAutoKillMs returns default 7 min when env is unset', async () => {
-    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
-    assert.equal(resolveStallAutoKillMs({}), 7 * 60_000);
-  });
-
-  it('#854: resolveStallAutoKillMs reads CLI_STALL_WARNING_MS from env', async () => {
-    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
-    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '600000' }), 600_000);
-  });
-
-  it('#854: resolveStallAutoKillMs rejects values below 60s floor (returns default)', async () => {
-    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
-    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '30000' }), 7 * 60_000);
-  });
-
-  it('#854: resolveStallAutoKillMs allows explicit 0 to disable stall auto-kill', async () => {
-    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
-    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '0' }), 0);
-  });
-
-  it('#854: resolveStallAutoKillMs ignores non-numeric values', async () => {
-    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
-    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: 'abc' }), 7 * 60_000);
-  });
-
   it('F101: game thread projectPath (games/*) does not trigger governance gate', async () => {
     const optionsSeen = [];
     const service = {

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5300,6 +5300,9 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     const apiDir = join(root, 'packages', 'api');
     await mkdir(apiDir, { recursive: true });
     await writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf-8');
+    const mcpDir = join(root, 'packages', 'mcp-server', 'dist');
+    await mkdir(mcpDir, { recursive: true });
+    await writeFile(join(mcpDir, 'index.js'), '// stub mcp server', 'utf-8');
 
     // Create a subscription-mode profile (no API key)
     const subscriptionProfile = await createProviderProfile(root, {

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5352,14 +5352,15 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       );
 
       const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
-      // Non-api_key auth still gets full runtime config (MCP + L0 + model routing)
+      // Non-api_key auth gets full runtime config (MCP + L0 + model routing)
+      // but signals instructions-only so buildEnv preserves native auth
       assert.ok(callbackEnv.OPENCODE_CONFIG, 'subscription path must get OPENCODE_CONFIG with MCP + L0');
       assert.strictEqual(
         callbackEnv.CAT_CAFE_OC_INSTRUCTIONS_ONLY,
-        undefined,
-        'full runtime config path — not instructions-only',
+        '1',
+        'non-api_key must signal instructions-only to preserve native auth',
       );
-      // Subscription mode: no API key injection (auth handled natively)
+      // Non-api_key: no credential injection (auth handled natively by OpenCode)
       assert.strictEqual(callbackEnv.CAT_CAFE_OC_API_KEY, undefined, 'no API key for non-api_key auth');
       assert.strictEqual(
         callbackEnv.CAT_CAFE_ANTHROPIC_PROFILE_MODE,

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5294,7 +5294,7 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
   );
 
   // F203 Phase I AC-I4: subscription/unresolved OpenCode path gets instructions-only L0 config
-  it('F203-I: OpenCode subscription path → instructions-only config + no API key injection', async () => {
+  it('F203-I: OpenCode subscription path → full runtime config (MCP + L0) + no API key injection', async () => {
     const { createProviderProfile } = await import('./helpers/create-test-account.js');
     const root = await mkdtemp(join(tmpdir(), 'f203-subscription-oc-'));
     const apiDir = join(root, 'packages', 'api');
@@ -5352,14 +5352,15 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       );
 
       const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
-      // F203 Phase I: subscription path must get instructions-only config for L0
-      assert.ok(callbackEnv.OPENCODE_CONFIG, 'subscription path must get OPENCODE_CONFIG for L0 instructions');
+      // Non-api_key auth still gets full runtime config (MCP + L0 + model routing)
+      assert.ok(callbackEnv.OPENCODE_CONFIG, 'subscription path must get OPENCODE_CONFIG with MCP + L0');
       assert.strictEqual(
         callbackEnv.CAT_CAFE_OC_INSTRUCTIONS_ONLY,
-        '1',
-        'subscription path must signal instructions-only',
+        undefined,
+        'full runtime config path — not instructions-only',
       );
-      // Subscription mode: no API key injection
+      // Subscription mode: no API key injection (auth handled natively)
+      assert.strictEqual(callbackEnv.CAT_CAFE_OC_API_KEY, undefined, 'no API key for non-api_key auth');
       assert.strictEqual(
         callbackEnv.CAT_CAFE_ANTHROPIC_PROFILE_MODE,
         'subscription',

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5328,10 +5328,15 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     });
 
     const optionsSeen = [];
+    let seenRuntimeConfig;
     const service = {
       l0CompilerFn: dummyL0CompilerFn,
       async *invoke(_prompt, options) {
         optionsSeen.push(options ?? {});
+        const configPath = options?.callbackEnv?.OPENCODE_CONFIG;
+        if (configPath) {
+          seenRuntimeConfig = JSON.parse(await readFile(configPath, 'utf-8'));
+        }
         yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
       },
     };
@@ -5367,6 +5372,21 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
         'subscription',
         'must pass subscription profile mode',
       );
+      const runtimeConfig = seenRuntimeConfig;
+      assert.ok(runtimeConfig, 'fake service must observe runtime config before cleanup');
+      assert.equal(runtimeConfig.model, 'anthropic/claude-opus-4-6', 'model routing must stay in runtime config');
+      assert.ok(runtimeConfig.provider?.anthropic, 'provider routing must stay in runtime config');
+      assert.equal(
+        runtimeConfig.provider.anthropic.options.apiKey,
+        undefined,
+        'non-api_key runtime config must not reference missing CAT_CAFE_OC_API_KEY',
+      );
+      assert.equal(
+        runtimeConfig.provider.anthropic.options.baseURL,
+        undefined,
+        'non-api_key runtime config must not reference missing CAT_CAFE_OC_BASE_URL',
+      );
+      assert.ok(runtimeConfig.mcp?.['cat-cafe'], 'MCP config must still be present for subscription path');
     } finally {
       process.chdir(previousCwd);
       catRegistry.reset();

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6109,6 +6109,32 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     );
   });
 
+  // #854: resolveStallAutoKillMs unit tests — env var configurability
+  it('#854: resolveStallAutoKillMs returns default 7 min when env is unset', async () => {
+    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
+    assert.equal(resolveStallAutoKillMs({}), 7 * 60_000);
+  });
+
+  it('#854: resolveStallAutoKillMs reads CLI_STALL_WARNING_MS from env', async () => {
+    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
+    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '600000' }), 600_000);
+  });
+
+  it('#854: resolveStallAutoKillMs rejects values below 60s floor (returns default)', async () => {
+    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
+    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '30000' }), 7 * 60_000);
+  });
+
+  it('#854: resolveStallAutoKillMs allows explicit 0 to disable stall auto-kill', async () => {
+    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
+    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: '0' }), 0);
+  });
+
+  it('#854: resolveStallAutoKillMs ignores non-numeric values', async () => {
+    const { resolveStallAutoKillMs } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
+    assert.equal(resolveStallAutoKillMs({ CLI_STALL_WARNING_MS: 'abc' }), 7 * 60_000);
+  });
+
   it('F101: game thread projectPath (games/*) does not trigger governance gate', async () => {
     const optionsSeen = [];
     const service = {

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -308,6 +308,32 @@ describe('generateOpenCodeRuntimeConfig', () => {
     });
   });
 
+  test('#871: non-api_key runtime config can omit provider auth placeholders', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'anthropic',
+      models: ['anthropic/claude-opus-4-6'],
+      defaultModel: 'anthropic/claude-opus-4-6',
+      apiType: 'anthropic',
+      hasBaseUrl: true,
+      mcpServerPath: '/absolute/path/to/packages/mcp-server/dist/index.js',
+      omitProviderAuth: true,
+    });
+
+    assert.equal(config.model, 'anthropic/claude-opus-4-6');
+    assert.ok(config.provider.anthropic, 'model/provider routing must still be present');
+    assert.equal(
+      config.provider.anthropic.options.apiKey,
+      undefined,
+      'OAuth/native-auth runtime config must not reference missing CAT_CAFE_OC_API_KEY',
+    );
+    assert.equal(
+      config.provider.anthropic.options.baseURL,
+      undefined,
+      'OAuth/native-auth runtime config must not reference missing CAT_CAFE_OC_BASE_URL',
+    );
+    assert.ok(config.mcp?.['cat-cafe'], 'MCP injection must still be present');
+  });
+
   test('mcp section is absent when mcpServerPath is not provided', () => {
     const config = generateOpenCodeRuntimeConfig({
       providerName: 'maas',

--- a/packages/api/test/process-liveness-probe.test.js
+++ b/packages/api/test/process-liveness-probe.test.js
@@ -210,10 +210,10 @@ test('parseCpuTime handles empty/invalid input', () => {
 
 // --- Windows platform guard tests ---
 
-test('on Windows, sampleOnce sets cpuGrowing=false (conservative idle-silent)', async () => {
+test('on Windows, sampleOnce sets cpuGrowing=true (benefit of the doubt — #854)', async () => {
   // This test runs on Windows where the platform guard is active.
-  // The probe should classify silent processes as idle-silent (not busy-silent),
-  // preserving stall detection semantics.
+  // Without CPU sampling, assume the process is busy so stall auto-kill
+  // does not fire prematurely. CLI_TIMEOUT_MS is the binding constraint.
   if (process.platform !== 'win32') {
     // On non-Windows, the Unix ps-based path runs instead — skip.
     return;
@@ -229,9 +229,9 @@ test('on Windows, sampleOnce sets cpuGrowing=false (conservative idle-silent)', 
   await new Promise((r) => setTimeout(r, 80));
 
   const state = probe.getState();
-  // On Windows, with cpuGrowing=false, the state should be idle-silent (not busy-silent)
-  assert.equal(state, 'idle-silent', 'Windows guard must set cpuGrowing=false → idle-silent');
-  assert.equal(probe.shouldExtendTimeout(), false, 'idle-silent must NOT extend timeout');
+  // On Windows, with cpuGrowing=true, the state should be busy-silent (not idle-silent)
+  assert.equal(state, 'busy-silent', 'Windows guard must set cpuGrowing=true → busy-silent');
+  assert.equal(probe.shouldExtendTimeout(), true, 'busy-silent extends timeout on Windows');
   probe.stop();
 });
 

--- a/packages/api/test/process-liveness-probe.test.js
+++ b/packages/api/test/process-liveness-probe.test.js
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { mock, test } from 'node:test';
 
 const { ProcessLivenessProbe } = await import('../dist/utils/ProcessLivenessProbe.js');
 
@@ -210,52 +210,58 @@ test('parseCpuTime handles empty/invalid input', () => {
 
 // --- Windows platform guard tests ---
 
-test('on Windows, sampleOnce sets cpuGrowing=true (benefit of the doubt — #854)', async () => {
-  // This test runs on Windows where the platform guard is active.
-  // Without CPU sampling, assume the process is busy so stall auto-kill
-  // does not fire prematurely. CLI_TIMEOUT_MS is the binding constraint.
-  if (process.platform !== 'win32') {
-    // On non-Windows, the Unix ps-based path runs instead — skip.
-    return;
-  }
+test('on Windows, sampleOnce keeps cpuGrowing=false and exposes cpuSamplingAvailable (#854)', async () => {
+  // Without `ps`, CPU sampling is unavailable on Windows. cpuGrowing stays false
+  // → state is idle-silent, shouldExtendTimeout() is false, and CLI_TIMEOUT_MS
+  // (not bounded extension) is the binding constraint.
+  // suspected_stall is gated on cpuSamplingAvailable so stall auto-kill won't fire.
+  mock.property(process, 'platform', 'win32');
 
   const probe = new ProcessLivenessProbe(process.pid, {
     sampleIntervalMs: 30,
     softWarningMs: 200,
     stallWarningMs: 500,
   });
-  probe.start();
-  // Wait past sampleIntervalMs so silence kicks in
-  await new Promise((r) => setTimeout(r, 80));
+  try {
+    assert.equal(probe.cpuSamplingAvailable, false, 'cpuSamplingAvailable must be false on Windows');
+    probe.start();
+    // Wait past sampleIntervalMs so silence kicks in
+    await new Promise((r) => setTimeout(r, 80));
 
-  const state = probe.getState();
-  // On Windows, with cpuGrowing=true, the state should be busy-silent (not idle-silent)
-  assert.equal(state, 'busy-silent', 'Windows guard must set cpuGrowing=true → busy-silent');
-  assert.equal(probe.shouldExtendTimeout(), true, 'busy-silent extends timeout on Windows');
-  probe.stop();
+    const state = probe.getState();
+    assert.equal(state, 'idle-silent', 'Windows: cpuGrowing=false → idle-silent');
+    assert.equal(probe.shouldExtendTimeout(), false, 'idle-silent does not extend timeout');
+  } finally {
+    probe.stop();
+    mock.restoreAll();
+  }
 });
 
-test('on Windows, silence warnings still fire correctly', async () => {
-  if (process.platform !== 'win32') {
-    return;
-  }
+test('on Windows, alive_but_silent fires but suspected_stall is suppressed (#854)', async () => {
+  // Without CPU evidence, suspected_stall would be a false positive — suppressed
+  // via cpuSamplingAvailable guard. alive_but_silent (informational) still fires.
+  mock.property(process, 'platform', 'win32');
 
   const probe = new ProcessLivenessProbe(process.pid, {
     sampleIntervalMs: 20,
     softWarningMs: 50,
     stallWarningMs: 150,
   });
-  probe.start();
-  await new Promise((r) => setTimeout(r, 200));
+  try {
+    probe.start();
+    await new Promise((r) => setTimeout(r, 200));
 
-  const warnings = probe.drainWarnings();
-  assert.ok(
-    warnings.some((w) => w.level === 'alive_but_silent'),
-    'should emit alive_but_silent warning on Windows',
-  );
-  assert.ok(
-    warnings.some((w) => w.level === 'suspected_stall'),
-    'should emit suspected_stall warning on Windows',
-  );
-  probe.stop();
+    const warnings = probe.drainWarnings();
+    assert.ok(
+      warnings.some((w) => w.level === 'alive_but_silent'),
+      'should emit alive_but_silent warning on Windows',
+    );
+    assert.ok(
+      !warnings.some((w) => w.level === 'suspected_stall'),
+      'must NOT emit suspected_stall without CPU sampling (#854)',
+    );
+  } finally {
+    probe.stop();
+    mock.restoreAll();
+  }
 });

--- a/packages/api/test/process-liveness-probe.test.js
+++ b/packages/api/test/process-liveness-probe.test.js
@@ -3,7 +3,7 @@
  */
 
 import assert from 'node:assert/strict';
-import { mock, test } from 'node:test';
+import { test } from 'node:test';
 
 const { ProcessLivenessProbe } = await import('../dist/utils/ProcessLivenessProbe.js');
 
@@ -37,25 +37,29 @@ test('new probe starts in active state', () => {
   probe.stop();
 });
 
-test('treats tiny CPU drift as idle-silent so stall auto-kill can fire', () => {
-  const probe = new ProcessLivenessProbe(process.pid, {
-    sampleIntervalMs: 1,
-    softWarningMs: 100,
-    stallWarningMs: 300,
-    minCpuGrowthMs: 50,
-  });
+test(
+  'treats tiny CPU drift as idle-silent so stall auto-kill can fire',
+  { skip: process.platform === 'win32' && 'suspected_stall suppressed without CPU sampling (#854)' },
+  () => {
+    const probe = new ProcessLivenessProbe(process.pid, {
+      sampleIntervalMs: 1,
+      softWarningMs: 100,
+      stallWarningMs: 300,
+      minCpuGrowthMs: 50,
+    });
 
-  probe.updateCpuSample(230);
-  probe.lastActivityAt = Date.now() - 1_000;
-  probe.updateCpuSample(270);
+    probe.updateCpuSample(230);
+    probe.lastActivityAt = Date.now() - 1_000;
+    probe.updateCpuSample(270);
 
-  const warnings = probe.drainWarnings();
-  const stallWarning = warnings.find((w) => w.level === 'suspected_stall');
-  assert.equal(probe.getState(), 'idle-silent');
-  assert.equal(probe.shouldExtendTimeout(), false);
-  assert.equal(stallWarning?.state, 'idle-silent');
-  probe.stop();
-});
+    const warnings = probe.drainWarnings();
+    const stallWarning = warnings.find((w) => w.level === 'suspected_stall');
+    assert.equal(probe.getState(), 'idle-silent');
+    assert.equal(probe.shouldExtendTimeout(), false);
+    assert.equal(stallWarning?.state, 'idle-silent');
+    probe.stop();
+  },
+);
 
 test('detects dead process (PID does not exist)', async () => {
   const probe = new ProcessLivenessProbe(99999, { sampleIntervalMs: 50 });
@@ -210,19 +214,19 @@ test('parseCpuTime handles empty/invalid input', () => {
 
 // --- Windows platform guard tests ---
 
-test('on Windows, sampleOnce keeps cpuGrowing=false and exposes cpuSamplingAvailable (#854)', async () => {
-  // Without `ps`, CPU sampling is unavailable on Windows. cpuGrowing stays false
-  // → state is idle-silent, shouldExtendTimeout() is false, and CLI_TIMEOUT_MS
-  // (not bounded extension) is the binding constraint.
-  // suspected_stall is gated on cpuSamplingAvailable so stall auto-kill won't fire.
-  mock.property(process, 'platform', 'win32');
-
-  const probe = new ProcessLivenessProbe(process.pid, {
-    sampleIntervalMs: 30,
-    softWarningMs: 200,
-    stallWarningMs: 500,
-  });
-  try {
+test(
+  'on Windows, sampleOnce keeps cpuGrowing=false and exposes cpuSamplingAvailable (#854)',
+  { skip: process.platform !== 'win32' && 'Windows platform guard — skipped on Unix' },
+  async () => {
+    // Without `ps`, CPU sampling is unavailable on Windows. cpuGrowing stays false
+    // → state is idle-silent, shouldExtendTimeout() is false, and CLI_TIMEOUT_MS
+    // (not bounded extension) is the binding constraint.
+    // suspected_stall is gated on cpuSamplingAvailable so stall auto-kill won't fire.
+    const probe = new ProcessLivenessProbe(process.pid, {
+      sampleIntervalMs: 30,
+      softWarningMs: 200,
+      stallWarningMs: 500,
+    });
     assert.equal(probe.cpuSamplingAvailable, false, 'cpuSamplingAvailable must be false on Windows');
     probe.start();
     // Wait past sampleIntervalMs so silence kicks in
@@ -231,23 +235,21 @@ test('on Windows, sampleOnce keeps cpuGrowing=false and exposes cpuSamplingAvail
     const state = probe.getState();
     assert.equal(state, 'idle-silent', 'Windows: cpuGrowing=false → idle-silent');
     assert.equal(probe.shouldExtendTimeout(), false, 'idle-silent does not extend timeout');
-  } finally {
     probe.stop();
-    mock.restoreAll();
-  }
-});
+  },
+);
 
-test('on Windows, alive_but_silent fires but suspected_stall is suppressed (#854)', async () => {
-  // Without CPU evidence, suspected_stall would be a false positive — suppressed
-  // via cpuSamplingAvailable guard. alive_but_silent (informational) still fires.
-  mock.property(process, 'platform', 'win32');
-
-  const probe = new ProcessLivenessProbe(process.pid, {
-    sampleIntervalMs: 20,
-    softWarningMs: 50,
-    stallWarningMs: 150,
-  });
-  try {
+test(
+  'on Windows, alive_but_silent fires but suspected_stall is suppressed (#854)',
+  { skip: process.platform !== 'win32' && 'Windows platform guard — skipped on Unix' },
+  async () => {
+    // Without CPU evidence, suspected_stall would be a false positive — suppressed
+    // via cpuSamplingAvailable guard. alive_but_silent (informational) still fires.
+    const probe = new ProcessLivenessProbe(process.pid, {
+      sampleIntervalMs: 20,
+      softWarningMs: 50,
+      stallWarningMs: 150,
+    });
     probe.start();
     await new Promise((r) => setTimeout(r, 200));
 
@@ -260,8 +262,6 @@ test('on Windows, alive_but_silent fires but suspected_stall is suppressed (#854
       !warnings.some((w) => w.level === 'suspected_stall'),
       'must NOT emit suspected_stall without CPU sampling (#854)',
     );
-  } finally {
     probe.stop();
-    mock.restoreAll();
-  }
-});
+  },
+);


### PR DESCRIPTION
## Summary
Batch fix for two OpenCode issues:

### Fix 1: OAuth users missing MCP config (#870)
- Remove redundant `authType === 'api_key'` gate — all auth types now receive runtime config when MCP/L0/model routing requires it
- Non-`api_key` OpenCode runtime configs omit provider auth placeholders (`CAT_CAFE_OC_API_KEY` / `CAT_CAFE_OC_BASE_URL`) so OAuth/subscription invocations do not point at missing env vars
- OAuth/subscription path signals `OC_INSTRUCTIONS_ONLY_ENV` so `buildEnv` preserves OpenCode native auth instead of clearing it for the runtime config path
- Credential injection remains api_key-only

### Fix 2: Windows false-stall suppression (#854)
- Windows cannot use `ps` CPU sampling, so silence-only stall detection can produce false `suspected_stall` warnings
- Add `cpuSamplingAvailable`; when CPU sampling is unavailable, `ProcessLivenessProbe` keeps silent processes `idle-silent` but suppresses `suspected_stall`
- Windows therefore does not extend `CLI_TIMEOUT_MS` through `busy-silent`, and does not auto-kill from silence-only stall evidence
- Unix behavior remains unchanged; this PR does not add user-configurable stall thresholds

## Test plan
- [x] OAuth config test verifies native-auth runtime configs omit provider auth placeholders while preserving model routing and MCP
- [x] OAuth subscription invoke test verifies `OPENCODE_CONFIG`, instructions-preserve signal, no API key injection, no provider auth placeholders, and MCP section present
- [x] Process liveness tests cover Windows no-CPU-sampling behavior and keep Unix stall behavior intact
- [x] CI: Lint, Build, Test Public, Test Windows, Directory Size Guard

Closes #870
Partially addresses #854