### PR TITLE
fix(opencode): repair session handoff execution chain (#915)

### DIFF
--- a/cat-template.json
+++ b/cat-template.json
@@ -732,7 +732,7 @@
       "caution": "OMOC Sisyphus 只编排自己的子 agent，不编排其他猫；opencode 原生 MCP 和 Cat Cafe MCP 需避免冲突",
       "defaultVariantId": "opencode-default",
       "features": {
-        "sessionChain": false
+        "sessionChain": true
       },
       "variants": [
         {

--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -26,11 +26,45 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
   'gemini-3.1-pro-preview': 1_000_000,
 };
 
+/**
+ * clowder#915 R5 cloud P2: when opencode runs against a model NOT in the
+ * fallback table (GLM-5.1, openrouter custom names, etc.), the F24
+ * context_health block silently skips and handoff never fires. This is
+ * a last-resort default used ONLY when both `usage.contextWindowSize`
+ * AND `getContextWindowFallback(model)` return undefined.
+ *
+ * 128_000 was chosen as a middle-ground: covers GLM-5.1 (128k), most
+ * GPT 128k variants, and stays safely under Claude (200k) so the
+ * 0.85 seal threshold trips around 108k — safely before any real
+ * provider's hard limit.
+ *
+ * Critical: this is a LAST-RESORT — known models (claude-opus-4-6,
+ * gpt-5.x, etc.) MUST resolve through the fallback table first so we
+ * use their precise window. Putting this unconditionally on the
+ * transformer would defeat the table for opencode's default
+ * claude-opus-4-6 (200k → wrongly capped at 128k).
+ */
+export const OPENCODE_DEFAULT_CONTEXT_WINDOW = 128_000;
+
 export function getContextWindowFallback(model: string): number | undefined {
-  if (CONTEXT_WINDOW_SIZES[model]) return CONTEXT_WINDOW_SIZES[model];
+  // Normalize provider-prefixed model IDs before lookup. The account routing
+  // path in invoke-single-cat sets `callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE`
+  // to a `safeProvider/model` form (see L1459 `safeProvider/safeModel`), and
+  // OpenCodeAgentService propagates that prefixed string as `metadata.model`.
+  // Without normalization, lookups like `anthropic/claude-opus-4-6` or
+  // `openai-compat/gpt-5.3` would miss the table entirely → no windowSize →
+  // F24 context_health silently skipped → opencode handoff (clowder#915)
+  // bypassed in production. (clowder#915 R2 cloud P1)
+  //
+  // Use lastIndexOf to handle multi-segment prefixes like `openai-compat/x/y`
+  // (defensive — current code emits at most one slash, but the cost is the
+  // same and we don't want to be the next migration's footgun).
+  const slashAt = model.lastIndexOf('/');
+  const bare = slashAt >= 0 ? model.slice(slashAt + 1) : model;
+  if (CONTEXT_WINDOW_SIZES[bare]) return CONTEXT_WINDOW_SIZES[bare];
   // Try prefix match (e.g. 'claude-opus-4-6-20260101' matches 'claude-opus-4-6')
   for (const [key, value] of Object.entries(CONTEXT_WINDOW_SIZES)) {
-    if (model.startsWith(key)) return value;
+    if (bare.startsWith(key)) return value;
   }
   return undefined;
 }

--- a/packages/api/src/config/session-strategy.ts
+++ b/packages/api/src/config/session-strategy.ts
@@ -50,6 +50,17 @@ const DEFAULT_STRATEGY_BY_PROVIDER: Record<string, SessionStrategyConfig> = {
     turnBudget: 12_000,
     safetyMargin: 4_000,
   },
+  // clowder#915: opencode (golden chinchilla / GLM-5.1) was falling through to
+  // GLOBAL_DEFAULT_STRATEGY because it had no entry here. The fallback values
+  // happened to be correct (handoff @ 0.75/0.85) but the gap masked an
+  // architectural issue: opencode had no first-class strategy provenance, and
+  // tuning would silently be dropped. Make it a peer of anthropic/openai/google.
+  opencode: {
+    strategy: 'handoff',
+    thresholds: { warn: 0.75, action: 0.85 },
+    turnBudget: 12_000,
+    safetyMargin: 4_000,
+  },
 };
 
 /** breedId-keyed overrides (same breed's variants share strategy) */

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -13,7 +13,14 @@ import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
-import { type CatId, type ContextHealth, catRegistry, type MessageContent, type SessionRecord } from '@cat-cafe/shared';
+import {
+  type CatId,
+  type ContextHealth,
+  catRegistry,
+  type MessageContent,
+  type SealReason,
+  type SessionRecord,
+} from '@cat-cafe/shared';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import {
   resolveBuiltinClientForProvider,
@@ -24,7 +31,10 @@ import { resolveBoundAccountRefForCat } from '../../../../../config/cat-account-
 import { isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { buildCatGitIdentityEnv } from '../../../../../config/cat-git-identity.js';
 import { getCatModel } from '../../../../../config/cat-models.js';
-import { getContextWindowFallback } from '../../../../../config/context-window-sizes.js';
+import {
+  getContextWindowFallback,
+  OPENCODE_DEFAULT_CONTEXT_WINDOW,
+} from '../../../../../config/context-window-sizes.js';
 import { getSessionStrategy, shouldTakeAction } from '../../../../../config/session-strategy.js';
 import { assertSafeTestConfigRoot } from '../../../../../config/test-config-write-guard.js';
 import { capturePromptIfEnabled } from '../../../../../infrastructure/debug/prompt-capture-bridge.js';
@@ -1636,6 +1646,22 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     const userVisibleOutputSessionIds = new Set<string>();
     const userVisibleOutputCountedSessionIds = new Set<string>();
 
+    // clowder#915 R4 cloud P1 #3 (defer seal): when a mid-stream agent_loop
+    // crosses the seal threshold (opencode step_finish ≥ 0.85 fillRatio),
+    // we capture the seal intent here instead of firing requestSeal inline.
+    // The actual sealer.requestSeal + sessionManager.delete + finalize is
+    // executed at the `done` event boundary, so post-seal text/tool events
+    // in the SAME opencode invocation (tool-loop tail) still find an active
+    // SessionRecord via getActive() and write to transcript normally.
+    // Cleared on done (after deferred execution) or any inline seal that
+    // already fired (the active record is gone so no second seal makes sense).
+    let pendingMidStreamSeal: {
+      sessionId: string;
+      reason: SealReason;
+      healthSnapshot: ContextHealth;
+      activeRecord: SessionRecord;
+    } | null = null;
+
     const recordActiveSessionUserVisibleOutput = async (): Promise<void> => {
       if (!deps.sessionChainStore || !sessionChainActive) return;
       try {
@@ -1661,6 +1687,344 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
 
     const processMessage = async (msg: AgentMessage): Promise<AgentMessage[]> => {
       const outputs: AgentMessage[] = [];
+
+      // clowder#915 (cloud P1): F8/F24 usage + context_health block extracted so
+      // it can run from BOTH the `done` branch (existing behavior) AND the
+      // `agent_loop` branch (NEW — opencode's step_finish event carries
+      // mid-stream token usage via agent_loop). Before this extraction, the
+      // agent_loop's early-return at L2322 silently dropped usage → no
+      // context_health → no seal → no handoff → opencode CLI hung at context
+      // limit. Closes over processMessage's lexical scope (catId, provider,
+      // sessionChainActive, deps, outputs, etc.). Parameter `msg` shadows the
+      // outer param so all the existing `msg.metadata.usage.*` refs resolve
+      // correctly to whatever message we're processing.
+      //
+      // clowder#915 R4 cloud P1 #3 (defer seal): callers from the agent_loop
+      // branch pass `deferSealForMidStream: true` so the seal case CAPTURES
+      // intent into `pendingMidStreamSeal` instead of firing `requestSeal`
+      // immediately. The actual seal is executed at the `done` boundary, so
+      // post-seal text/tool events from the same opencode tool loop still
+      // find an active session via getActive() and write to transcript.
+      const processUsageAndContextHealth = async (
+        msg: AgentMessage,
+        options: { deferSealForMidStream?: boolean } = {},
+      ): Promise<void> => {
+        if (!msg.metadata?.usage) return;
+        // F152: Record OTel token usage + LLM call duration
+        const modelBucket = normalizeModel(msg.metadata.model ?? '');
+        const providerSystem = provider ?? 'unknown';
+        const tokenAttrs = {
+          [AGENT_ID]: catId,
+          [GENAI_SYSTEM]: providerSystem,
+          [GENAI_MODEL]: modelBucket,
+          [OPERATION_NAME]: 'invoke',
+        };
+        if (msg.metadata.usage.inputTokens) {
+          tokenUsage.add(msg.metadata.usage.inputTokens, { ...tokenAttrs, [STATUS]: 'input' });
+        }
+        if (msg.metadata.usage.outputTokens) {
+          tokenUsage.add(msg.metadata.usage.outputTokens, { ...tokenAttrs, [STATUS]: 'output' });
+        }
+        if (msg.metadata.usage.durationApiMs) {
+          llmCallDuration.record(msg.metadata.usage.durationApiMs / 1000, tokenAttrs);
+        }
+
+        // F153 Phase B: Retrospective LLM call span (created after-the-fact from done event)
+        // Only create when durationApiMs is available — providers without timing data
+        // (Codex, Gemini, Kimi) would produce misleading 0-duration spans.
+        if (invocationSpan && msg.metadata.usage.durationApiMs) {
+          recordLlmCallSpan(
+            invocationSpan,
+            catId,
+            providerSystem,
+            modelBucket,
+            {
+              durationApiMs: msg.metadata.usage.durationApiMs,
+              inputTokens: msg.metadata.usage.inputTokens,
+              outputTokens: msg.metadata.usage.outputTokens,
+              cacheReadTokens: msg.metadata.usage.cacheReadTokens,
+            },
+            invocationId,
+          );
+        }
+
+        // F230: include model + provider so all carrier paths (PTY, bg, -p) can
+        // populate bubble footer metadata from invocation_usage.
+        // PTY carrier text events carry no metadata (transcriptEntriesToAgentMessages);
+        // this is their only metadata source. For -p/bg the frontend handler is
+        // first-write-wins → idempotent (text event writes metadata first, this is no-op).
+        outputs.push({
+          type: 'system_info' as const,
+          catId,
+          content: JSON.stringify({
+            type: 'invocation_usage',
+            catId,
+            usage: msg.metadata.usage,
+            model: msg.metadata.model,
+            provider: msg.metadata.provider,
+          }),
+          timestamp: Date.now(),
+        });
+
+        // F24: Compute and emit context health (only when session chain is enabled)
+        if (sessionChainActive) {
+          // #679: Gemini CLI token stats are cumulative across all turns — not usable
+          // for context fill. Skip entire context_health block (raw usage still in
+          // invocation_usage above). Guard auto-disables when lastTurnInputTokens exists.
+          const isCumulativeOnly =
+            msg.metadata.usage.isCumulativeUsage === true && msg.metadata.usage.lastTurnInputTokens == null;
+          // Use lastTurnInputTokens (per-API-call) for accurate context fill,
+          // then fallback to aggregated inputTokens, and finally totalTokens
+          // for providers (Gemini CLI) that only expose a total count.
+          // clowder#915 R5 cloud P2: 3-tier window resolution.
+          // 1) Explicit `usage.contextWindowSize` (CLI-reported — Claude's exact value)
+          // 2) Fallback table by bare model name (handles prefix-strip for
+          //    account-routing path's `provider/model` form per R2 P1 #2)
+          // 3) opencode-only last-resort default for unknown/custom-provider
+          //    models (GLM-5.1, openrouter customs — the breed clowder#915
+          //    actually targets). Crucially this is LAST so known opencode
+          //    models like the default claude-opus-4-6 get their precise 200k
+          //    from the table, NOT the 128k conservative default.
+          const windowSize =
+            msg.metadata.usage.contextWindowSize ??
+            getContextWindowFallback(msg.metadata.model ?? '') ??
+            (msg.metadata.provider === 'opencode' ? OPENCODE_DEFAULT_CONTEXT_WINDOW : undefined);
+          const usedFrom =
+            msg.metadata.usage.lastTurnInputTokens != null
+              ? 'last_turn'
+              : msg.metadata.usage.inputTokens != null
+                ? 'input'
+                : msg.metadata.usage.totalTokens != null
+                  ? 'total'
+                  : undefined;
+          const usedTokens =
+            usedFrom === 'last_turn'
+              ? msg.metadata.usage.lastTurnInputTokens!
+              : usedFrom === 'input'
+                ? msg.metadata.usage.inputTokens!
+                : usedFrom === 'total'
+                  ? msg.metadata.usage.totalTokens!
+                  : 0;
+          if (windowSize && usedTokens > 0 && isCumulativeOnly) {
+            log.warn(
+              {
+                catId,
+                threadId,
+                invocationId,
+                cumulativeUsedTokens: usedTokens,
+                windowSize,
+                usedFrom,
+              },
+              'Gemini cumulative-only usage observed; skipping context_health and auto-seal',
+            );
+            geminiContextFallback.add(1, { [AGENT_ID]: catId, [TRIGGER]: 'no_per_turn_signal' });
+          }
+          if (windowSize && usedTokens > 0 && !isCumulativeOnly) {
+            const source: ContextHealth['source'] =
+              msg.metadata.usage.contextWindowSize != null && usedFrom !== 'total' ? 'exact' : 'approx';
+            const health: ContextHealth = {
+              usedTokens,
+              windowTokens: windowSize,
+              fillRatio: Math.min(usedTokens / windowSize, 1.0),
+              source,
+              usedFrom,
+              measuredAt: Date.now(),
+            };
+            // Update SessionRecord (best-effort): persist health + usage snapshot
+            if (deps.sessionChainStore) {
+              try {
+                const activeRecord = await deps.sessionChainStore.getActive(catId, threadId);
+                if (activeRecord) {
+                  const u = msg.metadata?.usage!;
+                  await deps.sessionChainStore.update(activeRecord.id, {
+                    contextHealth: health,
+                    lastUsage: {
+                      ...(u.inputTokens != null ? { inputTokens: u.inputTokens } : {}),
+                      ...(u.outputTokens != null ? { outputTokens: u.outputTokens } : {}),
+                      ...(u.cacheReadTokens != null ? { cacheReadTokens: u.cacheReadTokens } : {}),
+                      ...(u.costUsd != null ? { costUsd: u.costUsd } : {}),
+                    },
+                    updatedAt: Date.now(),
+                  });
+                }
+              } catch {
+                /* best-effort */
+              }
+            }
+            // F-BLOAT: Detect context compression for re-injection on next turn.
+            // When usedTokens drops >60% from previous known value, the CLI
+            // auto-compacted its context. Flag for systemPrompt re-injection.
+            const cKey = `${userId}:${catId as string}:${threadId}`;
+            const prevFill = _prevContextFill.get(cKey);
+            _prevContextFill.set(cKey, usedTokens);
+            if (prevFill && usedTokens < prevFill * 0.4) {
+              _needsReinjection.add(cKey);
+            }
+            outputs.push({
+              type: 'system_info' as const,
+              catId,
+              content: JSON.stringify({ type: 'context_health', catId, health }),
+              timestamp: Date.now(),
+            });
+
+            // F33: Strategy-driven seal decision (replaces F24 Phase B shouldSeal)
+            if (deps.sessionSealer && deps.sessionChainStore) {
+              try {
+                // F062-fix:
+                // 1) api_key + approx health can be noisy on third-party gateways
+                // 2) api_key + compress strategy should not be force-sealed here
+                // Keep context_health observability in both cases.
+                const provider = catRegistry.tryGet(catId as string)?.config.clientId;
+                const profileMode = callbackEnv[ANTHROPIC_PROFILE_MODE_KEY];
+                const strategy = getSessionStrategy(catId as string);
+                const isAnthropicApiKey = provider === 'anthropic' && profileMode === ANTHROPIC_PROFILE_MODE_API_KEY;
+                const skipAutoSealForApproxApiKey = isAnthropicApiKey && health.source === 'approx';
+                const skipAutoSealForApiKeyCompress = isAnthropicApiKey && strategy.strategy === 'compress';
+                if (!skipAutoSealForApproxApiKey && !skipAutoSealForApiKeyCompress) {
+                  const activeRecord = await deps.sessionChainStore.getActive(catId, threadId);
+                  const action = shouldTakeAction(
+                    health.fillRatio,
+                    health.windowTokens,
+                    health.usedTokens,
+                    activeRecord?.compressionCount ?? 0,
+                    strategy,
+                  );
+
+                  switch (action.type) {
+                    case 'none':
+                      break;
+                    case 'warn': {
+                      // F225 软层: queue a cat-facing hint for the NEXT prompt. A
+                      // system_info output would never reach the cat (routing feeds only
+                      // `text` into previousResponses; ContextAssembler drops
+                      // userId='system') — so we ride the prompt-injection channel
+                      // (consumed at effectivePrompt assembly, ~line 1538). Nudges the cat
+                      // to run the context-self-management 3-axis self-check — NOT "handoff
+                      // now" (handoff-vs-compress is the cat's judgment). cKey matches the
+                      // compressionKey used there: `${userId}:${catId}:${threadId}`.
+                      queueContextHint(
+                        cKey,
+                        buildContextManagementHint({
+                          source: health.source,
+                          compressionCount: activeRecord?.compressionCount ?? 0,
+                        }),
+                      );
+                      break;
+                    }
+                    case 'seal':
+                    case 'seal_after_compress': {
+                      if (activeRecord) {
+                        // clowder#915 R4 cloud P1 #3: when called from agent_loop
+                        // (deferSealForMidStream=true), CAPTURE the seal intent
+                        // and let the `done` branch execute it. Firing inline
+                        // here would clear the active session pointer and break
+                        // transcript writes for the rest of the opencode
+                        // tool-loop's text/tool events.
+                        if (options.deferSealForMidStream) {
+                          pendingMidStreamSeal = {
+                            sessionId: activeRecord.id,
+                            reason: action.reason,
+                            healthSnapshot: health,
+                            activeRecord,
+                          };
+                          break;
+                        }
+                        const sealResult = await deps.sessionSealer.requestSeal({
+                          sessionId: activeRecord.id,
+                          reason: action.reason,
+                        });
+                        if (sealResult.accepted) {
+                          // If a done-path seal just fired inline, any pending
+                          // mid-stream intent is now obsolete (active record is
+                          // gone). Clear so the deferred-execution block below
+                          // does not double-seal.
+                          pendingMidStreamSeal = null;
+                          sessionManager.delete(userId, catId, threadId).catch(() => {});
+                          const sealTimestamp = Date.now();
+                          const continuityCapsule = params.continuityCapsule
+                            ? completeCapsuleForSeal(params.continuityCapsule, {
+                                invocationId,
+                                createdAt: sealTimestamp,
+                                seal: {
+                                  sessionId: activeRecord.id,
+                                  sessionSeq: activeRecord.seq + 1,
+                                  reason: action.reason,
+                                  healthSnapshot: health,
+                                },
+                              })
+                            : undefined;
+                          const sealInfoMessage = {
+                            type: 'system_info' as const,
+                            catId,
+                            content: JSON.stringify({
+                              type: 'session_seal_requested',
+                              catId,
+                              sessionId: activeRecord.id,
+                              sessionSeq: activeRecord.seq + 1,
+                              reason: action.reason,
+                              healthSnapshot: health,
+                              ...(continuityCapsule
+                                ? {
+                                    continuityCapsule,
+                                    continuityDiagnostics: {
+                                      source: 'route_state',
+                                      boundary: continuityCapsule.continuationReason,
+                                      generated: true,
+                                      persistedVia: 'session_seal_requested',
+                                      threadId,
+                                      catId,
+                                      invocationId,
+                                      sessionId: activeRecord.id,
+                                    },
+                                  }
+                                : {}),
+                            }),
+                            timestamp: sealTimestamp,
+                          };
+                          outputs.push(sealInfoMessage);
+                          if (deps.transcriptWriter) {
+                            const sessInfo: TranscriptSessionInfo = {
+                              sessionId: activeRecord.id,
+                              threadId,
+                              catId: activeRecord.catId,
+                              cliSessionId: activeRecord.cliSessionId,
+                              seq: activeRecord.seq,
+                            };
+                            deps.transcriptWriter.appendEvent(
+                              sessInfo,
+                              sealInfoMessage as unknown as Record<string, unknown>,
+                              invocationId,
+                            );
+                          }
+                          deps.sessionSealer.finalize({ sessionId: activeRecord.id }).catch(() => {});
+                        }
+                      }
+                      break;
+                    }
+                    case 'allow_compress':
+                      // Don't seal — let CLI compress. Log for observability.
+                      outputs.push({
+                        type: 'system_info' as const,
+                        catId,
+                        content: JSON.stringify({
+                          type: 'strategy_allow_compress',
+                          catId,
+                          strategy: strategy.strategy,
+                          compressionCount: activeRecord?.compressionCount ?? 0,
+                          healthSnapshot: health,
+                        }),
+                        timestamp: Date.now(),
+                      });
+                      break;
+                  }
+                }
+              } catch {
+                /* best-effort: strategy failure doesn't break invocation */
+              }
+            }
+          }
+        }
+      };
 
       if (msg.type === 'error') {
         hadStreamError = true;
@@ -2004,283 +2368,91 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           }
         }
 
-        // F8: Push token usage for frontend cost/token display
-        if (msg.metadata?.usage) {
-          // F152: Record OTel token usage + LLM call duration
-          const modelBucket = normalizeModel(msg.metadata.model ?? '');
-          const providerSystem = provider ?? 'unknown';
-          const tokenAttrs = {
-            [AGENT_ID]: catId,
-            [GENAI_SYSTEM]: providerSystem,
-            [GENAI_MODEL]: modelBucket,
-            [OPERATION_NAME]: 'invoke',
-          };
-          if (msg.metadata.usage.inputTokens) {
-            tokenUsage.add(msg.metadata.usage.inputTokens, { ...tokenAttrs, [STATUS]: 'input' });
-          }
-          if (msg.metadata.usage.outputTokens) {
-            tokenUsage.add(msg.metadata.usage.outputTokens, { ...tokenAttrs, [STATUS]: 'output' });
-          }
-          if (msg.metadata.usage.durationApiMs) {
-            llmCallDuration.record(msg.metadata.usage.durationApiMs / 1000, tokenAttrs);
-          }
+        // F8/F24 usage + context_health (extracted to helper for clowder#915
+        // — see processUsageAndContextHealth declaration at top of processMessage).
+        await processUsageAndContextHealth(msg);
 
-          // F153 Phase B: Retrospective LLM call span (created after-the-fact from done event)
-          // Only create when durationApiMs is available — providers without timing data
-          // (Codex, Gemini, Kimi) would produce misleading 0-duration spans.
-          if (invocationSpan && msg.metadata.usage.durationApiMs) {
-            recordLlmCallSpan(
-              invocationSpan,
-              catId,
-              providerSystem,
-              modelBucket,
-              {
-                durationApiMs: msg.metadata.usage.durationApiMs,
-                inputTokens: msg.metadata.usage.inputTokens,
-                outputTokens: msg.metadata.usage.outputTokens,
-                cacheReadTokens: msg.metadata.usage.cacheReadTokens,
-              },
-              invocationId,
-            );
-          }
-
-          outputs.push({
-            type: 'system_info' as const,
-            catId,
-            content: JSON.stringify({
-              type: 'invocation_usage',
-              catId,
-              usage: msg.metadata.usage,
-            }),
-            timestamp: Date.now(),
-          });
-
-          // F24: Compute and emit context health (only when session chain is enabled)
-          if (sessionChainActive) {
-            // #679: Gemini CLI token stats are cumulative across all turns — not usable
-            // for context fill. Skip entire context_health block (raw usage still in
-            // invocation_usage above). Guard auto-disables when lastTurnInputTokens exists.
-            const isCumulativeOnly =
-              msg.metadata.usage.isCumulativeUsage === true && msg.metadata.usage.lastTurnInputTokens == null;
-            // Use lastTurnInputTokens (per-API-call) for accurate context fill,
-            // then fallback to aggregated inputTokens, and finally totalTokens
-            // for providers (Gemini CLI) that only expose a total count.
-            const windowSize =
-              msg.metadata.usage.contextWindowSize ?? getContextWindowFallback(msg.metadata.model ?? '');
-            const usedFrom =
-              msg.metadata.usage.lastTurnInputTokens != null
-                ? 'last_turn'
-                : msg.metadata.usage.inputTokens != null
-                  ? 'input'
-                  : msg.metadata.usage.totalTokens != null
-                    ? 'total'
-                    : undefined;
-            const usedTokens =
-              usedFrom === 'last_turn'
-                ? msg.metadata.usage.lastTurnInputTokens!
-                : usedFrom === 'input'
-                  ? msg.metadata.usage.inputTokens!
-                  : usedFrom === 'total'
-                    ? msg.metadata.usage.totalTokens!
-                    : 0;
-            if (windowSize && usedTokens > 0 && isCumulativeOnly) {
-              log.warn(
-                {
-                  catId,
-                  threadId,
-                  invocationId,
-                  cumulativeUsedTokens: usedTokens,
-                  windowSize,
-                  usedFrom,
-                },
-                'Gemini cumulative-only usage observed; skipping context_health and auto-seal',
-              );
-              geminiContextFallback.add(1, { [AGENT_ID]: catId, [TRIGGER]: 'no_per_turn_signal' });
-            }
-            if (windowSize && usedTokens > 0 && !isCumulativeOnly) {
-              const source: ContextHealth['source'] =
-                msg.metadata.usage.contextWindowSize != null && usedFrom !== 'total' ? 'exact' : 'approx';
-              const health: ContextHealth = {
-                usedTokens,
-                windowTokens: windowSize,
-                fillRatio: Math.min(usedTokens / windowSize, 1.0),
-                source,
-                usedFrom,
-                measuredAt: Date.now(),
-              };
-              // Update SessionRecord (best-effort): persist health + usage snapshot
-              if (deps.sessionChainStore) {
-                try {
-                  const activeRecord = await deps.sessionChainStore.getActive(catId, threadId);
-                  if (activeRecord) {
-                    const u = msg.metadata?.usage!;
-                    await deps.sessionChainStore.update(activeRecord.id, {
-                      contextHealth: health,
-                      lastUsage: {
-                        ...(u.inputTokens != null ? { inputTokens: u.inputTokens } : {}),
-                        ...(u.outputTokens != null ? { outputTokens: u.outputTokens } : {}),
-                        ...(u.cacheReadTokens != null ? { cacheReadTokens: u.cacheReadTokens } : {}),
-                        ...(u.costUsd != null ? { costUsd: u.costUsd } : {}),
-                      },
-                      updatedAt: Date.now(),
-                    });
-                  }
-                } catch {
-                  /* best-effort */
-                }
-              }
-              // F-BLOAT: Detect context compression for re-injection on next turn.
-              // When usedTokens drops >60% from previous known value, the CLI
-              // auto-compacted its context. Flag for systemPrompt re-injection.
-              const cKey = `${userId}:${catId as string}:${threadId}`;
-              const prevFill = _prevContextFill.get(cKey);
-              _prevContextFill.set(cKey, usedTokens);
-              if (prevFill && usedTokens < prevFill * 0.4) {
-                _needsReinjection.add(cKey);
-              }
-              outputs.push({
+        // clowder#915 R4 cloud P1 #3 (defer seal execution): if an earlier
+        // agent_loop captured a pending seal intent and the done-branch
+        // helper above didn't already fire its own seal (which would have
+        // cleared pendingMidStreamSeal), execute the deferred seal NOW at
+        // this clean boundary. Built from the snapshot captured at agent_loop
+        // time, so health/reason/continuity reflect the moment the threshold
+        // was actually crossed (not whatever done's metadata.usage happens
+        // to carry, which is often empty for opencode).
+        if (pendingMidStreamSeal && deps.sessionSealer && deps.sessionChainStore) {
+          const pending = pendingMidStreamSeal;
+          pendingMidStreamSeal = null;
+          try {
+            const sealResult = await deps.sessionSealer.requestSeal({
+              sessionId: pending.sessionId,
+              reason: pending.reason,
+            });
+            if (sealResult.accepted) {
+              sessionManager.delete(userId, catId, threadId).catch(() => {});
+              const sealTimestamp = Date.now();
+              const continuityCapsule = params.continuityCapsule
+                ? completeCapsuleForSeal(params.continuityCapsule, {
+                    invocationId,
+                    createdAt: sealTimestamp,
+                    seal: {
+                      sessionId: pending.sessionId,
+                      sessionSeq: pending.activeRecord.seq + 1,
+                      reason: pending.reason,
+                      healthSnapshot: pending.healthSnapshot,
+                    },
+                  })
+                : undefined;
+              const sealInfoMessage = {
                 type: 'system_info' as const,
                 catId,
-                content: JSON.stringify({ type: 'context_health', catId, health }),
-                timestamp: Date.now(),
-              });
-
-              // F33: Strategy-driven seal decision (replaces F24 Phase B shouldSeal)
-              if (deps.sessionSealer && deps.sessionChainStore) {
-                try {
-                  // F062-fix:
-                  // 1) api_key + approx health can be noisy on third-party gateways
-                  // 2) api_key + compress strategy should not be force-sealed here
-                  // Keep context_health observability in both cases.
-                  const provider = catRegistry.tryGet(catId as string)?.config.clientId;
-                  const profileMode = callbackEnv[ANTHROPIC_PROFILE_MODE_KEY];
-                  const strategy = getSessionStrategy(catId as string);
-                  const isAnthropicApiKey = provider === 'anthropic' && profileMode === ANTHROPIC_PROFILE_MODE_API_KEY;
-                  const skipAutoSealForApproxApiKey = isAnthropicApiKey && health.source === 'approx';
-                  const skipAutoSealForApiKeyCompress = isAnthropicApiKey && strategy.strategy === 'compress';
-                  if (!skipAutoSealForApproxApiKey && !skipAutoSealForApiKeyCompress) {
-                    const activeRecord = await deps.sessionChainStore.getActive(catId, threadId);
-                    const action = shouldTakeAction(
-                      health.fillRatio,
-                      health.windowTokens,
-                      health.usedTokens,
-                      activeRecord?.compressionCount ?? 0,
-                      strategy,
-                    );
-
-                    switch (action.type) {
-                      case 'none':
-                        break;
-                      case 'warn': {
-                        // F225 软层: queue a cat-facing hint for the NEXT prompt. A
-                        // system_info output would never reach the cat (routing feeds only
-                        // `text` into previousResponses; ContextAssembler drops
-                        // userId='system') — so we ride the prompt-injection channel
-                        // (consumed at effectivePrompt assembly, ~line 1538). Nudges the cat
-                        // to run the context-self-management 3-axis self-check — NOT "handoff
-                        // now" (handoff-vs-compress is the cat's judgment). cKey matches the
-                        // compressionKey used there: `${userId}:${catId}:${threadId}`.
-                        queueContextHint(
-                          cKey,
-                          buildContextManagementHint({
-                            source: health.source,
-                            compressionCount: activeRecord?.compressionCount ?? 0,
-                          }),
-                        );
-                        break;
-                      }
-                      case 'seal':
-                      case 'seal_after_compress': {
-                        if (activeRecord) {
-                          const sealResult = await deps.sessionSealer.requestSeal({
-                            sessionId: activeRecord.id,
-                            reason: action.reason,
-                          });
-                          if (sealResult.accepted) {
-                            sessionManager.delete(userId, catId, threadId).catch(() => {});
-                            const sealTimestamp = Date.now();
-                            const continuityCapsule = params.continuityCapsule
-                              ? completeCapsuleForSeal(params.continuityCapsule, {
-                                  invocationId,
-                                  createdAt: sealTimestamp,
-                                  seal: {
-                                    sessionId: activeRecord.id,
-                                    sessionSeq: activeRecord.seq + 1,
-                                    reason: action.reason,
-                                    healthSnapshot: health,
-                                  },
-                                })
-                              : undefined;
-                            const sealInfoMessage = {
-                              type: 'system_info' as const,
-                              catId,
-                              content: JSON.stringify({
-                                type: 'session_seal_requested',
-                                catId,
-                                sessionId: activeRecord.id,
-                                sessionSeq: activeRecord.seq + 1,
-                                reason: action.reason,
-                                healthSnapshot: health,
-                                ...(continuityCapsule
-                                  ? {
-                                      continuityCapsule,
-                                      continuityDiagnostics: {
-                                        source: 'route_state',
-                                        boundary: continuityCapsule.continuationReason,
-                                        generated: true,
-                                        persistedVia: 'session_seal_requested',
-                                        threadId,
-                                        catId,
-                                        invocationId,
-                                        sessionId: activeRecord.id,
-                                      },
-                                    }
-                                  : {}),
-                              }),
-                              timestamp: sealTimestamp,
-                            };
-                            outputs.push(sealInfoMessage);
-                            if (deps.transcriptWriter) {
-                              const sessInfo: TranscriptSessionInfo = {
-                                sessionId: activeRecord.id,
-                                threadId,
-                                catId: activeRecord.catId,
-                                cliSessionId: activeRecord.cliSessionId,
-                                seq: activeRecord.seq,
-                              };
-                              deps.transcriptWriter.appendEvent(
-                                sessInfo,
-                                sealInfoMessage as unknown as Record<string, unknown>,
-                                invocationId,
-                              );
-                            }
-                            deps.sessionSealer.finalize({ sessionId: activeRecord.id }).catch(() => {});
-                          }
-                        }
-                        break;
-                      }
-                      case 'allow_compress':
-                        // Don't seal — let CLI compress. Log for observability.
-                        outputs.push({
-                          type: 'system_info' as const,
+                content: JSON.stringify({
+                  type: 'session_seal_requested',
+                  catId,
+                  sessionId: pending.sessionId,
+                  sessionSeq: pending.activeRecord.seq + 1,
+                  reason: pending.reason,
+                  healthSnapshot: pending.healthSnapshot,
+                  // Mark as deferred so downstream observers can distinguish
+                  // mid-stream-captured seals from synchronous done-time seals.
+                  deferredFrom: 'mid_stream_agent_loop',
+                  ...(continuityCapsule
+                    ? {
+                        continuityCapsule,
+                        continuityDiagnostics: {
+                          source: 'route_state',
+                          boundary: continuityCapsule.continuationReason,
+                          generated: true,
+                          persistedVia: 'session_seal_requested',
+                          threadId,
                           catId,
-                          content: JSON.stringify({
-                            type: 'strategy_allow_compress',
-                            catId,
-                            strategy: strategy.strategy,
-                            compressionCount: activeRecord?.compressionCount ?? 0,
-                            healthSnapshot: health,
-                          }),
-                          timestamp: Date.now(),
-                        });
-                        break;
-                    }
-                  }
-                } catch {
-                  /* best-effort: strategy failure doesn't break invocation */
-                }
+                          invocationId,
+                          sessionId: pending.sessionId,
+                        },
+                      }
+                    : {}),
+                }),
+                timestamp: sealTimestamp,
+              };
+              outputs.push(sealInfoMessage);
+              if (deps.transcriptWriter) {
+                const sessInfo: TranscriptSessionInfo = {
+                  sessionId: pending.activeRecord.id,
+                  threadId,
+                  catId: pending.activeRecord.catId,
+                  cliSessionId: pending.activeRecord.cliSessionId,
+                  seq: pending.activeRecord.seq,
+                };
+                deps.transcriptWriter.appendEvent(
+                  sessInfo,
+                  sealInfoMessage as unknown as Record<string, unknown>,
+                  invocationId,
+                );
               }
+              deps.sessionSealer.finalize({ sessionId: pending.sessionId }).catch(() => {});
             }
+          } catch {
+            /* best-effort: deferred seal failure doesn't break invocation */
           }
         }
 
@@ -2292,6 +2464,18 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         // is the correct way to skip the remaining branches and transcript writer below.
         if (msg.type === 'agent_loop') {
           if (invocationSpan) recordAgentLoop(invocationSpan);
+          // clowder#915: opencode emits step_finish (mid-stream LLM-call boundary)
+          // as agent_loop carrying token usage. Route through F8/F24 so
+          // context_health computes + seal can fire BEFORE the CLI hits its context
+          // window. For agent_loop messages without usage (other producers under
+          // F153 Phase I semantics), the helper returns early — no behavior change.
+          //
+          // clowder#915 R4 cloud P1 #3: deferSealForMidStream=true so the helper
+          // CAPTURES seal intent into pendingMidStreamSeal instead of firing
+          // requestSeal inline. The actual seal executes at the `done` boundary
+          // below — preserving transcript writes for the rest of the opencode
+          // tool-loop's text/tool events.
+          await processUsageAndContextHealth(msg, { deferSealForMidStream: true });
           return outputs;
         }
         // Main-merge: record user-visible session output (independent of toolTracing — uses raw msg).

--- a/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
@@ -335,7 +335,14 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
             sessionInitEmitted = true;
             if (result.sessionId) metadata.sessionId = result.sessionId;
           }
-          yield { ...result, metadata: yieldMetadata };
+          // clowder#915 R1 P1 (砚砚): transformer may carry `metadata.usage`
+          // (from step_finish). The naive `metadata: yieldMetadata` below would
+          // strip it because spread can't see nested keys. Merge `usage` onto
+          // the service-level metadata (which has correct provider + model) so
+          // invoke-single-cat's F8 token block + F24 contextHealth path can fire.
+          const mergedMetadata: MessageMetadata =
+            result.metadata?.usage != null ? { ...yieldMetadata, usage: result.metadata.usage } : yieldMetadata;
+          yield { ...result, metadata: mergedMetadata };
         }
       }
 

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-event-transform.ts
@@ -6,12 +6,17 @@
  *   { type, timestamp, sessionID, part: { type, ... } }
  *
  * Event mapping:
- *   step_start → session_init (first occurrence establishes session)
- *   text       → text (part.text)
- *   tool_use   → tool_use (part.tool, part.state.input)
- *   error      → error (error.data.message or error.name)
- *   step_finish → null (cost/token metadata, skipped)
- *   Others     → null
+ *   step_start  → session_init (first occurrence establishes session)
+ *   text        → text (part.text)
+ *   tool_use    → tool_use (part.tool, part.state.input)
+ *   error       → error (error.data.message or error.name)
+ *   step_finish → agent_loop + metadata.usage (telemetry-only). Lights up
+ *                 invoke-single-cat's F8 token block + F24 contextHealth
+ *                 path so handoff can fire BEFORE context fills.
+ *                 Pre-clowder#915 this returned null → usage dropped →
+ *                 contextHealth never produced → handoff never triggered →
+ *                 opencode hung at context limit.
+ *   Others      → null
  */
 
 import type { CatId } from '@cat-cafe/shared';
@@ -26,10 +31,32 @@ interface OpenCodeEvent {
     text?: string;
     tool?: string;
     callID?: string;
+    /** step_finish only: terminal reason — 'stop' = final answer (terminal),
+     *  'tool-calls' = LLM called tools, more steps follow (non-terminal),
+     *  'length'/'content-filter' = upstream halted mid-step (terminal). */
+    reason?: string;
     state?: {
       status?: string;
       input?: Record<string, unknown>;
       output?: string;
+    };
+    /** step_finish only: USD cost of this step from the upstream provider. */
+    cost?: number;
+    /** step_finish only: token counts for this step (per-API-call shape).
+     *  Note: opencode CLI reports cached prompt tokens under tokens.cache.{read,write}
+     *  SEPARATELY from tokens.input. The shared TokenUsage contract requires
+     *  inputTokens to be the TOTAL prompt (fresh + cached), so consumers must
+     *  sum input + cache.read + cache.write when emitting AgentMessage usage.
+     *  (clowder#915 R4 cloud P1 #1). */
+    tokens?: {
+      total?: number;
+      input?: number;
+      output?: number;
+      reasoning?: number;
+      cache?: {
+        read?: number;
+        write?: number;
+      };
     };
     [key: string]: unknown;
   };
@@ -97,8 +124,96 @@ export function transformOpenCodeEvent(event: unknown, catId: CatId | string): A
       };
     }
 
-    case 'step_finish':
-      return null;
+    case 'step_finish': {
+      // clowder#915: surface token usage so invoke-single-cat's F8 token block
+      // and F24 contextHealth path can compute fillRatio and trigger handoff
+      // before context fills. Without this, opencode's session-chain machinery
+      // sees zero usage signal and never seals → CLI hangs at context limit.
+      //
+      // 砚砚 R1 P1: don't set provider/model here — the transformer can't see
+      // variant.defaultModel, and a `model: ''` here would break OTel
+      // normalizeModel + getContextWindowFallback downstream. OpenCodeAgentService
+      // merges this `usage` onto its own `metadata: { provider, model: effectiveModel }`
+      // when yielding (see merge logic in OpenCodeAgentService.ts), so we emit a
+      // partial metadata that the service layer completes.
+      const tokens = event.part?.tokens;
+      const freshInput = typeof tokens?.input === 'number' ? tokens.input : undefined;
+      const cacheRead = typeof tokens?.cache?.read === 'number' ? tokens.cache.read : undefined;
+      const cacheWrite = typeof tokens?.cache?.write === 'number' ? tokens.cache.write : undefined;
+      const outputTokens = typeof tokens?.output === 'number' ? tokens.output : undefined;
+      const totalTokens = typeof tokens?.total === 'number' ? tokens.total : undefined;
+      const costUsd = typeof event.part?.cost === 'number' ? event.part.cost : undefined;
+
+      // clowder#915 R4 cloud P1 #1: opencode CLI reports cached prompt tokens
+      // (cache.read for resumed-context reuse, cache.write for first-time cache
+      // population) SEPARATELY from tokens.input (fresh tokens this step).
+      // The shared TokenUsage contract says inputTokens/lastTurnInputTokens
+      // represent the TOTAL input including cached, and F24's context-fill
+      // numerator reads lastTurnInputTokens. If we copied only tokens.input,
+      // a long cached session (e.g. 671 fresh + 21k cached) would look like
+      // 671 → fillRatio underflow → handoff never fires before context wall.
+      const totalInputTokens =
+        freshInput != null || cacheRead != null || cacheWrite != null
+          ? (freshInput ?? 0) + (cacheRead ?? 0) + (cacheWrite ?? 0)
+          : undefined;
+
+      // Defensive: opencode may emit step_finish without token data (cached responses,
+      // pre-flight steps, etc.). With no telemetry there's nothing to surface; emit
+      // nothing instead of an empty agent_loop marker.
+      if (totalInputTokens == null && outputTokens == null && totalTokens == null) return null;
+
+      // clowder#915 R4 cloud P1 #2: opencode CLI never emits contextWindowSize.
+      // For models not in getContextWindowFallback's table (GLM-5.1, custom
+      // providers), windowSize would be undefined and F24 silently skips. Attach
+      // a conservative default so handoff is guaranteed to engage. The
+      // helper's `usage.contextWindowSize ?? getContextWindowFallback(...)`
+      // gating means a known-model lookup still takes precedence — this
+      // default only kicks in when fallback would have returned undefined.
+      // BUT: we ALSO set contextWindowSize unconditionally so unknown-model
+      // runs (the production case for #915) always have a window.
+
+      // clowder#915 R4 cloud P1 #3 (defer seal): handled in invoke-single-cat
+      // by ALWAYS deferring opencode agent_loop seals to the `done` event,
+      // regardless of step_finish.reason ('stop' vs 'tool-calls'). Since
+      // `done` arrives after the CLI's final step, "defer to done" achieves
+      // the same effect as "defer to terminal step" without the transformer
+      // needing to leak step_finish.reason into TokenUsage shape.
+      return {
+        type: 'agent_loop',
+        catId: catId as CatId,
+        timestamp: ts,
+        // Provider/model intentionally placeholders — OpenCodeAgentService overrides
+        // them with effectiveModel + 'opencode' on yield. Only `usage` is the
+        // transformer's contribution.
+        metadata: {
+          provider: 'opencode',
+          model: '',
+          usage: {
+            ...(totalInputTokens != null
+              ? { inputTokens: totalInputTokens, lastTurnInputTokens: totalInputTokens }
+              : {}),
+            ...(outputTokens != null ? { outputTokens } : {}),
+            ...(totalTokens != null ? { totalTokens } : {}),
+            // Skip zero-valued cache fields: 0 means "no cache activity this step",
+            // emitting an explicit 0 is noise. Truthy check is enough (we already
+            // confirmed type === 'number' above).
+            ...(cacheRead ? { cacheReadTokens: cacheRead } : {}),
+            ...(cacheWrite ? { cacheCreationTokens: cacheWrite } : {}),
+            ...(costUsd != null ? { costUsd } : {}),
+            // clowder#915 R5 cloud P2: do NOT attach a default contextWindowSize
+            // here. opencode-event-transform doesn't know whether the model is
+            // known to getContextWindowFallback's table (e.g. claude-opus-4-6 has
+            // a precise 200k entry). Unconditionally setting a default would
+            // override the table because invoke-single-cat uses
+            // `usage.contextWindowSize ?? getContextWindowFallback(model)` —
+            // wrongly capping claude-opus-4-6 (default opencode breed model)
+            // at the conservative default. The unknown-model fallback is now
+            // applied in invoke-single-cat as a LAST resort, only after the
+            // fallback table also returns undefined.
+          },
+        },
+      };
+    }
 
     default:
       return null;

--- a/packages/api/test/cat-config-loader.test.js
+++ b/packages/api/test/cat-config-loader.test.js
@@ -512,6 +512,22 @@ describe('cat-config-loader', () => {
       assert.equal(isSessionChainEnabled('unknown-cat', config), true);
     });
 
+    it('opencode breed has sessionChain enabled in real cat-template.json (clowder#915)', () => {
+      // clowder#915 root cause 1: opencode breed had `features.sessionChain: false`,
+      // so the entire chain → seal → continuation → handoff infrastructure never spun
+      // up. Even though strategy fallback to GLOBAL_DEFAULT (handoff @ 0.75/0.85) was
+      // "correct", with sessionChain disabled the strategy could not execute and
+      // opencode hung when context filled.
+      // Guard the actual repo cat-template.json against re-introduction of this.
+      const repoTemplate = resolve(import.meta.dirname, '../../../cat-template.json');
+      const config = loadCatConfig(repoTemplate);
+      assert.equal(
+        isSessionChainEnabled('opencode', config),
+        true,
+        'opencode breed must have sessionChain enabled or context-fill handoff never fires (clowder#915)',
+      );
+    });
+
     it('prefers variant.sessionChain override over breed-level setting', () => {
       const cfg = validConfig();
       cfg.breeds[0].features = { sessionChain: true };

--- a/packages/api/test/context-window-sizes.test.js
+++ b/packages/api/test/context-window-sizes.test.js
@@ -36,6 +36,31 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback(''), undefined);
   });
 
+  // clowder#915 R2 cloud P1: opencode (and any provider routed through
+  // CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE in the account routing path) propagates
+  // a `safeProvider/model` form as `metadata.model`. Before this fix, those
+  // strings missed the table entirely and F24 context_health was silently
+  // skipped → handoff bypassed for the production opencode invocation path.
+  test('clowder#915: strips provider prefix for account-routing model IDs', async () => {
+    // Exact match after strip
+    assert.equal(getContextWindowFallback('anthropic/claude-opus-4-6'), 200_000);
+    assert.equal(getContextWindowFallback('anthropic/claude-sonnet-4-5'), 200_000);
+    assert.equal(getContextWindowFallback('openai-compat/gpt-5.3'), 128_000);
+    assert.equal(getContextWindowFallback('openai-compat/gpt-5.1-codex'), 400_000);
+    assert.equal(getContextWindowFallback('google/gemini-2.5-pro'), 1_000_000);
+    // Prefix match after strip (versioned model behind provider prefix)
+    assert.equal(getContextWindowFallback('anthropic/claude-opus-4-6-20260101'), 200_000);
+    assert.equal(getContextWindowFallback('openai-compat/gpt-5.3-turbo'), 128_000);
+    // Unknown model behind prefix still returns undefined
+    assert.equal(getContextWindowFallback('anthropic/unknown-model'), undefined);
+  });
+
+  test('clowder#915: handles multi-segment prefix defensively (last segment wins)', async () => {
+    // Defensive against hypothetical `provider/subgroup/model` shapes
+    assert.equal(getContextWindowFallback('openai-compat/v1/gpt-5.3'), 128_000);
+    assert.equal(getContextWindowFallback('anthropic/v1/claude-opus-4-6'), 200_000);
+  });
+
   test('covers all expected model families', async () => {
     const keys = Object.keys(CONTEXT_WINDOW_SIZES);
     // Claude

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -1736,6 +1736,414 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.ok(payload.health.fillRatio > 0 && payload.health.fillRatio <= 1);
   });
 
+  it('clowder#915: agent_loop with metadata.usage triggers context_health (opencode mid-stream handoff path)', async () => {
+    // GIVEN opencode emits step_finish (mid-stream LLM-call boundary) → transformer
+    // returns AgentMessage of type=agent_loop carrying token usage. Before the
+    // clowder#915 fix the F8/F24 usage+context_health block lived only inside the
+    // `done` branch of processMessage, so agent_loop's early-return in the `else`
+    // branch silently DROPPED metadata.usage → contextHealth never computed →
+    // seal never requested → opencode session never sealed → CLI hung at its
+    // context limit. This test pins the new behavior: agent_loop with usage MUST
+    // route through the same F8/F24 path as done, while preserving F153 Phase I
+    // telemetry-only semantics (agent_loop itself stays invisible to users).
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        yield { type: 'session_init', catId: 'opus', sessionId: 'cli-915', timestamp: Date.now() };
+        yield { type: 'text', catId: 'opus', content: 'mid-stream answer', timestamp: Date.now() };
+        // step_finish event (per LLM call inside opencode agentic loop) carries
+        // input/output/total tokens + cost. Transformer wraps it as agent_loop.
+        // The shape mirrors what OpenCodeAgentService yields after the R1 P1
+        // merge logic that puts service-level model/provider onto the metadata.
+        yield {
+          type: 'agent_loop',
+          catId: 'opus',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'opencode',
+            model: 'claude-opus-4-6',
+            usage: {
+              inputTokens: 36928,
+              lastTurnInputTokens: 36928,
+              outputTokens: 9,
+              totalTokens: 36937,
+              contextWindowSize: 200000,
+              costUsd: 0.036973,
+            },
+          },
+        };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-915-agent-loop',
+        isLastCat: true,
+      }),
+    );
+
+    // (1) context_health MUST be emitted (cloud P1 fix)
+    const healthInfos = msgs.filter((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'context_health';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(healthInfos.length, 1, 'agent_loop with usage MUST emit context_health (clowder#915)');
+    const payload = JSON.parse(healthInfos[0].content);
+    assert.equal(payload.catId, 'opus');
+    assert.equal(payload.health.usedTokens, 36928, 'must use lastTurnInputTokens for per-call accuracy');
+    assert.equal(payload.health.windowTokens, 200000);
+    assert.equal(payload.health.usedFrom, 'last_turn');
+    assert.equal(payload.health.source, 'exact');
+
+    // (2) invocation_usage must also be emitted (F8/F230 — bubble footer fuel)
+    const usageInfos = msgs.filter((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'invocation_usage';
+      } catch {
+        return false;
+      }
+    });
+    assert.ok(usageInfos.length >= 1, 'agent_loop with usage MUST emit invocation_usage system_info');
+
+    // (3) F153 Phase I telemetry-only semantics preserved: agent_loop must NOT
+    //     appear in user-visible outputs (no bubble, no transcript write).
+    const agentLoopVisible = msgs.filter((m) => m.type === 'agent_loop');
+    assert.equal(agentLoopVisible.length, 0, 'agent_loop must stay telemetry-only — no user-visible output');
+  });
+
+  it('clowder#915 R4 cloud P1 #3: agent_loop above seal threshold DEFERS seal to done (transcript continuity)', async () => {
+    // Cloud's failing scenario: an opencode tool loop with step_finish.reason='tool-calls'
+    // crosses the seal threshold mid-stream. If we fire requestSeal inline, the active
+    // session pointer is cleared immediately and the remaining text/tool events from
+    // the SAME opencode invocation lose their transcript writes (getActive returns null).
+    // The fix: capture seal intent at agent_loop time, execute at the `done` boundary.
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    const sealCalls = [];
+    let sealCalledAtIndex = -1; // tracks how many service yields had been observed when requestSeal fired
+    let yieldsObserved = 0;
+
+    const sessionSealer = {
+      requestSeal: async (args) => {
+        sealCalls.push(args);
+        sealCalledAtIndex = yieldsObserved;
+        return { accepted: true, status: 'sealing' };
+      },
+      finalize: async () => {},
+      reconcileStuck: async () => 0,
+      reconcileAllStuck: async () => 0,
+    };
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        yieldsObserved = 1;
+        yield { type: 'session_init', catId: 'opus', sessionId: 'cli-915-defer', timestamp: Date.now() };
+        yieldsObserved = 2;
+        yield { type: 'text', catId: 'opus', content: 'thinking...', timestamp: Date.now() };
+        yieldsObserved = 3;
+        // step_finish at high fill (180k of 200k = 90% — well above 0.85 threshold)
+        // would normally fire seal IMMEDIATELY in the inline path.
+        yield {
+          type: 'agent_loop',
+          catId: 'opus',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'opencode',
+            model: 'claude-opus-4-6',
+            usage: {
+              inputTokens: 180_000,
+              lastTurnInputTokens: 180_000,
+              outputTokens: 50,
+              totalTokens: 180_050,
+              contextWindowSize: 200_000,
+            },
+          },
+        };
+        yieldsObserved = 4;
+        // Post-seal-threshold tool/text events — these must NOT be sealed-while-emitting
+        yield { type: 'text', catId: 'opus', content: 'still here (post-threshold)', timestamp: Date.now() };
+        yieldsObserved = 5;
+        yield {
+          type: 'tool_use',
+          catId: 'opus',
+          toolName: 'bash',
+          toolInput: { command: 'ls' },
+          timestamp: Date.now(),
+        };
+        yieldsObserved = 6;
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore, sessionSealer };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-915-defer-seal',
+        isLastCat: true,
+      }),
+    );
+
+    // (1) Exactly one seal request fired — no double-seal
+    assert.equal(sealCalls.length, 1, 'must seal exactly once');
+
+    // (2) The seal must have fired AT or AFTER the done event (index 6), not at
+    //     agent_loop time (index 3). This is the heart of the defer fix.
+    assert.ok(
+      sealCalledAtIndex >= 6,
+      `seal must be deferred to done — fired at yield index ${sealCalledAtIndex}, expected ≥ 6 (done boundary)`,
+    );
+
+    // (3) The session_seal_requested system_info MUST carry the deferred marker
+    //     so observers can distinguish mid-stream-captured seals from synchronous
+    //     done-time seals.
+    const sealRequestedMsgs = msgs.filter((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'session_seal_requested';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(sealRequestedMsgs.length, 1, 'one session_seal_requested message');
+    const sealPayload = JSON.parse(sealRequestedMsgs[0].content);
+    assert.equal(sealPayload.deferredFrom, 'mid_stream_agent_loop', 'must carry deferred-origin marker');
+    assert.equal(sealPayload.healthSnapshot.usedTokens, 180_000, 'health snapshot from agent_loop moment');
+
+    // (4) context_health system_info still emits at agent_loop time (observability
+    //     not deferred — only the seal action is).
+    const healthInfos = msgs.filter((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'context_health';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(healthInfos.length, 1, 'context_health emits at mid-stream observation point');
+
+    // (5) Post-threshold text/tool events are still in user-visible outputs
+    //     (transcript continuity for the rest of the tool loop).
+    const postThresholdText = msgs.filter(
+      (m) => m.type === 'text' && typeof m.content === 'string' && m.content.includes('still here'),
+    );
+    assert.equal(postThresholdText.length, 1, 'post-threshold text must reach outputs (transcript continuity)');
+  });
+
+  it('clowder#915 R5 cloud P2: 3-tier window resolution — known opencode model uses fallback table (NOT clobbered by default)', async () => {
+    // Cloud's R5 regression catch: R4's unconditional 128k attach in the
+    // transformer would prevent claude-opus-4-6 (default opencode breed
+    // model per cat-template.json) from resolving to its true 200k via the
+    // fallback table. This test pins the 3-tier chain:
+    //   1) usage.contextWindowSize (none here)
+    //   2) getContextWindowFallback('claude-opus-4-6') = 200_000 ← THIS WINS
+    //   3) opencode last-resort default (128_000) — should NOT be used here
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        yield { type: 'session_init', catId: 'opus', sessionId: 'cli-915-r5-known', timestamp: Date.now() };
+        yield {
+          type: 'agent_loop',
+          catId: 'opus',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'opencode',
+            model: 'claude-opus-4-6', // KNOWN to fallback table (200k)
+            usage: {
+              inputTokens: 150_000,
+              lastTurnInputTokens: 150_000,
+              outputTokens: 50,
+              totalTokens: 150_050,
+              // NO contextWindowSize from transformer — forces tier 2+3
+            },
+          },
+        };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-915-r5-known-model',
+        isLastCat: true,
+      }),
+    );
+
+    const healthInfos = msgs
+      .filter((m) => m.type === 'system_info')
+      .map((m) => {
+        try {
+          return JSON.parse(m.content);
+        } catch {
+          return null;
+        }
+      })
+      .filter((p) => p && p.type === 'context_health');
+    assert.equal(healthInfos.length, 1, 'must emit context_health');
+    // CRITICAL: windowTokens MUST be 200_000 (from fallback table) NOT 128_000
+    // (the opencode last-resort default — which would wrongly cap claude-opus-4-6).
+    assert.equal(
+      healthInfos[0].health.windowTokens,
+      200_000,
+      'claude-opus-4-6 must resolve to its precise 200k via fallback table — NOT clobbered by opencode last-resort default',
+    );
+    // Sanity: 150k of 200k = 0.75 fillRatio (would be 1.17 if window were clobbered to 128k)
+    assert.ok(healthInfos[0].health.fillRatio < 0.8, 'fillRatio must reflect true 200k window');
+  });
+
+  it('clowder#915 R5 cloud P2: 3-tier window resolution — unknown opencode model falls back to default', async () => {
+    // Counterpart to the known-model test: when the model is NOT in the
+    // fallback table (GLM-5.1, openrouter customs — the actual breed
+    // clowder#915 targets), the opencode last-resort default (128_000)
+    // kicks in so handoff still fires. This is tier 3 of the chain.
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        yield { type: 'session_init', catId: 'opus', sessionId: 'cli-915-r5-unknown', timestamp: Date.now() };
+        yield {
+          type: 'agent_loop',
+          catId: 'opus',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'opencode',
+            model: 'glm-5.1', // UNKNOWN — golden-chinchilla model (not in table)
+            usage: {
+              inputTokens: 109_000,
+              lastTurnInputTokens: 109_000,
+              outputTokens: 50,
+              totalTokens: 109_050,
+            },
+          },
+        };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-915-r5-unknown-model',
+        isLastCat: true,
+      }),
+    );
+
+    const healthInfos = msgs
+      .filter((m) => m.type === 'system_info')
+      .map((m) => {
+        try {
+          return JSON.parse(m.content);
+        } catch {
+          return null;
+        }
+      })
+      .filter((p) => p && p.type === 'context_health');
+    assert.equal(healthInfos.length, 1, 'unknown opencode model must still emit context_health (last-resort fallback)');
+    assert.equal(healthInfos[0].health.windowTokens, 128_000, 'unknown opencode model resolves to last-resort 128k');
+  });
+
+  it('clowder#915 R2 cloud P1: agent_loop with provider-prefixed model (account-routing path) triggers context_health', async () => {
+    // Production opencode invocation path: invoke-single-cat.ts:1459 sets
+    // callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE to `safeProvider/safeModel`
+    // form. OpenCodeAgentService.ts:139 then propagates that as effectiveModel.
+    // Transformer doesn't set contextWindowSize, so we fall back to
+    // getContextWindowFallback. Before the R2 cloud P1 fix, the prefixed
+    // string missed the lookup table → no windowSize → context_health silently
+    // skipped → handoff bypassed. This test pins the production scenario.
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        yield { type: 'session_init', catId: 'opus', sessionId: 'cli-915-prefixed', timestamp: Date.now() };
+        yield { type: 'text', catId: 'opus', content: 'hi', timestamp: Date.now() };
+        yield {
+          type: 'agent_loop',
+          catId: 'opus',
+          timestamp: Date.now(),
+          metadata: {
+            provider: 'opencode',
+            // The model carries a provider prefix — this is the production
+            // account-routing path's normalized form (NOT a test artifact).
+            model: 'anthropic/claude-opus-4-6',
+            usage: {
+              inputTokens: 36928,
+              lastTurnInputTokens: 36928,
+              outputTokens: 9,
+              totalTokens: 36937,
+              // NO contextWindowSize — forces fallback through model lookup
+            },
+          },
+        };
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = { ...makeDeps(), sessionChainStore };
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user1',
+        threadId: 'thread-915-prefixed',
+        isLastCat: true,
+      }),
+    );
+
+    const healthInfos = msgs.filter((m) => {
+      if (m.type !== 'system_info') return false;
+      try {
+        return JSON.parse(m.content).type === 'context_health';
+      } catch {
+        return false;
+      }
+    });
+    assert.equal(
+      healthInfos.length,
+      1,
+      'prefixed-model agent_loop with usage MUST emit context_health (clowder#915 R2 P1)',
+    );
+    const payload = JSON.parse(healthInfos[0].content);
+    assert.equal(payload.health.windowTokens, 200_000, 'fallback must resolve anthropic/claude-opus-4-6 → 200k');
+    assert.equal(payload.health.usedTokens, 36928);
+    assert.equal(payload.health.source, 'approx', 'fallback (no contextWindowSize on usage) → approx');
+  });
+
   it('F24: uses fallback window size for models without contextWindowSize', async () => {
     const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
     const sessionChainStore = new SessionChainStore();

--- a/packages/api/test/opencode-agent-service.test.js
+++ b/packages/api/test/opencode-agent-service.test.js
@@ -453,6 +453,53 @@ describe('OpenCodeAgentService', () => {
     assert.strictEqual(textMsg.metadata.model, 'claude-sonnet-4-6');
   });
 
+  test('step_finish yields agent_loop with usage AND service-level model (clowder#915 R1 P1)', async () => {
+    // 砚砚 R1 P1 (#2271): transformer carries metadata.usage but pre-fix the
+    // service layer's `metadata: yieldMetadata` clobbered the transformer's
+    // metadata via spread-with-override. Without this merge, usage never
+    // reached invoke-single-cat → F24 contextHealth never fired → handoff
+    // never triggered → opencode hung at context limit (the clowder#915 bug).
+    //
+    // This test asserts the END-TO-END contract: step_finish → service yield →
+    // a yielded message that carries BOTH (a) the usage payload from the
+    // transformer AND (b) the effective model from the service layer (not '').
+    const proc = createMockProcess();
+    const spawnFn = mock.fn(() => proc);
+    const service = new OpenCodeAgentService({ catId: 'opencode', spawnFn, model: 'claude-sonnet-4-6' });
+    const promise = collect(service.invoke('Test'));
+    emitOpenCodeEvents(proc, [
+      STEP_START,
+      TEXT_RESPONSE,
+      {
+        type: 'step_finish',
+        timestamp: 1773304958508,
+        sessionID: 'ses_test123',
+        part: {
+          type: 'step-finish',
+          reason: 'stop',
+          cost: 0.036973,
+          tokens: { total: 36937, input: 36928, output: 9 },
+        },
+      },
+    ]);
+    const messages = await promise;
+
+    const loopMsg = messages.find((m) => m.type === 'agent_loop');
+    assert.ok(loopMsg, 'service must emit agent_loop for step_finish events');
+    assert.ok(loopMsg.metadata, 'agent_loop must carry metadata');
+    // usage from transformer must survive the service layer's metadata override
+    assert.ok(loopMsg.metadata.usage, 'usage must reach invoke-single-cat for F8/F24 to fire');
+    assert.strictEqual(loopMsg.metadata.usage.inputTokens, 36928);
+    assert.strictEqual(loopMsg.metadata.usage.lastTurnInputTokens, 36928);
+    assert.strictEqual(loopMsg.metadata.usage.outputTokens, 9);
+    assert.strictEqual(loopMsg.metadata.usage.totalTokens, 36937);
+    assert.strictEqual(loopMsg.metadata.usage.costUsd, 0.036973);
+    // model comes from the service layer (effectiveModel), NOT transformer's ''
+    // (砚砚 R1 P2: empty model would break getContextWindowFallback in invoke-single-cat).
+    assert.strictEqual(loopMsg.metadata.model, 'claude-sonnet-4-6');
+    assert.strictEqual(loopMsg.metadata.provider, 'opencode');
+  });
+
   test('metadata.sessionId set after session_init', async () => {
     const proc = createMockProcess();
     const spawnFn = mock.fn(() => proc);

--- a/packages/api/test/opencode-event-transform.test.js
+++ b/packages/api/test/opencode-event-transform.test.js
@@ -79,8 +79,8 @@ describe('transformOpenCodeEvent', () => {
     assert.strictEqual(result.toolName, 'read');
   });
 
-  // ── step_finish → null ──
-  test('maps step_finish → null (metadata only)', () => {
+  // ── step_finish → agent_loop + usage metadata (clowder#915 fix) ──
+  test('maps step_finish → agent_loop carrying metadata.usage (clowder#915)', () => {
     const event = {
       type: 'step_finish',
       timestamp: 1773304958508,
@@ -93,7 +93,131 @@ describe('transformOpenCodeEvent', () => {
       },
     };
     const result = transformOpenCodeEvent(event, catId);
-    assert.strictEqual(result, null);
+    // Must NOT be null — previously usage was discarded so contextHealth never fired,
+    // handoff never triggered, and opencode crashed at context limit (clowder#915).
+    assert.ok(result, 'step_finish must emit a message so downstream contextHealth path lights up');
+    assert.strictEqual(result.type, 'agent_loop', 'use telemetry-only type (no user-visible bubble)');
+    assert.strictEqual(result.catId, catId);
+    assert.ok(result.metadata, 'metadata must be set so invoke-single-cat F8/F24 block fires');
+    assert.strictEqual(result.metadata.provider, 'opencode');
+    assert.ok(result.metadata.usage, 'usage must be set so contextHealth can compute fillRatio');
+    assert.strictEqual(result.metadata.usage.inputTokens, 36928);
+    assert.strictEqual(result.metadata.usage.outputTokens, 9);
+    assert.strictEqual(result.metadata.usage.totalTokens, 36937);
+    assert.strictEqual(result.metadata.usage.costUsd, 0.036973);
+    // lastTurnInputTokens is the per-call signal used by F24 for accurate context fill.
+    // step_finish reports per-step input which IS per-API-call from opencode's perspective.
+    assert.strictEqual(result.metadata.usage.lastTurnInputTokens, 36928);
+    // clowder#915 R5 cloud P2: transformer must NOT attach a default
+    // contextWindowSize — that would override `getContextWindowFallback`'s
+    // precise lookup for known opencode models (e.g. claude-opus-4-6 → 200k).
+    // The unknown-model default is now applied as a LAST RESORT inside
+    // invoke-single-cat's helper, only after the fallback table also misses.
+    assert.strictEqual(result.metadata.usage.contextWindowSize, undefined);
+  });
+
+  test('clowder#915 R4 cloud P1 #1: step_finish includes cache.read/cache.write in inputTokens', () => {
+    // opencode CLI reports cached prompt tokens under tokens.cache.{read,write}
+    // SEPARATELY from tokens.input (which is only fresh-this-step). Per shared
+    // TokenUsage contract, inputTokens/lastTurnInputTokens MUST represent the
+    // TOTAL input (fresh + cached) since F24 uses lastTurnInputTokens as the
+    // context-fill numerator. Cloud's failing scenario: 671 fresh + 21k cached
+    // would look like 671 tokens → fillRatio ≈ 0 → handoff never fires.
+    const event = {
+      type: 'step_finish',
+      timestamp: 1773304958508,
+      sessionID: 'ses_xxx',
+      part: {
+        type: 'step-finish',
+        reason: 'stop',
+        cost: 0.012,
+        tokens: {
+          total: 21_680, // 671 + 21_000 + 9 = 21_680 (sanity)
+          input: 671, // fresh this step
+          output: 9,
+          cache: {
+            read: 21_000, // resumed-context reuse
+            write: 0,
+          },
+        },
+      },
+    };
+    const result = transformOpenCodeEvent(event, catId);
+    assert.ok(result);
+    assert.strictEqual(result.type, 'agent_loop');
+    // inputTokens MUST be total (fresh + cache.read + cache.write), NOT just 671
+    assert.strictEqual(result.metadata.usage.inputTokens, 21_671);
+    assert.strictEqual(result.metadata.usage.lastTurnInputTokens, 21_671);
+    // Observability: cache breakdown surfaces on TokenUsage
+    assert.strictEqual(result.metadata.usage.cacheReadTokens, 21_000);
+    // cacheCreationTokens absent because cache.write was 0 (we skip zero-valued)
+    assert.strictEqual(result.metadata.usage.cacheCreationTokens, undefined);
+  });
+
+  test('clowder#915 R4 cloud P1 #1: step_finish with cache.write only (first-time cache population)', () => {
+    // Edge case: cache.write reports prompt tokens being CACHED for first time
+    // (paid as fresh input + cached for next step). MUST also count toward
+    // inputTokens for accurate fillRatio.
+    const event = {
+      type: 'step_finish',
+      timestamp: 1773304958508,
+      sessionID: 'ses_xxx',
+      part: {
+        type: 'step-finish',
+        cost: 0.05,
+        tokens: {
+          total: 10_500,
+          input: 500,
+          output: 0,
+          cache: { read: 0, write: 10_000 },
+        },
+      },
+    };
+    const result = transformOpenCodeEvent(event, catId);
+    assert.ok(result);
+    assert.strictEqual(result.metadata.usage.inputTokens, 10_500); // 500 + 0 + 10_000
+    assert.strictEqual(result.metadata.usage.lastTurnInputTokens, 10_500);
+    assert.strictEqual(result.metadata.usage.cacheCreationTokens, 10_000);
+  });
+
+  test('clowder#915 R5 cloud P2: transformer leaves contextWindowSize blank — invoke-single-cat resolves via 3-tier chain', () => {
+    // After R5: transformer never sets contextWindowSize. Window resolution
+    // happens in invoke-single-cat.ts via:
+    //   usage.contextWindowSize ?? getContextWindowFallback(model) ?? (provider==='opencode' ? OPENCODE_DEFAULT : undefined)
+    // This test pins the transformer's contract; the full chain is tested
+    // end-to-end in invoke-single-cat.test.js (clowder#915 R5 fallback test).
+    const event = {
+      type: 'step_finish',
+      timestamp: 1773304958508,
+      sessionID: 'ses_xxx',
+      part: {
+        type: 'step-finish',
+        reason: 'tool-calls',
+        cost: 0.02,
+        tokens: { total: 109_000, input: 109_000, output: 0 },
+      },
+    };
+    const result = transformOpenCodeEvent(event, catId);
+    assert.ok(result);
+    // contextWindowSize MUST be undefined — leaving it for the helper to resolve
+    assert.strictEqual(result.metadata.usage.contextWindowSize, undefined);
+    // Usage data still surfaces correctly
+    assert.strictEqual(result.metadata.usage.inputTokens, 109_000);
+    assert.strictEqual(result.metadata.usage.lastTurnInputTokens, 109_000);
+  });
+
+  test('step_finish with no tokens still returns a message but with empty usage', () => {
+    // Defensive: opencode may emit step_finish without token data (e.g. cached responses).
+    // Don't crash — return null in that degenerate case so we don't litter agent_loop
+    // events that have no telemetry value.
+    const event = {
+      type: 'step_finish',
+      timestamp: 1773304958508,
+      sessionID: 'ses_xxx',
+      part: { type: 'step-finish', reason: 'stop' },
+    };
+    const result = transformOpenCodeEvent(event, catId);
+    assert.strictEqual(result, null, 'no tokens → nothing to telemeter → skip');
   });
 
   // ── error → error ──

--- a/packages/api/test/opencode-omoc-context.test.js
+++ b/packages/api/test/opencode-omoc-context.test.js
@@ -101,20 +101,29 @@ describe('Ralph Loop + Context Management (AC-11)', () => {
     const dones = messages.filter((m) => m.type === 'done');
     assert.strictEqual(dones.length, 1, 'must have exactly 1 done');
 
-    // step_finish events are mapped to null, so no extra messages
-    // Total expected: 1 session_init + 3 text + 3 tool_use + 1 done = 8
-    assert.strictEqual(messages.length, 8, `expected 8 messages total, got ${messages.length}`);
+    // clowder#915: step_finish now emits agent_loop with metadata.usage so
+    // invoke-single-cat's F8 token block + F24 contextHealth path can compute
+    // fillRatio and trigger handoff before context fills.
+    // Total: 1 session_init + 3 text + 3 tool_use + 3 step_finish (agent_loop) + 1 done = 11
+    assert.strictEqual(messages.length, 11, `expected 11 messages total, got ${messages.length}`);
+    const agentLoops = messages.filter((m) => m.type === 'agent_loop');
+    assert.strictEqual(agentLoops.length, 3, 'must have 3 agent_loop telemetry markers (one per step_finish)');
   });
 
-  // ── Context management: elevated token counts are handled ──
+  // ── Context management: elevated token counts surface as usage telemetry ──
 
-  test('OMOC context management: high token counts in step_finish are ignored', () => {
-    // OMOC adds ~12K system prompt tokens, so step_finish often shows 36K+ total
+  test('OMOC context management: high token counts surface in step_finish telemetry (clowder#915)', () => {
+    // OMOC adds ~12K system prompt tokens, so step_finish often shows 36K+ total.
+    // Pre-clowder#915 this was discarded; post-fix it must surface so handoff fires.
     const highTokenFinish = makeStepFinish(5000, 36937);
     const result = transformOpenCodeEvent(highTokenFinish, 'opencode');
 
-    // step_finish → null (metadata only, not propagated)
-    assert.strictEqual(result, null, 'step_finish with OMOC token overhead must still return null');
+    assert.ok(result, 'step_finish with token data must emit a message (clowder#915)');
+    assert.strictEqual(result.type, 'agent_loop');
+    assert.ok(result.metadata?.usage);
+    // makeStepFinish helper only sets tokens.total — assert on totalTokens (Gemini-style fallback path)
+    assert.strictEqual(result.metadata.usage.totalTokens, 36937);
+    assert.strictEqual(result.metadata.usage.costUsd, 0.01);
   });
 
   // ── Context warning: if opencode emits a text warning, it passes through ──
@@ -194,9 +203,11 @@ describe('Ralph Loop + Context Management (AC-11)', () => {
     emitOpenCodeEvents(proc, events);
     const messages = await promise;
 
-    // Unknown events should be dropped (transformOpenCodeEvent returns null)
-    // Expected: 1 session_init + 2 text + 1 done = 4
-    assert.strictEqual(messages.length, 4, `expected 4 messages, got ${messages.length}`);
+    // Unknown events should be dropped (transformOpenCodeEvent returns null).
+    // clowder#915: step_finish now emits agent_loop with usage telemetry.
+    // Expected: 1 session_init + 2 text + 2 step_finish (agent_loop) + 1 done = 6
+    assert.strictEqual(messages.length, 6, `expected 6 messages, got ${messages.length}`);
+    assert.strictEqual(messages.filter((m) => m.type === 'agent_loop').length, 2);
   });
 
   // ── Ralph Loop continuation maintains consistent catId ──

--- a/packages/api/test/session-strategy.test.js
+++ b/packages/api/test/session-strategy.test.js
@@ -265,6 +265,21 @@ describe('session-strategy', () => {
       assert.equal(config.thresholds.action, 0.65);
     });
 
+    test('returns opencode-specific defaults for opencode (clowder#915)', async () => {
+      // clowder#915: before this fix, opencode fell through to GLOBAL_DEFAULT_STRATEGY
+      // because DEFAULT_STRATEGY_BY_PROVIDER had no opencode entry. The fallback was
+      // technically correct (handoff at 0.75/0.85) but masked an architectural gap:
+      // any opencode-specific threshold tuning was silently dropped. We add an explicit
+      // entry so opencode is a first-class strategy peer with anthropic/openai/google.
+      const { getSessionStrategy } = await loadModule();
+      const config = getSessionStrategy('opencode');
+      assert.equal(config.strategy, 'handoff');
+      // Opencode (golden chinchilla / GLM-5.1) has 160k effective context per cat-template.
+      // Use 0.75/0.85 thresholds like openai (similar context budget envelope).
+      assert.equal(config.thresholds.warn, 0.75);
+      assert.equal(config.thresholds.action, 0.85);
+    });
+
     test('returns global default for unknown cat', async () => {
       const { getSessionStrategy } = await loadModule();
       const config = getSessionStrategy('unknown-cat-42');


### PR DESCRIPTION
## Summary
- Closes #915: opencode/golden-chinchilla cat session handoff never triggered (CLI hung at context limit)
- Repaired 3-layer break: opencode breed `sessionChain: false` → `step_finish` event mapped to null (no usage signal) → no explicit opencode entry in `DEFAULT_STRATEGY_BY_PROVIDER`
- Added shared `processUsageAndContextHealth` helper, prefix-stripping fallback, cache-token-aware input total, 3-tier window resolution, defer-seal to done boundary

## Root cause analysis (5-round cloud review on cat-cafe#2271)
- **R1**: Even with usage attached to `agent_loop`, F8/F24 block only ran inside `done` branch → telemetry early-return silently dropped the signal. Fix: extract helper, call from both branches.
- **R2**: `getContextWindowFallback` forward-startsWith match missed provider-prefixed model names (`anthropic/claude-opus-4-6`). Fix: strip `provider/` prefix before lookup.
- **R4 P1 #1**: opencode CLI reports cached prompt tokens separately. `inputTokens` must be TOTAL (fresh + cache.read + cache.write) per TokenUsage contract. Fix: transformer sums all three.
- **R4 P1 #2 → R5 P2**: Custom-provider models (GLM-5.1, openrouter) not in fallback table → undefined → context_health skipped. Fix: 3-tier chain `usage.contextWindowSize ?? fallback(model) ?? (opencode? 128k : undefined)`. Critically, the 128k default is LAST — known opencode models (claude-opus-4-6 → 200k) still use the table.
- **R4 P1 #3**: Sealing immediately on agent_loop crossed the threshold mid-stream cleared the active session pointer before opencode's tool-loop tail emitted. Fix: capture `pendingMidStreamSeal`, execute at `done` boundary so post-threshold text/tool events still write to transcript.

## Test plan
- [x] `pnpm --filter @cat-cafe/api run build` succeeds
- [x] `pnpm --filter @cat-cafe/api test` for opencode-* + invoke-single-cat + session-strategy + context-window-sizes + cat-config-loader + seal-trigger-integration: **290/290 pass** locally
- [ ] CI green
- [ ] Re-verify opencode session handoff fires correctly via runtime test once merged

## Cross-repo refs
- Originating cat-cafe PR: zts212653/cat-cafe#2271 (merged ff9493e97)
- R1-R5 cloud review trail + LL-072 封板 → 砚砚 (缅因猫 GPT-5.5) terminal確權 in cat-cafe thread

[宪宪/Opus-4.7🐾]