### PR TITLE
fix(hooks): add GEMINI/KIMI/BACKLOG to clutter-filter regex

### DIFF
--- a/.claude/hooks/user-level/session-start-recall.sh
+++ b/.claude/hooks/user-level/session-start-recall.sh
@@ -79,7 +79,7 @@ fi
 
 # 6. 检查根目录其他杂物（未跟踪且未 ignore 的文件）
 ROOT_CLUTTER=$(git ls-files --others --exclude-standard -- ':!.*' ':!packages/' ':!docs/' ':!assets/' ':!scripts/' ':!cat-cafe-skills/' ':!designs/' ':!desktop/' 2>/dev/null \
-  | grep -vE '^(package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|tsconfig|biome|README|LICENSE|CLAUDE|AGENTS|\.npmrc|\.nvmrc|\.node-version|\.editorconfig|\.prettierrc|Makefile|Dockerfile|Procfile|turbo\.json|\.tool-versions)' \
+  | grep -vE '^(package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|tsconfig|biome|README|LICENSE|CLAUDE|AGENTS|GEMINI|KIMI|BACKLOG|\.npmrc|\.nvmrc|\.node-version|\.editorconfig|\.prettierrc|Makefile|Dockerfile|Procfile|turbo\.json|\.tool-versions)' \
   | head -10)
 if [ -n "$ROOT_CLUTTER" ]; then
   WARNINGS="${WARNINGS}

--- a/.claude/hooks/user-level/session-stop-check.sh
+++ b/.claude/hooks/user-level/session-stop-check.sh
@@ -73,7 +73,7 @@ fi
 
 # 6. 检查根目录其他杂物（未跟踪且未 ignore 的文件）
 ROOT_CLUTTER=$(git ls-files --others --exclude-standard -- ':!.*' ':!packages/' ':!docs/' ':!assets/' ':!scripts/' ':!cat-cafe-skills/' ':!designs/' ':!desktop/' 2>/dev/null \
-  | grep -vE '^(package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|tsconfig|biome|README|LICENSE|CLAUDE|AGENTS|\.npmrc|\.nvmrc|\.node-version|\.editorconfig|\.prettierrc|Makefile|Dockerfile|Procfile|turbo\.json|\.tool-versions)' \
+  | grep -vE '^(package\.json|pnpm-workspace\.yaml|pnpm-lock\.yaml|tsconfig|biome|README|LICENSE|CLAUDE|AGENTS|GEMINI|KIMI|BACKLOG|\.npmrc|\.nvmrc|\.node-version|\.editorconfig|\.prettierrc|Makefile|Dockerfile|Procfile|turbo\.json|\.tool-versions)' \
   | head -10)
 if [ -n "$ROOT_CLUTTER" ]; then
   WARNINGS="${WARNINGS}


### PR DESCRIPTION
## fix(hooks): add GEMINI/KIMI/BACKLOG to clutter-filter regex

### What

`GovernanceBootstrapService` 在"初始化协作配置"流程中会在项目根目录创建：

- `GEMINI.md` / `KIMI.md` —— provider instruction files（`writeManagedBlock()` via `PROVIDER_FILES`）
- `BACKLOG.md` —— 方法论骨架模板（`writeTemplate()` via `methodology-templates.ts`，`relativePath: 'BACKLOG.md'`）

`CLAUDE.md` 和 `AGENTS.md` 早期已加入 session hooks 的杂物过滤 `grep -vE`，但这三个后续新增的文件未同步纳入，导致每次启停都弹 false-positive 警告。

### Changes

- `.claude/hooks/user-level/session-start-recall.sh`：杂物过滤 `grep -vE` 加入 `GEMINI|KIMI|BACKLOG`（line 82）
- `.claude/hooks/user-level/session-stop-check.sh`：杂物过滤 `grep -vE` 加入 `GEMINI|KIMI|BACKLOG`（line 76）

### Test

- [ ] 初始化协作配置后启停 session，不再误报 `GEMINI.md` / `KIMI.md` / `BACKLOG.md`
- [ ] 根目录放置一个真正的杂物文件（如 `foo.txt`）→ 仍能正确报出

Fixes #881