### PR TITLE
[codex] preserve sandbox across Codex resume

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -4,7 +4,7 @@
  *
  * CLI 调用方式:
  *   codex exec --json --sandbox danger-full-access --add-dir .git --config approval_policy="on-request" "prompt"
- *   codex exec resume SESSION_ID --json --config approval_policy="on-request" "prompt"
+ *   codex exec resume SESSION_ID --json --config sandbox_mode="danger-full-access" --config approval_policy="on-request" "prompt"
  *
  * NDJSON 事件格式:
  *   thread.started  → session_init (含 thread_id)
@@ -436,6 +436,7 @@ export class CodexAgentService implements AgentService {
     const approvalPolicy = getCodexApprovalPolicy();
     const effortLevel = getCatEffort(this.catId as string, undefined, 'openai');
     const reasoningArgs = ['--config', `model_reasoning_effort="${effortLevel}"`];
+    const sandboxConfigArgs = ['--config', `sandbox_mode="${sandboxMode}"`];
     const approvalArgs = ['--config', `approval_policy="${approvalPolicy}"`];
     const ctxConfig = getCatContextWindowConfig(this.catId as string);
     const contextWindowArgs: string[] = ctxConfig
@@ -529,10 +530,9 @@ export class CodexAgentService implements AgentService {
     }
     const developerInstructionsArgs = l0Result.args;
 
-    // resume 子命令不接受 --sandbox（sandbox 在创建时已锁定）
-    // --add-dir .git: 允许写入 .git/ 目录（index.lock、objects、refs），解锁 git commit
-    // 注意：旧 session resume 时沿用创建时的沙箱参数，不会带 --add-dir。
-    // 这是预期行为——新建会话即可获得 .git 写入权限。
+    // resume 子命令不接受 --sandbox / --add-dir（.git 写入权限仍由新会话创建时锁定）。
+    // 但 Codex resume 不会向 agent 暴露 sandbox provenance；为避免 resume 回落到 CLI 默认值，
+    // 这里通过 --config sandbox_mode=... 显式重放 runtime sandbox（#960）。
     // Incident 2026-05-29 (cross-thread-context-contamination): prompt 正文经 stdin
     // 传入（见下方 cliOpts.stdinInput），绝不进 argv —— 否则 `ps -o command=` /
     // /proc/<pid>/cmdline 会把完整对话历史（含跨 thread/猫/用户内容）暴露给任何
@@ -567,6 +567,7 @@ export class CodexAgentService implements AgentService {
           ...dedup(modelArgs),
           ...dedup(reasoningArgs),
           ...dedup(contextWindowArgs),
+          ...dedup(sandboxConfigArgs),
           ...dedup(approvalArgs),
           ...dedup(developerInstructionsArgs),
           ...dedup(customProviderArgs),

--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -6,7 +6,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { basename, resolve } from 'node:path';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -40,6 +40,48 @@ function collectNvmBinDirs(): string[] {
 }
 
 const resolvedCache = new Map<string, string>();
+
+function isExecutableCandidate(path: string): boolean {
+  return existsSync(path);
+}
+
+function isWindowsCodexDesktopRuntime(path: string): boolean {
+  const normalized = path.replace(/\//g, '\\').toLowerCase();
+  return (
+    normalized.endsWith('\\codex.exe') &&
+    (normalized.includes('\\appdata\\local\\openai\\codex\\bin\\') ||
+      normalized.includes('\\windowsapps\\openai.codex_'))
+  );
+}
+
+function collectWindowsCodexDesktopCandidates(): string[] {
+  const candidates: string[] = [];
+  const explicit = process.env.CODEX_CLI_PATH?.trim();
+  if (explicit) candidates.push(explicit);
+
+  const localAppData = process.env.LOCALAPPDATA;
+  if (localAppData) {
+    const binRoot = resolve(localAppData, 'OpenAI', 'Codex', 'bin');
+    try {
+      for (const entry of readdirSync(binRoot, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        candidates.push(resolve(binRoot, entry.name, 'codex.exe'));
+      }
+    } catch {
+      // Optional desktop-app install location; fall through to PATH/npm probes.
+    }
+  }
+
+  return candidates;
+}
+
+function resolveWindowsCodexDesktopRuntime(): string | null {
+  for (const candidate of collectWindowsCodexDesktopCandidates()) {
+    if (basename(candidate).toLowerCase() !== 'codex.exe') continue;
+    if (isExecutableCandidate(candidate)) return candidate;
+  }
+  return null;
+}
 
 /**
  * Drop a cache entry. Accepts EITHER the bare command name (cache key) OR the
@@ -81,6 +123,14 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
     resolvedCache.delete(command);
   }
 
+  if (IS_WINDOWS && command === 'codex') {
+    const desktopRuntime = resolveWindowsCodexDesktopRuntime();
+    if (desktopRuntime) {
+      resolvedCache.set(command, desktopRuntime);
+      return desktopRuntime;
+    }
+  }
+
   // Fast path: already in PATH
   // #894: caller can skip this when PATH was already probed (e.g. client-detection
   // does its own `command -v`; repeating `which` is redundant + slower).
@@ -93,8 +143,15 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
           .split('\n')
           .map((l) => l.trim())
           .filter(Boolean);
-        // On Windows, prefer the .cmd shim (more reliable for shim resolution)
-        const resolved = (IS_WINDOWS && lines.find((l) => /\.cmd$/i.test(l))) || lines[0];
+        // On Windows, prefer the official Codex desktop runtime over the npm shim:
+        // the npm-packaged Windows sandbox setup may require elevation (os error
+        // 740), while the desktop runtime ships with the app-managed helper.
+        const resolved =
+          (IS_WINDOWS && command === 'codex' && lines.find(isWindowsCodexDesktopRuntime)) ||
+          // On Windows, prefer the .cmd shim for generic npm CLIs (more reliable
+          // for shim resolution).
+          (IS_WINDOWS && lines.find((l) => /\.cmd$/i.test(l))) ||
+          lines[0];
         resolvedCache.set(command, resolved);
         return resolved;
       }

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -17,7 +17,7 @@ test('formatCliNotFoundError returns install hint for known CLI', () => {
 });
 
 test('formatCliNotFoundError returns native installer hint for agy', () => {
-  const msg = formatCliNotFoundError('agy');
+  const msg = formatCliNotFoundError('agy', 'linux');
   assert.match(msg, /agy CLI 未找到/);
   assert.match(msg, /https:\/\/antigravity\.google\/cli\/install\.sh/);
 });
@@ -124,9 +124,11 @@ test(
 
     const originalAppData = process.env.APPDATA;
     const originalLocalAppData = process.env.LOCALAPPDATA;
+    const originalPath = process.env.PATH;
     try {
       process.env.APPDATA = join(tempRoot, 'roaming');
       process.env.LOCALAPPDATA = join(tempRoot, 'local');
+      process.env.PATH = '';
       invalidateCliCommand('agy');
       const result = resolveCliCommand('agy');
       assert.equal(result, fakeAgy, 'should find official Windows AGY native binary path');
@@ -136,6 +138,43 @@ test(
       else process.env.APPDATA = originalAppData;
       if (originalLocalAppData === undefined) delete process.env.LOCALAPPDATA;
       else process.env.LOCALAPPDATA = originalLocalAppData;
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  'resolveCliCommand prefers CODEX_CLI_PATH for codex on Windows',
+  { skip: process.platform !== 'win32' && 'Windows-only (Codex desktop runtime fallback)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-codex-path-'));
+    const desktopDir = join(tempRoot, 'OpenAI', 'Codex', 'bin', 'runtime-id');
+    mkdirSync(desktopDir, { recursive: true });
+    const desktopCodex = join(desktopDir, 'codex.exe');
+    writeFileSync(desktopCodex, 'MZ', 'utf8');
+
+    const npmDir = join(tempRoot, 'npm');
+    mkdirSync(npmDir, { recursive: true });
+    const npmCodex = join(npmDir, 'codex.cmd');
+    writeFileSync(npmCodex, '@echo off\n', 'utf8');
+
+    const originalCodeCliPath = process.env.CODEX_CLI_PATH;
+    const originalAppData = process.env.APPDATA;
+    try {
+      invalidateCliCommand('codex');
+      process.env.CODEX_CLI_PATH = desktopCodex;
+      process.env.APPDATA = tempRoot;
+
+      const result = resolveCliCommand('codex');
+      assert.equal(result, desktopCodex, 'Codex cats should use the desktop runtime before npm shims');
+    } finally {
+      invalidateCliCommand('codex');
+      if (originalCodeCliPath === undefined) delete process.env.CODEX_CLI_PATH;
+      else process.env.CODEX_CLI_PATH = originalCodeCliPath;
+      if (originalAppData === undefined) delete process.env.APPDATA;
+      else process.env.APPDATA = originalAppData;
       rmSync(tempRoot, { recursive: true, force: true });
     }
   },

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -243,6 +243,7 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     assert.ok(modelFlagIndex >= 0, 'resume args must include --model');
     assert.equal(args[modelFlagIndex + 1], 'gpt-5.3-codex');
     assert.ok(args.includes('--config'), 'resume args must include approval policy override');
+    assert.ok(args.includes('sandbox_mode="danger-full-access"'), 'resume args must preserve sandbox via config');
     assert.ok(args.includes('approval_policy="on-request"'), 'default approval policy should be on-request');
     assert.ok(!args.includes('approval_policy=\\"on-request\\"'), 'argv should not contain literal backslash escapes');
   });
@@ -557,6 +558,39 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
+  test('uses env-configured sandbox as config override for resume', async () => {
+    const oldSandbox = process.env.CAT_CODEX_SANDBOX_MODE;
+    const oldApproval = process.env.CAT_CODEX_APPROVAL_POLICY;
+    process.env.CAT_CODEX_SANDBOX_MODE = 'read-only';
+    process.env.CAT_CODEX_APPROVAL_POLICY = 'never';
+
+    try {
+      const proc = createMockProcess();
+      const spawnFn = createMockSpawnFn(proc);
+      const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn });
+
+      const promise = collect(service.invoke('configurable resume', { sessionId: 'thread-config-resume' }));
+      emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 'thread-config-resume' }]);
+      await promise;
+
+      const args = spawnFn.mock.calls[0].arguments[1];
+      assert.ok(!args.includes('--sandbox'), 'resume args must not include --sandbox');
+      assert.ok(args.includes('sandbox_mode="read-only"'), 'resume sandbox should follow CAT_CODEX_SANDBOX_MODE');
+      assert.ok(args.includes('approval_policy="never"'), 'resume approval policy should follow env');
+    } finally {
+      if (oldSandbox === undefined) {
+        delete process.env.CAT_CODEX_SANDBOX_MODE;
+      } else {
+        process.env.CAT_CODEX_SANDBOX_MODE = oldSandbox;
+      }
+      if (oldApproval === undefined) {
+        delete process.env.CAT_CODEX_APPROVAL_POLICY;
+      } else {
+        process.env.CAT_CODEX_APPROVAL_POLICY = oldApproval;
+      }
+    }
+  });
+
   test('falls back to defaults for invalid sandbox/approval env values', async () => {
     const oldSandbox = process.env.CAT_CODEX_SANDBOX_MODE;
     const oldApproval = process.env.CAT_CODEX_APPROVAL_POLICY;
@@ -605,7 +639,7 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     assert.ok(args.includes('--sandbox'), 'new session must still include --sandbox');
   });
 
-  test('resume session does NOT include --add-dir (sandbox locked at creation)', async () => {
+  test('resume session does NOT include --add-dir or --sandbox flags', async () => {
     const proc = createMockProcess();
     const spawnFn = createMockSpawnFn(proc);
     const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn });
@@ -617,6 +651,7 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     const args = spawnFn.mock.calls[0].arguments[1];
     assert.ok(!args.includes('--add-dir'), 'resume args must not include --add-dir');
     assert.ok(!args.includes('--sandbox'), 'resume args must not include --sandbox');
+    assert.ok(args.includes('sandbox_mode="danger-full-access"'), 'resume args must preserve sandbox via config');
   });
 
   test('custom provider: model passed via --config as-is', async () => {

--- a/packages/api/test/windows-portable-redis-tools.test.js
+++ b/packages/api/test/windows-portable-redis-tools.test.js
@@ -184,27 +184,25 @@ test('Windows OAuth helpers do not force-remove global installer accounts before
 });
 
 test('Windows installer probes the npm shim path when pnpm is installed but not yet on PATH', () => {
-  assert.match(
-    commandHelpersScript,
-    /@\(\(Join-Path \$env:APPDATA "npm\\\$Name\.cmd"\), \(Join-Path \$env:APPDATA "npm\\\$Name\.ps1"\), \(Join-Path \$env:APPDATA "npm\\\$Name"\)\)/,
-  );
-  assert.match(commandHelpersScript, /Join-Path \$env:APPDATA "npm\\\$Name\.cmd"/);
-  assert.match(commandHelpersScript, /Join-Path \$env:APPDATA "npm\\\$Name\.ps1"/);
+  assert.match(commandHelpersScript, /\$npmDir = Join-Path \$env:APPDATA "npm"/);
+  assert.match(commandHelpersScript, /Join-Path \$npmDir "\$Name\.cmd"/);
+  assert.match(commandHelpersScript, /Join-Path \$npmDir "\$Name\.ps1"/);
   assert.match(commandHelpersScript, /prefix -g/);
   assert.match(commandHelpersScript, /Select-Object -Last 1/);
-  assert.match(
-    commandHelpersScript,
-    /@\(\(Join-Path \$npmPrefix "\$Name\.cmd"\), \(Join-Path \$npmPrefix "\$Name\.ps1"\), \(Join-Path \$npmPrefix \$Name\)\)/,
-  );
   assert.match(commandHelpersScript, /Join-Path \$npmPrefix "\$Name\.cmd"/);
   assert.match(commandHelpersScript, /Join-Path \$npmPrefix "\$Name\.ps1"/);
+  assert.ok(
+    commandHelpersScript.indexOf('$preferredCandidates += @((Join-Path $npmPrefix "$Name.cmd"') <
+      commandHelpersScript.indexOf('$fallbackCandidates += @((Join-Path $npmPrefix "$Name.ps1"))'),
+    'expected .cmd shim candidates to be tried before .ps1 fallbacks',
+  );
   assert.match(installScript, /Resolve-PnpmCommand/);
   assert.match(installScript, /Invoke-Pnpm/);
   assert.match(installScript, /Resolve-ToolCommand -Name "pnpm"/);
 });
 
 test('Windows pnpm resolver validates npm prefix output with Test-Path', () => {
-  const appDataShimIndex = commandHelpersScript.indexOf('Join-Path $env:APPDATA "npm\\$Name.cmd"');
+  const appDataShimIndex = commandHelpersScript.indexOf('$npmDir = Join-Path $env:APPDATA "npm"');
   const npmCommandIndex = commandHelpersScript.indexOf('$npmCommand = Get-Command npm -ErrorAction SilentlyContinue');
   const npmPrefixIndex = commandHelpersScript.indexOf(
     '$npmPrefix = @(& $npmPath prefix -g 2>$null) | Select-Object -Last 1',
@@ -269,7 +267,7 @@ test('Windows installer prints pnpm resolver diagnostics before giving up', () =
 test('Windows scripts share a generic npm shim resolver for pnpm and agent CLIs', () => {
   assert.match(commandHelpersScript, /function Resolve-ToolCommand/);
   assert.match(commandHelpersScript, /function Resolve-ToolCommandWithRetry/);
-  assert.match(commandHelpersScript, /Join-Path \$env:APPDATA "npm\\\$Name\.cmd"/);
+  assert.match(commandHelpersScript, /Join-Path \$npmDir "\$Name\.cmd"/);
   assert.match(commandHelpersScript, /function Invoke-ToolCommand/);
   assert.match(helpersScript, /\$hasClaude = \$null -ne \(Resolve-ToolCommandWithRetry -Name "claude" -Attempts 6\)/);
   assert.match(helpersScript, /\$hasCodex = \$null -ne \(Resolve-ToolCommandWithRetry -Name "codex" -Attempts 6\)/);
@@ -291,6 +289,15 @@ test('Windows tool resolution prefers explicit shim candidates before generic Ge
     candidatesIndex < getCommandIndex,
     'expected shim candidates to be preferred before generic Get-Command lookup',
   );
+});
+
+test('Windows tool resolution normalizes PowerShell shim fallbacks to cmd shims', () => {
+  assert.match(commandHelpersScript, /function Resolve-WindowsCommandShim/);
+  assert.match(commandHelpersScript, /\[System\.IO\.Path\]::GetExtension\(\$CommandPath\)/);
+  assert.match(commandHelpersScript, /if \(\$extension -ine "\.ps1"\) \{ return \$CommandPath \}/);
+  assert.match(commandHelpersScript, /Join-Path \$directory "\$nameWithoutExtension\.cmd"/);
+  assert.match(commandHelpersScript, /Resolve-WindowsCommandShim -CommandPath \$toolCommand\.Path/);
+  assert.match(commandHelpersScript, /Resolve-WindowsCommandShim -CommandPath \$toolCommand\.Source/);
 });
 
 test('Windows tool resolution validates shim candidates before returning the first existing path', () => {

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -47,7 +47,7 @@ export function AdvancedRuntimeSection({
   onCodexChange: (patch: Partial<CodexRuntimeSettings>) => void;
 }) {
   const effectiveCodexSettings = codexSettings ?? {
-    sandboxMode: 'workspace-write' as const,
+    sandboxMode: 'danger-full-access' as const,
     approvalPolicy: 'on-request' as const,
     authMode: 'oauth' as const,
   };

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -467,7 +467,7 @@ export function toCodexRuntimeSettings(config?: {
   };
 }): CodexRuntimeSettings {
   return {
-    sandboxMode: config?.cli?.codexSandboxMode ?? 'workspace-write',
+    sandboxMode: config?.cli?.codexSandboxMode ?? 'danger-full-access',
     approvalPolicy: config?.cli?.codexApprovalPolicy ?? 'on-request',
     authMode: config?.codexExecution?.authMode ?? 'oauth',
   };

--- a/scripts/windows-command-helpers.ps1
+++ b/scripts/windows-command-helpers.ps1
@@ -58,15 +58,19 @@ function Get-NpmConfigPrefixCandidates {
 
 function Get-ToolCommandCandidates {
     param([string]$Name)
-    $candidates = @()
+    $preferredCandidates = @()
+    $fallbackCandidates = @()
     if ($env:APPDATA) {
-        $candidates += @((Join-Path $env:APPDATA "npm\$Name.cmd"), (Join-Path $env:APPDATA "npm\$Name.ps1"), (Join-Path $env:APPDATA "npm\$Name"))
+        $npmDir = Join-Path $env:APPDATA "npm"
+        $preferredCandidates += @((Join-Path $npmDir "$Name.cmd"), (Join-Path $npmDir $Name))
+        $fallbackCandidates += @((Join-Path $npmDir "$Name.ps1"))
     }
     if ($Name -eq "agy" -and $env:LOCALAPPDATA) {
-        $candidates += @((Join-Path $env:LOCALAPPDATA "agy\bin\agy.exe"))
+        $preferredCandidates += @((Join-Path $env:LOCALAPPDATA "agy\bin\agy.exe"))
     }
     foreach ($npmPrefix in (Get-NpmConfigPrefixCandidates)) {
-        $candidates += @((Join-Path $npmPrefix "$Name.cmd"), (Join-Path $npmPrefix "$Name.ps1"), (Join-Path $npmPrefix $Name))
+        $preferredCandidates += @((Join-Path $npmPrefix "$Name.cmd"), (Join-Path $npmPrefix $Name))
+        $fallbackCandidates += @((Join-Path $npmPrefix "$Name.ps1"))
     }
     $npmCommand = Get-Command npm -ErrorAction SilentlyContinue
     if ($npmCommand) {
@@ -74,7 +78,8 @@ function Get-ToolCommandCandidates {
         try {
             $npmPrefix = @(& $npmPath prefix -g 2>$null) | Select-Object -Last 1
             if ($npmPrefix -and (Test-Path $npmPrefix -ErrorAction SilentlyContinue)) {
-                $candidates += @((Join-Path $npmPrefix "$Name.cmd"), (Join-Path $npmPrefix "$Name.ps1"), (Join-Path $npmPrefix $Name))
+                $preferredCandidates += @((Join-Path $npmPrefix "$Name.cmd"), (Join-Path $npmPrefix $Name))
+                $fallbackCandidates += @((Join-Path $npmPrefix "$Name.ps1"))
             }
         } catch {}
     }
@@ -83,10 +88,32 @@ function Get-ToolCommandCandidates {
         $nodePath = if ($nodeCommand.Path) { $nodeCommand.Path } else { $nodeCommand.Source }
         if ($nodePath) {
             $nodeDir = Split-Path -Parent $nodePath
-            $candidates += @((Join-Path $nodeDir "$Name.cmd"), (Join-Path $nodeDir "$Name.ps1"), (Join-Path $nodeDir $Name))
+            $preferredCandidates += @((Join-Path $nodeDir "$Name.cmd"), (Join-Path $nodeDir $Name))
+            $fallbackCandidates += @((Join-Path $nodeDir "$Name.ps1"))
         }
     }
-    return @($candidates | Where-Object { $_ } | Select-Object -Unique)
+    return @(($preferredCandidates + $fallbackCandidates) | Where-Object { $_ } | Select-Object -Unique)
+}
+
+function Resolve-WindowsCommandShim {
+    param([string]$CommandPath)
+
+    if (-not $CommandPath) { return $CommandPath }
+
+    $extension = [System.IO.Path]::GetExtension($CommandPath)
+    if ($extension -ine ".ps1") { return $CommandPath }
+
+    $directory = Split-Path -Parent $CommandPath
+    $nameWithoutExtension = [System.IO.Path]::GetFileNameWithoutExtension($CommandPath)
+    if (-not $directory -or -not $nameWithoutExtension) { return $CommandPath }
+
+    foreach ($shim in @((Join-Path $directory "$nameWithoutExtension.cmd"), (Join-Path $directory $nameWithoutExtension))) {
+        if (Test-Path $shim -ErrorAction SilentlyContinue) {
+            return $shim
+        }
+    }
+
+    return $CommandPath
 }
 
 function Test-ToolCommandCandidate {
@@ -112,8 +139,8 @@ function Resolve-ToolCommand {
         }
     }
     $toolCommand = Get-Command $Name -ErrorAction SilentlyContinue
-    if ($toolCommand -and $toolCommand.Path) { return $toolCommand.Path }
-    if ($toolCommand -and $toolCommand.Source) { return $toolCommand.Source }
+    if ($toolCommand -and $toolCommand.Path) { return (Resolve-WindowsCommandShim -CommandPath $toolCommand.Path) }
+    if ($toolCommand -and $toolCommand.Source) { return (Resolve-WindowsCommandShim -CommandPath $toolCommand.Source) }
     return $null
 }
 


### PR DESCRIPTION
﻿## Summary

Closes #960.

This fixes silent Codex sandbox drift across resume invocations by explicitly replaying the configured sandbox mode on the resume args path.

## What Changed

- Add `--config sandbox_mode="..."` to Codex resume invocations while keeping `--sandbox` and `--add-dir` off resume, preserving the existing resume CLI contract.
- Update the `CodexAgentService.ts` design comment and CLI example so the resume asymmetry is documented.
- Change missing Codex runtime settings fallback in the Hub editor from `workspace-write` to `danger-full-access`. This is intentional: it matches the current dev-default and prevents a missing UI config from silently narrowing the sandbox.
- Prefer the official Windows Codex desktop runtime / `CODEX_CLI_PATH` before npm shims, reducing Windows sandbox helper/elevation instability.
- Normalize Windows command shim resolution to prefer `.cmd` over PowerShell `.ps1` fallbacks.

## Root Cause

Fresh Codex exec passed `--sandbox`, but the resume path omitted it because `codex exec resume` rejects `--sandbox` / `--add-dir`. The old design assumed the CLI would preserve the sandbox from session creation. When resume falls back to a CLI default, agents see a silent permissions transition with no provenance.

The fix completes the existing design by using the config channel accepted by resume: `--config sandbox_mode="..."`.

## Validation

- `pnpm run build` passed from `packages/api`
- Targeted API tests passed after rebase: 86 tests, 82 pass, 4 skip, 0 fail
  - `test/codex-agent-service.test.js`
  - `test/cli-resolve.test.js`
  - `test/windows-portable-redis-tools.test.js`
- Targeted web test passed after rebase: `pnpm.CMD --dir ../web exec vitest run src/components/__tests__/hub-cat-editor.test.tsx` with 57/57 pass

## Notes

Full web vitest was attempted before the rebase via `pnpm.CMD --dir ../web exec vitest run`; it hit pre-existing/environmental failures unrelated to this patch:

- Windows command environment lacks `grep` for `color-token-audit.test.ts`
- Existing `CliDiagnosticsPanel` path redaction expectation mismatch
- Existing F190 raw pixel font guard failures in dev OKLCH tuner files
