### PR TITLE
fix(api): write back managed skill symlinks

### DIFF
--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -54,6 +54,11 @@ import {
 import { isManagedSkill, readSkillsState } from '../config/governance/skills-state.js';
 import { resourceCapId } from '../domains/plugin/PluginRegistry.js';
 import { parsePluginManifest } from '../domains/plugin/plugin-manifest.js';
+import {
+  ManagedSkillWritebackConflictError,
+  mountManagedSkillSymlinks,
+  unmountManagedSkillSymlinks,
+} from '../utils/managed-skill-writeback.js';
 import { validateProjectPath } from '../utils/project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 import {
@@ -996,6 +1001,22 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
         if (body.enabled === cap.enabled) {
           cap.overrides = cap.overrides.filter((o) => o.catId !== body.catId!);
           if (cap.overrides.length === 0) delete cap.overrides;
+        }
+      }
+
+      if (body.scope === 'global' && cap.type === 'skill' && cap.source === 'cat-cafe') {
+        try {
+          if (body.enabled) {
+            await mountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC);
+          } else {
+            await unmountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC);
+          }
+        } catch (err) {
+          if (err instanceof ManagedSkillWritebackConflictError) {
+            reply.status(409);
+            return { error: err.message };
+          }
+          throw err;
         }
       }
 

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -1009,7 +1009,13 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
           if (body.enabled) {
             await mountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC);
           } else {
-            await unmountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC);
+            await unmountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC, {
+              disabledSkillNames: config.capabilities
+                .filter(
+                  (entry) => entry.type === 'skill' && entry.source === 'cat-cafe' && !entry.pluginId && !entry.enabled,
+                )
+                .map((entry) => entry.id),
+            });
           }
         } catch (err) {
           if (err instanceof ManagedSkillWritebackConflictError) {

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -1006,15 +1006,17 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
 
       if (body.scope === 'global' && cap.type === 'skill' && cap.source === 'cat-cafe') {
         try {
+          const disabledSkillNames = config.capabilities
+            .filter(
+              (entry) => entry.type === 'skill' && entry.source === 'cat-cafe' && !entry.pluginId && !entry.enabled,
+            )
+            .map((entry) => entry.id);
+
           if (body.enabled) {
-            await mountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC);
+            await mountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC, { disabledSkillNames });
           } else {
             await unmountManagedSkillSymlinks(projectRoot, cap.id, CAT_CAFE_SKILLS_SRC, {
-              disabledSkillNames: config.capabilities
-                .filter(
-                  (entry) => entry.type === 'skill' && entry.source === 'cat-cafe' && !entry.pluginId && !entry.enabled,
-                )
-                .map((entry) => entry.id),
+              disabledSkillNames,
             });
           }
         } catch (err) {

--- a/packages/api/src/utils/managed-skill-writeback.ts
+++ b/packages/api/src/utils/managed-skill-writeback.ts
@@ -1,6 +1,7 @@
 import { lstat, mkdir, readlink, realpath, rm, symlink } from 'node:fs/promises';
 import { dirname, join, relative, resolve } from 'node:path';
 import { validateSkillName } from '../config/governance/skill-sync.js';
+import { listSourceSkillNames } from '../config/governance/skills-state.js';
 import { pathsEqual } from './project-path.js';
 
 const PROJECT_PROVIDER_SKILL_DIRS = ['.claude/skills', '.codex/skills', '.gemini/skills', '.kimi/skills'];
@@ -118,14 +119,59 @@ export async function unmountManagedSkillSymlinks(
   projectRoot: string,
   skillName: string,
   skillsSource: string,
+  opts?: { disabledSkillNames?: Iterable<string> },
 ): Promise<void> {
   validateSkillName(skillName);
 
+  const managedDirectoryRoots: string[] = [];
+  const skillLinksToRemove: string[] = [];
   for (const providerDir of PROJECT_PROVIDER_SKILL_DIRS) {
     const skillsDir = join(projectRoot, providerDir);
+    if (await isManagedDirectoryLevelSkillsSymlink(skillsDir, skillsSource)) {
+      managedDirectoryRoots.push(skillsDir);
+      continue;
+    }
     if (await isProviderRootSymlink(skillsDir)) continue;
     const linkPath = join(skillsDir, skillName);
-    if (!(await isManagedSkillSymlink(linkPath, skillsSource, skillName))) continue;
-    await rm(linkPath);
+    if (await isManagedSkillSymlink(linkPath, skillsSource, skillName)) {
+      skillLinksToRemove.push(linkPath);
+    }
+  }
+
+  const disabledSkillNames = new Set(opts?.disabledSkillNames ?? []);
+  disabledSkillNames.add(skillName);
+  const enabledSourceSkillNames = (await listSourceSkillNames(skillsSource)).filter(
+    (name) => !disabledSkillNames.has(name),
+  );
+
+  const convertedRoots: Array<{ skillsDir: string; target: string }> = [];
+  const removedLinks: Array<{ linkPath: string; target: string }> = [];
+  try {
+    for (const skillsDir of managedDirectoryRoots) {
+      const target = await readlink(skillsDir);
+      convertedRoots.push({ skillsDir, target });
+      await rm(skillsDir);
+      await mkdir(skillsDir, { recursive: true });
+      for (const sourceSkillName of enabledSourceSkillNames) {
+        const linkPath = join(skillsDir, sourceSkillName);
+        await symlink(symlinkTargetFor(linkPath, join(skillsSource, sourceSkillName)), linkPath);
+      }
+    }
+
+    for (const linkPath of skillLinksToRemove) {
+      const target = await readlink(linkPath);
+      removedLinks.push({ linkPath, target });
+      await rm(linkPath);
+    }
+  } catch (err) {
+    for (const { linkPath, target } of removedLinks.reverse()) {
+      await rm(linkPath, { force: true }).catch(() => {});
+      await symlink(target, linkPath).catch(() => {});
+    }
+    for (const { skillsDir, target } of convertedRoots.reverse()) {
+      await rm(skillsDir, { recursive: true, force: true }).catch(() => {});
+      await symlink(target, skillsDir).catch(() => {});
+    }
+    throw err;
   }
 }

--- a/packages/api/src/utils/managed-skill-writeback.ts
+++ b/packages/api/src/utils/managed-skill-writeback.ts
@@ -1,0 +1,131 @@
+import { lstat, mkdir, readlink, realpath, rm, symlink } from 'node:fs/promises';
+import { dirname, join, relative, resolve } from 'node:path';
+import { validateSkillName } from '../config/governance/skill-sync.js';
+import { pathsEqual } from './project-path.js';
+
+const PROJECT_PROVIDER_SKILL_DIRS = ['.claude/skills', '.codex/skills', '.gemini/skills', '.kimi/skills'];
+
+export class ManagedSkillWritebackConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ManagedSkillWritebackConflictError';
+  }
+}
+
+function symlinkTargetFor(linkPath: string, sourcePath: string): string {
+  return process.platform === 'win32' ? sourcePath : relative(dirname(linkPath), sourcePath);
+}
+
+async function lstatIfExists(path: string): Promise<Awaited<ReturnType<typeof lstat>> | null> {
+  try {
+    return await lstat(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function realpathOrSelf(path: string): Promise<string> {
+  return realpath(path).catch(() => path);
+}
+
+async function isManagedDirectoryLevelSkillsSymlink(skillsDir: string, skillsSource: string): Promise<boolean> {
+  const stat = await lstatIfExists(skillsDir);
+  if (!stat?.isSymbolicLink()) return false;
+
+  const [mountedRoot, expectedRoot] = await Promise.all([realpathOrSelf(skillsDir), realpath(skillsSource)]);
+  return pathsEqual(mountedRoot, expectedRoot);
+}
+
+async function isProviderRootSymlink(skillsDir: string): Promise<boolean> {
+  return (await lstatIfExists(skillsDir))?.isSymbolicLink() ?? false;
+}
+
+async function isManagedSkillSymlink(linkPath: string, skillsSource: string, skillName: string): Promise<boolean> {
+  const stat = await lstatIfExists(linkPath);
+  if (!stat?.isSymbolicLink()) return false;
+
+  const target = await readlink(linkPath);
+  const absoluteTarget = resolve(dirname(linkPath), target);
+  const expectedTarget = resolve(skillsSource, skillName);
+  if (pathsEqual(absoluteTarget, expectedTarget)) return true;
+  const [realTarget, realExpected] = await Promise.all([
+    realpathOrSelf(absoluteTarget),
+    realpathOrSelf(expectedTarget),
+  ]);
+  return pathsEqual(realTarget, realExpected);
+}
+
+async function classifySkillPath(
+  linkPath: string,
+  skillsSource: string,
+  skillName: string,
+): Promise<'missing' | 'managed' | 'conflict'> {
+  const stat = await lstatIfExists(linkPath);
+  if (!stat) return 'missing';
+  if (stat.isSymbolicLink() && (await isManagedSkillSymlink(linkPath, skillsSource, skillName))) {
+    return 'managed';
+  }
+  return 'conflict';
+}
+
+export async function mountManagedSkillSymlinks(
+  projectRoot: string,
+  skillName: string,
+  skillsSource: string,
+): Promise<void> {
+  validateSkillName(skillName);
+  await lstat(join(skillsSource, skillName));
+
+  const missingLinks: Array<{ skillsDir: string; linkPath: string }> = [];
+  for (const providerDir of PROJECT_PROVIDER_SKILL_DIRS) {
+    const skillsDir = join(projectRoot, providerDir);
+    if (await isManagedDirectoryLevelSkillsSymlink(skillsDir, skillsSource)) continue;
+    if (await isProviderRootSymlink(skillsDir)) {
+      throw new ManagedSkillWritebackConflictError(
+        `Refusing to mount skill "${skillName}" at ${skillsDir}: provider skills root is not a managed Cat Cafe symlink.`,
+      );
+    }
+
+    const linkPath = join(skillsDir, skillName);
+    const existing = await classifySkillPath(linkPath, skillsSource, skillName);
+    if (existing === 'managed') continue;
+    if (existing === 'conflict') {
+      throw new ManagedSkillWritebackConflictError(
+        `Refusing to mount skill "${skillName}" at ${linkPath}: path already exists and is not a managed Cat Cafe skill symlink.`,
+      );
+    }
+
+    missingLinks.push({ skillsDir, linkPath });
+  }
+
+  const createdLinks: string[] = [];
+  try {
+    for (const { skillsDir, linkPath } of missingLinks) {
+      await mkdir(skillsDir, { recursive: true });
+      await symlink(symlinkTargetFor(linkPath, join(skillsSource, skillName)), linkPath);
+      createdLinks.push(linkPath);
+    }
+  } catch (err) {
+    for (const linkPath of createdLinks.reverse()) {
+      await rm(linkPath).catch(() => {});
+    }
+    throw err;
+  }
+}
+
+export async function unmountManagedSkillSymlinks(
+  projectRoot: string,
+  skillName: string,
+  skillsSource: string,
+): Promise<void> {
+  validateSkillName(skillName);
+
+  for (const providerDir of PROJECT_PROVIDER_SKILL_DIRS) {
+    const skillsDir = join(projectRoot, providerDir);
+    if (await isProviderRootSymlink(skillsDir)) continue;
+    const linkPath = join(skillsDir, skillName);
+    if (!(await isManagedSkillSymlink(linkPath, skillsSource, skillName))) continue;
+    await rm(linkPath);
+  }
+}

--- a/packages/api/src/utils/managed-skill-writeback.ts
+++ b/packages/api/src/utils/managed-skill-writeback.ts
@@ -74,14 +74,19 @@ export async function mountManagedSkillSymlinks(
   projectRoot: string,
   skillName: string,
   skillsSource: string,
+  opts?: { disabledSkillNames?: Iterable<string> },
 ): Promise<void> {
   validateSkillName(skillName);
   await lstat(join(skillsSource, skillName));
 
+  const managedDirectoryRoots: string[] = [];
   const missingLinks: Array<{ skillsDir: string; linkPath: string }> = [];
   for (const providerDir of PROJECT_PROVIDER_SKILL_DIRS) {
     const skillsDir = join(projectRoot, providerDir);
-    if (await isManagedDirectoryLevelSkillsSymlink(skillsDir, skillsSource)) continue;
+    if (await isManagedDirectoryLevelSkillsSymlink(skillsDir, skillsSource)) {
+      managedDirectoryRoots.push(skillsDir);
+      continue;
+    }
     if (await isProviderRootSymlink(skillsDir)) {
       throw new ManagedSkillWritebackConflictError(
         `Refusing to mount skill "${skillName}" at ${skillsDir}: provider skills root is not a managed Cat Cafe symlink.`,
@@ -100,8 +105,26 @@ export async function mountManagedSkillSymlinks(
     missingLinks.push({ skillsDir, linkPath });
   }
 
+  const disabledSkillNames = new Set(opts?.disabledSkillNames ?? []);
+  const enabledSourceSkillNames =
+    managedDirectoryRoots.length === 0
+      ? []
+      : (await listSourceSkillNames(skillsSource)).filter((name) => !disabledSkillNames.has(name));
+
+  const convertedRoots: Array<{ skillsDir: string; target: string }> = [];
   const createdLinks: string[] = [];
   try {
+    for (const skillsDir of managedDirectoryRoots) {
+      const target = await readlink(skillsDir);
+      convertedRoots.push({ skillsDir, target });
+      await rm(skillsDir);
+      await mkdir(skillsDir, { recursive: true });
+      for (const sourceSkillName of enabledSourceSkillNames) {
+        const linkPath = join(skillsDir, sourceSkillName);
+        await symlink(symlinkTargetFor(linkPath, join(skillsSource, sourceSkillName)), linkPath);
+      }
+    }
+
     for (const { skillsDir, linkPath } of missingLinks) {
       await mkdir(skillsDir, { recursive: true });
       await symlink(symlinkTargetFor(linkPath, join(skillsSource, skillName)), linkPath);
@@ -110,6 +133,10 @@ export async function mountManagedSkillSymlinks(
   } catch (err) {
     for (const linkPath of createdLinks.reverse()) {
       await rm(linkPath).catch(() => {});
+    }
+    for (const { skillsDir, target } of convertedRoots.reverse()) {
+      await rm(skillsDir, { recursive: true, force: true }).catch(() => {});
+      await symlink(target, skillsDir).catch(() => {});
     }
     throw err;
   }

--- a/packages/api/test/capabilities-route.test.js
+++ b/packages/api/test/capabilities-route.test.js
@@ -1661,6 +1661,46 @@ describe('PATCH /api/capabilities write auth (Fastify)', () => {
     }
   });
 
+  it('converts legacy directory-level mounts before disabling managed skills', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const disabledSkill = 'debugging';
+    const keptSkill = 'tdd';
+    const sourceSkillsDir = join(findRepoRoot(), 'cat-cafe-skills');
+    const projectDir = await makeTmpDir('patch-managed-skill-legacy-root');
+    const codexSkillsDir = join(projectDir, '.codex', 'skills');
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(dirname(codexSkillsDir), { recursive: true });
+      await symlink(sourceSkillsDir, codexSkillsDir);
+      await writeCapabilitiesConfig(projectDir, {
+        version: 1,
+        capabilities: [
+          { id: disabledSkill, type: 'skill', enabled: true, source: 'cat-cafe' },
+          { id: keptSkill, type: 'skill', enabled: true, source: 'cat-cafe' },
+        ],
+      });
+
+      const res = await patchSkillCapability(app, projectDir, disabledSkill, false);
+
+      assert.equal(res.statusCode, 200, res.payload);
+      const rootStat = await lstat(codexSkillsDir);
+      assert.equal(rootStat.isDirectory(), true, 'legacy provider root should become a real directory');
+      assert.equal(rootStat.isSymbolicLink(), false, 'legacy provider root symlink should be removed');
+      await assert.rejects(() => lstat(join(codexSkillsDir, disabledSkill)), /ENOENT/);
+      assert.equal(await realpath(join(codexSkillsDir, keptSkill)), await realpath(join(sourceSkillsDir, keptSkill)));
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities.find((cap) => cap.id === disabledSkill)?.enabled, false);
+      assert.equal(config?.capabilities.find((cap) => cap.id === keptSkill)?.enabled, true);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
   it('creates managed cat-cafe skill symlinks on global enable', async () => {
     const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
     process.env.DEFAULT_OWNER_USER_ID = 'you';

--- a/packages/api/test/capabilities-route.test.js
+++ b/packages/api/test/capabilities-route.test.js
@@ -1729,6 +1729,49 @@ describe('PATCH /api/capabilities write auth (Fastify)', () => {
     }
   });
 
+  it('converts legacy directory-level mounts before enabling managed skills', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const enabledSkill = 'debugging';
+    const stillDisabledSkill = 'tdd';
+    const sourceSkillsDir = join(findRepoRoot(), 'cat-cafe-skills');
+    const projectDir = await makeTmpDir('patch-managed-skill-enable-legacy-root');
+    const codexSkillsDir = join(projectDir, '.codex', 'skills');
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(dirname(codexSkillsDir), { recursive: true });
+      await symlink(sourceSkillsDir, codexSkillsDir);
+      await writeCapabilitiesConfig(projectDir, {
+        version: 1,
+        capabilities: [
+          { id: enabledSkill, type: 'skill', enabled: false, source: 'cat-cafe' },
+          { id: stillDisabledSkill, type: 'skill', enabled: false, source: 'cat-cafe' },
+        ],
+      });
+
+      const res = await patchSkillCapability(app, projectDir, enabledSkill, true);
+
+      assert.equal(res.statusCode, 200, res.payload);
+      const rootStat = await lstat(codexSkillsDir);
+      assert.equal(rootStat.isDirectory(), true, 'legacy provider root should become a real directory');
+      assert.equal(rootStat.isSymbolicLink(), false, 'legacy provider root symlink should be removed');
+      assert.equal(
+        await realpath(join(codexSkillsDir, enabledSkill)),
+        await realpath(join(sourceSkillsDir, enabledSkill)),
+      );
+      await assert.rejects(() => lstat(join(codexSkillsDir, stillDisabledSkill)), /ENOENT/);
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities.find((cap) => cap.id === enabledSkill)?.enabled, true);
+      assert.equal(config?.capabilities.find((cap) => cap.id === stillDisabledSkill)?.enabled, false);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
   it('preserves user-owned skill paths when enabling managed skills', async () => {
     const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
     process.env.DEFAULT_OWNER_USER_ID = 'you';

--- a/packages/api/test/capabilities-route.test.js
+++ b/packages/api/test/capabilities-route.test.js
@@ -8,7 +8,7 @@
 import './helpers/setup-cat-registry.js';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdir, rm, symlink, writeFile } from 'node:fs/promises';
+import { lstat, mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -1600,6 +1600,189 @@ describe('PATCH /api/capabilities write auth (Fastify)', () => {
       },
     });
   }
+
+  function localOwnerHeaders() {
+    return {
+      ...OWNER_SESSION_HEADERS,
+      host: 'localhost:3004',
+      origin: 'http://localhost:3003',
+    };
+  }
+
+  async function seedManagedSkillProject(skillId = 'debugging', enabled = true) {
+    const projectDir = await makeTmpDir('patch-managed-skill');
+    await writeCapabilitiesConfig(projectDir, {
+      version: 1,
+      capabilities: [{ id: skillId, type: 'skill', enabled, source: 'cat-cafe' }],
+    });
+    return projectDir;
+  }
+
+  function patchSkillCapability(app, projectDir, skillId, enabled, scope = 'global') {
+    return app.inject({
+      method: 'PATCH',
+      url: '/api/capabilities',
+      headers: localOwnerHeaders(),
+      payload: {
+        projectPath: projectDir,
+        capabilityId: skillId,
+        capabilityType: 'skill',
+        scope,
+        ...(scope === 'cat' ? { catId: 'codex' } : {}),
+        enabled,
+      },
+    });
+  }
+
+  it('removes managed cat-cafe skill symlinks on global disable', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const skillId = 'debugging';
+    const sourceSkillsDir = join(findRepoRoot(), 'cat-cafe-skills');
+    const projectDir = await seedManagedSkillProject(skillId, true);
+    const linkPath = join(projectDir, '.codex', 'skills', skillId);
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(dirname(linkPath), { recursive: true });
+      await symlink(join(sourceSkillsDir, skillId), linkPath);
+
+      const res = await patchSkillCapability(app, projectDir, skillId, false);
+
+      assert.equal(res.statusCode, 200, res.payload);
+      await assert.rejects(() => lstat(linkPath), /ENOENT/);
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities[0]?.enabled, false);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
+  it('creates managed cat-cafe skill symlinks on global enable', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const skillId = 'debugging';
+    const sourceSkillsDir = join(findRepoRoot(), 'cat-cafe-skills');
+    const projectDir = await seedManagedSkillProject(skillId, false);
+    const app = await buildSessionApp();
+
+    try {
+      const res = await patchSkillCapability(app, projectDir, skillId, true);
+
+      assert.equal(res.statusCode, 200, res.payload);
+      for (const provider of ['.claude', '.codex', '.gemini', '.kimi']) {
+        const linkPath = join(projectDir, provider, 'skills', skillId);
+        const stat = await lstat(linkPath);
+        assert.equal(stat.isSymbolicLink(), true, `${provider} skill path should be a symlink`);
+        assert.equal(await realpath(linkPath), await realpath(join(sourceSkillsDir, skillId)));
+      }
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities[0]?.enabled, true);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
+  it('preserves user-owned skill paths when enabling managed skills', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const skillId = 'debugging';
+    const projectDir = await seedManagedSkillProject(skillId, false);
+    const localSkillDir = join(projectDir, '.codex', 'skills', skillId);
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(localSkillDir, { recursive: true });
+      await writeFile(join(localSkillDir, 'SKILL.md'), '# user debugging\n');
+
+      const res = await patchSkillCapability(app, projectDir, skillId, true);
+
+      assert.equal(res.statusCode, 409, res.payload);
+      assert.match(res.payload, /not a managed Cat Cafe skill symlink/);
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities[0]?.enabled, false);
+      assert.equal((await lstat(localSkillDir)).isDirectory(), true);
+      for (const provider of ['.claude', '.gemini', '.kimi']) {
+        await assert.rejects(
+          () => lstat(join(projectDir, provider, 'skills', skillId)),
+          /ENOENT/,
+          `${provider} must not get a partial managed symlink when another provider has a user-owned conflict`,
+        );
+      }
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
+  it('does not mutate symlinks when toggling external skills', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const skillId = 'debugging';
+    const projectDir = await makeTmpDir('patch-external-skill');
+    const externalSource = join(projectDir, 'external-skill-source', skillId);
+    const linkPath = join(projectDir, '.codex', 'skills', skillId);
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(externalSource, { recursive: true });
+      await writeFile(join(externalSource, 'SKILL.md'), '# external debugging\n');
+      await mkdir(dirname(linkPath), { recursive: true });
+      await symlink(externalSource, linkPath);
+      await writeCapabilitiesConfig(projectDir, {
+        version: 1,
+        capabilities: [{ id: skillId, type: 'skill', enabled: true, source: 'external' }],
+      });
+
+      const res = await patchSkillCapability(app, projectDir, skillId, false);
+
+      assert.equal(res.statusCode, 200, res.payload);
+      assert.equal(await realpath(linkPath), await realpath(externalSource));
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities[0]?.enabled, false);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
+  it('does not mutate symlinks for per-cat skill overrides', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const skillId = 'debugging';
+    const sourceSkillsDir = join(findRepoRoot(), 'cat-cafe-skills');
+    const projectDir = await seedManagedSkillProject(skillId, true);
+    const linkPath = join(projectDir, '.codex', 'skills', skillId);
+    const app = await buildSessionApp();
+
+    try {
+      await mkdir(dirname(linkPath), { recursive: true });
+      await symlink(join(sourceSkillsDir, skillId), linkPath);
+
+      const res = await patchSkillCapability(app, projectDir, skillId, false, 'cat');
+
+      assert.equal(res.statusCode, 200, res.payload);
+      assert.equal(await realpath(linkPath), await realpath(join(sourceSkillsDir, skillId)));
+      const config = await readCapabilitiesConfig(projectDir);
+      assert.equal(config?.capabilities[0]?.enabled, true);
+      assert.deepEqual(config?.capabilities[0]?.overrides, [{ catId: 'codex', enabled: false }]);
+    } finally {
+      await app.close();
+      await rm(projectDir, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
 
   it('rejects trusted header identity without a real session', async () => {
     const previousOwner = process.env.DEFAULT_OWNER_USER_ID;


### PR DESCRIPTION
## Summary

Addresses the #719 symlink writeback subset. Does not auto-close #719.

This is the narrow L1 bugfix split out from PR #760:

- global Console toggles for managed `source: cat-cafe` skills now write project provider skill symlinks;
- disabling removes only managed Cat Cafe symlinks;
- disabling also converts managed legacy directory-level roots like `.codex/skills -> cat-cafe-skills` into real provider dirs, preserving other enabled source skills while removing the disabled one;
- enabling creates `.claude/.codex/.gemini/.kimi` project skill symlinks after preflighting every provider path;
- user-owned same-name paths return 409 and do not leave partial symlinks;
- per-cat overrides, external skills, and plugin-owned capabilities stay off this filesystem write path.

## Scope intentionally excluded

- no MountRules policy system;
- no drift detection/resolver APIs;
- no Console drift UI or mount rules UI;
- no `capabilities.json` v2 migration;
- no `docs/features/F719-*` or roadmap-style feature anchor.

## Validation

Red → Green evidence:

- Initial new tests caught the baseline bug: managed disable left the symlink, managed enable did not create provider symlinks.
- Added a user-owned conflict assertion that caught partial writeback (`.claude` was created before `.codex` conflict); fixed by preflighting all provider paths before writing and rolling back links created during write failure.
- Review P2 caught legacy directory-level roots (`.codex/skills -> cat-cafe-skills`) staying loadable after disable; added `converts legacy directory-level mounts before disabling managed skills`, saw it fail, then fixed conversion + rollback.

Commands run:

- `pnpm --dir packages/api build`
- `CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import $(pwd)/packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/capabilities-route.test.js` → 46/46 passed
- `pnpm --dir packages/api lint`
- `pnpm exec biome check packages/api/src/routes/capabilities.ts packages/api/src/utils/managed-skill-writeback.ts packages/api/test/capabilities-route.test.js --diagnostic-level=error`
- `git diff --check`
- `pnpm check`

[砚砚/gpt-5.5🐾]