### PR TITLE
feat(#922): add storage mode status indicator

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -478,6 +478,8 @@ async function main(): Promise<void> {
   }
   const storageResult = assertStorageReady(!!redis);
   app.log.info(`[api] Storage mode: ${storageResult.mode}`);
+  const { systemStatusRoutes } = await import('./routes/system-status.js');
+  await app.register(systemStatusRoutes, { storageMode: storageResult.mode });
 
   // F102 KD-34: append listener placeholder (wired after memoryServices init)
   let appendListener: ((msg: { id: string; threadId: string; timestamp: number; content: string }) => void) | null =

--- a/packages/api/src/routes/system-status.ts
+++ b/packages/api/src/routes/system-status.ts
@@ -1,0 +1,45 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { resolveUserId } from '../utils/request-identity.js';
+
+export type StorageMode = 'redis' | 'memory';
+
+export interface SystemStatusRoutesOptions {
+  storageMode: StorageMode;
+}
+
+export interface SystemStatusResponse {
+  storageMode: StorageMode;
+  storage: {
+    mode: StorageMode;
+    persistent: boolean;
+    warning: string | null;
+  };
+}
+
+export function buildSystemStatus(storageMode: StorageMode): SystemStatusResponse {
+  const persistent = storageMode === 'redis';
+  return {
+    storageMode,
+    storage: {
+      mode: storageMode,
+      persistent,
+      warning: persistent ? null : 'Memory mode: data will be lost on restart.',
+    },
+  };
+}
+
+function requireIdentity(request: FastifyRequest, reply: FastifyReply): boolean {
+  const userId = resolveUserId(request);
+  if (!userId) {
+    reply.status(401);
+    return false;
+  }
+  return true;
+}
+
+export async function systemStatusRoutes(app: FastifyInstance, opts: SystemStatusRoutesOptions): Promise<void> {
+  app.get('/api/system/status', async (request, reply) => {
+    if (!requireIdentity(request, reply)) return { error: 'Identity required' };
+    return buildSystemStatus(opts.storageMode);
+  });
+}

--- a/packages/api/test/system-status-route.test.js
+++ b/packages/api/test/system-status-route.test.js
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import Fastify from 'fastify';
+
+const HEADERS = { 'x-cat-cafe-user': 'test-user' };
+
+describe('GET /api/system/status', () => {
+  it('requires request identity before returning system status', async () => {
+    const { systemStatusRoutes } = await import('../dist/routes/system-status.js');
+    const app = Fastify({ logger: false });
+    try {
+      await app.register(systemStatusRoutes, { storageMode: 'redis' });
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/api/system/status' });
+
+      assert.equal(res.statusCode, 401);
+      assert.deepStrictEqual(JSON.parse(res.payload), { error: 'Identity required' });
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reports active Redis persistent mode without exposing connection details', async () => {
+    const { systemStatusRoutes } = await import('../dist/routes/system-status.js');
+    const app = Fastify({ logger: false });
+    try {
+      await app.register(systemStatusRoutes, { storageMode: 'redis' });
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/api/system/status', headers: HEADERS });
+
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+      assert.deepStrictEqual(body, {
+        storageMode: 'redis',
+        storage: {
+          mode: 'redis',
+          persistent: true,
+          warning: null,
+        },
+      });
+      assert.equal(JSON.stringify(body).includes('redis://'), false);
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('reports explicit memory mode with a data-loss warning', async () => {
+    const { systemStatusRoutes } = await import('../dist/routes/system-status.js');
+    const app = Fastify({ logger: false });
+    try {
+      await app.register(systemStatusRoutes, { storageMode: 'memory' });
+      await app.ready();
+
+      const res = await app.inject({ method: 'GET', url: '/api/system/status', headers: HEADERS });
+
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+      assert.equal(body.storageMode, 'memory');
+      assert.deepStrictEqual(body.storage, {
+        mode: 'memory',
+        persistent: false,
+        warning: 'Memory mode: data will be lost on restart.',
+      });
+    } finally {
+      await app.close();
+    }
+  });
+});

--- a/packages/web/src/components/HubEnvFilesTab.tsx
+++ b/packages/web/src/components/HubEnvFilesTab.tsx
@@ -16,8 +16,32 @@ import {
 } from './settings/EnvSubComponents';
 import { SettingsStatusStrip } from './settings/primitives';
 
+type StorageMode = 'redis' | 'memory';
+
+interface SystemStatusData {
+  storage?: {
+    mode?: StorageMode;
+    persistent?: boolean;
+    warning?: string | null;
+  };
+}
+
+function normalizeStorageMode(data: SystemStatusData): StorageMode | null {
+  const mode = data.storage?.mode;
+  return mode === 'redis' || mode === 'memory' ? mode : null;
+}
+
+function StorageModeStatus({ mode }: { mode: StorageMode | null }) {
+  if (!mode) return null;
+  if (mode === 'memory') {
+    return <SettingsStatusStrip tone="warn">Memory mode — data will be lost on restart</SettingsStatusStrip>;
+  }
+  return <SettingsStatusStrip tone="success">Redis persistent mode</SettingsStatusStrip>;
+}
+
 export function HubEnvFilesTab({ excludeCategories }: { excludeCategories?: string[] } = {}) {
   const [data, setData] = useState<EnvSummaryData | null>(null);
+  const [storageMode, setStorageMode] = useState<StorageMode | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const saveLockRef = useRef(false);
@@ -43,6 +67,22 @@ export function HubEnvFilesTab({ excludeCategories }: { excludeCategories?: stri
         }
       })
       .catch(() => setError('环境信息加载失败'));
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiFetch('/api/system/status')
+      .then(async (res) => {
+        if (!res.ok) return;
+        const body = (await res.json()) as SystemStatusData;
+        if (!cancelled) setStorageMode(normalizeStorageMode(body));
+      })
+      .catch(() => {
+        if (!cancelled) setStorageMode(null);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   if (error) return <SettingsStatusStrip tone="error">{error}</SettingsStatusStrip>;
@@ -113,6 +153,7 @@ export function HubEnvFilesTab({ excludeCategories }: { excludeCategories?: stri
   return (
     <div className="space-y-4">
       <PageIntro />
+      <StorageModeStatus mode={storageMode} />
       <EnvVarsSection
         categories={
           excludeCategories

--- a/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
+++ b/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
@@ -73,6 +73,24 @@ const MOCK_ENV_SUMMARY = {
   },
 };
 
+const MOCK_SYSTEM_STATUS_REDIS = {
+  storageMode: 'redis',
+  storage: {
+    mode: 'redis',
+    persistent: true,
+    warning: null,
+  },
+};
+
+const MOCK_SYSTEM_STATUS_MEMORY = {
+  storageMode: 'memory',
+  storage: {
+    mode: 'memory',
+    persistent: false,
+    warning: 'Memory mode: data will be lost on restart.',
+  },
+};
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -83,6 +101,9 @@ function jsonResponse(body: unknown, status = 200): Response {
 function defaultEnvApiFetch(path: string, init?: RequestInit) {
   if (path === '/api/config/env-summary' && !init?.method) {
     return Promise.resolve(jsonResponse(MOCK_ENV_SUMMARY));
+  }
+  if (path === '/api/system/status' && !init?.method) {
+    return Promise.resolve(jsonResponse(MOCK_SYSTEM_STATUS_REDIS));
   }
   if (path === '/api/config/env' && init?.method === 'PATCH') {
     return Promise.resolve(jsonResponse({ ok: true }));
@@ -130,6 +151,34 @@ describe('HubEnvFilesTab', () => {
     act(() => root.unmount());
     container.remove();
     vi.clearAllMocks();
+  });
+
+  it('renders persistent Redis storage mode as a subtle healthy status', async () => {
+    await act(async () => {
+      root.render(React.createElement(HubEnvFilesTab));
+    });
+    await flushEffects();
+
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/system/status');
+    expect(container.textContent).toContain('Redis persistent mode');
+    expect(container.textContent).not.toContain('Memory mode — data will be lost on restart');
+  });
+
+  it('renders memory storage mode as a visible data-loss warning', async () => {
+    mockApiFetch.mockImplementation((path: string, init?: RequestInit) => {
+      if (path === '/api/system/status' && !init?.method) {
+        return Promise.resolve(jsonResponse(MOCK_SYSTEM_STATUS_MEMORY));
+      }
+      return defaultEnvApiFetch(path, init);
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HubEnvFilesTab));
+    });
+    await flushEffects();
+
+    expect(container.textContent).toContain('Memory mode — data will be lost on restart');
+    expect(container.textContent).not.toContain('Redis persistent mode');
   });
 
   it('renders editable env vars, keeps credentials masked, and saves back to .env', async () => {


### PR DESCRIPTION
## PR Type

- [ ] Patch — Bug fix, typo, test gap (no Feature Doc needed)
- [x] Feature — New capability or behavior change (requires Feature Doc)
- [ ] Protocol — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #922

## Feature Doc (Feature PRs only)

Source implementation: zts212653/cat-cafe#2298, merged as `6273bc22db8efe47d9fc63251462f8a25cfd38bb`.

## What

- Adds `GET /api/system/status`, authenticated with the shared request identity helper.
- Reports only the active runtime storage mode: `redis` or `memory`, plus persistence/warning metadata.
- Wires the endpoint from API startup using the storage mode returned by the existing Redis readiness decision.
- Shows the mode in the System settings env tab.
- Adds API and web regression tests for Redis mode, memory warning mode, and anonymous API access.

## Why

clowder-ai#922 asks users to see the actual runtime storage mode so they are not surprised by memory-mode data loss.

This replaces the closed full-sync PR #928 with a narrow #922-only PR by CVO direction. The branch intentionally contains only the five storage-mode files and does not pull unrelated source projection changes.

## Coordination Note

clowder-ai#929 also touches `packages/api/src/index.ts`, but in different hunks: #930 registers the system status route near the storage readiness decision, while #929 changes a separate import/register area. This is a normal same-file overlap, not a full-sync overwrite risk; whichever PR merges second should rebase and let Git surface any real conflict.

## Tradeoff

A full outbound sync would have included unrelated source changes and collided with public repo coordination. This narrow port keeps the change auditable and avoids exposing Redis connection details.

The UI reads the new nested `storage.mode` field only; it does not infer mode from config files or connection strings.

## Test Evidence

```
pnpm --dir packages/api build
# pass

cd packages/api && pnpm exec node --import "$(pwd)/test/helpers/setup-cat-registry.js" --test --test-timeout=60000 test/system-status-route.test.js
# 3 tests pass

cd packages/web && node scripts/run-with-node-env-test.mjs pnpm exec vitest run src/components/__tests__/hub-env-files-tab.test.tsx
# 5 tests pass

pnpm biome check packages/api/src/routes/system-status.ts packages/api/test/system-status-route.test.js packages/web/src/components/HubEnvFilesTab.tsx packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
# pass

pnpm --dir packages/api lint
# pass

pnpm --dir packages/web build
# pass

pnpm --dir packages/finance build && pnpm --dir packages/api test:public
# 12368 pass / 0 fail / 4 skipped

git diff --check
# pass
```

Known unrelated check result:

```
pnpm --dir packages/web exec tsc --noEmit --pretty false
# fails on pre-existing ProfileItem fixture errors in src/components/__tests__/hub-cat-editor-oc-providers.test.ts
```

## AC Checklist (Feature PRs only)

- [x] Displays the actual runtime storage mode decided at API startup.
- [x] Redis mode is shown as persistent.
- [x] Memory mode warns that data will be lost on restart.
- [x] The API does not expose Redis URLs or connection details.
- [x] The public PR is narrow to #922 and does not include unrelated full-sync projection files.

[砚砚/GPT-5.5🐾]
