### PR TITLE
fix(api): sanitize supervisor env-file args

### DIFF
--- a/packages/api/src/utils/cli-spawn.ts
+++ b/packages/api/src/utils/cli-spawn.ts
@@ -139,12 +139,30 @@ export interface CliSpawnerDeps {
   spawnFn?: SpawnFn;
 }
 
+const CLI_SUPERVISOR_ENV_FILE_FLAGS = new Set(['--env-file', '--env-file-if-exists']);
+
+function sanitizeCliSupervisorExecArgv(execArgv: string[]): string[] {
+  const safeArgs: string[] = [];
+  for (let index = 0; index < execArgv.length; index += 1) {
+    const arg = execArgv[index];
+    if (CLI_SUPERVISOR_ENV_FILE_FLAGS.has(arg)) {
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--env-file=') || arg.startsWith('--env-file-if-exists=')) {
+      continue;
+    }
+    safeArgs.push(arg);
+  }
+  return safeArgs;
+}
+
 export function resolveCliSupervisorNodeArgs(moduleUrl = import.meta.url, execArgv = process.execArgv): string[] {
   const jsPath = fileURLToPath(new URL('./cli-supervisor.js', moduleUrl));
   if (existsSync(jsPath)) return [jsPath];
 
   const tsPath = fileURLToPath(new URL('./cli-supervisor.ts', moduleUrl));
-  if (existsSync(tsPath)) return [...execArgv, tsPath];
+  if (existsSync(tsPath)) return [...sanitizeCliSupervisorExecArgv(execArgv), tsPath];
 
   return [jsPath];
 }

--- a/packages/api/test/cli-spawn.test.js
+++ b/packages/api/test/cli-spawn.test.js
@@ -223,6 +223,34 @@ test('resolveCliSupervisorNodeArgs falls back to source ts file under tsx runtim
   }
 });
 
+test('resolveCliSupervisorNodeArgs drops API env-file execArgv from source ts fallback', async () => {
+  const tempDir = await mkdtemp(join(tmpdir(), 'cat-cafe-cli-supervisor-env-file-'));
+  try {
+    const utilsDir = join(tempDir, 'src', 'utils');
+    await mkdir(utilsDir, { recursive: true });
+    const cliSpawnPath = join(utilsDir, 'cli-spawn.ts');
+    const supervisorPath = join(utilsDir, 'cli-supervisor.ts');
+    await writeFile(cliSpawnPath, '');
+    await writeFile(supervisorPath, '');
+
+    const args = resolveCliSupervisorNodeArgs(pathToFileURL(cliSpawnPath).href, [
+      '--import',
+      'tsx',
+      '--env-file=.env',
+      '--env-file',
+      '.env.local',
+      '--env-file-if-exists=.env.development',
+      '--env-file-if-exists',
+      '.env.optional',
+      '--trace-warnings',
+    ]);
+
+    assert.deepEqual(args, ['--import', 'tsx', '--trace-warnings', supervisorPath]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('resolveCliSupervisorNodeArgs prefers built js file when present', async () => {
   const tempDir = await mkdtemp(join(tmpdir(), 'cat-cafe-cli-supervisor-dist-'));
   try {
@@ -233,7 +261,13 @@ test('resolveCliSupervisorNodeArgs prefers built js file when present', async ()
     await writeFile(cliSpawnPath, '');
     await writeFile(supervisorPath, '');
 
-    const args = resolveCliSupervisorNodeArgs(pathToFileURL(cliSpawnPath).href, ['--import', 'tsx']);
+    const args = resolveCliSupervisorNodeArgs(pathToFileURL(cliSpawnPath).href, [
+      '--import',
+      'tsx',
+      '--env-file=.env',
+      '--env-file',
+      '.env.local',
+    ]);
 
     assert.deepEqual(args, [supervisorPath]);
   } finally {


### PR DESCRIPTION
## What

- Filters API-local Node env-file flags from the CLI supervisor TS source fallback path.
- Handles both inline and split forms for `--env-file` and `--env-file-if-exists`.
- Preserves loader/runtime args such as `--import tsx`, and keeps the built JS supervisor path isolated.
- Adds regression coverage for source fallback filtering and built JS path isolation.

## Why

Fixes #889

When the API process is launched with a relative env-file flag, the TS fallback supervisor inherited that flag through `process.execArgv`. The supervisor child runs with the external project cwd, so Node 24 could try to resolve the API-local `.env` there and exit before the supervisor could return a structured CLI diagnostic.

## Test Evidence

```text
pnpm --filter @cat-cafe/api run build
CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import $(pwd)/packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cli-spawn.test.js
# pass 78, fail 0

pnpm check
# pass

pnpm --filter @cat-cafe/api run lint
# pass
```

## Provenance

- Source-side PR: zts212653/cat-cafe#2201
- Source commit: 12831330f
- Hotfix base tag: sync/2026-06-10-063004
- Local reviewer: Opus 4.6 approved the source-side fix before merge.

## Tradeoff

The sanitizer stays narrow: it strips the cwd-sensitive env-file flag family only. It does not remove broader Node runtime flags because the dev TS fallback still needs loader args to execute through tsx.

---

Maintainer signature: 缅因猫/砚砚 (gpt-5.5)
