### PR TITLE
fix: prepare eval a2a publish source refs

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1636,6 +1636,16 @@ async function main(): Promise<void> {
   };
 
   const { evalHubRoutes } = await import('./routes/eval-hub.js');
+  const harnessFeedbackRoot = join(repoRoot, 'docs', 'harness-feedback');
+  const { createA2aPublishSourceRefsProducer } = await import(
+    './infrastructure/harness-eval/a2a/a2a-publish-source-refs.js'
+  );
+  const preparePublishSourceRefs = createA2aPublishSourceRefsProducer({
+    harnessFeedbackRoot,
+    traceStore: telemetryHandle.traceStore,
+    getMetricsText: telemetryHandle.getMetricsText ?? undefined,
+    metricsSnapshotStore: telemetryHandle.metricsSnapshotStore ?? undefined,
+  });
   // F192 Phase H AC-H4: real GitPublisher (git worktree + gh) + per-domain generators
   const { createGitWorktreePublisher } = await import(
     './infrastructure/harness-eval/publish-verdict/git-worktree-publisher.js'
@@ -1713,7 +1723,7 @@ async function main(): Promise<void> {
   const taskOutcomeDbPath = process.env.TASK_OUTCOME_DB ?? resolve(repoRoot, 'task-outcome-episodes.sqlite');
   const taskOutcomeStore = new TaskOutcomeEpisodeStore(taskOutcomeDbPath);
   await app.register(evalHubRoutes, {
-    harnessFeedbackRoot: resolve(repoRoot, 'docs', 'harness-feedback'),
+    harnessFeedbackRoot,
     threadStore,
     redis: redisClient ?? undefined,
     invokeTriggerProvider: invokeTriggerHolder,
@@ -1726,6 +1736,7 @@ async function main(): Promise<void> {
     agentKeyRegistry,
     taskOutcomeDbPath,
     eventMemoryDbPath: memoryServices.eventMemoryDbPath,
+    preparePublishSourceRefs,
   });
   // AC-G13: Cancel burst detector (in-memory, per-process)
   const { buildProposalRejectSignal } = await import(
@@ -3523,12 +3534,13 @@ async function main(): Promise<void> {
     wiredPublishDomains.add('eval:memory');
   }
   const evalScheduleOpts = {
-    harnessFeedbackRoot: resolve(repoRoot, 'docs', 'harness-feedback'),
+    harnessFeedbackRoot,
     threadStore,
     defaultUserId: getOwnerUserId(),
     listDynamicTasks: () => dynamicTaskStore.getAll(),
     redis: redisClient ?? undefined,
     wiredPublishDomains,
+    preparePublishSourceRefs,
   };
   taskRunnerV2.register(createEvalDomainDailySpec(evalScheduleOpts));
   taskRunnerV2.register(createEvalDomainWeeklySpec(evalScheduleOpts));

--- a/packages/api/src/infrastructure/harness-eval/a2a/a2a-publish-source-refs.ts
+++ b/packages/api/src/infrastructure/harness-eval/a2a/a2a-publish-source-refs.ts
@@ -1,0 +1,204 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { stringify as stringifyYaml } from 'yaml';
+import type { LocalTraceStore, TraceSpanDTO } from '../../telemetry/local-trace-store.js';
+import { type MetricsSnapshotStore, parsePrometheusText } from '../../telemetry/metrics-snapshot-store.js';
+import { type AttributionReport, generateAttributionReport } from '../attribution.js';
+import { type F167EvalInput, generateF167Snapshot, type RuntimeEvalSnapshot } from '../f167-eval.js';
+import type { A2aSnapshotAttributionRefs } from '../publish-verdict/types.js';
+import type { EvalMetricsHistoryResponse, EvalTraceSpan } from '../telemetry-adapter.js';
+
+export interface A2aPublishSourceRefsResult extends Required<A2aSnapshotAttributionRefs> {
+  snapshotPath: string;
+  attributionPath: string;
+}
+
+export interface WriteA2aPublishSourceRefsInput extends F167EvalInput {
+  harnessFeedbackRoot: string;
+  generatedAt?: string;
+}
+
+export interface A2aPublishSourceRefsProducerDeps {
+  harnessFeedbackRoot: string;
+  traceStore?: Pick<LocalTraceStore, 'query' | 'stats'> | null;
+  getMetricsText?: (() => Promise<string>) | null;
+  metricsSnapshotStore?: Pick<MetricsSnapshotStore, 'query'> | null;
+  now?: () => number;
+}
+
+export function writeA2aPublishSourceRefs(input: WriteA2aPublishSourceRefsInput): A2aPublishSourceRefsResult {
+  const baseSnapshot = generateF167Snapshot(input);
+  const generatedAt = input.generatedAt ?? baseSnapshot.generatedAt;
+  const snapshot: RuntimeEvalSnapshot = { ...baseSnapshot, generatedAt };
+  const date = generatedAt.slice(0, 10);
+  const evalSnapshotId = `eval-${snapshot.featureId}-${date}`;
+  const attribution = withAttributionIds(generateAttributionReport({ featureId: snapshot.featureId, snapshot }), {
+    evalSnapshotId,
+    generatedAt,
+  });
+
+  const slug = generatedAt.replace(/[:.]/g, '-').replace(/[^A-Za-z0-9-]/g, '-');
+  const snapshotName = `${slug}-${snapshot.featureId}-eval.yaml`;
+  const attributionName = `${slug}-${snapshot.featureId}-attribution.yaml`;
+  const snapshotPath = join(input.harnessFeedbackRoot, 'snapshots', snapshotName);
+  const attributionPath = join(input.harnessFeedbackRoot, 'attributions', attributionName);
+
+  mkdirSync(join(input.harnessFeedbackRoot, 'snapshots'), { recursive: true });
+  mkdirSync(join(input.harnessFeedbackRoot, 'attributions'), { recursive: true });
+  writeFileSync(snapshotPath, renderSnapshotYaml(snapshot, evalSnapshotId), 'utf8');
+  writeFileSync(attributionPath, renderAttributionYaml(attribution), 'utf8');
+
+  return {
+    kind: 'a2a-snapshot-attribution',
+    snapshotName,
+    attributionName,
+    snapshotPath,
+    attributionPath,
+  };
+}
+
+export function createA2aPublishSourceRefsProducer(
+  deps: A2aPublishSourceRefsProducerDeps,
+): () => Promise<A2aPublishSourceRefsResult> {
+  return async () => {
+    const input = await readF167EvalInput(deps);
+    return writeA2aPublishSourceRefs({
+      ...input,
+      harnessFeedbackRoot: deps.harnessFeedbackRoot,
+      ...(deps.now ? { generatedAt: new Date(deps.now()).toISOString() } : {}),
+    });
+  };
+}
+
+async function readF167EvalInput(deps: A2aPublishSourceRefsProducerDeps): Promise<F167EvalInput> {
+  const traceStats = deps.traceStore?.stats() ?? {
+    spanCount: 0,
+    maxSpans: 10_000,
+    maxAgeMs: 24 * 60 * 60 * 1000,
+    oldestStoredAt: null,
+    newestStoredAt: null,
+  };
+  const traceDtos = deps.traceStore?.query({ limit: traceStats.maxSpans }) ?? [];
+  const metrics = await readMetrics(deps.getMetricsText ?? undefined);
+  const metricsHistory = readMetricsHistory(deps.metricsSnapshotStore ?? undefined);
+  return {
+    traces: { spans: traceDtos.map(toEvalTraceSpan), count: traceDtos.length },
+    metrics,
+    metricsHistory,
+    traceStats,
+  };
+}
+
+async function readMetrics(getMetricsText?: () => Promise<string>): Promise<Record<string, number>> {
+  if (!getMetricsText) return {};
+  try {
+    return parsePrometheusText(await getMetricsText());
+  } catch {
+    return {};
+  }
+}
+
+function readMetricsHistory(store?: Pick<MetricsSnapshotStore, 'query'>): EvalMetricsHistoryResponse {
+  const snapshots = store?.query(undefined, 720) ?? [];
+  return { snapshots, count: snapshots.length };
+}
+
+function toEvalTraceSpan(dto: TraceSpanDTO): EvalTraceSpan {
+  return {
+    traceId: dto.traceId,
+    spanId: dto.spanId,
+    ...(dto.parentSpanId ? { parentSpanId: dto.parentSpanId } : {}),
+    name: dto.name,
+    startTimeMs: dto.startTimeMs,
+    endTimeMs: dto.endTimeMs,
+    durationMs: dto.durationMs,
+    status: dto.status,
+    attributes: dto.attributes,
+    events: dto.events,
+  };
+}
+
+function withAttributionIds(
+  report: AttributionReport,
+  ids: { evalSnapshotId: string; generatedAt: string },
+): AttributionReport {
+  return {
+    ...report,
+    evalSnapshotId: ids.evalSnapshotId,
+    generatedAt: ids.generatedAt,
+  };
+}
+
+function renderSnapshotYaml(snapshot: RuntimeEvalSnapshot, evalSnapshotId: string): string {
+  return renderRawYaml(
+    {
+      doc_kind: 'harness-feedback',
+      feedback_type: 'eval-snapshot',
+      feature_id: snapshot.featureId,
+      eval_snapshot_id: evalSnapshotId,
+      generated_at: snapshot.generatedAt,
+    },
+    {
+      window: {
+        start_ms: snapshot.window.startMs,
+        end_ms: snapshot.window.endMs,
+        duration_hours: snapshot.window.durationHours,
+      },
+      components: snapshot.components.map((component) => ({
+        id: component.componentId,
+        name: component.componentName,
+        confidence: component.confidence,
+        activation_counts: component.activationCounts,
+        friction_counts: component.frictionCounts,
+      })),
+    },
+  );
+}
+
+function renderAttributionYaml(report: AttributionReport): string {
+  return renderRawYaml(
+    {
+      doc_kind: 'harness-feedback',
+      feedback_type: 'attribution',
+      feature_id: report.featureId,
+      eval_snapshot_id: report.evalSnapshotId,
+      generated_at: report.generatedAt,
+    },
+    {
+      finding_count: report.findings.length,
+      findings: report.findings.map((finding) => ({
+        id: finding.id,
+        ...(finding.relatedFeature ? { related_feature: finding.relatedFeature } : {}),
+        friction_signal: {
+          type: finding.frictionSignal.type,
+          severity: finding.frictionSignal.severity,
+          confidence: finding.frictionSignal.confidence,
+          detected_at: finding.frictionSignal.detectedAt,
+        },
+        attribution: {
+          primary_layer: finding.attribution.primaryLayer,
+          pipeline_or_human: finding.attribution.pipelineOrHuman,
+          evidence: finding.attribution.evidence.map((evidence) => ({
+            type: evidence.type,
+            anchor: evidence.anchor,
+            excerpt: evidence.excerpt,
+          })),
+        },
+        proposed_action: finding.proposedAction,
+        status: finding.status,
+      })),
+      ...(report.noFindingRecord
+        ? {
+            no_finding_record: {
+              reason: report.noFindingRecord.reason,
+              evidence: report.noFindingRecord.evidence,
+            },
+          }
+        : {}),
+    },
+  );
+}
+
+function renderRawYaml(frontmatter: Record<string, unknown>, body: Record<string, unknown>): string {
+  return `---\n${stringifyYaml(frontmatter).trimEnd()}\n---\n\n${stringifyYaml(body).trimEnd()}\n`;
+}

--- a/packages/api/src/infrastructure/harness-eval/domain/eval-domain-daily.ts
+++ b/packages/api/src/infrastructure/harness-eval/domain/eval-domain-daily.ts
@@ -18,6 +18,7 @@ import type { TaskSpec_P1 } from '../../scheduler/types.js';
 import { buildEvalCatInvocation } from '../eval-cat-invocation.js';
 import { ensureEvalDomainThreads } from '../hub/eval-hub-thread-ensure.js';
 import { inventoryLegacyTasks, type LegacyScheduledTaskLike } from '../legacy-task-cleanup.js';
+import type { VerdictSourceRefs } from '../publish-verdict/types.js';
 import { getEvalCatOverride } from './eval-domain-override.js';
 import { type EvalDomainRegistryEntry, parseEvalDomainRegistryFile } from './eval-domain-registry.js';
 
@@ -38,6 +39,8 @@ export interface EvalDomainScheduleOpts {
    * → legacy default (all known-wireable domains get publish instructions in invocation).
    */
   wiredPublishDomains?: ReadonlySet<EvalDomainRegistryEntry['domainId']>;
+  /** Optional runtime producer for prepared publish sourceRefs (currently eval:a2a raw YAML evidence). */
+  preparePublishSourceRefs?: (domain: EvalDomainRegistryEntry) => Promise<VerdictSourceRefs | undefined>;
 }
 
 /** @deprecated Use EvalDomainScheduleOpts — kept for backward compat. */
@@ -151,12 +154,22 @@ function createEvalDomainSpec(config: EvalDomainSpecConfig): TaskSpec_P1<EvalDom
           }
         }
 
+        let publishSourceRefs: VerdictSourceRefs | undefined;
+        if (effectiveDomain.domainId === 'eval:a2a') {
+          try {
+            publishSourceRefs = await config.preparePublishSourceRefs?.(effectiveDomain);
+          } catch (err) {
+            console.warn('[eval:a2a] preparePublishSourceRefs failed; continuing without prepared refs', err);
+          }
+        }
+
         const invocation = buildEvalCatInvocation(
           {
             domain: effectiveDomain,
             trendRefs: [],
             verdictRefs: [],
             legacyCleanup: { status: legacyStatus },
+            ...(publishSourceRefs ? { publishSourceRefs } : {}),
           },
           // cloud R6 P2 (PR-2): gate scheduled invocation's publish instructions on
           // actual runtime support so weekly cw scheduled eval doesn't tell cat to

--- a/packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts
+++ b/packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts
@@ -1,4 +1,5 @@
 import { type EvalDomainRegistryEntry, parseEvalDomainRegistryEntry } from './domain/eval-domain-registry.js';
+import type { VerdictSourceRefs } from './publish-verdict/types.js';
 
 export interface LegacyCleanupStatus {
   status: 'not_checked' | 'dry_run_ready' | 'redirected' | 'disabled';
@@ -10,6 +11,7 @@ export interface EvalCatInvocationInput {
   trendRefs: string[];
   verdictRefs: string[];
   legacyCleanup: LegacyCleanupStatus;
+  publishSourceRefs?: VerdictSourceRefs;
 }
 
 export interface EvalCatInvocationPacket {
@@ -25,6 +27,7 @@ export interface EvalCatInvocationPacket {
     fixtures: EvalDomainRegistryEntry['fixtures'];
     legacyCleanup: LegacyCleanupStatus;
     sla: EvalDomainRegistryEntry['sla'];
+    publishSourceRefs?: VerdictSourceRefs;
   };
 }
 
@@ -93,6 +96,8 @@ Include your domain thread ID in the verdict PR body (the MCP tool does this aut
 /** a2a-specific sourceRefs section (snapshot/attribution YAML basenames). */
 const PUBLISH_VERDICT_INSTRUCTIONS_A2A = `${PUBLISH_VERDICT_PACKET_INSTRUCTIONS}
 You must also supply \`sourceRefs\` (NOT part of packet, separate input field): \`{ snapshotName, attributionName }\` — BASENAMES of your sanitized evidence YAMLs inside \`<harnessFeedbackRoot>/snapshots/\` and \`<harnessFeedbackRoot>/attributions/\` respectively. Path separators / \`..\` will be rejected (allowlist). The tool will NOT fabricate evidence — if you don't provide refs, publish fails.
+
+If the JSON context includes \`publishSourceRefs\`, pass that object exactly as the MCP tool's \`sourceRefs\`. If it is missing, stop and report that prepared eval:a2a publish evidence is missing; do not invent snapshot or attribution basenames.
 
 The MCP tool creates branch \`verdict/auto/{domainSlug}/{verdictId}\` + commits + opens PR. Returns commit SHA + PR URL.
 
@@ -279,6 +284,7 @@ export function buildEvalCatInvocation(
       fixtures: domain.fixtures,
       legacyCleanup: input.legacyCleanup,
       sla: domain.sla,
+      ...(input.publishSourceRefs ? { publishSourceRefs: input.publishSourceRefs } : {}),
     },
   };
 }

--- a/packages/api/src/infrastructure/harness-eval/manual-trigger/trigger-now.ts
+++ b/packages/api/src/infrastructure/harness-eval/manual-trigger/trigger-now.ts
@@ -2,6 +2,7 @@ import { getEvalCatOverride } from '../domain/eval-domain-override.js';
 import { buildEvalCatInvocation } from '../eval-cat-invocation.js';
 import { loadDomains } from '../hub/eval-hub-read-model.js';
 import { ensureEvalDomainThreads } from '../hub/eval-hub-thread-ensure.js';
+import type { VerdictSourceRefs } from '../publish-verdict/types.js';
 import type { HandlerError, ManualTriggerDeps } from './types.js';
 
 export interface TriggerNowInput {
@@ -92,12 +93,22 @@ export async function handleTriggerNow(
     }
   }
 
+  let publishSourceRefs: VerdictSourceRefs | undefined;
+  if (effectiveDomain.domainId === 'eval:a2a') {
+    try {
+      publishSourceRefs = await deps.preparePublishSourceRefs?.(effectiveDomain);
+    } catch (err) {
+      console.warn('[eval:a2a] preparePublishSourceRefs failed; continuing without prepared refs', err);
+    }
+  }
+
   const invocation = buildEvalCatInvocation(
     {
       domain: effectiveDomain,
       trendRefs: [],
       verdictRefs: [],
       legacyCleanup: { status: 'not_checked' },
+      ...(publishSourceRefs ? { publishSourceRefs } : {}),
     },
     // cloud R5 P2 (PR-2): gate publish instructions on actual runtime support so
     // cats don't waste a run producing a packet they can't publish (501 from

--- a/packages/api/src/infrastructure/harness-eval/manual-trigger/types.ts
+++ b/packages/api/src/infrastructure/harness-eval/manual-trigger/types.ts
@@ -1,6 +1,8 @@
 import type { Redis } from 'ioredis';
 import type { IMessageStore } from '../../../domains/cats/services/stores/ports/MessageStore.js';
 import type { IThreadStore } from '../../../domains/cats/services/stores/ports/ThreadStore.js';
+import type { EvalDomainRegistryEntry } from '../domain/eval-domain-registry.js';
+import type { VerdictSourceRefs } from '../publish-verdict/types.js';
 
 /**
  * F192 OQ-21 — Shared types for manual eval trigger handlers.
@@ -50,6 +52,8 @@ export interface ManualTriggerDeps {
    * legacy default (all known-wireable domains get publish instructions).
    */
   wiredPublishDomains?: ReadonlySet<string>;
+  /** Optional runtime producer for prepared publish sourceRefs (currently eval:a2a raw YAML evidence). */
+  preparePublishSourceRefs?: (domain: EvalDomainRegistryEntry) => Promise<VerdictSourceRefs | undefined>;
 }
 
 export interface HandlerError {

--- a/packages/api/src/routes/eval-hub.ts
+++ b/packages/api/src/routes/eval-hub.ts
@@ -8,6 +8,7 @@ import {
 import type { IMessageStore } from '../domains/cats/services/stores/ports/MessageStore.js';
 import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
 import { getEvalCatOverride, setEvalCatOverride } from '../infrastructure/harness-eval/domain/eval-domain-override.js';
+import type { EvalDomainRegistryEntry } from '../infrastructure/harness-eval/domain/eval-domain-registry.js';
 import { loadDomains, loadEvalHubSummary } from '../infrastructure/harness-eval/hub/eval-hub-read-model.js';
 import { ensureEvalDomainThreads } from '../infrastructure/harness-eval/hub/eval-hub-thread-ensure.js';
 import {
@@ -19,6 +20,7 @@ import {
   type GitPublisher,
   handlePublishVerdict,
   type VerdictGenerator,
+  type VerdictSourceRefs,
 } from '../infrastructure/harness-eval/publish-verdict/publish-verdict.js';
 import type { AgentKeyAuthRegistry, CallbackAuthRegistry } from './callback-auth-prehandler.js';
 import { registerCallbackAuthHook, requireCallbackPrincipal } from './callback-auth-prehandler.js';
@@ -58,6 +60,8 @@ export interface EvalHubRoutesOptions {
    * Missing entry for a domain → handler returns 501 unsupported_generator.
    */
   verdictGenerators?: Partial<Record<string, VerdictGenerator>>;
+  /** Runtime producer for prepared sourceRefs injected into eval-cat invocation context. */
+  preparePublishSourceRefs?: (domain: EvalDomainRegistryEntry) => Promise<VerdictSourceRefs | undefined>;
   /** Runtime-configured task-outcome DB path (trusted bootstrap config). */
   taskOutcomeDbPath?: string;
   /** Runtime-configured event-memory DB path (trusted bootstrap config). */
@@ -225,6 +229,7 @@ export const evalHubRoutes: FastifyPluginAsync<EvalHubRoutesOptions> = async (ap
         // cloud R5 P2 (PR-2): pass wired publish-verdict domain set so
         // buildEvalCatInvocation omits publish instructions for unwired domains.
         wiredPublishDomains: new Set(Object.keys(opts.verdictGenerators ?? {})),
+        preparePublishSourceRefs: opts.preparePublishSourceRefs,
       },
       { domainId, userId },
     );

--- a/packages/api/test/harness-eval/a2a-publish-source-refs.test.js
+++ b/packages/api/test/harness-eval/a2a-publish-source-refs.test.js
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, describe, it } from 'node:test';
+
+import { writeA2aPublishSourceRefs } from '../../dist/infrastructure/harness-eval/a2a/a2a-publish-source-refs.js';
+import { generateA2aLiveVerdict } from '../../dist/infrastructure/harness-eval/a2a/eval-a2a-live-verdict.js';
+
+const domain = {
+  domainId: 'eval:a2a',
+  displayName: 'A2A Harness Eval',
+  systemThreadId: 'thread_eval_a2a',
+  evalCat: { catId: 'codex', handle: '@codex', model: 'gpt-5.5' },
+  frequency: 'daily',
+  sourceAdapter: 'f167-runtime-eval',
+  threadPolicy: {
+    role: 'working-home',
+    stateSot: 'registry',
+    allowedContent: ['longitudinal-analysis', 'verdict-discussion', 'handoff-drafts'],
+  },
+  legacyScheduledTaskIds: [],
+  handoffTargetResolver: { featureId: 'F167', ownerCatId: 'opus47', threadLookup: 'feature-thread' },
+  sla: { acknowledgeHours: 24, reevalWithinHours: 72 },
+  fixtures: [],
+};
+
+describe('eval:a2a publish sourceRefs producer', () => {
+  const roots = [];
+  after(() => {
+    for (const root of roots) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('writes basename raw YAMLs that the a2a live verdict generator can consume', () => {
+    const root = mkdtempSync(join(tmpdir(), 'a2a-publish-refs-'));
+    roots.push(root);
+    const generatedAt = '2026-06-12T03:00:00.000Z';
+    const refs = writeA2aPublishSourceRefs({
+      harnessFeedbackRoot: root,
+      generatedAt,
+      traces: { spans: [], count: 0 },
+      metrics: {
+        cat_cafe_a2a_c2_verdict_hint_emitted: 10,
+        cat_cafe_a2a_c2_verdict_without_pass_count: 4,
+      },
+      metricsHistory: { snapshots: [], count: 0 },
+      traceStats: {
+        spanCount: 0,
+        maxSpans: 10000,
+        maxAgeMs: 86400000,
+        oldestStoredAt: Date.parse(generatedAt) - 3600000,
+        newestStoredAt: Date.parse(generatedAt),
+      },
+    });
+
+    assert.equal(refs.kind, 'a2a-snapshot-attribution');
+    assert.equal(refs.snapshotName, '2026-06-12T03-00-00-000Z-F167-eval.yaml');
+    assert.equal(refs.attributionName, '2026-06-12T03-00-00-000Z-F167-attribution.yaml');
+    assert.equal(existsSync(refs.snapshotPath), true);
+    assert.equal(existsSync(refs.attributionPath), true);
+    assert.match(readFileSync(refs.snapshotPath, 'utf8'), /eval_snapshot_id: eval-F167-2026-06-12/);
+    assert.match(readFileSync(refs.attributionPath, 'utf8'), /eval_snapshot_id: eval-F167-2026-06-12/);
+
+    const artifact = generateA2aLiveVerdict({
+      verdictId: '2026-06-12-a2a-producer-test',
+      rawSnapshotPath: refs.snapshotPath,
+      rawAttributionPath: refs.attributionPath,
+      harnessFeedbackRoot: root,
+      domain,
+    });
+
+    assert.equal(artifact.packet.domainId, 'eval:a2a');
+    assert.match(artifact.packet.evidencePacket.snapshotRefs[0], /snapshot:bundle\/2026-06-12-a2a-producer-test/);
+  });
+});

--- a/packages/api/test/harness-eval/eval-cat-invocation.test.js
+++ b/packages/api/test/harness-eval/eval-cat-invocation.test.js
@@ -120,4 +120,24 @@ describe('Eval cat invocation packet', () => {
       },
     ]);
   });
+
+  it('carries prepared publish sourceRefs in context when provided', () => {
+    const invocation = buildEvalCatInvocation({
+      domain,
+      trendRefs: [],
+      verdictRefs: [],
+      legacyCleanup: { status: 'disabled' },
+      publishSourceRefs: {
+        kind: 'a2a-snapshot-attribution',
+        snapshotName: '2026-06-12-F167-eval.yaml',
+        attributionName: '2026-06-12-F167-attribution.yaml',
+      },
+    });
+
+    assert.deepEqual(invocation.context.publishSourceRefs, {
+      kind: 'a2a-snapshot-attribution',
+      snapshotName: '2026-06-12-F167-eval.yaml',
+      attributionName: '2026-06-12-F167-attribution.yaml',
+    });
+  });
 });

--- a/packages/api/test/harness-eval/eval-domain-daily.test.js
+++ b/packages/api/test/harness-eval/eval-domain-daily.test.js
@@ -143,6 +143,71 @@ describe('eval-domain-daily task spec', () => {
     assert.equal(triggerArgs[4], 'msg_123'); // messageId
   });
 
+  it('execute prepares eval:a2a publishSourceRefs and includes them in delivered context', async () => {
+    const prepareCalls = [];
+    const spec = createEvalDomainDailySpec({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      defaultUserId: 'default-user',
+      preparePublishSourceRefs: async (domain) => {
+        prepareCalls.push(domain.domainId);
+        return {
+          kind: 'a2a-snapshot-attribution',
+          snapshotName: '2026-06-12-F167-eval.yaml',
+          attributionName: '2026-06-12-F167-attribution.yaml',
+        };
+      },
+    });
+
+    const gateResult = await spec.admission.gate();
+    assert.equal(gateResult.run, true);
+    const a2aItem = gateResult.workItems.find((w) => w.subjectKey === 'eval:a2a');
+    assert.ok(a2aItem);
+
+    const deliverMock = mock.fn(async () => 'msg_refs');
+    await spec.run.execute(a2aItem.signal, a2aItem.subjectKey, {
+      assignedCatId: null,
+      deliver: deliverMock,
+      invokeTrigger: { trigger: mock.fn() },
+    });
+
+    assert.deepEqual(prepareCalls, ['eval:a2a']);
+    const content = deliverMock.mock.calls[0].arguments[0].content;
+    assert.match(content, /"publishSourceRefs"/);
+    assert.match(content, /"snapshotName": "2026-06-12-F167-eval\.yaml"/);
+    assert.match(content, /"attributionName": "2026-06-12-F167-attribution\.yaml"/);
+  });
+
+  it('execute continues eval:a2a invocation when publishSourceRefs preparation fails', async () => {
+    const warnMock = mock.method(console, 'warn', () => {});
+    const spec = createEvalDomainDailySpec({
+      harnessFeedbackRoot: repoHarnessFeedbackRoot,
+      defaultUserId: 'default-user',
+      preparePublishSourceRefs: async () => {
+        throw new Error('disk full');
+      },
+    });
+
+    const gateResult = await spec.admission.gate();
+    assert.equal(gateResult.run, true);
+    const a2aItem = gateResult.workItems.find((w) => w.subjectKey === 'eval:a2a');
+    assert.ok(a2aItem);
+
+    const deliverMock = mock.fn(async () => 'msg_without_refs');
+    const triggerMock = mock.fn();
+
+    await spec.run.execute(a2aItem.signal, a2aItem.subjectKey, {
+      assignedCatId: null,
+      deliver: deliverMock,
+      invokeTrigger: { trigger: triggerMock },
+    });
+
+    assert.equal(deliverMock.mock.callCount(), 1);
+    assert.equal(triggerMock.mock.callCount(), 1);
+    assert.equal(warnMock.mock.callCount(), 1);
+    const content = deliverMock.mock.calls[0].arguments[0].content;
+    assert.doesNotMatch(content, /"publishSourceRefs"/);
+  });
+
   it('execute reports "disabled" when legacy task exists but is disabled (P2 regression)', async () => {
     // DynamicTaskStore.getAll() returns disabled defs too — execute must not
     // misreport them as 'dry_run_ready' when they're already disabled.

--- a/packages/api/test/harness-eval/eval-manual-trigger-handlers.test.js
+++ b/packages/api/test/harness-eval/eval-manual-trigger-handlers.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { readFileSync, rmSync } from 'node:fs';
-import { after, before, describe, it } from 'node:test';
+import { after, before, describe, it, mock } from 'node:test';
 
 import { handleGenerateNow, handleTriggerNow } from '../../dist/routes/eval-hub.js';
 import { setupHarnessFeedback, setupRawArtifacts } from './eval-manual-trigger-fixtures.js';
@@ -144,6 +144,76 @@ describe('Eval Manual Trigger Handlers (F192 OQ-21)', () => {
       assert.match(result.detail, /queue/);
       assert.match(result.detail, /retry/i);
       assert.equal(messageStoreCalls.length, 1, 'message delivered even though wake dropped');
+    });
+
+    it('includes prepared eval:a2a publishSourceRefs in manual trigger context', async () => {
+      const messageStoreCalls = [];
+      const prepareCalls = [];
+
+      const result = await handleTriggerNow(
+        {
+          harnessFeedbackRoot: root,
+          invokeTriggerProvider: { get: () => ({ trigger: () => 'dispatched' }) },
+          messageStore: {
+            append: async (msg) => {
+              messageStoreCalls.push(msg);
+              return { id: 'msg-with-refs' };
+            },
+          },
+          preparePublishSourceRefs: async (domain) => {
+            prepareCalls.push(domain.domainId);
+            return {
+              kind: 'a2a-snapshot-attribution',
+              snapshotName: '2026-06-12-F167-eval.yaml',
+              attributionName: '2026-06-12-F167-attribution.yaml',
+            };
+          },
+        },
+        { domainId: 'eval:a2a', userId: 'test-user' },
+      );
+
+      assert.ok(!('error' in result), `expected success, got: ${JSON.stringify(result)}`);
+      assert.deepEqual(prepareCalls, ['eval:a2a']);
+      assert.equal(messageStoreCalls.length, 1);
+      assert.match(messageStoreCalls[0].content, /"publishSourceRefs"/);
+      assert.match(messageStoreCalls[0].content, /"snapshotName": "2026-06-12-F167-eval\.yaml"/);
+      assert.match(messageStoreCalls[0].content, /"attributionName": "2026-06-12-F167-attribution\.yaml"/);
+    });
+
+    it('continues manual eval:a2a trigger when publishSourceRefs preparation fails', async () => {
+      const warnMock = mock.method(console, 'warn', () => {});
+      const messageStoreCalls = [];
+      const triggerCalls = [];
+
+      const result = await handleTriggerNow(
+        {
+          harnessFeedbackRoot: root,
+          invokeTriggerProvider: {
+            get: () => ({
+              trigger: (...args) => {
+                triggerCalls.push(args);
+                return 'dispatched';
+              },
+            }),
+          },
+          messageStore: {
+            append: async (msg) => {
+              messageStoreCalls.push(msg);
+              return { id: 'msg-without-refs' };
+            },
+          },
+          preparePublishSourceRefs: async () => {
+            throw new Error('permission denied');
+          },
+        },
+        { domainId: 'eval:a2a', userId: 'test-user' },
+      );
+
+      assert.ok(!('error' in result), `expected success, got: ${JSON.stringify(result)}`);
+      assert.equal(messageStoreCalls.length, 1);
+      assert.equal(triggerCalls.length, 1);
+      assert.equal(warnMock.mock.callCount(), 1);
+      assert.doesNotMatch(messageStoreCalls[0].content, /"publishSourceRefs"/);
     });
   });
 


### PR DESCRIPTION
## Summary
- prepare eval:a2a raw F167 snapshot/attribution YAML sourceRefs from in-process telemetry
- inject prepared publishSourceRefs into scheduled and manual eval-cat invocation context
- make sourceRefs preparation failures degrade to missing refs instead of aborting the eval invocation

## Why
F192 eval:a2a publish requires cat_cafe_publish_verdict to receive explicit sourceRefs.snapshotName and sourceRefs.attributionName. The publish tool must not fabricate evidence basenames, and the eval cat should stop/report missing prepared evidence when refs are unavailable.

## Validation
- pnpm --dir packages/api run build
- pnpm biome check --diagnostic-level=error <changed files>
- CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --test packages/api/test/harness-eval/a2a-publish-source-refs.test.js packages/api/test/harness-eval/eval-cat-invocation.test.js packages/api/test/harness-eval/eval-domain-daily.test.js packages/api/test/harness-eval/eval-manual-trigger-handlers.test.js (42 tests, 7 suites)
- pnpm check
- git diff --check

## Known Residual
An earlier full pnpm --dir packages/api run test run failed on baseline/open-source checkout artifact and root-doc expectations outside this diff, including missing scripts/redis-restore-from-rdb.sh, docs/reflections/README.md, .claude/settings.json, .githooks/pre-commit, and root markdown anchor checks.

[砚砚/GPT-5.5🐾]