### PR TITLE
fix: batch fix #934 #935 #936 #937 #947 #948 #950 #957 #967 #968 #969 #970 #971

### DIFF
--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -461,11 +461,16 @@ class ServiceManager {
     // (e.g. packaged Windows installs where the default 10000 exceeds the
     // process file descriptor limit).  512 is far above local desktop needs.
     const redisArgs = [
-      '--port', '6399',
-      '--dir', redisDataDir,
-      '--save', '60 1',
-      '--appendonly', 'yes',
-      '--maxclients', '512',
+      '--port',
+      '6399',
+      '--dir',
+      redisDataDir,
+      '--save',
+      '60 1',
+      '--appendonly',
+      'yes',
+      '--maxclients',
+      '512',
     ];
     let redisCwd = this.root;
 

--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -456,7 +456,17 @@ class ServiceManager {
     // Persist data to writable user directory so sessions survive app restart.
     const redisDataDir = path.join(userDataDir, 'data', 'redis');
     let redisCmd = 'redis-server';
-    const redisArgs = ['--port', '6399', '--dir', redisDataDir, '--save', '60 1', '--appendonly', 'yes'];
+    // Cap maxclients to a conservative desktop value so Redis does not emit a
+    // scary "Server can't set maximum open files" warning on low-ulimit systems
+    // (e.g. packaged Windows installs where the default 10000 exceeds the
+    // process file descriptor limit).  512 is far above local desktop needs.
+    const redisArgs = [
+      '--port', '6399',
+      '--dir', redisDataDir,
+      '--save', '60 1',
+      '--appendonly', 'yes',
+      '--maxclients', '512',
+    ];
     let redisCwd = this.root;
 
     if (hasPortable) {

--- a/packages/api/src/config/cat-catalog-store.ts
+++ b/packages/api/src/config/cat-catalog-store.ts
@@ -297,11 +297,10 @@ export function bootstrapCatCatalog(projectRoot: string, templatePath: string): 
   if (defaultCatId && templateBreeds.length > 0) {
     // Find the breed that owns the default cat ID (either as breed.catId or variant.catId)
     type BreedLike = { id: string; catId?: string; variants?: Array<{ catId?: string }> };
-    const seedBreed = (templateBreeds as BreedLike[]).find(
-      (breed) =>
-        breed.catId === defaultCatId ||
-        breed.variants?.some((v) => v.catId === defaultCatId),
-    ) ?? templateBreeds[0];
+    const seedBreed =
+      (templateBreeds as BreedLike[]).find(
+        (breed) => breed.catId === defaultCatId || breed.variants?.some((v) => v.catId === defaultCatId),
+      ) ?? templateBreeds[0];
     runtimeCatalog = {
       ...migratedCatalog,
       breeds: seedBreed ? [seedBreed as CatCafeConfig['breeds'][number]] : [],

--- a/packages/api/src/config/cat-catalog-store.ts
+++ b/packages/api/src/config/cat-catalog-store.ts
@@ -285,9 +285,36 @@ export function bootstrapCatCatalog(projectRoot: string, templatePath: string): 
   const { catalog: template } = readBootstrapSourceConfig(templatePath);
   const { catalog: migratedCatalog } = migrateCatalogVariants(template);
 
-  // Always start empty — first-run wizard guides users to add their first cat.
-  // Template breeds are used as a menu when adding members, not seeded on startup.
-  const runtimeCatalog = createEmptyRuntimeCatalog(migratedCatalog);
+  // #948: When DEFAULT_CAT_ID is set (packaged desktop), seed that breed from the
+  // template so the app starts with at least one usable member. Without this, the
+  // registry is empty and the frontend crashes before the first-run wizard is reachable.
+  // When DEFAULT_CAT_ID is not set (dev environments), start empty as before —
+  // developers use the wizard or manual config to add members.
+  const defaultCatId = process.env.DEFAULT_CAT_ID?.trim();
+  const templateBreeds = Array.isArray(migratedCatalog.breeds) ? migratedCatalog.breeds : [];
+
+  let runtimeCatalog: CatCafeConfig;
+  if (defaultCatId && templateBreeds.length > 0) {
+    // Find the breed that owns the default cat ID (either as breed.catId or variant.catId)
+    type BreedLike = { id: string; catId?: string; variants?: Array<{ catId?: string }> };
+    const seedBreed = (templateBreeds as BreedLike[]).find(
+      (breed) =>
+        breed.catId === defaultCatId ||
+        breed.variants?.some((v) => v.catId === defaultCatId),
+    ) ?? templateBreeds[0];
+    runtimeCatalog = {
+      ...migratedCatalog,
+      breeds: seedBreed ? [seedBreed as CatCafeConfig['breeds'][number]] : [],
+    };
+    // Preserve owner in roster
+    const ownerEntry = buildOwnerRosterEntry();
+    if ('roster' in runtimeCatalog) {
+      (runtimeCatalog.roster as Record<string, RosterEntry>)[OWNER_ROSTER_KEY] = ownerEntry;
+    }
+  } else {
+    // No DEFAULT_CAT_ID — start empty (first-run wizard guides member addition).
+    runtimeCatalog = createEmptyRuntimeCatalog(migratedCatalog);
+  }
 
   mkdirSync(dirname(catalogPath), { recursive: true });
   writeFileAtomic(catalogPath, `${JSON.stringify(runtimeCatalog, null, 2)}\n`);

--- a/packages/api/src/config/cat-catalog-store.ts
+++ b/packages/api/src/config/cat-catalog-store.ts
@@ -271,6 +271,57 @@ function readBootstrapSourceConfig(templatePath: string): { catalog: CatCafeConf
   };
 }
 
+/**
+ * #948 R2: Pick the best seed breed from the catalog.
+ * Prefers the breed matching DEFAULT_CAT_ID env (if set), otherwise falls back
+ * to the first breed in the template. Returns undefined when no breeds exist
+ * (dev environments with empty templates).
+ */
+type BreedLike = { id: string; catId?: string; variants?: Array<{ catId?: string }> };
+
+function pickSeedBreed(catalog: CatCafeConfig): CatCafeConfig['breeds'][number] | undefined {
+  const breeds = Array.isArray(catalog.breeds) ? catalog.breeds : [];
+  if (breeds.length === 0) return undefined;
+
+  const defaultCatId = process.env.DEFAULT_CAT_ID?.trim();
+  if (defaultCatId) {
+    const match = (breeds as BreedLike[]).find(
+      (breed) => breed.catId === defaultCatId || breed.variants?.some((v) => v.catId === defaultCatId),
+    );
+    if (match) return match as unknown as CatCafeConfig['breeds'][number];
+  }
+  // Fallback: first breed in template (works even without DEFAULT_CAT_ID)
+  return breeds[0];
+}
+
+/**
+ * #948 R2: If an existing catalog has zero breeds (persisted empty from a previous
+ * failed/incomplete install), seed from the template so the first-run wizard
+ * is reachable on next startup.
+ */
+function repairEmptyBreeds(catalogPath: string, templatePath: string): void {
+  let catalog: CatCafeConfig;
+  try {
+    catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as CatCafeConfig;
+  } catch {
+    return; // broken catalog — leave for the loader to handle
+  }
+  if (Array.isArray(catalog.breeds) && catalog.breeds.length > 0) return; // has breeds, no repair needed
+
+  let template: CatCafeConfig;
+  try {
+    template = JSON.parse(readFileSync(templatePath, 'utf-8')) as CatCafeConfig;
+  } catch {
+    return; // no template — nothing to seed from
+  }
+
+  const seedBreed = pickSeedBreed(template);
+  if (!seedBreed) return;
+
+  (catalog as { breeds: CatCafeConfig['breeds'] }).breeds = [seedBreed as CatCafeConfig['breeds'][number]];
+  writeFileAtomic(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
+}
+
 export function bootstrapCatCatalog(projectRoot: string, templatePath: string): string {
   const catalogPath = resolveCatCatalogPath(projectRoot);
   if (existsSync(catalogPath)) {
@@ -279,31 +330,30 @@ export function bootstrapCatCatalog(projectRoot: string, templatePath: string): 
     stripLegacySourceField(catalogPath);
     // Ensure owner is always present in roster.
     ensureOwnerInRoster(catalogPath);
+
+    // #948 R2: Repair existing catalogs that persisted with empty breeds (e.g.
+    // uninstall/reinstall on Windows where user-data dir survives). Seed from
+    // template so the first-run wizard is reachable.
+    repairEmptyBreeds(catalogPath, templatePath);
+
     return catalogPath;
   }
 
   const { catalog: template } = readBootstrapSourceConfig(templatePath);
   const { catalog: migratedCatalog } = migrateCatalogVariants(template);
 
-  // #948: When DEFAULT_CAT_ID is set (packaged desktop), seed that breed from the
-  // template so the app starts with at least one usable member. Without this, the
-  // registry is empty and the frontend crashes before the first-run wizard is reachable.
-  // When DEFAULT_CAT_ID is not set (dev environments), start empty as before —
-  // developers use the wizard or manual config to add members.
-  const defaultCatId = process.env.DEFAULT_CAT_ID?.trim();
-  const templateBreeds = Array.isArray(migratedCatalog.breeds) ? migratedCatalog.breeds : [];
+  // #948: Seed the first breed from the template so the app starts with at least
+  // one usable member. Without this, the registry is empty and the frontend
+  // crashes before the first-run wizard is reachable.
+  // In dev environments (template has no breeds), start empty — developers use
+  // the wizard or manual config to add members.
+  const seedBreed = pickSeedBreed(migratedCatalog);
 
   let runtimeCatalog: CatCafeConfig;
-  if (defaultCatId && templateBreeds.length > 0) {
-    // Find the breed that owns the default cat ID (either as breed.catId or variant.catId)
-    type BreedLike = { id: string; catId?: string; variants?: Array<{ catId?: string }> };
-    const seedBreed =
-      (templateBreeds as BreedLike[]).find(
-        (breed) => breed.catId === defaultCatId || breed.variants?.some((v) => v.catId === defaultCatId),
-      ) ?? templateBreeds[0];
+  if (seedBreed) {
     runtimeCatalog = {
       ...migratedCatalog,
-      breeds: seedBreed ? [seedBreed as CatCafeConfig['breeds'][number]] : [],
+      breeds: [seedBreed as CatCafeConfig['breeds'][number]],
     };
     // Preserve owner in roster
     const ownerEntry = buildOwnerRosterEntry();
@@ -311,7 +361,7 @@ export function bootstrapCatCatalog(projectRoot: string, templatePath: string): 
       (runtimeCatalog.roster as Record<string, RosterEntry>)[OWNER_ROSTER_KEY] = ownerEntry;
     }
   } else {
-    // No DEFAULT_CAT_ID — start empty (first-run wizard guides member addition).
+    // Template has no breeds — start empty (first-run wizard guides member addition).
     runtimeCatalog = createEmptyRuntimeCatalog(migratedCatalog);
   }
 

--- a/packages/api/src/config/cat-catalog-store.ts
+++ b/packages/api/src/config/cat-catalog-store.ts
@@ -294,33 +294,11 @@ function pickSeedBreed(catalog: CatCafeConfig): CatCafeConfig['breeds'][number] 
   return breeds[0];
 }
 
-/**
- * #948 R2: If an existing catalog has zero breeds (persisted empty from a previous
- * failed/incomplete install), seed from the template so the first-run wizard
- * is reachable on next startup.
- */
-function repairEmptyBreeds(catalogPath: string, templatePath: string): void {
-  let catalog: CatCafeConfig;
-  try {
-    catalog = JSON.parse(readFileSync(catalogPath, 'utf-8')) as CatCafeConfig;
-  } catch {
-    return; // broken catalog — leave for the loader to handle
-  }
-  if (Array.isArray(catalog.breeds) && catalog.breeds.length > 0) return; // has breeds, no repair needed
-
-  let template: CatCafeConfig;
-  try {
-    template = JSON.parse(readFileSync(templatePath, 'utf-8')) as CatCafeConfig;
-  } catch {
-    return; // no template — nothing to seed from
-  }
-
-  const seedBreed = pickSeedBreed(template);
-  if (!seedBreed) return;
-
-  (catalog as { breeds: CatCafeConfig['breeds'] }).breeds = [seedBreed as CatCafeConfig['breeds'][number]];
-  writeFileAtomic(catalogPath, `${JSON.stringify(catalog, null, 2)}\n`);
-}
+// NOTE: Repairing existing empty catalogs (e.g. Windows reinstall where user-data
+// dir survives) is intentionally NOT done here — we cannot distinguish "broken
+// install with empty breeds" from "user intentionally deleted all members".
+// Existing-install repair needs a separate mechanism (e.g. _bootstrapVersion marker).
+// See #948 for follow-up.
 
 export function bootstrapCatCatalog(projectRoot: string, templatePath: string): string {
   const catalogPath = resolveCatCatalogPath(projectRoot);
@@ -330,12 +308,6 @@ export function bootstrapCatCatalog(projectRoot: string, templatePath: string): 
     stripLegacySourceField(catalogPath);
     // Ensure owner is always present in roster.
     ensureOwnerInRoster(catalogPath);
-
-    // #948 R2: Repair existing catalogs that persisted with empty breeds (e.g.
-    // uninstall/reinstall on Windows where user-data dir survives). Seed from
-    // template so the first-run wizard is reachable.
-    repairEmptyBreeds(catalogPath, templatePath);
-
     return catalogPath;
   }
 

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -718,7 +718,11 @@ function isKnownAvailableDefaultCat(catId: string): boolean {
   const config = getCachedConfig();
   if (!config) {
     const id = createCatId(catId);
-    return catRegistry.getAllIds().length === 0 || catRegistry.has(id);
+    // Empty registry = bootstrap/no members → nothing is "known available".
+    // Returning true here would let any catId pass (including hardcoded ones
+    // that don't exist), causing "Unknown cat ID" errors downstream (#937).
+    if (catRegistry.getAllIds().length === 0) return false;
+    return catRegistry.has(id);
   }
 
   if (!_catIdToBreed || _catIdToBreedSource !== config) {
@@ -758,8 +762,17 @@ export function getDefaultCatId(): CatId {
     return _defaultCatId;
   }
 
-  // Ultimate fallback for zero-member bootstrap mode.
-  return createCatId('opus');
+  // Ultimate fallback: prefer DEFAULT_CAT_ID env even if not yet "known available"
+  // (config may not be loaded yet on first message), then try first registered cat,
+  // then fall back to env value raw. Never hardcode a specific cat ID (#937).
+  const envFallback = process.env.DEFAULT_CAT_ID?.trim();
+  const registeredIds = catRegistry.getAllIds();
+  if (registeredIds.length > 0) return registeredIds[0]!;
+  if (envFallback) return createCatId(envFallback);
+  // Truly empty — no config, no env, no registered cats. Return a sentinel
+  // that callers (AgentRouter) should handle as "no targets available".
+  log.warn('No cats registered and no DEFAULT_CAT_ID set — returning __none__ sentinel');
+  return createCatId('__none__');
 }
 
 /** F154 AC-A4: Set runtime default cat override. Owner-gated at the API layer. */

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1466,6 +1466,18 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       }
     }
 
+    const openCodeExternalDirs: string[] = [];
+    if (provider === 'opencode') {
+      if (workingDirectory && !isSameProject(workingDirectory, hostProjectRoot)) {
+        // External project — grant access to Cat Cafe host root (configs, MCP, etc.)
+        openCodeExternalDirs.push(hostProjectRoot);
+      }
+      if (workingProjectRoot && workingProjectRoot !== workingDirectory) {
+        // Working directory is a subdirectory of a monorepo — grant monorepo root.
+        openCodeExternalDirs.push(workingProjectRoot);
+      }
+    }
+
     // authType is either 'api_key' or 'oauth' — both need runtime config (MCP +
     // L0 + model routing). The only difference is credential injection below.
     const isApiKey = resolvedAccount?.authType === 'api_key';
@@ -1487,18 +1499,6 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE = safeModel;
       const apiType = deriveOpenCodeApiType(effectiveProviderName);
       const rawModels = resolvedAccount.models?.length ? resolvedAccount.models : [effectiveModel];
-      // #935: Collect directories that OpenCode should be allowed to access outside
-      // its working directory. This avoids Windows users having to edit global
-      // OpenCode config to grant `permission.external_directory` manually.
-      const externalDirs: string[] = [];
-      if (workingDirectory && !isSameProject(workingDirectory, hostProjectRoot)) {
-        // External project — grant access to Cat Cafe host root (configs, MCP, etc.)
-        externalDirs.push(hostProjectRoot);
-      }
-      if (workingProjectRoot && workingProjectRoot !== workingDirectory) {
-        // Working directory is a subdirectory of a monorepo — grant monorepo root
-        externalDirs.push(workingProjectRoot);
-      }
       const runtimeConfigOptions = {
         providerName: effectiveProviderName,
         models: rawModels,
@@ -1510,7 +1510,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         // F203 Phase I: inject compiled L0 + OPENCODE.md into instructions.
         instructions: openCodeL0InstructionPaths,
         // #935: External directory permissions for Windows/cross-project access.
-        ...(externalDirs.length > 0 ? { externalDirectories: externalDirs } : {}),
+        ...(openCodeExternalDirs.length > 0 ? { externalDirectories: openCodeExternalDirs } : {}),
       } as const;
       openCodeRuntimeConfigPath = writeOpenCodeRuntimeConfig(
         projectRoot,
@@ -1558,6 +1558,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         catId as string,
         invocationId,
         openCodeL0InstructionPaths,
+        openCodeExternalDirs,
       );
       callbackEnv.OPENCODE_CONFIG = openCodeRuntimeConfigPath;
       callbackEnv[OC_INSTRUCTIONS_ONLY_ENV] = '1';

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1487,6 +1487,18 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE = safeModel;
       const apiType = deriveOpenCodeApiType(effectiveProviderName);
       const rawModels = resolvedAccount.models?.length ? resolvedAccount.models : [effectiveModel];
+      // #935: Collect directories that OpenCode should be allowed to access outside
+      // its working directory. This avoids Windows users having to edit global
+      // OpenCode config to grant `permission.external_directory` manually.
+      const externalDirs: string[] = [];
+      if (workingDirectory && !isSameProject(workingDirectory, hostProjectRoot)) {
+        // External project — grant access to Cat Cafe host root (configs, MCP, etc.)
+        externalDirs.push(hostProjectRoot);
+      }
+      if (workingProjectRoot && workingProjectRoot !== workingDirectory) {
+        // Working directory is a subdirectory of a monorepo — grant monorepo root
+        externalDirs.push(workingProjectRoot);
+      }
       const runtimeConfigOptions = {
         providerName: effectiveProviderName,
         models: rawModels,
@@ -1497,6 +1509,8 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         mcpServerPath,
         // F203 Phase I: inject compiled L0 + OPENCODE.md into instructions.
         instructions: openCodeL0InstructionPaths,
+        // #935: External directory permissions for Windows/cross-project access.
+        ...(externalDirs.length > 0 ? { externalDirectories: externalDirs } : {}),
       } as const;
       openCodeRuntimeConfigPath = writeOpenCodeRuntimeConfig(
         projectRoot,

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -41,6 +41,14 @@ interface OpenCodeConfig {
   mcp?: Record<string, unknown>;
   /** F203 Phase I: instruction file paths for native L0 injection (compression-immune system role). */
   instructions?: string[];
+  /**
+   * #935: OpenCode permission grants for directories outside the working directory.
+   * Without this, OpenCode on Windows rejects tool calls that access external project
+   * directories, forcing users to edit global config manually.
+   */
+  permission?: {
+    external_directory?: string[];
+  };
 }
 
 export function generateOpenCodeConfig(options: OpenCodeConfigOptions): OpenCodeConfig {
@@ -118,6 +126,12 @@ export interface OpenCodeRuntimeConfigOptions {
    * Typical contents: [compiledL0Path, "OPENCODE.md"].
    */
   instructions?: readonly string[];
+  /**
+   * #935: Directories outside the OpenCode working directory that should be
+   * granted `permission.external_directory` access. Typically includes the
+   * Cat Cafe host project root when the thread's working directory is external.
+   */
+  externalDirectories?: readonly string[];
 }
 
 export interface OpenCodeRuntimeConfigDebugSummary {
@@ -176,6 +190,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
     omitProviderAuth = false,
     mcpServerPath,
     instructions,
+    externalDirectories,
   } = options;
 
   const configName = safeProviderName(providerName);
@@ -221,6 +236,15 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
   // so these are additive to any project-root opencode.json instructions.
   if (instructions && instructions.length > 0) {
     config.instructions = [...instructions];
+  }
+
+  // #935: Grant external_directory permission for Clowder-approved workspace roots.
+  // Without this, OpenCode on Windows rejects tool calls that touch paths outside
+  // the working directory, forcing users to edit global config manually.
+  if (externalDirectories && externalDirectories.length > 0) {
+    config.permission = {
+      external_directory: [...externalDirectories],
+    };
   }
 
   return config;

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -1,17 +1,6 @@
 import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-/**
- * opencode Config Template Generator
- * Generates opencode.json configuration for Clowder AI runtime.
- *
- * opencode reads its config from opencode.json (per-project or ~/.config/opencode/).
- * This generator produces a config with:
- * - Anthropic provider (via proxy)
- * - Optional OMOC plugin (oh-my-opencode)
- * - Optional Clowder AI MCP server (deterministic injection via mcpServerPath)
- */
-
 interface OpenCodeConfigOptions {
   /** Anthropic API key — validated but NOT written to config (stays in ANTHROPIC_API_KEY env var) */
   apiKey: string;
@@ -32,6 +21,8 @@ type OpenCodeProviderConfig = {
   };
 };
 
+type OpenCodePermissionAction = 'allow' | 'ask' | 'deny';
+
 interface OpenCodeConfig {
   $schema: string;
   model?: string;
@@ -39,15 +30,11 @@ interface OpenCodeConfig {
   provider: Record<string, OpenCodeProviderConfig>;
   plugin?: string[];
   mcp?: Record<string, unknown>;
-  /** F203 Phase I: instruction file paths for native L0 injection (compression-immune system role). */
+  /** Instruction file paths for native L0 injection (compression-immune system role). */
   instructions?: string[];
-  /**
-   * #935: OpenCode permission grants for directories outside the working directory.
-   * Without this, OpenCode on Windows rejects tool calls that access external project
-   * directories, forcing users to edit global config manually.
-   */
+  /** OpenCode permission grants for directories outside the working directory. */
   permission?: {
-    external_directory?: string[];
+    external_directory?: Record<string, OpenCodePermissionAction>;
   };
 }
 
@@ -180,6 +167,17 @@ export function safeProviderName(name: string): string {
   return OPENCODE_BUILTIN_NAMES.has(name) ? `${name}-compat` : name;
 }
 
+function buildExternalDirectoryPermissions(
+  externalDirectories?: readonly string[],
+): Record<string, OpenCodePermissionAction> | undefined {
+  const rules: Record<string, OpenCodePermissionAction> = {};
+  for (const directory of externalDirectories ?? []) {
+    const normalized = directory.trim().replace(/\\/g, '/').replace(/\/+$/, '');
+    if (normalized) rules[`${normalized}/**`] = 'allow';
+  }
+  return Object.keys(rules).length > 0 ? rules : undefined;
+}
+
 export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOptions): OpenCodeConfig {
   const {
     providerName,
@@ -241,9 +239,10 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
   // #935: Grant external_directory permission for Clowder-approved workspace roots.
   // Without this, OpenCode on Windows rejects tool calls that touch paths outside
   // the working directory, forcing users to edit global config manually.
-  if (externalDirectories && externalDirectories.length > 0) {
+  const externalDirectoryPermissions = buildExternalDirectoryPermissions(externalDirectories);
+  if (externalDirectoryPermissions) {
     config.permission = {
-      external_directory: [...externalDirectories],
+      external_directory: externalDirectoryPermissions,
     };
   }
 
@@ -303,6 +302,7 @@ export function writeOpenCodeInstructionsOnlyConfig(
   catId: string,
   invocationId: string,
   instructions: readonly string[],
+  externalDirectories?: readonly string[],
 ): string {
   const safeCatId = sanitizePathSegment(catId);
   const safeInvocationId = sanitizePathSegment(invocationId);
@@ -310,10 +310,14 @@ export function writeOpenCodeInstructionsOnlyConfig(
   mkdirSync(configDir, { recursive: true });
   const configPath = join(configDir, 'opencode.json');
   const tempPath = `${configPath}.tmp-${process.pid}`;
-  const config: Pick<OpenCodeConfig, '$schema' | 'instructions'> = {
+  const config: Pick<OpenCodeConfig, '$schema' | 'instructions' | 'permission'> = {
     $schema: 'https://opencode.ai/config.json',
     instructions: [...instructions],
   };
+  const externalDirectoryPermissions = buildExternalDirectoryPermissions(externalDirectories);
+  if (externalDirectoryPermissions) {
+    config.permission = { external_directory: externalDirectoryPermissions };
+  }
   writeFileSync(tempPath, JSON.stringify(config, null, 2), 'utf-8');
   renameSync(tempPath, configPath);
   return configPath;

--- a/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/AgentRouter.ts
@@ -111,6 +111,21 @@ interface MentionPattern {
   catId: CatId;
 }
 
+/**
+ * #969: Zero-width Unicode characters that LLMs may insert before mentions.
+ * These are invisible in consoles but break line-start `@` detection.
+ */
+function isZeroWidthChar(code: number): boolean {
+  return (
+    code === 0x200b || // Zero Width Space
+    code === 0x200c || // Zero Width Non-Joiner
+    code === 0x200d || // Zero Width Joiner
+    code === 0xfeff || // Zero Width No-Break Space (BOM)
+    code === 0x00ad || // Soft Hyphen
+    code === 0x2060 // Word Joiner
+  );
+}
+
 function getRouteLineStart(line: string): number | null {
   let cursor = line.match(LINE_START_MENTION_PREFIX_RE)?.[0].length ?? 0;
 
@@ -122,6 +137,10 @@ function getRouteLineStart(line: string): number | null {
   }
 
   while (line[cursor] === ' ' || line[cursor] === '\t') cursor++;
+  // #969: Skip zero-width chars and markdown bold/italic markers before @
+  while (cursor < line.length && isZeroWidthChar(line.charCodeAt(cursor))) cursor++;
+  while (cursor < line.length && (line[cursor] === '*' || line[cursor] === '_')) cursor++;
+  while (cursor < line.length && isZeroWidthChar(line.charCodeAt(cursor))) cursor++;
   return line[cursor] === '@' ? cursor : null;
 }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2074,12 +2074,13 @@ async function main(): Promise<void> {
         : {}),
     };
   };
-  const fetchIssueCommentCursor = async (repoFullName: string, issueNumber: number): Promise<number> => {
-    const { fetchPaginated } = await import('./infrastructure/github/fetch-paginated.js');
-    const comments = await fetchPaginated(`/repos/${repoFullName}/issues/${issueNumber}/comments`, {
-      ghToken: getGitHubToken(),
-    });
-    return maxGithubId(comments as { id?: unknown }[]);
+  // #957: Seed to 0 so the first poll discovers ALL existing comments.
+  // The echo filter (isEchoIssueComment) in IssueCommentTaskSpec already
+  // skips self-authored comments, and commitCursor advances the cursor
+  // after processing — so late-registered tracking correctly notifies
+  // about unprocessed external comments without risk of replay.
+  const fetchIssueCommentCursor = async (_repoFullName: string, _issueNumber: number): Promise<number> => {
+    return 0;
   };
 
   // F202: Plugin framework — discovery + config + resource activation

--- a/packages/api/src/infrastructure/connectors/mention-parser.ts
+++ b/packages/api/src/infrastructure/connectors/mention-parser.ts
@@ -11,6 +11,18 @@ const MENTION_BOUNDARY_RIGHT = '[\\s,.:;!?，。！？；：、)\\]）】」』]
 const MENTION_BOUNDARY_LEFT = '(?<!\\w)';
 
 /**
+ * #969: Strip zero-width Unicode characters that LLMs may insert around mentions.
+ * Also strips markdown bold/italic markers (`**`, `*`, `__`, `_`) immediately before `@`.
+ */
+const ZERO_WIDTH_RE = /(?:​|‌|‍|﻿|­|⁠)/g;
+const MD_BEFORE_MENTION_RE = /(?:\*{1,2}|_{1,2})(?=@)/g;
+const MD_AFTER_MENTION_RE = /(@\S+?)(?:\*{1,2}|_{1,2})(?=\s|$|[,.:;!?，。！？])/g;
+
+function normalizeMentionNoise(text: string): string {
+  return text.replace(ZERO_WIDTH_RE, '').replace(MD_BEFORE_MENTION_RE, '').replace(MD_AFTER_MENTION_RE, '$1');
+}
+
+/**
  * Parse @-mentions from external platform message text.
  * Returns the **first-in-text** matched cat or defaultCatId.
  *
@@ -19,6 +31,8 @@ const MENTION_BOUNDARY_LEFT = '(?<!\\w)';
  * @param defaultCatId — fallback when no mention found
  */
 export function parseMentions(text: string, allPatterns: Map<string, string[]>, defaultCatId: CatId): ParsedMention {
+  // #969: normalize invisible chars and markdown around mentions before matching
+  const normalizedText = normalizeMentionNoise(text);
   let bestIndex = Infinity;
   let bestCatId: string | undefined;
 
@@ -26,7 +40,7 @@ export function parseMentions(text: string, allPatterns: Map<string, string[]>, 
     for (const pattern of patterns) {
       const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       const regex = new RegExp(`${MENTION_BOUNDARY_LEFT}${escaped}(?=${MENTION_BOUNDARY_RIGHT}|$)`, 'i');
-      const match = regex.exec(text);
+      const match = regex.exec(normalizedText);
       if (match && match.index < bestIndex) {
         bestIndex = match.index;
         bestCatId = catId;

--- a/packages/api/src/utils/active-project-root.ts
+++ b/packages/api/src/utils/active-project-root.ts
@@ -55,8 +55,8 @@ export function resolveActiveProjectRoot(start = process.cwd()): string {
   // Only cache when the result came from a valid source — if env pointed to an
   // invalid path and we fell through, don't cache the fallback under those env
   // values (the env path might become valid later on first-run).
-  const envWasInvalid = (configRoot && result !== resolve(configRoot))
-    || (templatePath && result !== dirname(resolve(templatePath)));
+  const envWasInvalid =
+    (configRoot && result !== resolve(configRoot)) || (templatePath && result !== dirname(resolve(templatePath)));
   if (!envWasInvalid) {
     _activeRootCache.set(cacheKey, result);
   }

--- a/packages/api/src/utils/active-project-root.ts
+++ b/packages/api/src/utils/active-project-root.ts
@@ -9,31 +9,62 @@ import { findMonorepoRoot } from './monorepo-root.js';
  * 1. CAT_CAFE_CONFIG_ROOT — explicit platform config root (decoupled from cwd).
  * 2. CAT_TEMPLATE_PATH   — worktree-aware template directory.
  * 3. findMonorepoRoot()  — walk up from `start` looking for pnpm-workspace.yaml.
+ *
+ * Results are cached by (start, env vars) composite key (#950).
+ * Env-set paths that point to invalid/inaccessible locations are NOT cached
+ * so that corrections (e.g. creating the directory) take effect immediately.
  */
+const _activeRootCache = new Map<string, string>();
+
 export function resolveActiveProjectRoot(start = process.cwd()): string {
-  const configRoot = process.env.CAT_CAFE_CONFIG_ROOT?.trim();
+  const configRoot = process.env.CAT_CAFE_CONFIG_ROOT?.trim() ?? '';
+  const templatePath = process.env.CAT_TEMPLATE_PATH?.trim() ?? '';
+  const cacheKey = `${resolve(start)}|${configRoot}|${templatePath}`;
+  const cached = _activeRootCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  let result: string | undefined;
+
   if (configRoot) {
     const resolved = resolve(configRoot);
     try {
       if (statSync(resolved).isDirectory()) {
-        return resolved;
+        result = resolved;
       }
     } catch {
       // Non-existent or inaccessible — fall through to other strategies.
     }
   }
 
-  const templatePath = process.env.CAT_TEMPLATE_PATH?.trim();
-  if (templatePath) {
+  if (result === undefined && templatePath) {
     const resolvedTemplatePath = resolve(templatePath);
     try {
       if (statSync(resolvedTemplatePath).isFile()) {
         accessSync(resolvedTemplatePath, constants.R_OK);
-        return dirname(resolvedTemplatePath);
+        result = dirname(resolvedTemplatePath);
       }
     } catch {
       // Missing/unreadable templates should not redirect account/config lookups.
     }
   }
-  return findMonorepoRoot(start);
+
+  if (result === undefined) {
+    result = findMonorepoRoot(start);
+  }
+
+  // Only cache when the result came from a valid source — if env pointed to an
+  // invalid path and we fell through, don't cache the fallback under those env
+  // values (the env path might become valid later on first-run).
+  const envWasInvalid = (configRoot && result !== resolve(configRoot))
+    || (templatePath && result !== dirname(resolve(templatePath)));
+  if (!envWasInvalid) {
+    _activeRootCache.set(cacheKey, result);
+  }
+
+  return result;
+}
+
+/** @internal — exposed only for testing. */
+export function _clearActiveRootCacheForTest(): void {
+  _activeRootCache.clear();
 }

--- a/packages/api/src/utils/monorepo-root.ts
+++ b/packages/api/src/utils/monorepo-root.ts
@@ -1,13 +1,55 @@
 import { existsSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
+/**
+ * Process-lifetime caches for filesystem-resolved paths (#950).
+ *
+ * These paths (monorepo root, git common dir) do not change during process
+ * lifetime, so caching avoids repeated synchronous I/O that blocks the Node
+ * event loop — especially painful on Windows + HDD where each stat/readFile
+ * can take 5-50ms per seek.
+ *
+ * Windows NTFS is case-insensitive so cache keys are lowercased on win32.
+ */
+const _isWin = process.platform === 'win32';
+function cacheKey(p: string): string {
+  const resolved = resolve(p);
+  return _isWin ? resolved.toLowerCase() : resolved;
+}
+
+const _monorepoRootCache = new Map<string, string>();
+
 export function findMonorepoRoot(start = process.cwd()): string {
+  const startKey = cacheKey(start);
+  const cached = _monorepoRootCache.get(startKey);
+  if (cached !== undefined) return cached;
+
+  const trail: string[] = [];
   let dir = resolve(start);
+  let root: string | null = null;
+
   while (dir !== dirname(dir)) {
-    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) return dir;
+    const dirKey = cacheKey(dir);
+    const dirCached = _monorepoRootCache.get(dirKey);
+    if (dirCached !== undefined) {
+      root = dirCached;
+      break;
+    }
+    trail.push(dirKey);
+    if (existsSync(resolve(dir, 'pnpm-workspace.yaml'))) {
+      root = dir;
+      break;
+    }
     dir = dirname(dir);
   }
-  return resolve(start);
+
+  const result = root ?? resolve(start);
+  // Memoize all directories we traversed — they all share the same root.
+  _monorepoRootCache.set(startKey, result);
+  for (const key of trail) {
+    _monorepoRootCache.set(key, result);
+  }
+  return result;
 }
 
 /**
@@ -15,21 +57,34 @@ export function findMonorepoRoot(start = process.cwd()): string {
  * Handles both regular repos (.git is a directory) and
  * worktrees (.git is a file pointing to the main repo).
  */
+const _gitCommonDirCache = new Map<string, string | null>();
+
 function resolveGitCommonDir(projectPath: string): string | null {
+  const key = cacheKey(projectPath);
+  if (_gitCommonDirCache.has(key)) return _gitCommonDirCache.get(key)!;
+
   const gitPath = join(projectPath, '.git');
+  let result: string | null = null;
   try {
     const stat = statSync(gitPath);
-    if (stat.isDirectory()) return resolve(gitPath);
-    // Worktree: .git file contains "gitdir: <path>/worktrees/<name>"
-    const content = readFileSync(gitPath, 'utf-8').trim();
-    const m = content.match(/^gitdir:\s*(.+)/);
-    if (!m) return null;
-    const gitdir = resolve(projectPath, m[1]!);
-    // .git/worktrees/<name> → .git
-    return resolve(gitdir, '..', '..');
+    if (stat.isDirectory()) {
+      result = resolve(gitPath);
+    } else {
+      // Worktree: .git file contains "gitdir: <path>/worktrees/<name>"
+      const content = readFileSync(gitPath, 'utf-8').trim();
+      const m = content.match(/^gitdir:\s*(.+)/);
+      if (m) {
+        const gitdir = resolve(projectPath, m[1]!);
+        // .git/worktrees/<name> → .git
+        result = resolve(gitdir, '..', '..');
+      }
+    }
   } catch {
-    return null;
+    // No .git found — result stays null
   }
+
+  _gitCommonDirCache.set(key, result);
+  return result;
 }
 
 /** Check if two paths belong to the same git project (handles worktrees). */
@@ -38,4 +93,10 @@ export function isSameProject(pathA: string, pathB: string): boolean {
   const dirA = resolveGitCommonDir(pathA);
   const dirB = resolveGitCommonDir(pathB);
   return dirA !== null && dirA === dirB;
+}
+
+/** @internal — exposed only for testing. */
+export function _clearCachesForTest(): void {
+  _monorepoRootCache.clear();
+  _gitCommonDirCache.clear();
 }

--- a/packages/api/src/utils/monorepo-root.ts
+++ b/packages/api/src/utils/monorepo-root.ts
@@ -17,12 +17,22 @@ function cacheKey(p: string): string {
   return _isWin ? resolved.toLowerCase() : resolved;
 }
 
-const _monorepoRootCache = new Map<string, string>();
+type MonorepoRootCacheEntry = {
+  root: string;
+  /**
+   * Workspace hits are safe to reuse for descendants/ancestors in the traversal
+   * trail. Fallback hits are exact-start only because "no workspace found"
+   * returns the original start directory by contract.
+   */
+  shared: boolean;
+};
+
+const _monorepoRootCache = new Map<string, MonorepoRootCacheEntry>();
 
 export function findMonorepoRoot(start = process.cwd()): string {
   const startKey = cacheKey(start);
   const cached = _monorepoRootCache.get(startKey);
-  if (cached !== undefined) return cached;
+  if (cached !== undefined) return cached.root;
 
   const trail: string[] = [];
   let dir = resolve(start);
@@ -31,8 +41,8 @@ export function findMonorepoRoot(start = process.cwd()): string {
   while (dir !== dirname(dir)) {
     const dirKey = cacheKey(dir);
     const dirCached = _monorepoRootCache.get(dirKey);
-    if (dirCached !== undefined) {
-      root = dirCached;
+    if (dirCached?.shared) {
+      root = dirCached.root;
       break;
     }
     trail.push(dirKey);
@@ -44,10 +54,15 @@ export function findMonorepoRoot(start = process.cwd()): string {
   }
 
   const result = root ?? resolve(start);
-  // Memoize all directories we traversed — they all share the same root.
-  _monorepoRootCache.set(startKey, result);
-  for (const key of trail) {
-    _monorepoRootCache.set(key, result);
+  if (root) {
+    const entry: MonorepoRootCacheEntry = { root: result, shared: true };
+    // Memoize all directories we traversed — they all share the same workspace root.
+    _monorepoRootCache.set(startKey, entry);
+    for (const key of trail) {
+      _monorepoRootCache.set(key, entry);
+    }
+  } else {
+    _monorepoRootCache.set(startKey, { root: result, shared: false });
   }
   return result;
 }

--- a/packages/api/test/cat-catalog-store.test.js
+++ b/packages/api/test/cat-catalog-store.test.js
@@ -241,7 +241,7 @@ describe('cat-catalog-store', () => {
     else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = savedGlobalRoot;
   });
 
-  it('bootstraps an empty catalog by default (first-run quest)', () => {
+  it('bootstraps with one seed breed from template (#948)', () => {
     const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-f127-default-'));
     const templatePath = join(projectRoot, 'cat-template.json');
     const template = makeF127BootstrapTemplate();
@@ -250,10 +250,11 @@ describe('cat-catalog-store', () => {
     const catalogPath = bootstrapCatCatalog(projectRoot, templatePath);
     const runtimeCatalog = JSON.parse(readFileSync(catalogPath, 'utf-8'));
 
-    assert.deepEqual(runtimeCatalog.breeds, []);
-    assert.deepEqual(runtimeCatalog.roster, {
-      owner: { family: 'owner', roles: ['owner'], lead: false, available: true, evaluation: 'co-creator / 大当家' },
-    });
+    // #948: New catalogs seed the first breed from template so the app starts
+    // with at least one usable member (empty registry crashes before wizard).
+    assert.equal(runtimeCatalog.breeds.length, 1, 'should seed exactly one breed');
+    assert.equal(runtimeCatalog.breeds[0].id, 'ragdoll', 'seed breed should be the first template breed');
+    assert.ok(runtimeCatalog.roster?.owner, 'owner roster entry must be present');
     // Non-breed config (reviewPolicy, coCreator) is preserved from template.
     assert.deepEqual(runtimeCatalog.reviewPolicy, template.reviewPolicy);
     assert.deepEqual(runtimeCatalog.coCreator, template.coCreator);

--- a/packages/api/test/monorepo-root.test.js
+++ b/packages/api/test/monorepo-root.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+
+const { _clearCachesForTest, findMonorepoRoot } = await import('../dist/utils/monorepo-root.js');
+
+describe('findMonorepoRoot', () => {
+  afterEach(() => {
+    _clearCachesForTest();
+  });
+
+  it('does not cache a child fallback root for traversed ancestor directories', () => {
+    const project = mkdtempSync(join(tmpdir(), 'plain-project-'));
+    const subdir = join(project, 'subdir');
+    const nested = join(subdir, 'nested');
+    mkdirSync(subdir);
+    mkdirSync(nested);
+
+    assert.equal(findMonorepoRoot(subdir), subdir);
+    assert.equal(findMonorepoRoot(nested), nested);
+    assert.equal(findMonorepoRoot(project), project);
+  });
+});

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -12,6 +12,7 @@ import {
   OC_BASE_URL_ENV,
   parseOpenCodeModel,
   summarizeOpenCodeRuntimeConfigForDebug,
+  writeOpenCodeInstructionsOnlyConfig,
   writeOpenCodeRuntimeConfig,
 } from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
 
@@ -468,6 +469,23 @@ describe('generateOpenCodeRuntimeConfig', () => {
     assert.strictEqual(config.mcp, undefined, 'config must not have mcp section without mcpServerPath');
   });
 
+  test('#935: externalDirectories emits OpenCode external_directory permission globs', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'anthropic',
+      models: ['anthropic/claude-opus-4-6'],
+      defaultModel: 'anthropic/claude-opus-4-6',
+      apiType: 'anthropic',
+      externalDirectories: ['/Users/lysander/projects/cat-cafe/', 'C:\\Users\\lysander\\monorepo'],
+    });
+
+    assert.deepStrictEqual(config.permission, {
+      external_directory: {
+        '/Users/lysander/projects/cat-cafe/**': 'allow',
+        'C:/Users/lysander/monorepo/**': 'allow',
+      },
+    });
+  });
+
   test('summarizeOpenCodeRuntimeConfigForDebug reports provider adapter and model keys', () => {
     const summary = summarizeOpenCodeRuntimeConfigForDebug({
       providerName: 'anthropic',
@@ -489,6 +507,34 @@ describe('generateOpenCodeRuntimeConfig', () => {
         baseUrlSource: `env:${OC_BASE_URL_ENV}`,
       },
     });
+  });
+});
+
+describe('writeOpenCodeInstructionsOnlyConfig', () => {
+  test('#935: writes external_directory permission rules without provider config', () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'oc-instructions-only-external-'));
+    try {
+      const configPath = writeOpenCodeInstructionsOnlyConfig(
+        tmpRoot,
+        'opencode',
+        'inv-external',
+        ['/tmp/l0.md', '/project/OPENCODE.md'],
+        ['/opt/cat-cafe'],
+      );
+
+      const content = JSON.parse(readFileSync(configPath, 'utf-8'));
+      assert.deepStrictEqual(content.instructions, ['/tmp/l0.md', '/project/OPENCODE.md']);
+      assert.deepStrictEqual(content.permission, {
+        external_directory: {
+          '/opt/cat-cafe/**': 'allow',
+        },
+      });
+      assert.strictEqual(content.provider, undefined, 'instructions-only config must not add provider');
+      assert.strictEqual(content.model, undefined, 'instructions-only config must not add model');
+      assert.strictEqual(content.mcp, undefined, 'instructions-only config must not add mcp');
+    } finally {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -58,13 +58,13 @@ import { MessageActions } from './MessageActions';
 import { MessageNavigator } from './MessageNavigator';
 import { MobileStatusSheet } from './MobileStatusSheet';
 import { ParallelStatusBar } from './ParallelStatusBar';
+import { PendingMemberBubble } from './PendingMemberBubble';
 import { ProjectSetupCard } from './ProjectSetupCard';
 
 import { QueuePanel } from './QueuePanel';
 import { RightStatusPanel } from './RightStatusPanel';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 import { SplitPaneView } from './SplitPaneView';
-import { PendingMemberBubble } from './PendingMemberBubble';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ThreadExecutionBar } from './ThreadExecutionBar';
 import { ThreadSidebar } from './ThreadSidebar';

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -64,6 +64,7 @@ import { QueuePanel } from './QueuePanel';
 import { RightStatusPanel } from './RightStatusPanel';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 import { SplitPaneView } from './SplitPaneView';
+import { PendingMemberBubble } from './PendingMemberBubble';
 import { ThinkingIndicator } from './ThinkingIndicator';
 import { ThreadExecutionBar } from './ThreadExecutionBar';
 import { ThreadSidebar } from './ThreadSidebar';
@@ -668,6 +669,26 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
     intentMode === 'execute' ||
     (intentMode == null && hasActiveInvocation && (activeInvocationCount === 1 || singleSpawningTarget));
 
+  // #936: Identify active invocations that don't yet have a corresponding message
+  // bubble — these need a pending placeholder with member avatar + animation.
+  const pendingInvocations = useMemo(() => {
+    if (!hasActiveInvocation || activeInvocationCount === 0) return [];
+    // Collect catIds that already have a streaming/recent assistant message
+    const streamingCatIds = new Set<string>();
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const m = messages[i];
+      if (!m) continue;
+      if (m.type === 'user') break; // stop at last user message boundary
+      if (m.type === 'assistant' && m.catId) {
+        streamingCatIds.add(m.catId);
+      }
+    }
+    // Active invocations without a corresponding bubble = pending
+    return Object.entries(activeInvocations)
+      .filter(([, inv]) => !streamingCatIds.has(inv.catId))
+      .map(([invId, inv]) => ({ invocationId: invId, catId: inv.catId }));
+  }, [hasActiveInvocation, activeInvocationCount, activeInvocations, messages]);
+
   useVoiceAutoPlay();
   useVoiceStream();
   useVadInterrupt();
@@ -998,7 +1019,16 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
                 })()}
               </div>
             ) : (
-              messages.map(renderSingleMessage)
+              <>
+                {messages.map(renderSingleMessage)}
+                {pendingInvocations.map((inv) => (
+                  <PendingMemberBubble
+                    key={`pending-${inv.invocationId}`}
+                    catId={inv.catId}
+                    invocationId={inv.invocationId}
+                  />
+                ))}
+              </>
             )}
             <div ref={messagesEndRef} />
           </main>

--- a/packages/web/src/components/ChatInput.tsx
+++ b/packages/web/src/components/ChatInput.tsx
@@ -23,11 +23,18 @@ import { MobileInputToolbar } from './MobileInputToolbar';
 import { PathCompletionMenu } from './PathCompletionMenu';
 import { ReplyPreviewBar } from './ReplyPreviewBar';
 import { pushThreadRouteWithHistory } from './ThreadSidebar/thread-navigation';
-import { hasPendingThreadDraft, syncDraftToStorage, threadDrafts, threadImageDrafts } from './thread-drafts';
+import {
+  hasPendingThreadDraft,
+  syncDraftToStorage,
+  syncReplyDraftToStorage,
+  threadDrafts,
+  threadImageDrafts,
+  threadReplyDrafts,
+} from './thread-drafts';
 import { WhisperCatSelector, WhisperTargetChips } from './WhisperCatSelector';
 
 /** Module-level draft storage — survives component unmount/remount across thread switches */
-export { syncDraftToStorage, threadDrafts, threadImageDrafts } from './thread-drafts';
+export { syncDraftToStorage, syncReplyDraftToStorage, threadDrafts, threadImageDrafts, threadReplyDrafts } from './thread-drafts';
 
 const MAX_IMAGE_DRAFT_THREADS = 5;
 
@@ -67,9 +74,21 @@ export function ChatInput({
 
   // #699: Reply-to (quote) state — thread-scoped to prevent split-pane leaks
   const rawReplyToMessage = useChatStore((s) => s.replyToMessage);
+  const setReplyToStore = useChatStore((s) => s.setReplyTo);
   const clearReplyTo = useChatStore((s) => s.clearReplyTo);
   // Only surface the reply when it belongs to this ChatInput's thread
   const replyToMessage = rawReplyToMessage?.threadId === threadId ? rawReplyToMessage : null;
+
+  // #934: Restore reply context from thread draft store on mount.
+  // ChatInput is keyed by threadId so this runs once per thread visit.
+  useEffect(() => {
+    if (!threadId) return;
+    const savedReply = threadReplyDrafts.get(threadId);
+    if (savedReply && !rawReplyToMessage) {
+      setReplyToStore(savedReply);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: run once on mount
+  }, [threadId]);
 
   // F122B AC-B10: track which cats are actively executing (for whisper disable)
   const activeInvocations = useChatStore((s) => s.activeInvocations);
@@ -583,7 +602,7 @@ export function ChatInput({
     });
   }, []);
 
-  // Sync input text + images to module-level draft maps (covers all sources: typing, voice, mentions)
+  // Sync input text + images + reply context to module-level draft maps (covers all sources: typing, voice, mentions)
   // useLayoutEffect runs synchronously before browser paint and before unmount,
   // ensuring the draft is written to the Map before the component is destroyed
   // on thread switch (key={threadId}). useEffect would lose the final keystroke.
@@ -591,6 +610,8 @@ export function ChatInput({
     if (!threadId) return;
     const hasDraft = input.trim().length > 0 || images.length > 0;
     syncDraftToStorage(threadId, input || undefined);
+    // #934: Persist reply context alongside text/image drafts
+    syncReplyDraftToStorage(threadId, replyToMessage ?? null);
     if (images.length > 0) {
       threadImageDrafts.delete(threadId); // move to end (Map insertion order)
       threadImageDrafts.set(threadId, images);
@@ -605,8 +626,8 @@ export function ChatInput({
     } else {
       threadImageDrafts.delete(threadId);
     }
-    setThreadHasDraft(threadId, hasDraft);
-  }, [input, images, threadId, setThreadHasDraft]);
+    setThreadHasDraft(threadId, hasDraft || Boolean(replyToMessage));
+  }, [input, images, threadId, setThreadHasDraft, replyToMessage]);
 
   // F080: recalculate ghost suggestion whenever input changes (covers all setInput paths)
   useEffect(() => {

--- a/packages/web/src/components/ChatInput.tsx
+++ b/packages/web/src/components/ChatInput.tsx
@@ -34,7 +34,13 @@ import {
 import { WhisperCatSelector, WhisperTargetChips } from './WhisperCatSelector';
 
 /** Module-level draft storage — survives component unmount/remount across thread switches */
-export { syncDraftToStorage, syncReplyDraftToStorage, threadDrafts, threadImageDrafts, threadReplyDrafts } from './thread-drafts';
+export {
+  syncDraftToStorage,
+  syncReplyDraftToStorage,
+  threadDrafts,
+  threadImageDrafts,
+  threadReplyDrafts,
+} from './thread-drafts';
 
 const MAX_IMAGE_DRAFT_THREADS = 5;
 

--- a/packages/web/src/components/ChatInput.tsx
+++ b/packages/web/src/components/ChatInput.tsx
@@ -84,17 +84,19 @@ export function ChatInput({
   const clearReplyTo = useChatStore((s) => s.clearReplyTo);
   // Only surface the reply when it belongs to this ChatInput's thread
   const replyToMessage = rawReplyToMessage?.threadId === threadId ? rawReplyToMessage : null;
+  const replyHydrationThreadRef = useRef<string | null>(null);
+  const replyPersistenceThreadRef = useRef<string | null>(null);
 
-  // #934: Restore reply context from thread draft store on mount.
+  // #934: Restore reply context from thread draft store before mount-time persistence.
   // ChatInput is keyed by threadId so this runs once per thread visit.
-  useEffect(() => {
-    if (!threadId) return;
+  useLayoutEffect(() => {
+    if (!threadId || replyHydrationThreadRef.current === threadId) return;
+    replyHydrationThreadRef.current = threadId;
     const savedReply = threadReplyDrafts.get(threadId);
-    if (savedReply && !rawReplyToMessage) {
+    if (savedReply && rawReplyToMessage?.threadId !== threadId) {
       setReplyToStore(savedReply);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: run once on mount
-  }, [threadId]);
+  }, [threadId, rawReplyToMessage, setReplyToStore]);
 
   // F122B AC-B10: track which cats are actively executing (for whisper disable)
   const activeInvocations = useChatStore((s) => s.activeInvocations);
@@ -211,7 +213,7 @@ export function ChatInput({
     }
     setPendingChatInsert(null);
     textareaRef.current?.focus();
-  }, [pendingChatInsert, setPendingChatInsert, threadId]);
+  }, [pendingChatInsert, setPendingChatInsert, setThreadHasDraft, threadId]);
 
   const handleTranscript = useCallback((text: string) => {
     setInput((prev) => {
@@ -615,9 +617,11 @@ export function ChatInput({
   useLayoutEffect(() => {
     if (!threadId) return;
     const hasDraft = input.trim().length > 0 || images.length > 0;
+    const firstPersistenceForThread = replyPersistenceThreadRef.current !== threadId;
+    const replyDraft = replyToMessage ?? (firstPersistenceForThread ? (threadReplyDrafts.get(threadId) ?? null) : null);
     syncDraftToStorage(threadId, input || undefined);
     // #934: Persist reply context alongside text/image drafts
-    syncReplyDraftToStorage(threadId, replyToMessage ?? null);
+    syncReplyDraftToStorage(threadId, replyDraft);
     if (images.length > 0) {
       threadImageDrafts.delete(threadId); // move to end (Map insertion order)
       threadImageDrafts.set(threadId, images);
@@ -632,7 +636,8 @@ export function ChatInput({
     } else {
       threadImageDrafts.delete(threadId);
     }
-    setThreadHasDraft(threadId, hasDraft || Boolean(replyToMessage));
+    setThreadHasDraft(threadId, hasDraft || Boolean(replyDraft));
+    replyPersistenceThreadRef.current = threadId;
   }, [input, images, threadId, setThreadHasDraft, replyToMessage]);
 
   // F080: recalculate ghost suggestion whenever input changes (covers all setInput paths)

--- a/packages/web/src/components/HubMemberOverviewCard.tsx
+++ b/packages/web/src/components/HubMemberOverviewCard.tsx
@@ -206,6 +206,9 @@ function MemberMeta({ cat, configCat }: { cat: CatData; configCat?: CatConfig })
   return (
     <>
       <span>
+        <SettingsText tone="muted" className="mr-1.5 font-mono text-[10px]">
+          {cat.id}
+        </SettingsText>
         {getMetaSummary(cat, configCat)}
         {cat.adapterMode && (
           <SettingsBadge

--- a/packages/web/src/components/PendingMemberBubble.tsx
+++ b/packages/web/src/components/PendingMemberBubble.tsx
@@ -26,19 +26,21 @@ export function PendingMemberBubble({ catId, invocationId }: PendingMemberBubble
     <MessageBubble
       messageId={`pending-${invocationId}`}
       avatar={<CatAvatar catId={catId} size={32} status="streaming" />}
-      header={
-        <span className="text-sm font-medium text-cafe-fg-secondary">
-          {catName}
-        </span>
-      }
+      header={<span className="text-sm font-medium text-cafe-fg-secondary">{catName}</span>}
       wrapperClassName="group cat-persona-derived"
     >
       <div className="flex items-center gap-1 py-2 text-cafe-fg-muted">
         <span className="text-sm">分析处理中</span>
         <span className="inline-flex gap-0.5">
-          <span className="animate-bounce text-sm" style={{ animationDelay: '0ms' }}>.</span>
-          <span className="animate-bounce text-sm" style={{ animationDelay: '150ms' }}>.</span>
-          <span className="animate-bounce text-sm" style={{ animationDelay: '300ms' }}>.</span>
+          <span className="animate-bounce text-sm" style={{ animationDelay: '0ms' }}>
+            .
+          </span>
+          <span className="animate-bounce text-sm" style={{ animationDelay: '150ms' }}>
+            .
+          </span>
+          <span className="animate-bounce text-sm" style={{ animationDelay: '300ms' }}>
+            .
+          </span>
         </span>
       </div>
     </MessageBubble>

--- a/packages/web/src/components/PendingMemberBubble.tsx
+++ b/packages/web/src/components/PendingMemberBubble.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useCatData } from '@/hooks/useCatData';
+import { CatAvatar } from './CatAvatar';
+import { MessageBubble } from './MessageBubble';
+
+interface PendingMemberBubbleProps {
+  catId: string;
+  invocationId: string;
+}
+
+/**
+ * #936: Show a member-level pending bubble with avatar and animated dots
+ * as soon as an invocation starts, before any stream content arrives.
+ *
+ * This replaces the gap where the user sees nothing between sending a message
+ * and the first assistant stream chunk. The bubble is keyed by invocationId
+ * so it naturally unmounts when replaced by real content.
+ */
+export function PendingMemberBubble({ catId, invocationId }: PendingMemberBubbleProps) {
+  const { getCatById } = useCatData();
+  const catData = getCatById(catId);
+  const catName = catData?.name ?? catId;
+
+  return (
+    <MessageBubble
+      messageId={`pending-${invocationId}`}
+      avatar={<CatAvatar catId={catId} size={32} status="streaming" />}
+      header={
+        <span className="text-sm font-medium text-cafe-fg-secondary">
+          {catName}
+        </span>
+      }
+      wrapperClassName="group cat-persona-derived"
+    >
+      <div className="flex items-center gap-1 py-2 text-cafe-fg-muted">
+        <span className="text-sm">分析处理中</span>
+        <span className="inline-flex gap-0.5">
+          <span className="animate-bounce text-sm" style={{ animationDelay: '0ms' }}>.</span>
+          <span className="animate-bounce text-sm" style={{ animationDelay: '150ms' }}>.</span>
+          <span className="animate-bounce text-sm" style={{ animationDelay: '300ms' }}>.</span>
+        </span>
+      </div>
+    </MessageBubble>
+  );
+}

--- a/packages/web/src/components/PlanBoardPanel.tsx
+++ b/packages/web/src/components/PlanBoardPanel.tsx
@@ -97,7 +97,8 @@ function PlanCard({ catId, threadId, inv }: { catId: string; threadId: string; i
             className="text-micro px-2 py-0.5 rounded-full border border-[var(--console-border-soft)] hover:bg-[var(--console-hover-bg)] transition-colors"
             onClick={async () => {
               if (await confirm({ title: '继续任务', message: '确认继续上次任务？' })) {
-                void handleSend(buildContinueMessage(catId, tp), undefined, threadId);
+                const mentionHandle = cat?.mentionPatterns?.[0] ?? `@${catId}`;
+                void handleSend(buildContinueMessage(mentionHandle, tp), undefined, threadId);
               }
             }}
           >

--- a/packages/web/src/components/__tests__/chat-input-draft-persistence.test.ts
+++ b/packages/web/src/components/__tests__/chat-input-draft-persistence.test.ts
@@ -10,7 +10,7 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ChatInput, threadDrafts, threadImageDrafts } from '@/components/ChatInput';
+import { ChatInput, threadDrafts, threadImageDrafts, threadReplyDrafts } from '@/components/ChatInput';
 import { useChatStore } from '@/stores/chatStore';
 
 // ── Mocks ──
@@ -68,11 +68,13 @@ const originalRevokeObjectURL = URL.revokeObjectURL;
 beforeEach(() => {
   threadDrafts.clear();
   threadImageDrafts.clear();
+  threadReplyDrafts.clear();
   useChatStore.setState({
     currentThreadId: 'default',
     hasDraft: false,
     threadStates: {},
     pendingChatInsert: null,
+    replyToMessage: null,
   });
   URL.createObjectURL = vi.fn((file: Blob) => `blob:${(file as File).name ?? 'image'}`);
   URL.revokeObjectURL = vi.fn();
@@ -146,6 +148,24 @@ describe('ChatInput draft persistence', () => {
 
     // Draft should be restored
     expect(getTextarea().value).toBe('hello from A');
+  });
+
+  it('hydrates saved reply drafts before mount-time persistence can clear them', () => {
+    const onSend = vi.fn();
+    const savedReply = {
+      id: 'msg-parent',
+      content: 'quoted parent',
+      senderCatId: 'opus',
+      threadId: 'thread-REPLY',
+    };
+    threadReplyDrafts.set('thread-REPLY', savedReply);
+
+    act(() => {
+      root.render(React.createElement(ChatInput, { threadId: 'thread-REPLY', onSend }));
+    });
+
+    expect(useChatStore.getState().replyToMessage).toEqual(savedReply);
+    expect(threadReplyDrafts.get('thread-REPLY')).toEqual(savedReply);
   });
 
   it('maintains independent drafts per thread', () => {

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -95,12 +95,21 @@ export function IdentitySection({
           <input type="hidden" aria-label="Cat ID" value={form.catId} />
         </>
       ) : (
-        <TextField
-          label="名称"
-          ariaLabel="Name"
-          value={form.name}
-          onChange={(value) => onChange({ name: value, displayName: value })}
-        />
+        <>
+          <TextField
+            label="名称"
+            ariaLabel="Name"
+            value={form.name}
+            onChange={(value) => onChange({ name: value, displayName: value })}
+          />
+          {/* #968: Show catId (read-only) so users can correlate notifications with members */}
+          <div className="flex items-center gap-2 text-xs text-cafe-fg-muted">
+            <span className="font-medium">Cat ID:</span>
+            <code className="rounded bg-cafe-surface-sunken px-1.5 py-0.5 font-mono text-[11px] select-all">
+              {form.catId}
+            </code>
+          </div>
+        </>
       )}
 
       <TextField

--- a/packages/web/src/components/thread-drafts.ts
+++ b/packages/web/src/components/thread-drafts.ts
@@ -1,4 +1,16 @@
 const STORAGE_KEY = 'cat-cafe:thread-drafts';
+const REPLY_STORAGE_KEY = 'cat-cafe:thread-reply-drafts';
+
+/**
+ * Reply context persisted alongside the text draft so quoted messages survive
+ * thread switching (#934).
+ */
+export interface DraftReplyContext {
+  id: string;
+  content: string;
+  senderCatId: string | null;
+  threadId: string;
+}
 
 /**
  * Hydrate text drafts from sessionStorage on module init.
@@ -24,6 +36,25 @@ function hydrateFromStorage(): Map<string, string> {
   return map;
 }
 
+function hydrateReplyDrafts(): Map<string, DraftReplyContext> {
+  const map = new Map<string, DraftReplyContext>();
+  if (typeof window === 'undefined') return map;
+  try {
+    const raw = window.sessionStorage.getItem(REPLY_STORAGE_KEY);
+    if (raw) {
+      const entries: [string, DraftReplyContext][] = JSON.parse(raw);
+      for (const [k, v] of entries) {
+        if (typeof k === 'string' && v && typeof v.id === 'string') {
+          map.set(k, v);
+        }
+      }
+    }
+  } catch {
+    // Corrupt or unavailable — start fresh
+  }
+  return map;
+}
+
 function persistToStorage(map: Map<string, string>): void {
   if (typeof window === 'undefined') return;
   try {
@@ -37,8 +68,22 @@ function persistToStorage(map: Map<string, string>): void {
   }
 }
 
+function persistReplyDrafts(map: Map<string, DraftReplyContext>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    if (map.size === 0) {
+      window.sessionStorage.removeItem(REPLY_STORAGE_KEY);
+    } else {
+      window.sessionStorage.setItem(REPLY_STORAGE_KEY, JSON.stringify([...map.entries()]));
+    }
+  } catch {
+    // QuotaExceededError or SecurityError — best effort
+  }
+}
+
 export const threadDrafts = hydrateFromStorage();
 export const threadImageDrafts = new Map<string, File[]>();
+export const threadReplyDrafts = hydrateReplyDrafts();
 
 /** Sync a draft write to sessionStorage. Call after mutating threadDrafts. */
 export function syncDraftToStorage(threadId: string, text: string | undefined): void {
@@ -50,10 +95,23 @@ export function syncDraftToStorage(threadId: string, text: string | undefined): 
   persistToStorage(threadDrafts);
 }
 
+/** #934: Save/clear reply context for a thread draft. */
+export function syncReplyDraftToStorage(threadId: string, reply: DraftReplyContext | null): void {
+  if (reply) {
+    threadReplyDrafts.set(threadId, reply);
+  } else {
+    threadReplyDrafts.delete(threadId);
+  }
+  persistReplyDrafts(threadReplyDrafts);
+}
+
 export function hasPendingThreadDraft(threadId: string): boolean {
   const textDraft = threadDrafts.get(threadId);
   if (typeof textDraft === 'string' && textDraft.trim().length > 0) return true;
 
   const imageDrafts = threadImageDrafts.get(threadId);
-  return Array.isArray(imageDrafts) && imageDrafts.length > 0;
+  if (Array.isArray(imageDrafts) && imageDrafts.length > 0) return true;
+
+  // A reply-to without text still counts as a pending draft (#934)
+  return threadReplyDrafts.has(threadId);
 }

--- a/packages/web/src/lib/mention-highlight.ts
+++ b/packages/web/src/lib/mention-highlight.ts
@@ -17,12 +17,19 @@ function buildMentionToCat(cats: Array<{ id: string; mentionPatterns: string[] }
   );
 }
 
+// #969: Zero-width Unicode chars LLMs may insert before/around mentions
+const ZW_CLASS = '[​‌‍﻿­⁠]*';
+
 function buildMentionRe(toCat: Record<string, string>): RegExp {
   const aliases = Object.keys(toCat).sort((a, b) => b.length - a.length);
   if (aliases.length === 0) return /(?!)/g; // never-match fallback
   const pattern = aliases.map(escapeRegExp).join('|');
   // Boundary chars aligned with backend AgentRouter.parseMentions
-  return new RegExp(`@(${pattern})(?=$|\\s|[,.:;!?()\\[\\]{}<>，。！？、：；（）【】《》「」『』〈〉])`, 'gi');
+  // #969: optionally match zero-width chars and markdown bold/italic before @
+  return new RegExp(
+    `(?:[*_]{0,2})${ZW_CLASS}@(${pattern})(?=$|\\s|[,.:;!?()\\[\\]{}<>，。！？、：；（）【】《》「」『』〈〉])`,
+    'gi',
+  );
 }
 
 function buildMentionColor(cats: Array<{ id: string; color: { primary: string } }>): Record<string, string> {

--- a/packages/web/src/stores/chatStore.ts
+++ b/packages/web/src/stores/chatStore.ts
@@ -2282,7 +2282,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
           [state.currentThreadId]: saved,
         },
         ...flattened,
-        // #699: Clear reply-to when switching threads
+        // #934: Clear reply-to on switch — ChatInput will restore from threadReplyDrafts on mount.
+        // This prevents stale reply context from the outgoing thread leaking into the new thread.
         replyToMessage: null,
       };
     }),

--- a/packages/web/src/utils/__tests__/taskProgressContinue.test.ts
+++ b/packages/web/src/utils/__tests__/taskProgressContinue.test.ts
@@ -20,4 +20,15 @@ describe('buildContinueMessage', () => {
     expect(msg).toContain('- [ ] Fix bug');
     expect(msg).toContain('- [ ] Run tests');
   });
+
+  it('does not duplicate an existing @ mention prefix', () => {
+    const msg = buildContinueMessage('@opus', {
+      tasks: [],
+      lastUpdate: 1,
+      snapshotStatus: 'interrupted',
+    });
+
+    expect(msg).toContain('@opus 🔁');
+    expect(msg).not.toContain('@@opus');
+  });
 });

--- a/packages/web/src/utils/taskProgressContinue.ts
+++ b/packages/web/src/utils/taskProgressContinue.ts
@@ -1,11 +1,16 @@
 import type { TaskProgressState } from '@/stores/chat-types';
 
-export function buildContinueMessage(catId: string, progress: TaskProgressState): string {
+/**
+ * Build a "continue interrupted task" message.
+ * @param mentionHandle — full mention alias including `@` prefix (e.g. `@opus`).
+ *   Falls back to `@${rawId}` if no alias is available (#967).
+ */
+export function buildContinueMessage(mentionHandle: string, progress: TaskProgressState): string {
   const tasks = progress.tasks ?? [];
   const remaining = tasks.filter((t) => t.status !== 'completed');
 
   const lines: string[] = [];
-  lines.push(`@${catId} 🔁 继续上次任务（已中断，上次 checklist 见下）`);
+  lines.push(`${mentionHandle} 🔁 继续上次任务（已中断，上次 checklist 见下）`);
   lines.push('');
 
   const render = (label: string, list: typeof tasks) => {

--- a/packages/web/src/utils/taskProgressContinue.ts
+++ b/packages/web/src/utils/taskProgressContinue.ts
@@ -8,9 +8,13 @@ import type { TaskProgressState } from '@/stores/chat-types';
 export function buildContinueMessage(mentionHandle: string, progress: TaskProgressState): string {
   const tasks = progress.tasks ?? [];
   const remaining = tasks.filter((t) => t.status !== 'completed');
+  const trimmedMentionHandle = mentionHandle.trim();
+  const normalizedMentionHandle = trimmedMentionHandle.startsWith('@')
+    ? trimmedMentionHandle
+    : `@${trimmedMentionHandle}`;
 
   const lines: string[] = [];
-  lines.push(`${mentionHandle} 🔁 继续上次任务（已中断，上次 checklist 见下）`);
+  lines.push(`${normalizedMentionHandle} 🔁 继续上次任务（已中断，上次 checklist 见下）`);
   lines.push('');
 
   const render = (label: string, list: typeof tasks) => {


### PR DESCRIPTION
## Summary

Batch fix covering 13 accepted issues/follow-ups. Each issue is a separate or clearly-scoped commit for easy review and revert; #970/#971 are #935 follow-ups folded into the final review scope.

### Bug fixes (closes)
- **#934** — Preserve quoted reply context (`replyToMessage`) in thread drafts via sessionStorage
- **#935** — Generate `permission.external_directory` in OpenCode runtime config for cross-project access
- **#970** — Emit `permission.external_directory` in OpenCode's rule-map form instead of a string array
- **#971** — Include external directory grants in the instructions-only OpenCode fallback config
- **#937** — Replace hardcoded `opus` fallback with dynamic default cat resolution chain
- **#947** — Set explicit `--maxclients 512` for packaged Redis to suppress ulimit warnings
- **#957** — Seed `issue_tracking` cursor to 0 for late-registration scenarios
- **#967** — Use mention alias (e.g. `opus`) instead of raw catId when resuming interrupted tasks

### Bug fixes (partial — issue stays open)
- **#948** — Seed default breed from template on first-run bootstrap. Partial: existing empty catalog repair (Windows reinstall where `%LOCALAPPDATA%` persists) deferred — cannot distinguish "broken install" from "user intentionally deleted all members"
- **#969** — Strip zero-width Unicode chars and markdown bold/italic markers before mention parsing. Partial: HTML tag stripping (`<b>at-alias</b>`) deferred per CVO decision
- **#936** — Show member-level pending bubble with avatar + animated dots on invocation start. Partial: failure→member bubble requires bubble-reducer refactoring — deferred

### Performance (closes)
- **#950** — Add process-lifetime `Map` caches to `findMonorepoRoot` / `resolveActiveProjectRoot`

### Features (closes)
- **#968** — Display catId (read-only) in member overview card and editor

### Closing refs
Closes #934
Closes #935
Closes #937
Closes #947
Closes #950
Closes #957
Closes #967
Closes #968
Closes #970
Closes #971
Refs #936
Refs #948
Refs #969

### Review notes
- **#948 R3**: Removed `repairEmptyBreeds()` per codex R2 review — it broke "delete last member" scenario. `pickSeedBreed()` only seeds during NEW catalog creation.
- **#936**: Commit message changed from `Closes #936` to `Partial fix for #936`.
- **#969**: HTML tag stripping deferred per CVO decision. Commit changed from `Closes #969` to `Ref #969`.
- **#935/#970/#971**: Windows-specific `permission.external_directory` coverage now emits OpenCode rule-map form and covers the instructions-only fallback path.

## Test plan
- [x] `pnpm check` (Biome) — ✅
- [x] `pnpm lint` (TypeScript) — ✅
- [x] `cat-catalog-store.test.js` — 20/20 pass
- [x] `opencode-config-template.test.js` — covers #935/#970/#971 config generation
- [x] `f203-phase-i-opencode-l0.test.js` — covers instructions-only fallback invariants
- [ ] Verify reply draft restore on thread switch (#934)
- [ ] Verify pending bubble appears on invocation start (#936)
- [ ] Verify catId visible in member settings (#968)
- [ ] Verify task resume uses mention alias (#967)
- [ ] Verify mention parsing handles `​at-alias` (zero-width prefix) (#969)

🐾 [宪宪/claude-opus-4-6]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
