### PR TITLE
fix: batch theme + UI + API fixes (8 issues)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/QueueProcessor.ts
@@ -172,6 +172,8 @@ export interface QueueProcessorDeps {
   streamingHook?: StreamingOutboundHookLike;
   /** F088 fix: optional thread metadata lookup for outbound delivery. */
   threadMetaLookup?: (threadId: string) => ThreadMetaLike | undefined | Promise<ThreadMetaLike | undefined>;
+  /** Outbound delivery timeout in ms (default 10_000). Mirrors ConnectorInvokeTrigger. */
+  deliverTimeoutMs?: number;
   /** #813: Thread store for passive continuation (write/consume pending continuation). */
   threadStore?: ThreadStoreLike;
   /** F224: continuation lifecycle coordinator boundary. */
@@ -877,6 +879,10 @@ export class QueueProcessor {
     // Cloud Codex P2: defer A2A consumption to success path — entries stay in queue
     // until the batch actually succeeds. The invocationTracker prevents double-pickup.
     let deferredA2AConsume = new Set<string>();
+    // R4 fix: hoist streamStartPromise above try so the catch block can await it
+    // before calling onStreamEnd → cleanupPlaceholders (the correct failure cleanup
+    // sequence per messages.ts cleanupStreamingOnFailure).
+    let streamStartPromise: Promise<void> | undefined;
 
     try {
       // 1. Create InvocationRecord (before batching — avoid claiming entries on duplicate)
@@ -1192,7 +1198,6 @@ export class QueueProcessor {
       const hook = this.entryCompleteHooks.get(entry.id);
 
       // F088 fix: start streaming placeholder on external platforms
-      let streamStartPromise: Promise<void> | undefined;
       if (this.deps.streamingHook) {
         streamStartPromise = this.deps.streamingHook
           .onStreamStart(threadId, primaryCat, invocationId, entry.senderMeta)
@@ -1203,7 +1208,7 @@ export class QueueProcessor {
 
       // F151: Mid-loop delivery to preserve ordering (same fix as ConnectorInvokeTrigger)
       const deliveredTurnIndices = new Set<number>();
-      const DELIVER_TIMEOUT_MS = 10_000;
+      const DELIVER_TIMEOUT_MS = this.deps.deliverTimeoutMs ?? 10_000;
       let threadMeta: ThreadMetaLike | undefined;
       let threadMetaPromise: Promise<ThreadMetaLike | undefined> | undefined;
       if (this.deps.outboundHook && this.deps.threadMetaLookup) {
@@ -1485,6 +1490,48 @@ export class QueueProcessor {
         /* ignore secondary errors */
       }
 
+      // R4 fix (#873): correct failure cleanup sequence per messages.ts
+      // cleanupStreamingOnFailure — onStreamEnd moves sessions from active →
+      // pendingCleanup; cleanupPlaceholders only acts on pendingCleanup, so
+      // calling it alone is a no-op when sessions are still active.
+      if (this.deps.streamingHook && invocationId) {
+        try {
+          const STREAM_START_TIMEOUT_MS = 5000;
+          if (streamStartPromise) {
+            await Promise.race([streamStartPromise, new Promise<void>((r) => setTimeout(r, STREAM_START_TIMEOUT_MS))]);
+          }
+          await this.deps.streamingHook.onStreamEnd(threadId, '', invocationId);
+          await this.deps.streamingHook.cleanupPlaceholders?.(threadId, invocationId);
+        } catch (cleanupErr) {
+          log.warn({ err: cleanupErr, threadId }, '[QueueProcessor] Error-path streaming cleanup failed');
+        }
+      }
+
+      // R3 P2 fix (#873): Deliver error message to external IM so user sees
+      // a reply instead of silence (mirrors ConnectorInvokeTrigger error path).
+      // R6 fix: timeout prevents adapter hang from pinning queue slot (Cloud P1).
+      if (this.deps.outboundHook) {
+        const ERROR_DELIVER_TIMEOUT_MS = this.deps.deliverTimeoutMs ?? 10_000;
+        try {
+          await Promise.race([
+            this.deps.outboundHook.deliver(
+              threadId,
+              '抱歉，处理消息时遇到问题，请稍后重试。',
+              primaryCat,
+              undefined,
+              undefined,
+              undefined,
+              messageId ?? undefined,
+            ),
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('deliver timeout')), ERROR_DELIVER_TIMEOUT_MS),
+            ),
+          ]);
+        } catch (deliverErr) {
+          log.error({ err: deliverErr, threadId }, '[QueueProcessor] Error-path outbound delivery failed');
+        }
+      }
+
       return 'failed';
     } finally {
       // Always cleanup tracker + queue (all target cat slots)
@@ -1648,7 +1695,7 @@ export class QueueProcessor {
         }
       }
 
-      const DELIVER_TIMEOUT_MS = 10_000;
+      const DELIVER_TIMEOUT_MS = this.deps.deliverTimeoutMs ?? 10_000;
       // F151: skip turns already delivered mid-loop
       const nonEmptyTurns = outboundTurns.filter(
         (t, i) =>
@@ -1752,10 +1799,53 @@ export class QueueProcessor {
           }
         });
       }
-    } else if (this.deps.streamingHook?.cleanupPlaceholders) {
-      await this.deps.streamingHook.cleanupPlaceholders(threadId, invocationId).catch((err) => {
-        log.warn({ err, threadId }, '[QueueProcessor] StreamingHook.cleanupPlaceholders failed (silent)');
-      });
+    } else {
+      // R6+R7 fix: deliver fallback FIRST (with timeout), then cleanup placeholder
+      // only on success — preserves "thinking" card if delivery fails (Cloud P2).
+      // Timeout prevents adapter hang from pinning queue slot (Cloud P1).
+      // R7: late-success cleanup mirrors normal content-delivery pattern (lines 1783-1798).
+      const SILENT_DELIVER_TIMEOUT_MS = this.deps.deliverTimeoutMs ?? 10_000;
+      let silentDeliveryOk = !this.deps.outboundHook;
+      let silentDeliverPromise: Promise<void> | undefined;
+      if (this.deps.outboundHook) {
+        silentDeliverPromise = this.deps.outboundHook.deliver(
+          threadId,
+          '处理完成，但未产生回复内容。',
+          primaryCat,
+          undefined,
+          preResolvedMeta,
+          undefined,
+          triggerMessageId,
+        );
+        try {
+          await Promise.race([
+            silentDeliverPromise,
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('deliver timeout')), SILENT_DELIVER_TIMEOUT_MS),
+            ),
+          ]);
+          silentDeliveryOk = true;
+        } catch (deliverErr) {
+          log.error({ err: deliverErr, threadId }, '[QueueProcessor] Silent-path outbound delivery failed');
+        }
+      }
+      if (silentDeliveryOk && this.deps.streamingHook?.cleanupPlaceholders) {
+        await this.deps.streamingHook.cleanupPlaceholders(threadId, invocationId).catch((err) => {
+          log.warn({ err, threadId }, '[QueueProcessor] StreamingHook.cleanupPlaceholders failed (silent)');
+        });
+      } else if (silentDeliverPromise && this.deps.streamingHook?.cleanupPlaceholders) {
+        // R7: timeout fired but delivery may still succeed — defer cleanup to late-success
+        const cleanupFn = this.deps.streamingHook.cleanupPlaceholders.bind(this.deps.streamingHook);
+        silentDeliverPromise
+          .then(() => {
+            cleanupFn(threadId, invocationId).catch((err: unknown) => {
+              log.warn({ err, threadId }, '[QueueProcessor] Silent late-success placeholder cleanup failed');
+            });
+          })
+          .catch(() => {
+            /* delivery truly failed — thinking card stays as fallback UX */
+          });
+      }
     }
   }
 

--- a/packages/api/src/domains/cats/services/first-run-quest/client-detection.ts
+++ b/packages/api/src/domains/cats/services/first-run-quest/client-detection.ts
@@ -12,6 +12,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { resolveCliCommand } from '../../../../utils/cli-resolve.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -81,7 +82,10 @@ const defaultExistsOnPath: ExistsOnPath = async (cli) => {
     }
     return true;
   } catch {
-    return false;
+    // PATH probe failed — fall back to well-known directory search (macOS GUI
+    // apps / Electron don't inherit the user's shell PATH).
+    // #894: skipPathProbe since we already probed PATH above; only scan fallback dirs.
+    return resolveCliCommand(cli, { skipPathProbe: true }) !== null;
   }
 };
 

--- a/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
+++ b/packages/api/src/infrastructure/email/ConnectorInvokeTrigger.ts
@@ -274,6 +274,9 @@ export class ConnectorInvokeTrigger {
     const HEARTBEAT_INTERVAL_MS = 30_000;
     let heartbeatInterval: ReturnType<typeof setInterval> | undefined;
     let invocationId: string | undefined;
+    // R4 fix: hoist above try so catch can await it for correct failure cleanup
+    // (onStreamEnd → cleanupPlaceholders, per messages.ts cleanupStreamingOnFailure).
+    let streamStartPromise: Promise<void> | undefined;
 
     try {
       // ① Atomic create InvocationRecord (inside try so finally releases controller on throw)
@@ -335,7 +338,6 @@ export class ConnectorInvokeTrigger {
       // Phase 4: Start streaming placeholder on external platforms
       // Fire-and-forget for the loop, but save the promise so onStreamEnd can await it
       // to prevent race (onStreamEnd before onStreamStart finishes registering sessions).
-      let streamStartPromise: Promise<void> | undefined;
       if (this.opts.streamingHook) {
         streamStartPromise = this.opts.streamingHook
           .onStreamStart(threadId, catId, createResult.invocationId, sender)
@@ -650,11 +652,56 @@ export class ConnectorInvokeTrigger {
               }
             });
           }
-        } else if (this.opts.streamingHook?.cleanupPlaceholders) {
-          // Cloud-P1-R3: silent invocation (no content) — still clean up placeholder
-          await this.opts.streamingHook.cleanupPlaceholders(threadId, createResult.invocationId).catch((err) => {
-            log.warn({ err, threadId }, '[ConnectorInvokeTrigger] StreamingHook.cleanupPlaceholders failed (silent)');
-          });
+        } else {
+          // R6+R7 fix: deliver fallback FIRST (with timeout), then cleanup placeholder
+          // only on success — preserves "thinking" card if delivery fails (Cloud P2).
+          // Timeout prevents adapter hang from blocking finally (Cloud P1).
+          // R7: late-success cleanup mirrors normal content-delivery pattern (lines 641-653).
+          let silentDeliveryOk = !this.opts.outboundHook; // no hook → proceed to cleanup
+          let silentDeliverPromise: Promise<void> | undefined;
+          if (this.opts.outboundHook) {
+            silentDeliverPromise = this.opts.outboundHook.deliver(
+              threadId,
+              '处理完成，但未产生回复内容。',
+              catId,
+              undefined,
+              undefined,
+              undefined,
+              messageId,
+            );
+            try {
+              await Promise.race([
+                silentDeliverPromise,
+                new Promise<void>((_, reject) =>
+                  setTimeout(() => reject(new Error('deliver timeout')), DELIVER_TIMEOUT_MS),
+                ),
+              ]);
+              silentDeliveryOk = true;
+            } catch (deliverErr) {
+              log.error({ err: deliverErr, threadId }, '[ConnectorInvokeTrigger] Silent-path outbound delivery failed');
+            }
+          }
+          if (silentDeliveryOk && this.opts.streamingHook?.cleanupPlaceholders) {
+            await this.opts.streamingHook.cleanupPlaceholders(threadId, createResult.invocationId).catch((err) => {
+              log.warn({ err, threadId }, '[ConnectorInvokeTrigger] StreamingHook.cleanupPlaceholders failed (silent)');
+            });
+          } else if (silentDeliverPromise && this.opts.streamingHook?.cleanupPlaceholders) {
+            // R7: timeout fired but delivery may still succeed — defer cleanup to late-success
+            const cleanupHook = this.opts.streamingHook;
+            const scopedInvocationId = createResult.invocationId;
+            silentDeliverPromise
+              .then(() => {
+                cleanupHook.cleanupPlaceholders(threadId, scopedInvocationId).catch((err) => {
+                  log.warn(
+                    { err, threadId },
+                    '[ConnectorInvokeTrigger] Silent late-success placeholder cleanup failed',
+                  );
+                });
+              })
+              .catch(() => {
+                /* delivery truly failed — thinking card stays as fallback UX */
+              });
+          }
         }
       }
 
@@ -687,6 +734,46 @@ export class ConnectorInvokeTrigger {
         },
         threadId,
       );
+
+      // R4 fix (#873): correct failure cleanup — onStreamEnd transitions sessions
+      // from active → pendingCleanup; cleanupPlaceholders alone is a no-op on active
+      // sessions. Matches messages.ts cleanupStreamingOnFailure() sequence.
+      if (this.opts.streamingHook) {
+        try {
+          const STREAM_START_TIMEOUT_MS = 5000;
+          if (streamStartPromise) {
+            await Promise.race([streamStartPromise, new Promise<void>((r) => setTimeout(r, STREAM_START_TIMEOUT_MS))]);
+          }
+          await this.opts.streamingHook.onStreamEnd(threadId, '', invocationId);
+          await this.opts.streamingHook.cleanupPlaceholders?.(threadId, invocationId);
+        } catch (cleanupErr) {
+          log.warn({ err: cleanupErr, threadId }, '[ConnectorInvokeTrigger] Error-path streaming cleanup failed');
+        }
+      }
+
+      // #873: Deliver error message to external IM platform so user sees a reply (not silence)
+      // R6 fix: timeout prevents adapter hang from blocking finally (Cloud P1).
+      if (this.opts.outboundHook) {
+        const ERROR_DELIVER_TIMEOUT_MS = this.opts.deliverTimeoutMs ?? 10_000;
+        try {
+          await Promise.race([
+            this.opts.outboundHook.deliver(
+              threadId,
+              '抱歉，处理消息时遇到问题，请稍后重试。',
+              catId,
+              undefined,
+              undefined,
+              undefined,
+              messageId,
+            ),
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('deliver timeout')), ERROR_DELIVER_TIMEOUT_MS),
+            ),
+          ]);
+        } catch (deliverErr) {
+          log.error({ err: deliverErr, threadId }, '[ConnectorInvokeTrigger] Error-path outbound delivery failed');
+        }
+      }
     } finally {
       if (heartbeatInterval) clearInterval(heartbeatInterval);
       invocationTracker.complete(threadId, catId, controller);

--- a/packages/api/src/utils/cli-diagnostics.ts
+++ b/packages/api/src/utils/cli-diagnostics.ts
@@ -145,12 +145,21 @@ function truncateEvidenceString(value: string, maxChars: number): string {
   return `${sanitized.slice(0, maxChars - 3)}...`;
 }
 
-function truncateSilentEvidenceString(value: string, maxChars: number): string {
-  const sanitized = sanitizeCliStderr(value)
+/**
+ * R3 P1 fix (#857): aggressive path redaction for non-HOME absolute paths.
+ * sanitizeCliStderr only handles HOME/USERPROFILE/C:\Users/tmp — server installs
+ * under /srv, /workspace, /var/lib, D:\work would leak raw paths. This helper
+ * strips ALL multi-segment absolute paths (both Unix and Windows) that survived
+ * the HOME sanitizer. Used by unknown_raw + silent_completion evidence surfaces.
+ */
+function redactNonHomePaths(input: string): string {
+  return input
     .replace(/\b[A-Za-z]:\\(?:[^\s"'`<>|]+\\)*[^\s"'`<>|]+/g, '[PATH_REDACTED]')
-    .replace(/(^|[\s"'`(=:[{,])\/(?!tmp\/\[REDACTED\])(?:[^\s"'`<>{}|]+\/)+[^\s"'`<>{}|]+/g, '$1[PATH_REDACTED]')
-    .replace(/\s+/g, ' ')
-    .trim();
+    .replace(/(^|[\s"'`(=:[{,])\/(?!tmp\/\[REDACTED\])(?:[^\s"'`<>{}|]+\/)+[^\s"'`<>{}|]+/g, '$1[PATH_REDACTED]');
+}
+
+function truncateSilentEvidenceString(value: string, maxChars: number): string {
+  const sanitized = redactNonHomePaths(sanitizeCliStderr(value)).replace(/\s+/g, ' ').trim();
   if (sanitized.length <= maxChars) return sanitized;
   if (maxChars <= 3) return sanitized.slice(0, maxChars);
   return `${sanitized.slice(0, maxChars - 3)}...`;
@@ -289,16 +298,31 @@ export function buildCliDiagnostics(args: {
     }
   }
 
-  // Truly unknown (no structured CC error) — keep KD-1: no safeExcerpt.
+  // Truly unknown (no structured CC error).
+  // #857: when rawText is available, sanitize + truncate and surface as safeExcerpt so
+  // users see a desensitized message instead of having to check backend logs.
   // F212 Phase F (AC-F4/F5): pick honest unknown hint by stderrEmpty signal when caller
   // provides it; fall back to legacy hint for backward-compat (callers without Phase F awareness).
   let unknownHint: string = UNKNOWN_TEXT.hint;
   if (args.stderrEmpty === true) unknownHint = UNKNOWN_HINT_EMPTY_STDERR;
   else if (args.stderrEmpty === false) unknownHint = UNKNOWN_HINT_HAS_STDERR;
+
+  const trimmedRaw = args.rawText?.trim();
+  let safeExcerpt: string | undefined;
+  let excerptSource: CliDiagnostics['excerptSource'] | undefined;
+  if (trimmedRaw) {
+    // R3 P1 fix (#857): sanitize + redact non-HOME paths. sanitizeCliStderr only
+    // covers HOME/USERPROFILE/C:\Users/tmp; server installs under /srv, /workspace,
+    // /var/lib, D:\work would leak raw paths without the extra redaction layer.
+    safeExcerpt = redactNonHomePaths(sanitizeCliStderr(trimmedRaw)).slice(0, MAX_CHARS);
+    excerptSource = 'unknown_raw';
+  }
+
   return {
     publicSummary: panicHeadline ? `CLI panic — ${panicHeadline}` : UNKNOWN_TEXT.summary,
     publicHint: unknownHint,
     debugRef: args.debugRef,
+    ...(safeExcerpt && { safeExcerpt, excerptSource }),
   };
 }
 

--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -74,7 +74,7 @@ export function invalidateCliCommand(commandOrPath: string): void {
  * fall through to re-probe instead of handing callers a stale path that would
  * spawn ENOENT in a loop until process restart.
  */
-export function resolveCliCommand(command: string): string | null {
+export function resolveCliCommand(command: string, opts?: { skipPathProbe?: boolean }): string | null {
   const cached = resolvedCache.get(command);
   if (cached !== undefined) {
     if (existsSync(cached)) return cached;
@@ -82,21 +82,25 @@ export function resolveCliCommand(command: string): string | null {
   }
 
   // Fast path: already in PATH
-  try {
-    const which = IS_WINDOWS ? `where ${command}` : `which ${command}`;
-    const result = execSync(which, { timeout: 5000, encoding: 'utf-8' }).trim();
-    if (result) {
-      const lines = result
-        .split('\n')
-        .map((l) => l.trim())
-        .filter(Boolean);
-      // On Windows, prefer the .cmd shim (more reliable for shim resolution)
-      const resolved = (IS_WINDOWS && lines.find((l) => /\.cmd$/i.test(l))) || lines[0];
-      resolvedCache.set(command, resolved);
-      return resolved;
+  // #894: caller can skip this when PATH was already probed (e.g. client-detection
+  // does its own `command -v`; repeating `which` is redundant + slower).
+  if (!opts?.skipPathProbe) {
+    try {
+      const which = IS_WINDOWS ? `where ${command}` : `which ${command}`;
+      const result = execSync(which, { timeout: 5000, encoding: 'utf-8' }).trim();
+      if (result) {
+        const lines = result
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean);
+        // On Windows, prefer the .cmd shim (more reliable for shim resolution)
+        const resolved = (IS_WINDOWS && lines.find((l) => /\.cmd$/i.test(l))) || lines[0];
+        resolvedCache.set(command, resolved);
+        return resolved;
+      }
+    } catch {
+      // fall through to manual search
     }
-  } catch {
-    // fall through to manual search
   }
 
   // Search common install directories

--- a/packages/api/test/cli-diagnostics-unknown-raw.test.js
+++ b/packages/api/test/cli-diagnostics-unknown-raw.test.js
@@ -1,0 +1,91 @@
+/**
+ * #857 regression: buildCliDiagnostics surfaces a sanitized safeExcerpt for
+ * truly unknown CLI errors when rawText is available (excerptSource='unknown_raw').
+ *
+ * Security invariants:
+ * - Secret tokens in rawText are redacted by sanitizeCliStderr
+ * - excerptSource is 'unknown_raw' (admitted by frontend KNOWN_EXCERPT_SOURCES)
+ * - Missing rawText → no safeExcerpt (fail-closed)
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+const { buildCliDiagnostics } = await import('../dist/utils/cli-diagnostics.js');
+
+const debugRef = { command: 'test-cli', exitCode: 1, exitSignal: undefined, durationMs: 100 };
+
+describe('buildCliDiagnostics — unknown_raw excerpt (#857)', () => {
+  it('surfaces sanitized rawText as safeExcerpt with source unknown_raw', () => {
+    const result = buildCliDiagnostics({
+      rawText: 'Error: could not connect to server',
+      debugRef,
+    });
+    assert.equal(result.excerptSource, 'unknown_raw');
+    assert.ok(result.safeExcerpt);
+    assert.ok(result.safeExcerpt.includes('could not connect to server'));
+  });
+
+  it('redacts secrets in rawText before surfacing', () => {
+    const result = buildCliDiagnostics({
+      rawText: 'Auth failed: api_key="sk-ant-api03-xxxxxxxxxxxxxxxxx" invalid',
+      debugRef,
+    });
+    assert.equal(result.excerptSource, 'unknown_raw');
+    assert.ok(result.safeExcerpt);
+    assert.ok(!result.safeExcerpt.includes('sk-ant-api03'), 'token should be redacted');
+    assert.ok(result.safeExcerpt.includes('[TOKEN_REDACTED]'));
+  });
+
+  // R3 P1 fix: non-HOME absolute paths (e.g. /srv, /workspace, D:\work) must be
+  // redacted by redactNonHomePaths — sanitizeCliStderr alone only covers HOME paths.
+  it('redacts non-HOME Unix paths in rawText (#857 R3 P1)', () => {
+    const result = buildCliDiagnostics({
+      rawText: 'Failed to open /srv/app/config/secrets.json: ENOENT',
+      debugRef,
+    });
+    assert.equal(result.excerptSource, 'unknown_raw');
+    assert.ok(result.safeExcerpt);
+    assert.ok(!result.safeExcerpt.includes('/srv/app'), 'non-HOME Unix path should be redacted');
+    assert.ok(result.safeExcerpt.includes('[PATH_REDACTED]'));
+  });
+
+  it('redacts non-HOME Windows paths in rawText (#857 R3 P1)', () => {
+    const result = buildCliDiagnostics({
+      rawText: 'Cannot find D:\\work\\project\\credentials.txt',
+      debugRef,
+    });
+    assert.equal(result.excerptSource, 'unknown_raw');
+    assert.ok(result.safeExcerpt);
+    assert.ok(!result.safeExcerpt.includes('D:\\work'), 'non-HOME Windows path should be redacted');
+    assert.ok(result.safeExcerpt.includes('[PATH_REDACTED]'));
+  });
+
+  it('redacts /workspace and /var/lib paths in rawText (#857 R3 P1)', () => {
+    const result = buildCliDiagnostics({
+      rawText: 'Error at /workspace/build/output/binary and /var/lib/data/db.sqlite',
+      debugRef,
+    });
+    assert.equal(result.excerptSource, 'unknown_raw');
+    assert.ok(result.safeExcerpt);
+    assert.ok(!result.safeExcerpt.includes('/workspace/build'), '/workspace path should be redacted');
+    assert.ok(!result.safeExcerpt.includes('/var/lib/data'), '/var/lib path should be redacted');
+  });
+
+  it('omits safeExcerpt when rawText is empty (fail-closed)', () => {
+    const result = buildCliDiagnostics({
+      rawText: '',
+      debugRef,
+    });
+    assert.equal(result.safeExcerpt, undefined);
+    assert.equal(result.excerptSource, undefined);
+  });
+
+  it('omits safeExcerpt when rawText is whitespace-only', () => {
+    const result = buildCliDiagnostics({
+      rawText: '   \n  ',
+      debugRef,
+    });
+    assert.equal(result.safeExcerpt, undefined);
+    assert.equal(result.excerptSource, undefined);
+  });
+});

--- a/packages/api/test/cli-diagnostics.test.js
+++ b/packages/api/test/cli-diagnostics.test.js
@@ -12,10 +12,12 @@ import { maybeCollectStreamError } from '../dist/utils/cli-spawn.js';
 
 const baseRef = { command: 'codex', exitCode: 1, signal: null, invocationId: 'inv-1' };
 
-test('AC-A5: unknown stderr → no safeExcerpt, publicSummary fallback', () => {
+test('AC-A5: unknown stderr → sanitized safeExcerpt (#857), publicSummary fallback', () => {
   const d = buildCliDiagnostics({ rawText: 'some weird thing happened', debugRef: baseRef });
   assert.strictEqual(d.reasonCode, undefined);
-  assert.strictEqual(d.safeExcerpt, undefined);
+  // #857: unknown raw text now surfaced as sanitized safeExcerpt (was: undefined per KD-1)
+  assert.ok(d.safeExcerpt, 'unknown raw text should produce safeExcerpt (#857)');
+  assert.strictEqual(d.excerptSource, 'unknown_raw');
   assert.match(d.publicSummary, /未识别/);
   assert.ok(d.publicHint.length > 0);
 });
@@ -57,7 +59,7 @@ test('AC-A6: panic stack — safeExcerpt strips frame lines if any', () => {
   assert.ok(!d.safeExcerpt.includes('.cargo/registry'), 'cargo path leaked');
 });
 
-test('AC-A6: panic without classifier match — publicSummary surfaces headline, no safeExcerpt', () => {
+test('AC-A6: panic without classifier match — publicSummary surfaces headline, sanitized safeExcerpt (#857)', () => {
   const rawText = [
     'thread "worker" panicked at src/bar.rs:99:1:',
     'completely unknown failure mode',
@@ -66,7 +68,9 @@ test('AC-A6: panic without classifier match — publicSummary surfaces headline,
   ].join('\n');
   const d = buildCliDiagnostics({ rawText, debugRef: baseRef });
   assert.strictEqual(d.reasonCode, undefined);
-  assert.strictEqual(d.safeExcerpt, undefined);
+  // #857: unknown raw text now surfaced as sanitized safeExcerpt
+  assert.ok(d.safeExcerpt, 'panic raw text should produce safeExcerpt (#857)');
+  assert.strictEqual(d.excerptSource, 'unknown_raw');
   assert.match(d.publicSummary, /panic/i);
   assert.match(d.publicSummary, /worker/);
 });
@@ -274,13 +278,13 @@ test('AC-D3: unknown reasonCode + structuredErrorText → "Claude Code 报告：
   assert.strictEqual(d.excerptSource, 'cc_structured', 'AC-D3 path tags excerptSource for frontend whitelist');
 });
 
-test('AC-D3: truly unknown (no structuredErrorText) → keeps KD-1 no-safeExcerpt + 未识别 + no excerptSource', () => {
+test('AC-D3: truly unknown (no structuredErrorText) → sanitized safeExcerpt (#857) + 未识别', () => {
   const d = buildCliDiagnostics({ rawText: 'random noise no cause', debugRef: baseRef });
   assert.strictEqual(d.reasonCode, undefined);
-  assert.strictEqual(d.safeExcerpt, undefined, 'KD-1: no safeExcerpt for truly unknown');
+  // #857: unknown raw text now surfaced as sanitized safeExcerpt (overrides KD-1 for non-empty rawText)
+  assert.ok(d.safeExcerpt, 'unknown raw text should produce safeExcerpt (#857)');
+  assert.strictEqual(d.excerptSource, 'unknown_raw');
   assert.ok(d.publicSummary.includes('未识别'), 'truly unknown keeps 未识别');
-  // Phase D P2 fix: no safeExcerpt → no excerptSource (frontend membership check will fail closed)
-  assert.strictEqual(d.excerptSource, undefined, 'truly unknown: no excerptSource (fail-closed)');
 });
 
 // F212 Phase E — server_overloaded provider-neutral invariant (cloud codex R2 P2 on adf26db37):

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -168,6 +168,44 @@ test(
   },
 );
 
+// --- #894: skipPathProbe skips PATH and goes straight to fallback dirs ---
+
+test(
+  'resolveCliCommand with skipPathProbe finds CLI in fallback dir without PATH probe (#894)',
+  { skip: process.platform === 'win32' && 'Unix-only (HOME fallback)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-skipprobe-'));
+    const localBin = join(tempRoot, '.local', 'bin');
+    mkdirSync(localBin, { recursive: true });
+
+    // Use a unique name that definitely won't be on PATH
+    const cmdName = 'fake-skipprobe-test-tool-894';
+    const fakeBin = join(localBin, cmdName);
+    writeFileSync(fakeBin, '#!/bin/sh\necho ok\n', { mode: 0o755 });
+
+    const originalHome = process.env.HOME;
+    try {
+      process.env.HOME = tempRoot;
+      // Clear any cached result first
+      invalidateCliCommand(cmdName);
+
+      const result = resolveCliCommand(cmdName, { skipPathProbe: true });
+      assert.equal(result, fakeBin, 'should find binary in fallback dir even with skipPathProbe');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test('resolveCliCommand with skipPathProbe returns null when not in fallback dirs', () => {
+  const cmdName = 'nonexistent-skipprobe-xyz-894';
+  invalidateCliCommand(cmdName);
+  const result = resolveCliCommand(cmdName, { skipPathProbe: true });
+  assert.equal(result, null, 'should return null for truly missing CLI');
+});
+
 // --- F173 Phase D AC-D1/D2: cache invalidation on stale entry ---
 
 test(

--- a/packages/api/test/cli-spawn.test.js
+++ b/packages/api/test/cli-spawn.test.js
@@ -1757,7 +1757,7 @@ test('F212 AC-A1: __cliError includes cliDiagnostics with reasonCode for known s
   assert.equal(err.cliDiagnostics.debugRef.invocationId, 'inv-A1');
 });
 
-test('F212 AC-A1: __cliError for unknown stderr has cliDiagnostics with no reasonCode/safeExcerpt', async () => {
+test('F212 AC-A1: __cliError for unknown stderr has cliDiagnostics with sanitized safeExcerpt (#857)', async () => {
   const proc = createMockProcess({ exitOnKill: false });
   const spawnFn = createMockSpawnFn(proc);
 
@@ -1771,7 +1771,9 @@ test('F212 AC-A1: __cliError for unknown stderr has cliDiagnostics with no reaso
   assert.ok(err);
   assert.ok(err.cliDiagnostics);
   assert.equal(err.cliDiagnostics.reasonCode, undefined);
-  assert.equal(err.cliDiagnostics.safeExcerpt, undefined);
+  // #857: unknown raw text now surfaced as sanitized safeExcerpt
+  assert.ok(err.cliDiagnostics.safeExcerpt, 'unknown stderr should produce safeExcerpt (#857)');
+  assert.equal(err.cliDiagnostics.excerptSource, 'unknown_raw');
   assert.match(err.cliDiagnostics.publicSummary, /未识别/);
 });
 

--- a/packages/api/test/connector-invoke-trigger.test.js
+++ b/packages/api/test/connector-invoke-trigger.test.js
@@ -613,8 +613,9 @@ describe('ConnectorInvokeTrigger', () => {
     assert.deepStrictEqual(deliverOrder, ['opus', 'codex'], 'Should deliver in cat order, not race order');
   });
 
-  it('cloud-P1: does NOT deliver empty reply for silent invocation (no text, no richBlocks)', async () => {
-    // Router yields only 'done' — no text, no richBlocks
+  it('cloud-P1: delivers fallback message for silent invocation (#873)', async () => {
+    // Router yields only 'done' — no text, no richBlocks.
+    // #873 fix: silent path now delivers a fallback so IM users aren't left hanging.
     const silentRouter = /** @type {any} */ ({
       async *routeExecution(userId, message, threadId, userMessageId, targetCats, intent, options) {
         yield {
@@ -639,7 +640,9 @@ describe('ConnectorInvokeTrigger', () => {
     trigger.trigger('thread-1', /** @type {any} */ ('opus'), 'user-1', 'msg', 'msg-1');
     await waitForTrigger();
 
-    assert.strictEqual(deliverCalls.length, 0, 'Should NOT deliver empty reply for silent cat');
+    assert.strictEqual(deliverCalls.length, 1, 'Should deliver fallback for silent invocation');
+    assert.strictEqual(deliverCalls[0].catId, 'opus');
+    assert.ok(deliverCalls[0].content, 'Fallback content should be non-empty');
   });
 
   it('cloud-P1: hanging deliver does not block tracker cleanup', async () => {
@@ -757,6 +760,117 @@ describe('ConnectorInvokeTrigger', () => {
       cleanupCalled,
       false,
       'cleanup must NOT run after hard delivery failure (R5-P1: preserve placeholder)',
+    );
+  });
+
+  it('R7: silent fallback late-success triggers deferred placeholder cleanup', async () => {
+    // Silent invocation (only done, no text) → deliver times out → deliver later succeeds
+    // → cleanupPlaceholders must be called on late-success (R7 fix).
+    const silentRouter = /** @type {any} */ ({
+      async *routeExecution(_u, _m, _t, _mid, targetCats, _i, _o) {
+        yield {
+          type: 'done',
+          catId: targetCats[0],
+          content: '',
+          timestamp: Date.now(),
+          metadata: { usage: { inputTokens: 0, outputTokens: 0 } },
+        };
+      },
+      async ackCollectedCursors() {},
+    });
+
+    /** @type {() => void} */
+    let resolveDeliver = () => {};
+    const deliverPromise = new Promise((r) => {
+      resolveDeliver = r;
+    });
+    const outboundHook = {
+      deliver: async () => {
+        await deliverPromise;
+      },
+    };
+    let cleanupCalled = false;
+    const streamingHook = {
+      async onStreamStart() {},
+      async onStreamChunk() {},
+      async onStreamEnd() {},
+      cleanupPlaceholders: async () => {
+        cleanupCalled = true;
+      },
+    };
+
+    const trigger = createTrigger({
+      router: silentRouter,
+      outboundHook,
+      streamingHook,
+      deliverTimeoutMs: 50,
+    });
+    trigger.trigger('thread-1', /** @type {any} */ ('opus'), 'user-1', 'msg', 'msg-1');
+
+    // Wait for timeout to fire
+    await new Promise((r) => setTimeout(r, 200));
+    assert.strictEqual(cleanupCalled, false, 'cleanup must NOT run immediately after silent timeout');
+
+    // Late-success: deliver finally resolves
+    resolveDeliver();
+    await new Promise((r) => setTimeout(r, 100));
+    assert.strictEqual(cleanupCalled, true, 'cleanup must run after silent late-success delivery (R7)');
+  });
+
+  it('R7: silent fallback late-failure must NOT trigger cleanup (preserve placeholder)', async () => {
+    // Silent invocation → deliver times out → deliver later rejects
+    // → cleanupPlaceholders must NOT be called (thinking card stays as fallback UX).
+    const silentRouter = /** @type {any} */ ({
+      async *routeExecution(_u, _m, _t, _mid, targetCats, _i, _o) {
+        yield {
+          type: 'done',
+          catId: targetCats[0],
+          content: '',
+          timestamp: Date.now(),
+          metadata: { usage: { inputTokens: 0, outputTokens: 0 } },
+        };
+      },
+      async ackCollectedCursors() {},
+    });
+
+    /** @type {(err: Error) => void} */
+    let rejectDeliver = () => {};
+    const deliverPromise = new Promise((_, rej) => {
+      rejectDeliver = rej;
+    });
+    const outboundHook = {
+      deliver: async () => {
+        await deliverPromise;
+      },
+    };
+    let cleanupCalled = false;
+    const streamingHook = {
+      async onStreamStart() {},
+      async onStreamChunk() {},
+      async onStreamEnd() {},
+      cleanupPlaceholders: async () => {
+        cleanupCalled = true;
+      },
+    };
+
+    const trigger = createTrigger({
+      router: silentRouter,
+      outboundHook,
+      streamingHook,
+      deliverTimeoutMs: 50,
+    });
+    trigger.trigger('thread-1', /** @type {any} */ ('opus'), 'user-1', 'msg', 'msg-1');
+
+    await new Promise((r) => setTimeout(r, 200));
+    assert.strictEqual(cleanupCalled, false, 'cleanup must NOT run after silent timeout');
+
+    // Late-failure: deliver rejects
+    rejectDeliver(new Error('connector down'));
+    await new Promise((r) => setTimeout(r, 100));
+    assert.strictEqual(
+      cleanupCalled,
+      false,
+      'cleanup must NOT run after silent hard failure (R7: preserve placeholder)',
     );
   });
 

--- a/packages/api/test/queue-processor.test.js
+++ b/packages/api/test/queue-processor.test.js
@@ -2424,6 +2424,130 @@ describe('QueueProcessor', () => {
     });
   });
 
+  // ── R7: silent fallback late-success/failure cleanup ──
+
+  describe('silent fallback late-success cleanup (R7)', () => {
+    /** Poll until predicate returns true or timeout. */
+    async function waitFor(predicate, timeoutMs = 5000, intervalMs = 10) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        if (predicate()) return;
+        await new Promise((r) => setTimeout(r, intervalMs));
+      }
+      throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+    }
+
+    it('silent fallback timeout + late-success → cleanupPlaceholders called', async () => {
+      // Silent invocation (only done, no text) → deliver times out → deliver
+      // later succeeds → cleanupPlaceholders must be called on late-success.
+      let resolveDeliver;
+      const deliverGate = new Promise((r) => {
+        resolveDeliver = r;
+      });
+      const outboundHook = {
+        deliver: mock.fn(async () => {
+          await deliverGate;
+        }),
+      };
+      const streamingHook = {
+        onStreamStart: mock.fn(async () => {}),
+        onStreamChunk: mock.fn(async () => {}),
+        onStreamEnd: mock.fn(async () => {}),
+        cleanupPlaceholders: mock.fn(async () => {}),
+      };
+
+      // Silent router: only yields done, no text content.
+      // deliverTimeoutMs: 50 — short timeout so test doesn't wait 10s.
+      const silentDeps = stubDeps({
+        router: {
+          routeExecution: mock.fn(async function* () {
+            yield { type: 'done', catId: 'opus', content: '', timestamp: Date.now() };
+          }),
+          ackCollectedCursors: mock.fn(async () => {}),
+        },
+        outboundHook,
+        streamingHook,
+        deliverTimeoutMs: 50,
+        threadMetaLookup: mock.fn(async () => undefined),
+      });
+      const silentProcessor = new QueueProcessor(silentDeps);
+
+      const entry = enqueueEntry(silentDeps.queue);
+      silentDeps.queue.backfillMessageId('t1', 'u1', entry.id, 'msg-1');
+
+      await silentProcessor.processNext('t1', 'u1');
+
+      // Timeout (50ms) has already fired; deliver still hanging on deliverGate
+      await new Promise((r) => setTimeout(r, 100));
+      assert.equal(
+        streamingHook.cleanupPlaceholders.mock.calls.length,
+        0,
+        'cleanup must NOT run immediately after silent timeout',
+      );
+
+      // Late-success: deliver finally resolves
+      resolveDeliver();
+      await waitFor(() => streamingHook.cleanupPlaceholders.mock.calls.length >= 1);
+      assert.equal(
+        streamingHook.cleanupPlaceholders.mock.calls.length,
+        1,
+        'cleanup must run after silent late-success delivery (R7)',
+      );
+    });
+
+    it('silent fallback timeout + late-failure → cleanupPlaceholders NOT called', async () => {
+      // Silent invocation → deliver times out → deliver later rejects
+      // → cleanupPlaceholders must NOT be called (thinking card stays).
+      let rejectDeliver;
+      const deliverGate = new Promise((_, rej) => {
+        rejectDeliver = rej;
+      });
+      const outboundHook = {
+        deliver: mock.fn(async () => {
+          await deliverGate;
+        }),
+      };
+      const streamingHook = {
+        onStreamStart: mock.fn(async () => {}),
+        onStreamChunk: mock.fn(async () => {}),
+        onStreamEnd: mock.fn(async () => {}),
+        cleanupPlaceholders: mock.fn(async () => {}),
+      };
+
+      const silentDeps = stubDeps({
+        router: {
+          routeExecution: mock.fn(async function* () {
+            yield { type: 'done', catId: 'opus', content: '', timestamp: Date.now() };
+          }),
+          ackCollectedCursors: mock.fn(async () => {}),
+        },
+        outboundHook,
+        streamingHook,
+        deliverTimeoutMs: 50,
+        threadMetaLookup: mock.fn(async () => undefined),
+      });
+      const silentProcessor = new QueueProcessor(silentDeps);
+
+      const entry = enqueueEntry(silentDeps.queue);
+      silentDeps.queue.backfillMessageId('t1', 'u1', entry.id, 'msg-1');
+
+      await silentProcessor.processNext('t1', 'u1');
+
+      // Timeout (50ms) has already fired; deliver still hanging on deliverGate
+      await new Promise((r) => setTimeout(r, 100));
+      assert.equal(streamingHook.cleanupPlaceholders.mock.calls.length, 0, 'cleanup must NOT run after silent timeout');
+
+      // Late-failure: deliver rejects
+      rejectDeliver(new Error('connector down'));
+      await new Promise((r) => setTimeout(r, 100));
+      assert.equal(
+        streamingHook.cleanupPlaceholders.mock.calls.length,
+        0,
+        'cleanup must NOT run after silent hard failure (R7: preserve placeholder)',
+      );
+    });
+  });
+
   // ── F175 Task 5: user-message batching at dequeue ──
 
   describe('user-message batching (F175)', () => {

--- a/packages/shared/src/types/cli-diagnostics.ts
+++ b/packages/shared/src/types/cli-diagnostics.ts
@@ -56,7 +56,7 @@ export interface CliDiagnostics {
    *  excerpt rendering on `KNOWN_EXCERPT_SOURCES.has(excerptSource)` — both protects
    *  malformed payloads (no source) AND fails closed when older clients see a future
    *  source value they don't recognize (e.g. a hypothetical 'pii_redacted'). */
-  excerptSource?: 'classifier' | 'cc_structured';
+  excerptSource?: 'classifier' | 'cc_structured' | 'unknown_raw';
   /** Debug correlation metadata — safe to expose */
   debugRef: {
     command: string;

--- a/packages/web/src/app/cat-persona-derived.css
+++ b/packages/web/src/app/cat-persona-derived.css
@@ -24,13 +24,13 @@
     var(--cat-bubble-l, 0.62) calc(var(--msg-chroma, 0.1) * var(--cat-bubble-cmul, 1)) var(--msg-hue, 297)
   );
   --cat-msg-surface: oklch(
-    var(--cat-surface-l, 0.94) calc(var(--msg-chroma, 0.1) * var(--cat-surface-cmul, 0.25)) var(--msg-hue, 297)
+    var(--cat-surface-l, 0.85) calc(var(--msg-chroma, 0.1) * var(--cat-surface-cmul, 0.45)) var(--msg-hue, 297)
   );
   --cat-msg-inset: oklch(
-    var(--cat-inset-l, 0.9) calc(var(--msg-chroma, 0.1) * var(--cat-inset-cmul, 0.15)) var(--msg-hue, 297)
+    var(--cat-inset-l, 0.25) calc(var(--msg-chroma, 0.1) * var(--cat-inset-cmul, 0.15)) var(--msg-hue, 297)
   );
-  --cat-msg-inset-text: oklch(var(--cat-inset-text-l, 0.25) var(--cat-inset-text-c, 0.02) 30);
-  --cat-msg-text: oklch(var(--cat-msg-text-l, 0.2) var(--cat-msg-text-c, 0.005) 30);
+  --cat-msg-inset-text: oklch(var(--cat-inset-text-l, 0.85) var(--cat-inset-text-c, 0.03) 30);
+  --cat-msg-text: oklch(var(--cat-msg-text-l, 0.25) var(--cat-msg-text-c, 0.01) 30);
   --cat-msg-ring: oklch(
     var(--cat-ring-l, 0.55) calc(var(--msg-chroma, 0.1) * var(--cat-ring-cmul, 1.1)) var(--msg-hue, 297)
   );
@@ -41,13 +41,13 @@
     var(--cat-bubble-l, 0.68) calc(var(--msg-chroma, 0.1) * var(--cat-bubble-cmul, 0.85)) var(--msg-hue, 297)
   );
   --cat-msg-surface: oklch(
-    var(--cat-surface-l, 0.28) calc(var(--msg-chroma, 0.1) * var(--cat-surface-cmul, 0.25)) var(--msg-hue, 297)
+    var(--cat-surface-l, 0.3) calc(var(--msg-chroma, 0.1) * var(--cat-surface-cmul, 0.15)) var(--msg-hue, 297)
   );
   --cat-msg-inset: oklch(
     var(--cat-inset-l, 0.24) calc(var(--msg-chroma, 0.1) * var(--cat-inset-cmul, 0.1)) var(--msg-hue, 297)
   );
   --cat-msg-inset-text: oklch(var(--cat-inset-text-l, 0.8) var(--cat-inset-text-c, 0.02) 250);
-  --cat-msg-text: oklch(var(--cat-msg-text-l, 0.8) var(--cat-msg-text-c, 0.02) 30);
+  --cat-msg-text: oklch(var(--cat-msg-text-l, 0.8) var(--cat-msg-text-c, 0.04) 30);
   --cat-msg-ring: oklch(
     var(--cat-ring-l, 0.7) calc(var(--msg-chroma, 0.1) * var(--cat-ring-cmul, 1)) var(--msg-hue, 297)
   );
@@ -59,15 +59,15 @@
  * 等仅在当前 mode 可用的变量。buildCSS() 运行后会用 Tuner 实际值覆盖。
  * ⚠️ 硬编码值必须与 INIT defaults (oklch-tuner-engine.ts) 保持一致。 */
 .cat-persona-preview-light {
-  --cat-msg-surface: oklch(0.94 calc(var(--msg-chroma, 0.1) * 0.25) var(--msg-hue, 297));
-  --cat-msg-inset: oklch(0.9 calc(var(--msg-chroma, 0.1) * 0.15) var(--msg-hue, 297));
-  --cat-msg-inset-text: oklch(0.25 0.02 30);
-  --cat-msg-text: oklch(0.2 0.005 30);
+  --cat-msg-surface: oklch(0.85 calc(var(--msg-chroma, 0.1) * 0.45) var(--msg-hue, 297));
+  --cat-msg-inset: oklch(0.25 calc(var(--msg-chroma, 0.1) * 0.15) var(--msg-hue, 297));
+  --cat-msg-inset-text: oklch(0.85 0.03 30);
+  --cat-msg-text: oklch(0.25 0.01 30);
 }
 
 .cat-persona-preview-dark {
-  --cat-msg-surface: oklch(0.28 calc(var(--msg-chroma, 0.1) * 0.25) var(--msg-hue, 297));
+  --cat-msg-surface: oklch(0.3 calc(var(--msg-chroma, 0.1) * 0.15) var(--msg-hue, 297));
   --cat-msg-inset: oklch(0.24 calc(var(--msg-chroma, 0.1) * 0.1) var(--msg-hue, 297));
   --cat-msg-inset-text: oklch(0.8 0.02 250);
-  --cat-msg-text: oklch(0.8 0.02 30);
+  --cat-msg-text: oklch(0.8 0.04 30);
 }

--- a/packages/web/src/app/cat-persona-tokens.css
+++ b/packages/web/src/app/cat-persona-tokens.css
@@ -14,7 +14,7 @@
  *
  * 公式（L 档位 / chroma 乘数）：
  *   light: bubble L=0.62 C×1.0 / surface L=0.85 C×0.45 / ring L=0.55 C×1.1
- *   dark:  bubble L=0.68 C×0.85 / surface L=0.28 C×0.25 / ring L=0.70 C×1.0
+ *   dark:  bubble L=0.68 C×0.85 / surface L=0.30 C×0.15 / ring L=0.70 C×1.0
  *   text 走中性 --cafe-text（不带猫色相）
  *
  * Runtime catId is the resolved name (e.g. "opus", "codex"), NOT the template
@@ -39,7 +39,7 @@
   --color-cocreator-surface: oklch(
     var(--cat-surface-l, 0.85) calc(var(--cocreator-chroma) * var(--cat-surface-cmul, 0.45)) var(--cocreator-hue)
   );
-  --color-cocreator-text: oklch(var(--cat-name-l, 0.24) var(--cat-name-c, 0.005) var(--cat-name-h, 139));
+  --color-cocreator-text: oklch(var(--cat-name-l, 0.15) var(--cat-name-c, 0.025) var(--cat-name-h, 5));
   --color-cocreator-ring: oklch(
     var(--cat-ring-l, 0.55) calc(var(--cocreator-chroma) * var(--cat-ring-cmul, 1.1)) var(--cocreator-hue)
   );
@@ -54,9 +54,9 @@
     var(--cat-bubble-l, 0.68) calc(var(--cocreator-chroma) * var(--cat-bubble-cmul, 0.85)) var(--cocreator-hue)
   );
   --color-cocreator-surface: oklch(
-    var(--cat-surface-l, 0.28) calc(var(--cocreator-chroma) * var(--cat-surface-cmul, 0.25)) var(--cocreator-hue)
+    var(--cat-surface-l, 0.3) calc(var(--cocreator-chroma) * var(--cat-surface-cmul, 0.15)) var(--cocreator-hue)
   );
-  --color-cocreator-text: oklch(var(--cat-name-l, 0.88) var(--cat-name-c, 0.005) var(--cat-name-h, 139));
+  --color-cocreator-text: oklch(var(--cat-name-l, 0.95) var(--cat-name-c, 0.1) var(--cat-name-h, 25));
   --color-cocreator-ring: oklch(
     var(--cat-ring-l, 0.7) calc(var(--cocreator-chroma) * var(--cat-ring-cmul, 1)) var(--cocreator-hue)
   );

--- a/packages/web/src/app/connector-tokens.css
+++ b/packages/web/src/app/connector-tokens.css
@@ -102,10 +102,10 @@
   --conn-icon-default: #6b7280;
 
   /* Queue agent accent (feature-level accent, not IM brand) */
-  --queue-accent: #9b7ebd;
-  --queue-accent-hover: #8b6fae;
-  --queue-accent-surface: #f3eefa;
-  --queue-on-accent: #ffffff;
+  --queue-accent: oklch(0.5 0.12 300);
+  --queue-accent-hover: oklch(0.44 0.13 300);
+  --queue-accent-surface: oklch(0.96 0.024 300);
+  --queue-on-accent: oklch(1 0 0);
 }
 
 [data-theme="dark"] {
@@ -188,8 +188,8 @@
   --conn-icon-default: #9ca3af;
 
   /* Queue agent accent — dark mode */
-  --queue-accent: #c4b5fd;
-  --queue-accent-hover: #d8b4fe;
-  --queue-accent-surface: rgba(155, 126, 189, 0.12);
-  --queue-on-accent: #1a1025;
+  --queue-accent: oklch(0.76 0.17 290);
+  --queue-accent-hover: oklch(0.82 0.19 290);
+  --queue-accent-surface: oklch(0.25 0.06 290);
+  --queue-on-accent: oklch(0.18 0.03 290);
 }

--- a/packages/web/src/app/theme-tokens.css
+++ b/packages/web/src/app/theme-tokens.css
@@ -56,26 +56,26 @@
   --accent-900: oklch(0.2 calc(var(--accent-chroma) * 0.5) var(--accent-hue));
 
   /* --- 4. Semantic 5色（固定，不派生）— L 选定保证 vs cafe-surface 对比度 ≥3:1（WCAG icon） --- */
-  --semantic-critical: oklch(0.57 0.12 38); /* unread + error + delete + critical 合并 */
-  --semantic-success: oklch(0.57 0.12 135);
-  --semantic-warning: oklch(0.57 0.12 46); /* 暖橙：对比度 ≥3:1 (icon) */
-  --semantic-info: oklch(0.57 0.12 209); /* 跨线程气泡蓝亦用 */
-  --semantic-spotlight: oklch(0.67 0.12 46); /* F155 guide + quest input glow 合并 */
-  --semantic-critical-surface: oklch(0.96 0.03 38);
+  --semantic-critical: oklch(0.55 0.12 35); /* unread + error + delete + critical 合并 */
+  --semantic-success: oklch(0.55 0.12 135);
+  --semantic-warning: oklch(0.55 0.12 45); /* 暖橙：对比度 ≥3:1 (icon) */
+  --semantic-info: oklch(0.55 0.12 210); /* 跨线程气泡蓝亦用 */
+  --semantic-spotlight: oklch(0.65 0.12 45); /* F155 guide + quest input glow 合并 */
+  --semantic-critical-surface: oklch(0.96 0.03 35);
   --semantic-success-surface: oklch(0.96 0.03 135);
-  --semantic-warning-surface: oklch(0.96 0.04 46);
-  --semantic-info-surface: oklch(0.96 0.03 209);
-  --semantic-spotlight-surface: oklch(0.96 0.04 46);
+  --semantic-warning-surface: oklch(0.96 0.04 45);
+  --semantic-info-surface: oklch(0.96 0.03 210);
+  --semantic-spotlight-surface: oklch(0.96 0.04 45);
 
   /* --- 5. Code Block（github-light 风格固定 palette） --- */
-  --code-bg: oklch(0.92 0.005 30);
-  --code-text: oklch(0.2 0.02 30);
+  --code-bg: oklch(0.9 0.005 30);
+  --code-text: oklch(0.19 0.02 30);
   --code-keyword: oklch(0.5 0.18 320);
   --code-string: oklch(0.5 0.15 140);
   --code-comment: oklch(0.55 0.05 100);
   --code-function: oklch(0.5 0.18 250);
   --code-number: oklch(0.5 0.18 30);
-  --code-border: oklch(0.92 0.005 30);
+  --code-border: oklch(0.9 0.005 30);
 
   /* --- 6. Chart palette 12色（OKLCH H 均匀分布 30°/60°） --- */
   --chart-1: oklch(0.55 0.15 30);
@@ -160,13 +160,13 @@
   --neutral-50: oklch(0.13 0.005 30);
   --neutral-100: oklch(0.18 0.005 30);
   --neutral-200: oklch(0.24 0.005 30);
-  --neutral-300: oklch(0.32 0.005 30);
-  --neutral-400: oklch(0.45 0.005 30);
+  --neutral-300: oklch(0.35 0.005 30);
+  --neutral-400: oklch(0.4 0.005 30);
   --neutral-500: oklch(0.66 0.005 30);
-  --neutral-600: oklch(0.76 0.005 30);
+  --neutral-600: oklch(0.75 0.005 30);
   --neutral-700: oklch(0.84 0.005 30);
   --neutral-800: oklch(0.88 0.005 30);
-  --neutral-900: oklch(0.94 0.005 30);
+  --neutral-900: oklch(0.95 0.005 30);
   --neutral-950: oklch(0.98 0.005 30);
 
   /* --- 2. App Accent 9档（dark: 略亮 + 降饱和） --- */
@@ -181,11 +181,11 @@
   --accent-900: oklch(0.95 calc(var(--accent-chroma) * 0.4) var(--accent-hue));
 
   /* --- 4. Semantic 5色（dark: 略亮 + 微调） --- */
-  --semantic-critical: oklch(0.68 0.2 25);
-  --semantic-success: oklch(0.68 0.16 145);
-  --semantic-warning: oklch(0.75 0.16 70);
-  --semantic-info: oklch(0.7 0.14 230);
-  --semantic-spotlight: oklch(0.75 0.16 70);
+  --semantic-critical: oklch(0.7 0.17 25);
+  --semantic-success: oklch(0.7 0.17 145);
+  --semantic-warning: oklch(0.7 0.17 70);
+  --semantic-info: oklch(0.7 0.17 230);
+  --semantic-spotlight: oklch(0.8 0.17 70);
   --semantic-critical-surface: oklch(0.25 0.05 25);
   --semantic-success-surface: oklch(0.25 0.05 145);
   --semantic-warning-surface: oklch(0.25 0.05 70);
@@ -193,14 +193,14 @@
   --semantic-spotlight-surface: oklch(0.25 0.06 70);
 
   /* --- 5. Code Block（vscode-dark+ 风格固定 palette） --- */
-  --code-bg: oklch(0.25 0.01 250);
-  --code-text: oklch(0.9 0.01 30);
+  --code-bg: oklch(0.25 0.005 30);
+  --code-text: oklch(0.9 0.02 30);
   --code-keyword: oklch(0.72 0.16 280);
   --code-string: oklch(0.72 0.14 140);
   --code-comment: oklch(0.5 0.04 100);
   --code-function: oklch(0.78 0.14 210);
   --code-number: oklch(0.72 0.16 30);
-  --code-border: oklch(0.28 0.005 250);
+  --code-border: oklch(0.35 0.005 30);
 
   /* --- 6. Chart palette（dark: L 略提到 0.68/0.78） --- */
   --chart-1: oklch(0.68 0.14 30);
@@ -226,26 +226,26 @@
   --avatar-fallback-7: oklch(0.55 0.13 300);
   --avatar-fallback-8: oklch(0.55 0.13 345);
 
-  /* --- Surface 四档（dark — 铲屎官 2026-05-28 调优）---
-   * sunken=0.275 / surface=0.18 / elevated=0.1 / canvas=0.18
-   * Chroma unified with light (0.015/0.012/0.005/0.003).
+  /* --- Surface 四档（dark — 铲屎官 2026-06-10 调优）---
+   * sunken=0.36 / surface=0.28 / elevated=0.21 / canvas=0.24
+   * Chroma = base chroma × 0.15 (0.0022/0.0018/0.0008/0.0004).
    * 空间映射见 console-tokens.css（light/dark 统一，不再镜像） */
-  --cafe-surface-sunken: oklch(0.36 0.015 var(--surface-hue));
-  --cafe-surface: oklch(0.28 0.012 var(--surface-hue));
-  --cafe-surface-elevated: oklch(0.21 0.005 var(--surface-hue));
-  --cafe-surface-canvas: oklch(0.24 0.003 var(--surface-hue));
+  --cafe-surface-sunken: oklch(0.36 0.0022 var(--surface-hue));
+  --cafe-surface: oklch(0.28 0.0018 var(--surface-hue));
+  --cafe-surface-elevated: oklch(0.21 0.0008 var(--surface-hue));
+  --cafe-surface-canvas: oklch(0.24 0.0004 var(--surface-hue));
 
   /* --- Cafe semantic shortcuts dark（重新映射 Neutral） --- */
   --cafe-text: var(--neutral-900);
-  --cafe-text-secondary: var(--neutral-700);
+  --cafe-text-secondary: var(--neutral-600);
   --cafe-text-muted: var(--neutral-500);
-  --cafe-border: var(--neutral-200);
-  --cafe-border-subtle: var(--neutral-100);
+  --cafe-border: var(--neutral-300);
+  --cafe-border-subtle: var(--neutral-400);
   --cafe-accent: var(--accent-500);
   --cafe-accent-hover: var(--accent-600);
   --cafe-accent-foreground: var(--neutral-50);
   --cafe-crosspost: var(--semantic-info);
-  --cafe-interactive: var(--neutral-600);
+  --cafe-interactive: var(--neutral-700);
 
   /* --- Elevation 阴影（dark: inset 高光 + 深外阴影） --- */
   --shadow-elevation-1: 0 1px 2px oklch(0 0 0 / 0.5), inset 0 1px 0 oklch(1 0 0 / 0.1);

--- a/packages/web/src/components/CatHueInjector.tsx
+++ b/packages/web/src/components/CatHueInjector.tsx
@@ -31,7 +31,7 @@ function lightDecl(id: string): string {
   return (
     `--color-${id}-bubble:oklch(var(--cat-bubble-l, 0.62) calc(var(--${id}-chroma) * var(--cat-bubble-cmul, 1)) var(--${id}-hue));` +
     `--color-${id}-surface:oklch(var(--cat-surface-l, 0.85) calc(var(--${id}-chroma) * var(--cat-surface-cmul, 0.45)) var(--${id}-hue));` +
-    `--color-${id}-text:oklch(var(--cat-name-l, 0.24) var(--cat-name-c, 0.005) var(--cat-name-h, 139));` +
+    `--color-${id}-text:oklch(var(--cat-name-l, 0.15) var(--cat-name-c, 0.025) var(--cat-name-h, 5));` +
     `--color-${id}-ring:oklch(var(--cat-ring-l, 0.55) calc(var(--${id}-chroma) * var(--cat-ring-cmul, 1.1)) var(--${id}-hue));` +
     `--color-${id}-primary:var(--color-${id}-bubble);` +
     `--color-${id}-light:var(--color-${id}-surface);` +
@@ -43,8 +43,8 @@ function lightDecl(id: string): string {
 function darkDecl(id: string): string {
   return (
     `--color-${id}-bubble:oklch(var(--cat-bubble-l, 0.68) calc(var(--${id}-chroma) * var(--cat-bubble-cmul, 0.85)) var(--${id}-hue));` +
-    `--color-${id}-surface:oklch(var(--cat-surface-l, 0.28) calc(var(--${id}-chroma) * var(--cat-surface-cmul, 0.25)) var(--${id}-hue));` +
-    `--color-${id}-text:oklch(var(--cat-name-l, 0.88) var(--cat-name-c, 0.005) var(--cat-name-h, 139));` +
+    `--color-${id}-surface:oklch(var(--cat-surface-l, 0.3) calc(var(--${id}-chroma) * var(--cat-surface-cmul, 0.15)) var(--${id}-hue));` +
+    `--color-${id}-text:oklch(var(--cat-name-l, 0.95) var(--cat-name-c, 0.1) var(--cat-name-h, 25));` +
     `--color-${id}-ring:oklch(var(--cat-ring-l, 0.70) calc(var(--${id}-chroma) * var(--cat-ring-cmul, 1)) var(--${id}-hue));`
   );
 }

--- a/packages/web/src/components/CliDiagnosticsPanel.tsx
+++ b/packages/web/src/components/CliDiagnosticsPanel.tsx
@@ -115,7 +115,7 @@ const UNKNOWN_PALETTE: Palette = { ...PALETTE_SYSTEM, Icon: UnknownReasonIcon };
  * no excerptSource and (b) forward-compat: any future api source value the current web
  * doesn't recognize yet (e.g. a hypothetical 'pii_redacted') is treated as untrusted.
  */
-const KNOWN_EXCERPT_SOURCES: ReadonlySet<string> = new Set(['classifier', 'cc_structured']);
+const KNOWN_EXCERPT_SOURCES: ReadonlySet<string> = new Set(['classifier', 'cc_structured', 'unknown_raw']);
 
 /**
  * 云端 codex P2 (2026-05-27): persisted/hydrated `cliDiagnostics.reasonCode` may carry

--- a/packages/web/src/components/ThemeApplier.tsx
+++ b/packages/web/src/components/ThemeApplier.tsx
@@ -14,7 +14,7 @@ import { useCafeTheme } from '@/hooks/useCafeTheme';
 import { applyThemeCSS, getActiveTheme, restoreFromServer, useThemeStore } from '@/stores/themeStore';
 
 export function ThemeApplier() {
-  const { setTheme } = useCafeTheme();
+  const { theme, setTheme } = useCafeTheme();
   const active = useThemeStore((s) => getActiveTheme(s));
   const recoveryAttempted = useRef(false);
 
@@ -36,8 +36,9 @@ export function ThemeApplier() {
 
   /* Sync base mode to next-themes (manages data-theme attribute on <html>) */
   useEffect(() => {
+    if (theme === active.base) return;
     setTheme(active.base);
-  }, [active.base, setTheme]);
+  }, [active.base, setTheme, theme]);
 
   /* Inject CSS overrides for the active theme's OKLCH params */
   useEffect(() => {

--- a/packages/web/src/components/UnifiedAuthModal.tsx
+++ b/packages/web/src/components/UnifiedAuthModal.tsx
@@ -376,31 +376,35 @@ export function UnifiedAuthModal({ open, onClose, onCreated, editProfile, initia
                 <div className="space-y-1.5">
                   {envEntries.map((entry, i) => (
                     <div key={i} className="flex items-center gap-1.5">
-                      <input
-                        value={entry.key}
-                        onChange={(e) => {
-                          const next = [...envEntries];
-                          next[i] = { ...next[i], key: e.target.value };
-                          setEnvEntries(next);
-                        }}
-                        placeholder="KEY"
-                        className={`w-[38%] font-mono ${
-                          entry.key.trim() && !isValidEnvKey(entry.key.trim())
-                            ? `${formInputClass} !border-semantic-critical !bg-semantic-critical-surface !text-semantic-critical`
-                            : formInputClass
-                        }`}
-                      />
+                      <div className="w-[38%] shrink-0">
+                        <input
+                          value={entry.key}
+                          onChange={(e) => {
+                            const next = [...envEntries];
+                            next[i] = { ...next[i], key: e.target.value };
+                            setEnvEntries(next);
+                          }}
+                          placeholder="KEY"
+                          className={`font-mono ${
+                            entry.key.trim() && !isValidEnvKey(entry.key.trim())
+                              ? `${formInputClass} !border-semantic-critical !bg-semantic-critical-surface !text-semantic-critical`
+                              : formInputClass
+                          }`}
+                        />
+                      </div>
                       <span className="text-micro text-cafe-muted">=</span>
-                      <input
-                        value={entry.value}
-                        onChange={(e) => {
-                          const next = [...envEntries];
-                          next[i] = { ...next[i], value: e.target.value };
-                          setEnvEntries(next);
-                        }}
-                        placeholder="value"
-                        className={`flex-1 font-mono ${formInputClass}`}
-                      />
+                      <div className="min-w-0 flex-1">
+                        <input
+                          value={entry.value}
+                          onChange={(e) => {
+                            const next = [...envEntries];
+                            next[i] = { ...next[i], value: e.target.value };
+                            setEnvEntries(next);
+                          }}
+                          placeholder="value"
+                          className={`font-mono ${formInputClass}`}
+                        />
+                      </div>
                       <button
                         type="button"
                         onClick={() => setEnvEntries(envEntries.filter((_, j) => j !== i))}

--- a/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
+++ b/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, it } from 'vitest';
-import { KNOWN_OC_PROVIDERS, resolveOpenCodeEndpoint } from '@/components/hub-cat-editor.sections';
+import { buildCallHint, KNOWN_OC_PROVIDERS, resolveOpenCodeEndpoint } from '@/components/hub-cat-editor.sections';
+
+/** Minimal profile stub for buildCallHint tests */
+function mkProfile(baseUrl: string) {
+  return {
+    id: 't',
+    displayName: '',
+    name: '',
+    authType: 'api-key' as const,
+    kind: 'opencode' as const,
+    builtin: false,
+    mode: 'default' as const,
+    baseUrl,
+  };
+}
 
 describe('KNOWN_OC_PROVIDERS datalist suggestions', () => {
   it('includes openai-responses for Responses API users (#292)', () => {
@@ -17,5 +31,37 @@ describe('KNOWN_OC_PROVIDERS datalist suggestions', () => {
     expect(resolveOpenCodeEndpoint('anthropic')).toBe('/v1/messages');
     expect(resolveOpenCodeEndpoint('google')).toBe('/models/{model}:generateContent');
     expect(resolveOpenCodeEndpoint('maas')).toBe('/v1/chat/completions');
+  });
+});
+
+describe('buildCallHint — API version URL display (#886)', () => {
+  it('base ending /v1 avoids /v1/v1 duplication', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://api.example.com/v1'), 'gpt-4', 'openai');
+    expect(hint?.url).toBe('https://api.example.com/v1/chat/completions');
+  });
+
+  it('base ending /v2 produces /v2/chat/completions, not /v2/v1/chat/completions', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://maas-api.cn-huabei-1.xf-yun.com/v2'), 'spark', 'maas');
+    expect(hint?.url).toBe('https://maas-api.cn-huabei-1.xf-yun.com/v2/chat/completions');
+  });
+
+  it('base without version appends full /v1 suffix', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://api.example.com'), 'gpt-4', 'openai');
+    expect(hint?.url).toBe('https://api.example.com/v1/chat/completions');
+  });
+
+  it('trailing slash in base is stripped', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://api.example.com/v2/'), 'spark', 'maas');
+    expect(hint?.url).toBe('https://api.example.com/v2/chat/completions');
+  });
+
+  it('google endpoint with /v1 base does not strip version', () => {
+    const hint = buildCallHint('google', mkProfile('https://gateway.example.com/v1'), 'gemini-pro', 'google');
+    expect(hint?.url).toBe('https://gateway.example.com/v1/models/gemini-pro:generateContent');
+  });
+
+  it('non-opencode clients keep their runtime /v1 suffix after non-v1 base URLs', () => {
+    const hint = buildCallHint('anthropic', mkProfile('https://gateway.example.com/v2'), 'claude-sonnet', 'anthropic');
+    expect(hint?.url).toBe('https://gateway.example.com/v2/v1/messages');
   });
 });

--- a/packages/web/src/components/__tests__/theme-applier.test.tsx
+++ b/packages/web/src/components/__tests__/theme-applier.test.tsx
@@ -1,0 +1,65 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+(
+  globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT: boolean;
+  }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mockSetTheme = vi.fn();
+let mockTheme: 'light' | 'dark' | 'system' = 'light';
+
+vi.mock('@/hooks/useCafeTheme', () => ({
+  useCafeTheme: () => ({
+    theme: mockTheme,
+    resolvedTheme: mockTheme === 'dark' ? 'dark' : 'light',
+    setTheme: mockSetTheme,
+    toggleTheme: vi.fn(),
+  }),
+}));
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: false })),
+}));
+
+const { ThemeApplier } = await import('../ThemeApplier');
+
+let root: Root;
+let container: HTMLDivElement;
+
+describe('ThemeApplier', () => {
+  beforeEach(() => {
+    mockTheme = 'light';
+    mockSetTheme.mockClear();
+    localStorage.setItem('cat-cafe:themes', JSON.stringify({ version: 'test', activeId: 'light', custom: [] }));
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    localStorage.clear();
+  });
+
+  it('does not rewrite next-themes when it already matches the active base', () => {
+    act(() => {
+      root.render(React.createElement(ThemeApplier));
+    });
+
+    expect(mockSetTheme).not.toHaveBeenCalled();
+  });
+
+  it('syncs next-themes when it differs from the active base', () => {
+    mockTheme = 'dark';
+
+    act(() => {
+      root.render(React.createElement(ThemeApplier));
+    });
+
+    expect(mockSetTheme).toHaveBeenCalledWith('light');
+  });
+});

--- a/packages/web/src/components/__tests__/unified-auth-modal-envvar-layout.test.ts
+++ b/packages/web/src/components/__tests__/unified-auth-modal-envvar-layout.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment node
+/**
+ * #862 regression: env-var KEY/VALUE inputs in UnifiedAuthModal must be wrapped
+ * in separate div containers with flex-constraining classes so that formInputClass's
+ * w-full doesn't collapse the flex layout into a single column.
+ *
+ * KEY wrapper → `w-[38%] shrink-0`  (fixed proportion)
+ * VALUE wrapper → `min-w-0 flex-1`  (fills remaining space)
+ */
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(__dirname, '../UnifiedAuthModal.tsx'), 'utf-8');
+
+describe('UnifiedAuthModal env-var layout (#862)', () => {
+  it('KEY input is wrapped in a w-[38%] shrink-0 container', () => {
+    expect(source).toContain('w-[38%] shrink-0');
+    const wrapperIdx = source.indexOf('w-[38%] shrink-0');
+    const keyInputIdx = source.indexOf('placeholder="KEY"');
+    expect(keyInputIdx).toBeGreaterThan(wrapperIdx);
+    expect(keyInputIdx - wrapperIdx).toBeLessThan(500);
+  });
+
+  it('VALUE input is wrapped in a min-w-0 flex-1 container', () => {
+    expect(source).toContain('min-w-0 flex-1');
+    const wrapperIdx = source.indexOf('min-w-0 flex-1');
+    const valueInputIdx = source.indexOf('placeholder="value"');
+    expect(valueInputIdx).toBeGreaterThan(wrapperIdx);
+    expect(valueInputIdx - wrapperIdx).toBeLessThan(500);
+  });
+
+  it('formInputClass contains w-full (the root cause that requires wrappers)', () => {
+    const helperSource = readFileSync(resolve(__dirname, '../mcp-form-helpers.tsx'), 'utf-8');
+    expect(helperSource).toMatch(/formInputClass[\s\S]*?w-full/);
+  });
+});

--- a/packages/web/src/components/dev/__tests__/oklch-tuner-defaults.test.ts
+++ b/packages/web/src/components/dev/__tests__/oklch-tuner-defaults.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { exportText } from '../oklch-tuner-css';
+import { INIT_DARK, INIT_LIGHT } from '../oklch-tuner-engine';
+
+describe('OKLCH tuner defaults', () => {
+  it('exports the CVO-tuned light token defaults', () => {
+    expect(exportText(INIT_LIGHT, 'light')).toBe(
+      [
+        'OKLCH Token Values (light)',
+        'accent H=50 C=0.14',
+        'surface H=80 C*=1',
+        '==============================',
+        'light:',
+        '  primary   L=0.62  C*1.00',
+        '  surface   L=0.85  C*0.45',
+        '  text      L=0.24  C*0.80',
+        '  inset     L=0.25  C*0.15',
+        '  ring      L=0.55  C*1.10',
+        '  insetText L=0.85  C=0.030',
+        '  msgText   L=0.25  C=0.010',
+        '  elevation: 0.92/0.95/0.99/0.995',
+        '',
+        'semantic (light):',
+        '  H: crit=35 suc=135 warn=45 info=210  L=0.55 C=0.120 surfL=0.96 surfC=0.030',
+        'queue: H=300 C=0.12 L=0.5',
+        'neutral: H=30 C=0.005  txt=0.2 sec=0.45 mut=0.56 int=0.36 bdr=0.84 sub=0.915 codeBg=0.9 codeTx=0.19',
+        'catText: H=5 C=0.025 L=0.15',
+      ].join('\n'),
+    );
+  });
+
+  it('exports the CVO-tuned dark token defaults', () => {
+    expect(exportText(INIT_DARK, 'dark')).toBe(
+      [
+        'OKLCH Token Values (dark)',
+        'accent H=35 C=0.08',
+        'surface H=30 C*=0.15',
+        '==============================',
+        'dark:',
+        '  primary   L=0.68  C*0.85',
+        '  surface   L=0.30  C*0.15',
+        '  text      L=0.88  C*0.60',
+        '  inset     L=0.24  C*0.10',
+        '  ring      L=0.70  C*1.00',
+        '  insetText L=0.80  C=0.020',
+        '  msgText   L=0.80  C=0.040',
+        '  elevation: 0.36/0.28/0.21/0.24',
+        '',
+        'semantic (dark):',
+        '  H: crit=25 suc=145 warn=70 info=230  L=0.70 C=0.170 surfL=0.25 surfC=0.050',
+        'queue: H=290 C=0.15 L=0.6',
+        'neutral: H=30 C=0.005  txt=0.95 sec=0.75 mut=0.66 int=0.84 bdr=0.35 sub=0.4 codeBg=0.25 codeTx=0.9',
+        'catText: H=25 C=0.1 L=0.95',
+      ].join('\n'),
+    );
+  });
+});

--- a/packages/web/src/components/dev/oklch-tuner-engine.ts
+++ b/packages/web/src/components/dev/oklch-tuner-engine.ts
@@ -122,7 +122,7 @@ export const NEUTRAL_ROWS: [keyof NeutralP, string][] = [
   ['codeTextL', '代码字'],
 ];
 
-/* ── Per-theme INIT defaults (CVO-tuned 2026-05-28) ──
+/* ── Per-theme INIT defaults (CVO-tuned 2026-06-10) ──
  * Light and Dark themes have different accent hue, inset/msgText tuning,
  * surface elevation, and catText color. INIT = INIT_DARK (migration fallback). */
 export const INIT_LIGHT: TunerState = {
@@ -132,12 +132,12 @@ export const INIT_LIGHT: TunerState = {
   surfaceChroma: 1.0,
   light: {
     primary: { L: 0.62, Cmul: 1.0 },
-    surface: { L: 0.94, Cmul: 0.25 },
+    surface: { L: 0.85, Cmul: 0.45 },
     text: { L: 0.24, Cmul: 0.8 },
-    inset: { L: 0.9, Cmul: 0.15 },
+    inset: { L: 0.25, Cmul: 0.15 },
     ring: { L: 0.55, Cmul: 1.1 },
-    insetText: { L: 0.25, C: 0.02 },
-    msgText: { L: 0.2, C: 0.005 },
+    insetText: { L: 0.85, C: 0.03 },
+    msgText: { L: 0.25, C: 0.01 },
     elev: { sunken: 0.92, base: 0.95, elevated: 0.99, canvas: 0.995 },
   },
   dark: {
@@ -151,9 +151,9 @@ export const INIT_LIGHT: TunerState = {
     elev: { sunken: 0.275, base: 0.18, elevated: 0.1, canvas: 0.18 },
   },
   // biome-ignore format: compact INIT block
-  semanticLight: { criticalH: 38, successH: 135, warningH: 46, infoH: 209, L: 0.57, C: 0.12, surfL: 0.96, surfC: 0.03 },
+  semanticLight: { criticalH: 35, successH: 135, warningH: 45, infoH: 210, L: 0.55, C: 0.12, surfL: 0.96, surfC: 0.03 },
   semanticDark: { criticalH: 25, successH: 145, warningH: 70, infoH: 230, L: 0.7, C: 0.17, surfL: 0.25, surfC: 0.05 },
-  queue: { H: 290, C: 0.1, L: 0.62 },
+  queue: { H: 300, C: 0.12, L: 0.5 },
   neutralHue: 30,
   neutralChroma: 0.005,
   neutralLight: {
@@ -163,8 +163,8 @@ export const INIT_LIGHT: TunerState = {
     interactiveL: 0.36,
     borderL: 0.84,
     borderSubtleL: 0.915,
-    codeBgL: 0.92,
-    codeTextL: 0.2,
+    codeBgL: 0.9,
+    codeTextL: 0.19,
   },
   neutralDark: {
     textL: 0.94,
@@ -208,9 +208,9 @@ export const INIT_DARK: TunerState = {
     elev: { sunken: 0.36, base: 0.28, elevated: 0.21, canvas: 0.24 },
   },
   // biome-ignore format: compact INIT block
-  semanticLight: { criticalH: 38, successH: 135, warningH: 46, infoH: 209, L: 0.57, C: 0.12, surfL: 0.96, surfC: 0.03 },
+  semanticLight: { criticalH: 35, successH: 135, warningH: 45, infoH: 210, L: 0.55, C: 0.12, surfL: 0.96, surfC: 0.03 },
   semanticDark: { criticalH: 25, successH: 145, warningH: 70, infoH: 230, L: 0.7, C: 0.17, surfL: 0.25, surfC: 0.05 },
-  queue: { H: 290, C: 0.1, L: 0.62 },
+  queue: { H: 290, C: 0.15, L: 0.6 },
   neutralHue: 30,
   neutralChroma: 0.005,
   neutralLight: {
@@ -224,12 +224,12 @@ export const INIT_DARK: TunerState = {
     codeTextL: 0.22,
   },
   neutralDark: {
-    textL: 0.94,
-    secondaryL: 0.76,
+    textL: 0.95,
+    secondaryL: 0.75,
     mutedL: 0.66,
     interactiveL: 0.84,
-    borderL: 0.32,
-    borderSubtleL: 0.24,
+    borderL: 0.35,
+    borderSubtleL: 0.4,
     codeBgL: 0.25,
     codeTextL: 0.9,
   },

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -273,8 +273,9 @@ interface CallHint {
   warning: string;
 }
 
-// Generate a hint showing what API endpoint the CLI will actually call
-function buildCallHint(
+// Generate a hint showing what API endpoint the CLI will actually call.
+// Exported for testing (#886 regression coverage).
+export function buildCallHint(
   client: string,
   profile: ProfileItem | undefined,
   model: string,
@@ -282,9 +283,9 @@ function buildCallHint(
 ): CallHint | null {
   if (!profile || profile.authType === 'oauth' || !profile.baseUrl) return null;
   const base = profile.baseUrl.replace(/\/+$/, '');
-  const hasV1Suffix = /\/v1$/i.test(base);
-  // Strip trailing /v1 from base to avoid /v1/v1 duplication when pathSuffix already includes /v1
-  const baseWithoutV1 = hasV1Suffix ? base.replace(/\/v1$/i, '') : base;
+  // #886: detect ANY api-version suffix (/v1, /v2, …), not just /v1.
+  const versionMatch = base.match(/\/(v\d+)$/i);
+  const baseWithoutVersion = versionMatch ? base.slice(0, -versionMatch[0].length) : base;
 
   // For opencode, derive endpoint dynamically from provider name (sole authority)
   const ocPath = client === 'opencode' ? resolveOpenCodeEndpoint(providerName) : undefined;
@@ -299,9 +300,21 @@ function buildCallHint(
   const info = cliEndpoints[client];
   if (!info) return null;
 
-  // Use baseWithoutV1 for paths starting with /v1 to avoid duplication
-  const effectiveBase = info.pathSuffix.startsWith('/v1') ? baseWithoutV1 : base;
-  const fullUrl = `${effectiveBase}${info.pathSuffix}`;
+  // Match display URL to actual CLI runtime behavior:
+  // - base has /v1 + suffix has /v1 → strip /v1 from base to avoid /v1/v1.
+  // - only opencode uses provider base URLs as exact endpoint roots; for /vN
+  //   bases it calls /vN/<endpoint>, not /vN/v1/<endpoint> (#886).
+  //   Other CLIs keep their own /v1 suffix semantics.
+  let effectiveBase = base;
+  let effectiveSuffix = info.pathSuffix;
+  if (info.pathSuffix.startsWith('/v1') && versionMatch) {
+    if (versionMatch[1].toLowerCase() === 'v1') {
+      effectiveBase = baseWithoutVersion;
+    } else if (client === 'opencode') {
+      effectiveSuffix = info.pathSuffix.slice(3); // strip "/v1" prefix
+    }
+  }
+  const fullUrl = `${effectiveBase}${effectiveSuffix}`;
   let warning = '';
   if (client === 'google') {
     warning = '\n注意: Google 官方 endpoint 仍要求 builtin OAuth；第三方 gateway 会走这里展示的 baseUrl。';

--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -581,6 +581,7 @@ export function useChatHistory(threadId: string) {
         if ((canSettle && reachedTarget) || framesRemaining <= 0) {
           rememberScrollState(scheduledForThread, el);
           restoreFrameRef.current = null;
+          window.dispatchEvent(new Event(CHAT_LAYOUT_CHANGED_EVENT));
           return;
         }
 

--- a/packages/web/src/lib/__tests__/f056-wcag-contrast.test.ts
+++ b/packages/web/src/lib/__tests__/f056-wcag-contrast.test.ts
@@ -10,7 +10,7 @@
  * Token 派生公式来源：
  *   theme-tokens.css        — primitives（neutral / accent / semantic / chart）
  *   cat-persona-tokens.css  — text 走中性 --cafe-text（neutral-900）；
- *                            surface light L=0.94 / dark L=0.25（per-cat 派生）
+ *                            surface light L=0.85 / dark L=0.30（per-cat 派生）
  */
 import { describe, expect, it } from 'vitest';
 import { type OklchColor, oklchContrast } from '../color-utils';
@@ -25,14 +25,14 @@ function catPersonaDerived(hue: number, chroma: number, mode: 'light' | 'dark') 
     return {
       bubble: oklch(0.62, chroma, hue),
       surface: oklch(0.85, chroma * 0.45, hue),
-      text: oklch(0.36, 0.03, 30),
+      text: oklch(0.25, 0.01, 30),
       ring: oklch(0.55, chroma * 1.1, hue),
     };
   }
   return {
     bubble: oklch(0.68, chroma * 0.85, hue),
-    surface: oklch(0.28, chroma * 0.25, hue),
-    text: oklch(0.8, 0.02, 30),
+    surface: oklch(0.3, chroma * 0.15, hue),
+    text: oklch(0.8, 0.04, 30),
     ring: oklch(0.7, chroma, hue),
   };
 }
@@ -53,7 +53,7 @@ describe('F056 Phase E AC-E10 — WCAG contrast (OKLCH derived tokens)', () => {
       it(`${slug} light: text vs surface`, () => {
         const { text, surface } = catPersonaDerived(hue, chroma, 'light');
         const ratio = oklchContrast(text, surface);
-        // --cat-msg-text (L=0.36) is intentionally softer than --cafe-text (L=0.2)
+        // --cat-msg-text (L=0.25) is intentionally softer than --cafe-text (L=0.2)
         // inside colored bubbles. INIT_LIGHT.msgText tuned for readability + aesthetics.
         // Threshold: enhanced AA (6.5) — all cats score 6.86–6.97. Full AAA (7.0)
         // would require L≤0.33 which conflicts with the tuned visual design.
@@ -76,7 +76,7 @@ describe('F056 Phase E AC-E10 — WCAG contrast (OKLCH derived tokens)', () => {
 
     it('dark: neutral-900 text vs neutral-50 surface (mode-inverted)', () => {
       // dark mode: neutral-900=light text, neutral-50=dark surface (反转)
-      const ratio = oklchContrast(oklch(0.94, 0.005, 30), oklch(0.13, 0.005, 30));
+      const ratio = oklchContrast(oklch(0.95, 0.005, 30), oklch(0.13, 0.005, 30));
       expect(ratio).toBeGreaterThanOrEqual(7);
     });
   });
@@ -88,7 +88,7 @@ describe('F056 Phase E AC-E10 — WCAG contrast (OKLCH derived tokens)', () => {
     });
 
     it('dark: cafe-text (neutral-900) vs cafe-surface', () => {
-      const ratio = oklchContrast(oklch(0.94, 0.005, 30), oklch(0.18, 0.005, 30));
+      const ratio = oklchContrast(oklch(0.95, 0.005, 30), oklch(0.28, 0.0018, 30));
       expect(ratio).toBeGreaterThanOrEqual(7);
     });
   });
@@ -121,15 +121,14 @@ describe('F056 Phase E AC-E10 — WCAG contrast (OKLCH derived tokens)', () => {
 
   describe('Surface 三档 — dark mode L 跨度 ≥ 0.05 (perceptually distinguishable)', () => {
     it('dark: surface vs surface-elevated L 跨度 ≥ 0.05', () => {
-      // spec line 268: dark L 跨度 5-6 个点
-      const base = 0.18;
-      const elevated = 0.24;
+      const base = 0.28;
+      const elevated = 0.21;
       expect(Math.abs(elevated - base)).toBeGreaterThanOrEqual(0.05);
     });
 
     it('dark: surface vs surface-sunken L 跨度 ≥ 0.05', () => {
-      const base = 0.18;
-      const sunken = 0.12;
+      const base = 0.28;
+      const sunken = 0.36;
       expect(Math.abs(base - sunken)).toBeGreaterThanOrEqual(0.05);
     });
   });

--- a/packages/web/src/stores/__tests__/themeStore.test.ts
+++ b/packages/web/src/stores/__tests__/themeStore.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(() => Promise.resolve({ ok: false })),
+}));
+
+const LS_KEY = 'cat-cafe:themes';
+
+describe('themeStore migrations', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it('discards stale built-in overrides when INIT defaults change', async () => {
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        version: '2026-05-28-per-theme-init',
+        activeId: 'light',
+        custom: [],
+        builtInOverrides: {
+          light: {
+            accentHue: 50,
+            accentChroma: 0.14,
+            surfaceHue: 80,
+            surfaceChroma: 1,
+            light: {
+              primary: { L: 0.62, Cmul: 1 },
+              surface: { L: 0.12, Cmul: 0.12 },
+              text: { L: 0.24, Cmul: 0.8 },
+              inset: { L: 0.12, Cmul: 0.12 },
+              ring: { L: 0.55, Cmul: 1.1 },
+              insetText: { L: 0.12, C: 0.012 },
+              msgText: { L: 0.12, C: 0.012 },
+              elev: { sunken: 0.12, base: 0.12, elevated: 0.12, canvas: 0.12 },
+            },
+            dark: {
+              primary: { L: 0.68, Cmul: 0.85 },
+              surface: { L: 0.28, Cmul: 0.25 },
+              text: { L: 0.88, Cmul: 0.6 },
+              inset: { L: 0.24, Cmul: 0.1 },
+              ring: { L: 0.7, Cmul: 1 },
+              insetText: { L: 0.8, C: 0.02 },
+              msgText: { L: 0.8, C: 0.02 },
+              elev: { sunken: 0.36, base: 0.28, elevated: 0.21, canvas: 0.24 },
+            },
+            semanticLight: {
+              criticalH: 38,
+              successH: 135,
+              warningH: 46,
+              infoH: 209,
+              L: 0.57,
+              C: 0.12,
+              surfL: 0.96,
+              surfC: 0.03,
+            },
+            semanticDark: {
+              criticalH: 25,
+              successH: 145,
+              warningH: 70,
+              infoH: 230,
+              L: 0.7,
+              C: 0.17,
+              surfL: 0.25,
+              surfC: 0.05,
+            },
+            queue: { H: 290, C: 0.1, L: 0.62 },
+            neutralHue: 30,
+            neutralChroma: 0.005,
+            neutralLight: {
+              textL: 0.2,
+              secondaryL: 0.45,
+              mutedL: 0.56,
+              interactiveL: 0.36,
+              borderL: 0.84,
+              borderSubtleL: 0.915,
+              codeBgL: 0.92,
+              codeTextL: 0.2,
+            },
+            neutralDark: {
+              textL: 0.94,
+              secondaryL: 0.76,
+              mutedL: 0.66,
+              interactiveL: 0.84,
+              borderL: 0.32,
+              borderSubtleL: 0.24,
+              codeBgL: 0.2,
+              codeTextL: 0.92,
+            },
+            catTextH: 5,
+            catTextC: 0.025,
+            catTextLightL: 0.15,
+            catTextDarkL: 0.88,
+          },
+        },
+      }),
+    );
+
+    const [{ getActiveTheme, useThemeStore }, { INIT_LIGHT }] = await Promise.all([
+      import('../themeStore'),
+      import('@/components/dev/oklch-tuner-engine'),
+    ]);
+
+    expect(getActiveTheme(useThemeStore.getState()).params).toEqual(INIT_LIGHT);
+  });
+
+  it('discards stale dark built-in overrides after the dark INIT defaults change', async () => {
+    const { INIT_DARK } = await import('@/components/dev/oklch-tuner-engine');
+    const staleDark = structuredClone(INIT_DARK);
+    staleDark.accentHue = 50;
+    staleDark.queue = { H: 300, C: 0.12, L: 0.5 };
+    staleDark.neutralDark = {
+      textL: 0.94,
+      secondaryL: 0.76,
+      mutedL: 0.66,
+      interactiveL: 0.84,
+      borderL: 0.32,
+      borderSubtleL: 0.24,
+      codeBgL: 0.2,
+      codeTextL: 0.92,
+    };
+
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({
+        version: '2026-06-10-light-token-init',
+        activeId: 'dark',
+        custom: [],
+        builtInOverrides: {
+          dark: staleDark,
+        },
+      }),
+    );
+
+    const { getActiveTheme, useThemeStore } = await import('../themeStore');
+
+    expect(getActiveTheme(useThemeStore.getState()).params).toEqual(INIT_DARK);
+  });
+});

--- a/packages/web/src/stores/themeStore.ts
+++ b/packages/web/src/stores/themeStore.ts
@@ -23,7 +23,7 @@ const NO_HC: HcOverride = { on: false, hue: 0, chroma: 0 };
 /* Bump when INIT defaults change in a way that user's persisted built-in
  * overrides should be discarded (so they see the new defaults instead of
  * stale tuner edits from an older INIT). Custom themes are preserved. */
-const INIT_VERSION = '2026-05-28-per-theme-init';
+const INIT_VERSION = '2026-06-10-dark-token-init';
 
 export interface ThemePreset {
   id: string;


### PR DESCRIPTION
## Summary

Batch fix for multiple independent issues. The PR branch is squashed to one commit, with regression coverage where practical.

Fixes #691, Fixes #857, Fixes #862, Fixes #873, Fixes #886, Fixes #894, Fixes #896, Fixes #897

> **Supersedes #874** — This PR is a superset of #874 for #873, adding timeout protection, late-success cleanup, and QueueProcessor parity that #874 did not cover. #874 can be closed after this merges.

### Fixes included (accepted issues)

| Issue | Title | Change |
|-------|-------|--------|
| #691 | Chat layout shift after restore | Dispatch `CHAT_LAYOUT_CHANGED_EVENT` in restore settle |
| #857 | CLI diagnostics unknown error display | Surface sanitized `rawText` as `safeExcerpt` with `unknown_raw` source; fail-closed when empty |
| #862 | Env-var KEY/VALUE layout collapse | Wrap KEY in `w-[38%] shrink-0`, VALUE in `min-w-0 flex-1` |
| #873 | Silent connector invocation drops reply | Deliver fallback message on no-content path so IM users aren't left hanging |
| #886 | Call hint URL wrong for non-v1 base URLs | Match per-client runtime URL normalization: opencode folds non-v1 bases, non-opencode clients keep their runtime `/v1` suffix |
| #894 | Redundant PATH probe in client-detection catch | Add `skipPathProbe` option to `resolveCliCommand()` |
| #896 | OKLCH light/dark default values wrong | Fix `INIT_LIGHT` and `INIT_DARK` tuner defaults; bump `INIT_VERSION` so stale built-in overrides migrate |
| #897 | Dark→Light theme switch flicker | Add idempotency guard in `ThemeApplier` |

### Latest dark-token follow-up

- `INIT_DARK.queue`: `H=290 C=0.15 L=0.6`
- `INIT_DARK.neutralDark`: `txt=0.95 sec=0.75 mut=0.66 int=0.84 bdr=0.35 sub=0.4 codeBg=0.25 codeTx=0.9`
- Static dark fallbacks now match dynamic generation for surface chroma, semantic colors, queue accent, code colors, cat persona surface/text, and neutral aliases.
- `INIT_VERSION` bumped from `2026-06-10-light-token-init` to `2026-06-10-dark-token-init` so old persisted dark built-in overrides are discarded while custom themes stay preserved.

### Test coverage

- **`oklch-tuner-defaults.test.ts`** — golden export coverage for CVO-tuned light and dark token defaults (#896)
- **`themeStore.test.ts`** — stale built-in override migration for both older light-token and dark-token INIT versions (#896)
- **`f056-wcag-contrast.test.ts`** — updated dark cat persona, neutral, cafe-surface, and surface-tier contrast checks
- **`hub-cat-editor-oc-providers.test.ts`** — 9 tests: `KNOWN_OC_PROVIDERS` entries + `resolveOpenCodeEndpoint` + 6 `buildCallHint` URL regression cases, including non-opencode `/v2` bases keeping `/v1/messages` (#886)
- **`unified-auth-modal-envvar-layout.test.ts`** — 3 tests: structural source-level verification of wrapper classes (#862)
- **`cli-diagnostics-unknown-raw.test.js`** — 7 tests: sanitize + fail-closed + non-HOME path redaction for unknown_raw excerpt (#857)
- **`cli-diagnostics.test.js`** — 3 existing tests updated to expect `safeExcerpt` + `unknown_raw` (#857)
- **`cli-spawn.test.js`** — 1 existing test updated for `unknown_raw` expectation (#857)
- **`cli-resolve.test.js`** — 2 new tests: `skipPathProbe` finds CLI in fallback dir / returns null when not found (#894)
- **`connector-invoke-trigger.test.js`** — silent invocation fallback and timeout cleanup coverage (#873)
- **`queue-processor.test.js`** — queue silent fallback late-success / late-failure timeout coverage (#873)

### Review rounds

- **R2**: Biome lint + 5 CI test failures + 2 `skipPathProbe` regression tests
- **R3**: Non-HOME path redaction (P1), queue error delivery (P2), dark catText fallback (P2)
- **R4**: Correct error-path streaming cleanup — `onStreamEnd` before `cleanupPlaceholders`
- **R6** (cloud codex): Bound all 4 fallback deliveries with `DELIVER_TIMEOUT_MS` timeout (P1×2); reorder silent path to deliver before cleanup (P2×2)
- **R7**: Added silent fallback late-success / late-failure regression tests for ConnectorInvokeTrigger and QueueProcessor
- **R8**: Dark-mode OKLCH defaults aligned to CVO spec; static fallbacks and migration version updated
- **R9** (cloud codex): Scoped non-v1 URL hint suffix folding to opencode and added non-opencode `/v2/v1/messages` regression coverage
- **R10**: PR metadata — closing keywords, provenance chain, supersedes #874

## Test plan

- [x] `pnpm --filter @cat-cafe/web exec vitest run src/components/dev/__tests__/oklch-tuner-defaults.test.ts src/stores/__tests__/themeStore.test.ts src/lib/__tests__/f056-wcag-contrast.test.ts` — 29/29 pass
- [x] `pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/hub-cat-editor-oc-providers.test.ts` — 9/9 pass
- [x] `pnpm biome check` on touched web files — no errors
- [x] `pnpm --filter @cat-cafe/web run test:lint-rules` — pass
- [x] `pnpm --filter @cat-cafe/web build` — exit 0; existing warnings only
- [x] Browser dogfood on `http://127.0.0.1:3017/`: actual dark CSS variables show accent `35/0.08`, surface `30`, neutral `0.95/0.75/0.66/0.84/0.35/0.4`, queue `290` derived accent, and dark surface chroma `0.0022/0.0018/0.0008/0.0004`
- [x] Squashed PR branch to one commit: `bb0f72342 fix: batch theme UI and API fixes (#898)`
- [x] CI for squashed head `bb0f72342` — 5/5 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

