### PR TITLE
fix(api): resolve memory docs root via monorepo marker

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -240,6 +240,7 @@ import { previewRoutes } from './routes/preview.js';
 import { terminalRoutes } from './routes/terminal.js';
 import { threadExportRoutes } from './routes/thread-export.js';
 import { ApiInstanceLease, type ApiInstanceLeaseInvalidation } from './services/ApiInstanceLease.js';
+import { resolveMemoryRepoPaths } from './utils/memory-root.js';
 import { findMonorepoRoot } from './utils/monorepo-root.js';
 import { resolveUserId } from './utils/request-identity.js';
 import { getDefaultUploadDir } from './utils/upload-paths.js';
@@ -596,14 +597,8 @@ async function main(): Promise<void> {
   );
 
   // F102: Memory services — SQLite-only
-  // P1 fix: resolve paths relative to repo root, not CWD (which may be packages/api)
-  const { existsSync } = await import('node:fs');
   const { resolve } = await import('node:path');
-  const repoRoot = existsSync(resolve(process.cwd(), 'docs', 'features'))
-    ? process.cwd()
-    : existsSync(resolve(process.cwd(), '..', '..', 'docs', 'features'))
-      ? resolve(process.cwd(), '..', '..')
-      : process.cwd();
+  const { repoRoot, docsRoot, markersDir } = resolveMemoryRepoPaths(process.cwd());
 
   const { initRepoIdentity, isSameRepo } = await import('./utils/is-same-repo.js');
   initRepoIdentity(repoRoot);
@@ -634,8 +629,8 @@ async function main(): Promise<void> {
   const memoryServices = await createMemoryServices({
     type: 'sqlite',
     sqlitePath: process.env.EVIDENCE_DB ?? resolve(repoRoot, 'evidence.sqlite'),
-    docsRoot: process.env.DOCS_ROOT ?? resolve(repoRoot, 'docs'),
-    markersDir: resolve(repoRoot, 'docs', 'markers'),
+    docsRoot,
+    markersDir,
     transcriptDataDir, // reuse the same resolved path as Writer/Reader (line 282)
     embed: { embedMode: resolvedEmbedMode },
     // Phase E-2: message passage indexing — provide a callback that reads thread messages
@@ -1679,7 +1674,7 @@ async function main(): Promise<void> {
       evidenceDb: memoryServices.store.getDb(),
       markersProvider: memoryServices.markerQueue,
       repoRoot,
-      docsRoot: process.env.DOCS_ROOT ?? resolve(repoRoot, 'docs'),
+      docsRoot,
     });
     verdictGenerators['eval:memory'] = createMemoryGeneratorAdapter(memProvider);
   }
@@ -2611,7 +2606,7 @@ async function main(): Promise<void> {
     knowledgeResolver: memoryServices.knowledgeResolver,
     markerQueue: memoryServices.markerQueue,
     repoRoot,
-    docsRoot: process.env.DOCS_ROOT ?? resolve(repoRoot, 'docs'),
+    docsRoot,
   });
 
   // F152 Phase C: Distillation routes (global lesson reflow)
@@ -2675,7 +2670,7 @@ async function main(): Promise<void> {
       ...(redisClient ? { redis: redisClient } : {}),
       // AC-H1 P1 R3: runtime exclude updates for parent IndexBuilder
       indexBuilder: memoryServices.indexBuilder as import('./domains/memory/IndexBuilder.js').IndexBuilder | undefined,
-      parentRoot: process.env.DOCS_ROOT ?? resolve(repoRoot, 'docs'),
+      parentRoot: docsRoot,
     });
   }
 

--- a/packages/api/src/utils/memory-root.ts
+++ b/packages/api/src/utils/memory-root.ts
@@ -1,0 +1,22 @@
+import { resolve } from 'node:path';
+import { findMonorepoRoot } from './monorepo-root.js';
+
+export interface MemoryRepoPaths {
+  repoRoot: string;
+  docsRoot: string;
+  markersDir: string;
+}
+
+export function resolveMemoryRepoPaths(
+  start = process.cwd(),
+  env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
+): MemoryRepoPaths {
+  const repoRoot = findMonorepoRoot(start);
+  const docsRoot = env.DOCS_ROOT ?? resolve(repoRoot, 'docs');
+
+  return {
+    repoRoot,
+    docsRoot,
+    markersDir: resolve(docsRoot, 'markers'),
+  };
+}

--- a/packages/api/test/memory-root.test.js
+++ b/packages/api/test/memory-root.test.js
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+const { resolveMemoryRepoPaths } = await import('../dist/utils/memory-root.js');
+
+describe('resolveMemoryRepoPaths', () => {
+  const tmpDirs = [];
+
+  function createTempMonorepo() {
+    const repoRoot = mkdtempSync(join(tmpdir(), 'memory-root-'));
+    tmpDirs.push(repoRoot);
+    mkdirSync(join(repoRoot, 'packages', 'api'), { recursive: true });
+    writeFileSync(join(repoRoot, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n');
+    return repoRoot;
+  }
+
+  afterEach(() => {
+    for (const dir of tmpDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the monorepo root when a nested packages/api docs/features placeholder exists', () => {
+    const repoRoot = createTempMonorepo();
+    mkdirSync(join(repoRoot, 'docs', 'features'), { recursive: true });
+    mkdirSync(join(repoRoot, 'packages', 'api', 'docs', 'features'), { recursive: true });
+    writeFileSync(join(repoRoot, 'docs', 'features', 'F102-memory.md'), '# F102 Memory\n');
+    writeFileSync(join(repoRoot, 'packages', 'api', 'docs', 'features', 'TEMPLATE.md'), '# Template\n');
+
+    const result = resolveMemoryRepoPaths(join(repoRoot, 'packages', 'api'), {});
+
+    assert.equal(result.repoRoot, repoRoot);
+    assert.equal(result.docsRoot, join(repoRoot, 'docs'));
+    assert.equal(result.markersDir, join(repoRoot, 'docs', 'markers'));
+  });
+
+  it('keeps DOCS_ROOT as an explicit override for evidence indexing docs', () => {
+    const repoRoot = createTempMonorepo();
+    const docsOverride = join(repoRoot, 'custom-docs');
+    mkdirSync(docsOverride, { recursive: true });
+
+    const result = resolveMemoryRepoPaths(join(repoRoot, 'packages', 'api'), {
+      DOCS_ROOT: docsOverride,
+    });
+
+    assert.equal(result.repoRoot, repoRoot);
+    assert.equal(result.docsRoot, docsOverride);
+    assert.equal(result.markersDir, join(docsOverride, 'markers'));
+  });
+});


### PR DESCRIPTION
## PR Type

- [x] Patch - Bug fix, typo, test gap (no Feature Doc needed)
- [ ] Feature - New capability or behavior change (requires Feature Doc)
- [ ] Protocol - Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #890

## Feature Doc (Feature PRs only)

N/A - patch.

## What

- Add `resolveMemoryRepoPaths()` to resolve the memory service repo/docs paths from the monorepo marker instead of nearby `docs/features` directories.
- Replace the inline F102 memory root heuristic in `packages/api/src/index.ts` with that helper.
- Keep `DOCS_ROOT` as an explicit override and make `markersDir` follow the resolved `docsRoot`.
- Add a regression test for a nested `packages/api/docs/features/TEMPLATE.md` alongside real root feature docs.

## Why

When `packages/api/docs/features/` exists, the old nearest-directory heuristic can choose `packages/api` as `repoRoot`, causing the memory/evidence indexer to ignore the monorepo root `docs/features` tree. The existing `findMonorepoRoot()` marker search is the right coordinate system for this service.

## Tradeoff

This intentionally does not reorder the old `docs/features` checks. It removes that content-based heuristic from memory root detection and uses the monorepo marker first, with the same CWD fallback for non-monorepo setups. `DOCS_ROOT` remains the highest-priority explicit override.

## Test Evidence

```
pnpm --filter @cat-cafe/api run build
# pass

pnpm --filter @cat-cafe/api run lint
# pass

cd packages/api && CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import $(pwd)/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/memory-root.test.js test/memory/evidence-rebuild-route.test.js test/evidence-route.test.js
# pass: 44/44

pnpm check
# pass on rerun; pre-merge Redis orphan subcheck also passed when rerun directly

pnpm --filter @cat-cafe/api run test:public
# fail: 12299 pass / 4 fail, all in test/cli-spawn-win.test.js Windows shim resolver cases on this macOS host; no changed files overlap those tests or resolver code
```

## AC Checklist (Feature PRs only)

N/A - patch.
