### PR TITLE
fix: restore accidentally deleted GitHub plugin manifest

### DIFF
--- a/plugins/github/plugin.yaml
+++ b/plugins/github/plugin.yaml
@@ -1,0 +1,42 @@
+id: github
+name: GitHub
+version: 1.0.0
+description: "GitHub PR tracking, CI/CD monitoring, conflict detection, and repository scanning"
+icon: github
+docsUrl: "https://cli.github.com/manual/gh_auth_login"
+setupSteps:
+  - "Log in with the GitHub CLI (`gh auth login`) on the machine running Cat Cafe"
+  - "Optional: configure a token only for plugin-managed child processes that explicitly consume it"
+  - "Optional: configure Noise Bot list to reduce setup-only comment noise"
+
+config:
+  - envName: GITHUB_TOKEN
+    label: "Personal Access Token"
+    sensitive: true
+    required: false
+  - envName: GITHUB_SETUP_NOISE_BOT_LOGINS
+    label: "Noise Bot Login List"
+    sensitive: false
+    required: false
+  - envName: GITHUB_MCP_PAT
+    label: "MCP Token"
+    sensitive: true
+    required: false
+
+resources:
+  - type: schedule
+    name: cicd-check
+    factoryId: github.cicd-check
+  - type: schedule
+    name: conflict-check
+    factoryId: github.conflict-check
+  - type: schedule
+    name: review-feedback
+    factoryId: github.review-feedback
+  - type: schedule
+    name: repo-scan
+    factoryId: github.repo-scan
+    optional: true
+  - type: schedule
+    name: issue-tracking
+    factoryId: github.issue-tracking


### PR DESCRIPTION
## Summary

- Restores `plugins/github/plugin.yaml` which was accidentally deleted in sync commit `9e92eab32`
- Without this manifest, all 5 GitHub schedule resources (cicd-check, conflict-check, review-feedback, repo-scan, issue-tracking) silently fail to register on startup
- This is the root cause of PR tracking and other GitHub pollers disappearing after restart

## Root Cause

The sync commit `9e92eab32` ("sync: cat-cafe 0952b3770566 to clowder-ai") deleted `plugins/github/plugin.yaml` (42 lines). The sync script likely treated the cat-cafe source tree (which doesn't have this file — it's a public-repo-only plugin manifest) as authoritative and removed it.

Chain: file deleted → `PluginRegistry.getManifest('github')` returns null → `if (githubManifest)` block skipped → no schedule entries in capabilities.json → no GitHub pollers registered

## Test plan

- [ ] After merge + restart, verify `capabilities.json` gains 5 schedule entries (type: "schedule", pluginId: "github")
- [ ] Verify PR tracking pollers resume (check via `/api/schedule/tasks`)
- [ ] Verify migration marker `.cat-cafe/f202-phase2-github-schedule-migrated` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #906