### PR TITLE
fix(connector-gateway): lazy-resolve defaultCatId for IM messages (#910)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3558,7 +3558,13 @@ async function main(): Promise<void> {
     invokeTrigger,
     socketManager,
     defaultUserId: 'default-user' as const,
-    defaultCatId: 'opus' as CatId,
+    // clowder-ai#910 + cloud P1: pass a getter (not a value) so runtime
+    // `PUT /api/config/default-cat` (which calls `setRuntimeDefaultCatId` →
+    // updates `_runtimeDefaultCatId`) propagates to ConnectorRouter's
+    // per-message parseMentions resolve, without needing a gateway restart.
+    // An object getter or a one-shot value would still be copied as a
+    // string into `new ConnectorRouter({ defaultCatId, ... })` and frozen.
+    defaultCatId: getDefaultCatId,
     redis: redisClient ?? undefined,
     log: app.log,
     agentRegistry,

--- a/packages/api/src/infrastructure/connectors/ConnectorRouter.ts
+++ b/packages/api/src/infrastructure/connectors/ConnectorRouter.ts
@@ -124,7 +124,14 @@ export interface ConnectorRouterOptions {
       }
     | undefined;
   readonly defaultUserId: string;
-  readonly defaultCatId: CatId;
+  /**
+   * Default cat to invoke when an IM message has no @mention and the target
+   * thread has no recent active cat. Accepts either a static id (used by tests
+   * and historical callers) or a getter (cloud P1 #2253: bootstrap passes a
+   * `() => getDefaultCatId()` so runtime `PUT /api/config/default-cat` is
+   * honored without a gateway restart). Resolved at every parseMentions call.
+   */
+  readonly defaultCatId: CatId | (() => CatId);
   readonly log: FastifyBaseLogger;
   readonly commandLayer?: ConnectorCommandLayer | undefined;
   readonly permissionStore?: IConnectorPermissionStore | undefined;
@@ -154,6 +161,18 @@ export class ConnectorRouter {
   private readonly hubThreadResolvers = new Map<string, Promise<string | undefined>>();
 
   constructor(private readonly opts: ConnectorRouterOptions) {}
+
+  /**
+   * Resolve `opts.defaultCatId` whether it was passed as a static id or a
+   * getter. Called per parseMentions site so runtime
+   * `PUT /api/config/default-cat` propagates without a gateway restart
+   * (cloud P1 #2253). Tests historically pass a string; production passes
+   * `() => getDefaultCatId()`.
+   */
+  private resolveDefaultCatId(): CatId {
+    const d = this.opts.defaultCatId;
+    return typeof d === 'function' ? d() : d;
+  }
 
   /** Build @-mention patterns from catRegistry for parseMentions. */
   private getMentionPatterns(): Map<string, string[]> {
@@ -296,7 +315,7 @@ export class ConnectorRouter {
             icon: connectorSourceIcon(def2),
           };
           const mentionPatterns = this.getMentionPatterns();
-          const { targetCatId } = parseMentions(fwdText, mentionPatterns, this.opts.defaultCatId);
+          const { targetCatId } = parseMentions(fwdText, mentionPatterns, this.resolveDefaultCatId());
           const fwdTimestamp = Date.now();
           const fwdStored = await messageStore.append({
             threadId: fwdThreadId,
@@ -442,7 +461,7 @@ export class ConnectorRouter {
 
     // Parse @-mentions to determine target cat
     const mentionPatterns = this.getMentionPatterns();
-    const mentionResult = parseMentions(resolvedText, mentionPatterns, this.opts.defaultCatId);
+    const mentionResult = parseMentions(resolvedText, mentionPatterns, this.resolveDefaultCatId());
     let targetCatId = mentionResult.targetCatId;
     if (!mentionResult.matched && this.opts.threadStore.getParticipantsWithActivity) {
       const participants = await this.opts.threadStore.getParticipantsWithActivity(binding.threadId);

--- a/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
+++ b/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
@@ -166,7 +166,8 @@ export interface ConnectorGatewayDeps {
       }
     | undefined;
   readonly defaultUserId: string;
-  readonly defaultCatId: CatId;
+  /** Static catId or getter; getter form propagates runtime PUT default-cat (cloud P1 #2253). */
+  readonly defaultCatId: CatId | (() => CatId);
   readonly redis?: RedisClient | undefined;
   readonly log: FastifyBaseLogger;
   readonly frontendBaseUrl?: string | undefined;

--- a/packages/api/test/connector-gateway-default-cat-invariant.test.js
+++ b/packages/api/test/connector-gateway-default-cat-invariant.test.js
@@ -1,0 +1,75 @@
+/**
+ * #910 Invariant guard: connector gateway bootstrap MUST NOT hardcode a
+ * legacy catId like `'opus'` for `defaultCatId`. It must source the default
+ * from `getDefaultCatId()` (cat-config-loader), so production runtime
+ * catalogs (where `'opus'` does not exist) don't fail with
+ * `Unknown cat ID: opus` on no-mention IM messages.
+ *
+ * Bug report: https://github.com/zts212653/clowder-ai/issues/910
+ * Root cause:
+ *   packages/api/src/index.ts: `defaultCatId: 'opus' as CatId,`
+ *   - parseMentions falls back to this when no @mention matches
+ *   - ConnectorInvokeTrigger → routeExecution → service map lookup
+ *   - With runtime catalog mapped to `cat-*` IDs, 'opus' is invalid
+ *
+ * This invariant test is the regression guard: future edits cannot
+ * silently re-introduce a hardcoded breed/variant id without flipping
+ * this assertion red.
+ */
+import './helpers/setup-cat-registry.js';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_TS_PATH = resolve(__dirname, '../src/index.ts');
+
+describe('#910: connector gateway bootstrap default catId invariant', () => {
+  it("packages/api/src/index.ts does NOT hardcode `defaultCatId: 'opus'`", () => {
+    const source = readFileSync(INDEX_TS_PATH, 'utf8');
+
+    // Reject the exact pattern that produces the bug.
+    // Tolerates whitespace, allows the type assertion `as CatId`.
+    const hardcodedPattern = /defaultCatId\s*:\s*['"]opus['"](\s+as\s+CatId)?/;
+    const match = source.match(hardcodedPattern);
+
+    assert.equal(
+      match,
+      null,
+      `index.ts must not hardcode defaultCatId to 'opus'. ` +
+        `Production runtime catalogs use cat-* ids and break with 'Unknown cat ID: opus' ` +
+        `on no-mention IM messages. Found: ${match?.[0]}. ` +
+        `Use getDefaultCatId() from cat-config-loader instead.`,
+    );
+  });
+
+  it('packages/api/src/index.ts uses getDefaultCatId() for connector gateway defaultCatId', async () => {
+    const source = readFileSync(INDEX_TS_PATH, 'utf8');
+
+    // Positive assertion: the connectorGatewayOptions block must reference
+    // getDefaultCatId(). We search the whole file because the import + the
+    // call site live on different lines.
+    assert.match(source, /\bgetDefaultCatId\b/, 'index.ts must import getDefaultCatId from cat-config-loader');
+
+    // Every `defaultCatId` site (value form OR `get defaultCatId()` form OR
+    // function-reference form `defaultCatId: getDefaultCatId`) must resolve
+    // through cat-config-loader. Cloud-P1 fix made the production site a
+    // function reference (not a call) so ConnectorRouter can lazy-resolve
+    // per-message and runtime PUT /api/config/default-cat propagates.
+    const valueLines = source.match(/^.*\bdefaultCatId\s*:.*$/gm) ?? [];
+    const getterIndex = source.search(/^\s*get\s+defaultCatId\s*\(/m);
+    const getterBlock = getterIndex >= 0 ? source.slice(getterIndex, source.indexOf('}', getterIndex) + 1) : '';
+    for (const line of valueLines) {
+      assert.match(
+        line,
+        /\bgetDefaultCatId\b/,
+        `Every defaultCatId assignment in index.ts must reference getDefaultCatId. Offending line: ${line.trim()}`,
+      );
+    }
+    if (getterBlock) {
+      assert.match(getterBlock, /\bgetDefaultCatId\b/, 'The `get defaultCatId()` body must use getDefaultCatId.');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Hotfix-lane cherry-pick of [cat-cafe#2253](https://github.com/zts212653/cat-cafe/pull/2253) (`bd03244a6`) to close #910 without waiting for the next full outbound sync.

## Why

`connectorGatewayOptions.defaultCatId` hardcoded `'opus' as CatId`. In production runtime catalogs (cat-* ids) `'opus'` is invalid → all no-mention IM messages (WeChat / Feishu / DingTalk / Telegram) crashed at `ConnectorInvokeTrigger.routeExecution` with `Unknown cat ID: opus`. Blocked F226 Phase 3 IM integration.

## What

- `index.ts`: passes `getDefaultCatId` as a function reference (not a one-shot value)
- `ConnectorRouter.ts`: widens `defaultCatId` to `CatId | (() => CatId)` and adds `resolveDefaultCatId()` called at every `parseMentions` site, so runtime `PUT /api/config/default-cat` propagates without a gateway restart
- `connector-gateway-bootstrap.ts`: same union widen on the deps type
- new source-text invariant test guards `index.ts` against re-introduction of the hardcoded `'opus'` pattern (the previous regression suite registered `'opus'` in setup and so masked the production failure mode)

## Tests

- 114/114 connector regression pass on cat-cafe (`connector-router` + `connector-invoke-trigger` + `connector-gateway-bootstrap` + new #910 invariant)
- `pnpm --filter @cat-cafe/api build` PASS

## Review trail (cat-cafe#2253)

- 砚砚 (Maine Coon GPT-5.5) approved across multiple rounds; final A2A APPROVE on commit `cad3d132f`
- Cloud Codex review: R1 P2 (frozen value), R2 P1 (lazy-getter still copied) — both fixed
- cat-cafe#2253 squash-merged at 2026-06-12T11:12:19Z

## Why hotfix lane, not next batch sync

The previous full outbound sync ran 2026-06-10. By the next batch, real users hitting this bug would be blocked for another ~7 days. Hotfix lane keeps scope to exactly the 4 files in #910 scope.

## Closes

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)