### PR TITLE
feat(web): Team Home dashboard on Mission Hub

### DIFF
--- a/packages/web/src/app/console-tokens.css
+++ b/packages/web/src/app/console-tokens.css
@@ -40,6 +40,8 @@
 
   /* ============ Shadows — elevation tokens（dark mode 自动 inset 高光） ============ */
   --console-shadow-soft: var(--shadow-elevation-1);
+  /* Card lift — brown-tinted, used by dashboard cards across Mission Hub */
+  --console-card-shadow: 0 8px 22px oklch(0.22 0.02 50 / 0.04);
   /* Rail (ActivityBar) active/hover lift — wider/softer than elevation-1, brown-tinted */
   --console-rail-shadow: 0 5px 14px oklch(0.22 0.02 50 / 0.07);
 
@@ -198,6 +200,8 @@
 [data-theme="dark"] {
   /* Dark rail shadow — deeper, no brown tint to avoid muddy look on dark surfaces */
   --console-rail-shadow: 0 5px 14px oklch(0 0 0 / 0.4), inset 0 1px 0 oklch(1 0 0 / 0.08);
+  /* Dark card lift — deeper, no brown tint */
+  --console-card-shadow: 0 8px 22px oklch(0 0 0 / 0.35), inset 0 1px 0 oklch(1 0 0 / 0.06);
 
   /* Mission Control dark */
   --mc-status-open-dot: #b8a88f;

--- a/packages/web/src/components/__tests__/team-home-adapter.test.ts
+++ b/packages/web/src/components/__tests__/team-home-adapter.test.ts
@@ -89,6 +89,32 @@ describe('adaptTeamHomeData', () => {
     expect(data.missions[0]?.requiredEvidence).toBeUndefined();
   });
 
+  it('prefers active lease over dispatched over approved regardless of item order', () => {
+    const approved = makeBacklogItem({
+      id: 'approved-1',
+      status: 'approved',
+      title: 'Approved Mission',
+    });
+    const dispatchedWithLease = makeBacklogItem({
+      id: 'dispatched-1',
+      status: 'dispatched',
+      title: 'Dispatched With Lease',
+      lease: {
+        ownerCatId: catId('claude'),
+        state: 'active',
+        acquiredAt: Date.UTC(2026, 5, 18, 9, 10, 0),
+        heartbeatAt: Date.UTC(2026, 5, 18, 9, 20, 0),
+        expiresAt: Date.UTC(2026, 5, 18, 10, 0, 0),
+      },
+    });
+
+    const data = adaptTeamHomeData({ items: [approved, dispatchedWithLease] });
+
+    expect(data.baton.scope).toBe('Dispatched With Lease');
+    expect(data.baton.holder).toBe('claude');
+    expect(data.mission.activeFeatureId).toBe('F049');
+  });
+
   it('only treats approved or dispatched items as active work', () => {
     const suggested = makeBacklogItem({ id: 'suggested-1', status: 'suggested' });
     const done = makeBacklogItem({ id: 'done-1', status: 'done' });

--- a/packages/web/src/components/__tests__/team-home-adapter.test.ts
+++ b/packages/web/src/components/__tests__/team-home-adapter.test.ts
@@ -1,6 +1,7 @@
 import type { BacklogItem, CatId } from '@cat-cafe/shared';
 import { describe, expect, it } from 'vitest';
 import { adaptTeamHomeData } from '../mission-control/team-home/adapter';
+import { teamHomeFixture } from '../mission-control/team-home/fixture';
 
 function catId(id: string): CatId {
   return id as CatId;
@@ -69,5 +70,32 @@ describe('adaptTeamHomeData', () => {
     expect(data.team.find((member) => member.id === 'codex')?.lastActiveAt).toBe(new Date(lastActiveAt).toISOString());
     expect(data.team.find((member) => member.id === 'claude')?.currentContext).toBe('参与：Team Home MVP');
     expect(data.team.find((member) => member.id === 'claude')?.lastActiveAt).toBe(new Date(lastActiveAt).toISOString());
+  });
+
+  it('does not treat audit lifecycle logs as evidence items', () => {
+    const data = adaptTeamHomeData({
+      items: [
+        makeBacklogItem({
+          audit: [
+            { id: 'audit-created', action: 'created', actor: { kind: 'user', id: 'u_test' }, timestamp: 1 },
+            { id: 'audit-dispatched', action: 'dispatched', actor: { kind: 'user', id: 'u_test' }, timestamp: 2 },
+            { id: 'audit-heartbeat', action: 'lease_heartbeat', actor: { kind: 'cat', id: 'codex' }, timestamp: 3 },
+          ],
+        }),
+      ],
+    });
+
+    expect(data.missions[0]?.evidenceCount).toBeUndefined();
+    expect(data.missions[0]?.requiredEvidence).toBeUndefined();
+  });
+
+  it('only treats approved or dispatched items as active work', () => {
+    const suggested = makeBacklogItem({ id: 'suggested-1', status: 'suggested' });
+    const done = makeBacklogItem({ id: 'done-1', status: 'done' });
+    const data = adaptTeamHomeData({ items: [suggested, done] });
+
+    expect(data.missions).toHaveLength(0);
+    expect(data.baton.scope).toBe(teamHomeFixture.baton.scope);
+    expect(data.mission.activeFeatureId).toBe('—');
   });
 });

--- a/packages/web/src/components/__tests__/team-home-adapter.test.ts
+++ b/packages/web/src/components/__tests__/team-home-adapter.test.ts
@@ -1,0 +1,73 @@
+import type { BacklogItem, CatId } from '@cat-cafe/shared';
+import { describe, expect, it } from 'vitest';
+import { adaptTeamHomeData } from '../mission-control/team-home/adapter';
+
+function catId(id: string): CatId {
+  return id as CatId;
+}
+
+function makeBacklogItem(overrides: Partial<BacklogItem> = {}): BacklogItem {
+  const now = Date.UTC(2026, 5, 18, 9, 0, 0);
+  return {
+    id: 'backlog-f049',
+    userId: 'u_test',
+    title: '[F049] Mission Hub',
+    summary: 'Mission Hub work',
+    priority: 'p1',
+    tags: ['source:docs-backlog', 'feature:f049'],
+    status: 'dispatched',
+    createdBy: 'user',
+    createdAt: now - 10_000,
+    updatedAt: now - 1_000,
+    dispatchedAt: now - 5_000,
+    dispatchedThreadId: 'thread-f049',
+    dispatchedThreadPhase: 'coding',
+    audit: [{ id: 'audit-dispatched', action: 'dispatched', actor: { kind: 'user', id: 'u_test' }, timestamp: now }],
+    ...overrides,
+  };
+}
+
+describe('adaptTeamHomeData', () => {
+  it('derives the active feature from docs backlog feature tags', () => {
+    const data = adaptTeamHomeData({ items: [makeBacklogItem()] });
+
+    expect(data.mission.activeFeatureId).toBe('F049');
+    expect(data.mission.truthSourceUrl).toBe('/api/backlog/feature-doc-detail?featureId=F049');
+  });
+
+  it('projects active lease and thread state into the baton and team cards', () => {
+    const acquiredAt = Date.UTC(2026, 5, 18, 9, 5, 0);
+    const heartbeatAt = Date.UTC(2026, 5, 18, 9, 20, 0);
+    const lastActiveAt = Date.UTC(2026, 5, 18, 9, 25, 0);
+    const item = makeBacklogItem({
+      title: 'Team Home MVP',
+      lease: {
+        ownerCatId: catId('codex'),
+        state: 'active',
+        acquiredAt,
+        heartbeatAt,
+        expiresAt: Date.UTC(2026, 5, 18, 10, 0, 0),
+      },
+    });
+
+    const data = adaptTeamHomeData({
+      items: [item],
+      threadsByBacklogId: {
+        [item.id]: {
+          lastActiveAt,
+          participants: [catId('codex'), catId('claude')],
+        },
+      },
+    });
+
+    expect(data.baton.holder).toBe('codex');
+    expect(data.baton.scope).toBe('Team Home MVP');
+    expect(data.baton.since).toBe(new Date(acquiredAt).toISOString());
+    expect(data.baton.nextStep).toBe('@codex 正在实现中');
+
+    expect(data.team.find((member) => member.id === 'codex')?.currentContext).toBe('持球：Team Home MVP');
+    expect(data.team.find((member) => member.id === 'codex')?.lastActiveAt).toBe(new Date(lastActiveAt).toISOString());
+    expect(data.team.find((member) => member.id === 'claude')?.currentContext).toBe('参与：Team Home MVP');
+    expect(data.team.find((member) => member.id === 'claude')?.lastActiveAt).toBe(new Date(lastActiveAt).toISOString());
+  });
+});

--- a/packages/web/src/components/mission-control/MissionControlPage.tsx
+++ b/packages/web/src/components/mission-control/MissionControlPage.tsx
@@ -13,6 +13,7 @@ import { ImportProjectModal } from './ImportProjectModal';
 import { QuickCreateForm } from './QuickCreateForm';
 import { SuggestionDrawer } from './SuggestionDrawer';
 import { ThreadSituationPanel } from './ThreadSituationPanel';
+import { TeamHomePanel } from './team-home/TeamHomePanel';
 import { WorkflowSopPanel } from './WorkflowSopPanel';
 
 interface BacklogListResponse {
@@ -472,6 +473,18 @@ export function MissionControlPage() {
           <div className="mt-4 flex console-divider-b">
             <button
               type="button"
+              onClick={() => setActiveTab('today')}
+              className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
+                activeTab === 'today'
+                  ? 'rounded-lg bg-[var(--console-active-bg)] text-cafe'
+                  : 'text-cafe-muted hover:text-cafe-secondary hover:bg-[var(--console-hover-bg)]'
+              }`}
+              data-testid="mc-tab-today"
+            >
+              今日团队
+            </button>
+            <button
+              type="button"
               onClick={() => setActiveTab('features')}
               className={`px-5 py-2.5 text-sm font-semibold transition-colors ${
                 activeTab === 'features'
@@ -541,6 +554,8 @@ export function MissionControlPage() {
           <div className="min-h-0 flex-1 pt-4">
             {activeProject ? (
               <ExternalProjectTab project={activeProject} />
+            ) : activeTab === 'today' ? (
+              <TeamHomePanel items={items} threadsByBacklogId={threadsByBacklogId} />
             ) : activeTab === 'features' ? (
               <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_340px]">
                 <div className="space-y-4">

--- a/packages/web/src/components/mission-control/team-home/TeamHomePanel.tsx
+++ b/packages/web/src/components/mission-control/team-home/TeamHomePanel.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import type { BacklogItem, CatId } from '@cat-cafe/shared';
+import { useMemo } from 'react';
+import { adaptTeamHomeData } from './adapter';
+import { ActiveMissionsTable } from './blocks/ActiveMissionsTable';
+import { BatonBoard } from './blocks/BatonBoard';
+import { CultureConstitutionPanel } from './blocks/CultureConstitutionPanel';
+import { CVODecisionQueue } from './blocks/CVODecisionQueue';
+import { QualityGateChecklist } from './blocks/QualityGateChecklist';
+import { RecentMemoryFeed } from './blocks/RecentMemoryFeed';
+import { RiskWatch } from './blocks/RiskWatch';
+import { SharedMissionBanner } from './blocks/SharedMissionBanner';
+import { TeamStatusCards } from './blocks/TeamStatusCards';
+
+interface TeamHomePanelProps {
+  items: BacklogItem[];
+  threadsByBacklogId?: Record<string, { lastActiveAt: number; participants: CatId[] }>;
+}
+
+export function TeamHomePanel({ items, threadsByBacklogId }: TeamHomePanelProps) {
+  const data = useMemo(() => adaptTeamHomeData({ items, threadsByBacklogId }), [items, threadsByBacklogId]);
+
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row">
+      <div className="min-w-0 flex-1 space-y-4">
+        <SharedMissionBanner mission={data.mission} />
+        <BatonBoard baton={data.baton} />
+        <div className="grid gap-4 md:grid-cols-2">
+          <QualityGateChecklist gates={data.qualityGates} />
+          <TeamStatusCards members={data.team} />
+        </div>
+        <ActiveMissionsTable missions={data.missions} />
+        <CultureConstitutionPanel culture={data.culture} />
+      </div>
+      <aside className="w-full shrink-0 space-y-4 lg:w-80">
+        <CVODecisionQueue items={data.cvoDecisions} />
+        <RiskWatch risks={data.risks} />
+        <RecentMemoryFeed items={data.recentMemory} />
+      </aside>
+    </div>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/adapter.ts
+++ b/packages/web/src/components/mission-control/team-home/adapter.ts
@@ -1,0 +1,122 @@
+import type { BacklogItem, CatId, ThreadPhase } from '@cat-cafe/shared';
+import { teamHomeFixture } from './fixture';
+import type { TeamHomeData, TeamHomeMissionSummary, TeamHomeParticipantId, TeamHomeSOPStage } from './types';
+
+export interface TeamHomeAdapterInput {
+  items: BacklogItem[];
+  threadsByBacklogId?: Record<string, { lastActiveAt: number; participants: CatId[] }>;
+}
+
+function mapThreadPhaseToSOP(phase: ThreadPhase | undefined): TeamHomeSOPStage {
+  switch (phase) {
+    case 'coding':
+      return 'impl';
+    case 'research':
+    case 'brainstorm':
+      return 'kickoff';
+    default:
+      return 'impl';
+  }
+}
+
+function inferSOPStage(item: BacklogItem): TeamHomeSOPStage {
+  const leaseState = item.lease?.state;
+  if (leaseState === 'active') return mapThreadPhaseToSOP(item.dispatchedThreadPhase);
+
+  switch (item.status) {
+    case 'suggested':
+    case 'approved':
+      return 'kickoff';
+    case 'dispatched':
+      return mapThreadPhaseToSOP(item.dispatchedThreadPhase);
+    case 'done':
+      return 'completion';
+    default:
+      return 'kickoff';
+  }
+}
+
+function inferOwner(item: BacklogItem): TeamHomeParticipantId {
+  if (item.lease?.state === 'active' && item.lease.ownerCatId) {
+    return item.lease.ownerCatId;
+  }
+  if (item.suggestion?.catId) {
+    return item.suggestion.catId;
+  }
+  return 'kiimi' as CatId;
+}
+
+function inferNextAction(item: BacklogItem): string {
+  const stage = inferSOPStage(item);
+  const owner = inferOwner(item);
+  switch (stage) {
+    case 'kickoff':
+      return `等待 @${owner} 领取或进入 kickoff`;
+    case 'impl':
+      return `@${owner} 正在实现中`;
+    case 'quality_gate':
+      return `@${owner} 自检中，等待 quality gate 通过`;
+    case 'review':
+      return `@${owner} 完成后进入 cross-cat review`;
+    case 'merge':
+      return '等待 merge gate 与最终合入';
+    case 'completion':
+      return '已完成';
+    default:
+      return '等待下一步动作';
+  }
+}
+
+function extractFeatureIdFromTags(tags: readonly string[]): string | undefined {
+  const featureTag = tags.find((tag) => /^F\d+$/i.test(tag));
+  return featureTag ? featureTag.toUpperCase() : undefined;
+}
+
+function deriveMissionFromItems(
+  items: BacklogItem[],
+): Pick<TeamHomeData['mission'], 'phase' | 'activeFeatureId' | 'truthSourceUrl'> {
+  if (items.length === 0) {
+    return { phase: 'kickoff', activeFeatureId: '—' };
+  }
+
+  const dispatched = items.find((i) => i.status === 'dispatched');
+  const candidate = dispatched ?? items.find((i) => i.status === 'approved') ?? items[0];
+  const featureId = extractFeatureIdFromTags(candidate?.tags ?? []);
+
+  return {
+    phase: inferSOPStage(candidate),
+    activeFeatureId: candidate?.id ?? '—',
+    truthSourceUrl: featureId ? `/docs/features/${featureId}.md` : undefined,
+  };
+}
+
+export function adaptTeamHomeData(input: TeamHomeAdapterInput): TeamHomeData {
+  const { items } = input;
+
+  const activeStatuses = new Set<BacklogItem['status']>(['approved', 'dispatched']);
+
+  const missions: TeamHomeMissionSummary[] = items
+    .filter((item) => activeStatuses.has(item.status))
+    .slice(0, 8)
+    .map((item) => ({
+      id: item.id,
+      name: item.title,
+      owner: inferOwner(item),
+      stage: inferSOPStage(item),
+      evidenceCount: item.audit?.length ?? 0,
+      requiredEvidence: 4,
+      nextAction: inferNextAction(item),
+      updatedAt: new Date(item.updatedAt).toISOString(),
+    }));
+
+  const missionOverride = deriveMissionFromItems(items);
+
+  return {
+    ...teamHomeFixture,
+    mission: {
+      ...teamHomeFixture.mission,
+      ...missionOverride,
+    },
+    missions,
+  };
+}

--- a/packages/web/src/components/mission-control/team-home/adapter.ts
+++ b/packages/web/src/components/mission-control/team-home/adapter.ts
@@ -57,6 +57,8 @@ function inferOwner(item: BacklogItem): TeamHomeParticipantId {
   return 'kiimi' as CatId;
 }
 
+const MAX_VISIBLE_MISSIONS = 8;
+
 function inferNextAction(item: BacklogItem): string {
   const stage = inferSOPStage(item);
   const owner = inferOwner(item);
@@ -65,12 +67,6 @@ function inferNextAction(item: BacklogItem): string {
       return `等待 @${owner} 领取或进入 kickoff`;
     case 'impl':
       return `@${owner} 正在实现中`;
-    case 'quality_gate':
-      return `@${owner} 自检中，等待 quality gate 通过`;
-    case 'review':
-      return `@${owner} 完成后进入 cross-cat review`;
-    case 'merge':
-      return '等待 merge gate 与最终合入';
     case 'completion':
       return '已完成';
     default:
@@ -93,13 +89,8 @@ function extractFeatureIdFromTags(tags: readonly string[]): string | undefined {
 }
 
 function pickActiveItem(items: BacklogItem[]): BacklogItem | undefined {
-  return (
-    items.find((item) => item.lease?.state === 'active') ??
-    items.find((item) => item.status === 'dispatched') ??
-    items.find((item) => item.status === 'approved') ??
-    items.find((item) => item.status === 'suggested') ??
-    items[0]
-  );
+  const activeStatuses = new Set<BacklogItem['status']>(['approved', 'dispatched']);
+  return items.find((item) => activeStatuses.has(item.status));
 }
 
 function deriveMissionFromItem(
@@ -219,14 +210,12 @@ export function adaptTeamHomeData(input: TeamHomeAdapterInput): TeamHomeData {
 
   const missions: TeamHomeMissionSummary[] = items
     .filter((item) => activeStatuses.has(item.status))
-    .slice(0, 8)
+    .slice(0, MAX_VISIBLE_MISSIONS)
     .map((item) => ({
       id: item.id,
       name: item.title,
       owner: inferOwner(item),
       stage: inferSOPStage(item),
-      evidenceCount: item.audit?.length ?? 0,
-      requiredEvidence: 4,
       nextAction: inferNextAction(item),
       updatedAt: new Date(item.updatedAt).toISOString(),
     }));

--- a/packages/web/src/components/mission-control/team-home/adapter.ts
+++ b/packages/web/src/components/mission-control/team-home/adapter.ts
@@ -2,9 +2,20 @@ import type { BacklogItem, CatId, ThreadPhase } from '@cat-cafe/shared';
 import { teamHomeFixture } from './fixture';
 import type { TeamHomeData, TeamHomeMissionSummary, TeamHomeParticipantId, TeamHomeSOPStage } from './types';
 
+interface TeamHomeThreadSummary {
+  lastActiveAt: number;
+  participants: CatId[];
+}
+
+interface TeamMemberUpdate {
+  currentContext: string;
+  lastActiveAt: number;
+  priority: number;
+}
+
 export interface TeamHomeAdapterInput {
   items: BacklogItem[];
-  threadsByBacklogId?: Record<string, { lastActiveAt: number; participants: CatId[] }>;
+  threadsByBacklogId?: Record<string, TeamHomeThreadSummary>;
 }
 
 function mapThreadPhaseToSOP(phase: ThreadPhase | undefined): TeamHomeSOPStage {
@@ -67,33 +78,144 @@ function inferNextAction(item: BacklogItem): string {
   }
 }
 
-function extractFeatureIdFromTags(tags: readonly string[]): string | undefined {
-  const featureTag = tags.find((tag) => /^F\d+$/i.test(tag));
-  return featureTag ? featureTag.toUpperCase() : undefined;
+function normalizeFeatureId(raw: string): string | undefined {
+  const match = raw.match(/^f0*(\d+)$/i);
+  return match ? `F${match[1].padStart(3, '0')}` : undefined;
 }
 
-function deriveMissionFromItems(
-  items: BacklogItem[],
+function extractFeatureIdFromTags(tags: readonly string[]): string | undefined {
+  for (const tag of tags) {
+    const prefixed = tag.match(/^feature:(f\d+)$/i);
+    if (prefixed) return normalizeFeatureId(prefixed[1]);
+    if (/^F\d+$/i.test(tag)) return normalizeFeatureId(tag);
+  }
+  return undefined;
+}
+
+function pickActiveItem(items: BacklogItem[]): BacklogItem | undefined {
+  return (
+    items.find((item) => item.lease?.state === 'active') ??
+    items.find((item) => item.status === 'dispatched') ??
+    items.find((item) => item.status === 'approved') ??
+    items.find((item) => item.status === 'suggested') ??
+    items[0]
+  );
+}
+
+function deriveMissionFromItem(
+  item: BacklogItem | undefined,
 ): Pick<TeamHomeData['mission'], 'phase' | 'activeFeatureId' | 'truthSourceUrl'> {
-  if (items.length === 0) {
+  if (!item) {
     return { phase: 'kickoff', activeFeatureId: '—' };
   }
 
-  const dispatched = items.find((i) => i.status === 'dispatched');
-  const candidate = dispatched ?? items.find((i) => i.status === 'approved') ?? items[0];
-  const featureId = extractFeatureIdFromTags(candidate?.tags ?? []);
+  const featureId = extractFeatureIdFromTags(item.tags);
 
   return {
-    phase: inferSOPStage(candidate),
-    activeFeatureId: candidate?.id ?? '—',
-    truthSourceUrl: featureId ? `/docs/features/${featureId}.md` : undefined,
+    phase: inferSOPStage(item),
+    activeFeatureId: featureId ?? item.id,
+    truthSourceUrl: featureId
+      ? `/api/backlog/feature-doc-detail?featureId=${encodeURIComponent(featureId)}`
+      : undefined,
   };
 }
 
+function deriveBatonFromItem(item: BacklogItem | undefined): TeamHomeData['baton'] {
+  if (!item) return teamHomeFixture.baton;
+
+  const holder = inferOwner(item);
+  const since = item.lease?.state === 'active' ? item.lease.acquiredAt : (item.dispatchedAt ?? item.updatedAt);
+  return {
+    ...teamHomeFixture.baton,
+    holder,
+    scope: item.title,
+    since: new Date(since).toISOString(),
+    nextStep: inferNextAction(item),
+    nextOwner: undefined,
+    blocker: null,
+  };
+}
+
+function shouldReplaceTeamUpdate(existing: TeamMemberUpdate | undefined, next: TeamMemberUpdate): boolean {
+  return (
+    !existing ||
+    next.priority > existing.priority ||
+    (next.priority === existing.priority && next.lastActiveAt > existing.lastActiveAt)
+  );
+}
+
+function setTeamUpdate(
+  updates: Map<string, TeamMemberUpdate>,
+  id: TeamHomeParticipantId,
+  currentContext: string,
+  lastActiveAt: number,
+  priority: number,
+): void {
+  const next = { currentContext, lastActiveAt, priority };
+  if (shouldReplaceTeamUpdate(updates.get(id), next)) {
+    updates.set(id, next);
+  }
+}
+
+function isVisibleTeamItem(item: BacklogItem): boolean {
+  return item.status === 'approved' || item.status === 'dispatched';
+}
+
+function ownerContextPrefix(item: BacklogItem): string {
+  if (item.lease?.state === 'active') return '持球';
+  if (item.status === 'dispatched') return '执行';
+  return '待派发';
+}
+
+function addItemTeamUpdates(
+  updates: Map<string, TeamMemberUpdate>,
+  item: BacklogItem,
+  thread: TeamHomeThreadSummary | undefined,
+): void {
+  const owner = inferOwner(item);
+  const ownerTimestamp = thread?.lastActiveAt ?? item.lease?.heartbeatAt ?? item.updatedAt;
+  setTeamUpdate(updates, owner, `${ownerContextPrefix(item)}：${item.title}`, ownerTimestamp, 2);
+
+  if (!thread) return;
+  for (const participant of thread.participants) {
+    if (participant === owner) continue;
+    setTeamUpdate(updates, participant, `参与：${item.title}`, thread.lastActiveAt, 1);
+  }
+}
+
+function collectTeamUpdates(
+  items: BacklogItem[],
+  threadsByBacklogId: Record<string, TeamHomeThreadSummary>,
+): Map<string, TeamMemberUpdate> {
+  const updates = new Map<string, TeamMemberUpdate>();
+  for (const item of items) {
+    if (isVisibleTeamItem(item)) addItemTeamUpdates(updates, item, threadsByBacklogId[item.id]);
+  }
+  return updates;
+}
+
+function deriveTeamFromItems(
+  items: BacklogItem[],
+  threadsByBacklogId: Record<string, TeamHomeThreadSummary>,
+): TeamHomeData['team'] {
+  const updates = collectTeamUpdates(items, threadsByBacklogId);
+  return teamHomeFixture.team.map((member) => {
+    const update = updates.get(member.id);
+    const baseMember = { ...member, capabilities: [...member.capabilities] };
+    if (!update) return baseMember;
+    return {
+      ...baseMember,
+      currentContext: update.currentContext,
+      lastActiveAt: new Date(update.lastActiveAt).toISOString(),
+    };
+  });
+}
+
 export function adaptTeamHomeData(input: TeamHomeAdapterInput): TeamHomeData {
-  const { items } = input;
+  const { items, threadsByBacklogId = {} } = input;
 
   const activeStatuses = new Set<BacklogItem['status']>(['approved', 'dispatched']);
+  const activeItem = pickActiveItem(items);
 
   const missions: TeamHomeMissionSummary[] = items
     .filter((item) => activeStatuses.has(item.status))
@@ -109,7 +231,7 @@ export function adaptTeamHomeData(input: TeamHomeAdapterInput): TeamHomeData {
       updatedAt: new Date(item.updatedAt).toISOString(),
     }));
 
-  const missionOverride = deriveMissionFromItems(items);
+  const missionOverride = deriveMissionFromItem(activeItem);
 
   return {
     ...teamHomeFixture,
@@ -117,6 +239,8 @@ export function adaptTeamHomeData(input: TeamHomeAdapterInput): TeamHomeData {
       ...teamHomeFixture.mission,
       ...missionOverride,
     },
+    baton: deriveBatonFromItem(activeItem),
+    team: deriveTeamFromItems(items, threadsByBacklogId),
     missions,
   };
 }

--- a/packages/web/src/components/mission-control/team-home/adapter.ts
+++ b/packages/web/src/components/mission-control/team-home/adapter.ts
@@ -88,9 +88,17 @@ function extractFeatureIdFromTags(tags: readonly string[]): string | undefined {
   return undefined;
 }
 
+function isActiveMissionItem(item: BacklogItem): boolean {
+  return item.status === 'approved' || item.status === 'dispatched';
+}
+
 function pickActiveItem(items: BacklogItem[]): BacklogItem | undefined {
-  const activeStatuses = new Set<BacklogItem['status']>(['approved', 'dispatched']);
-  return items.find((item) => activeStatuses.has(item.status));
+  const activeItems = items.filter(isActiveMissionItem);
+  return (
+    activeItems.find((item) => item.lease?.state === 'active') ??
+    activeItems.find((item) => item.status === 'dispatched') ??
+    activeItems.find((item) => item.status === 'approved')
+  );
 }
 
 function deriveMissionFromItem(

--- a/packages/web/src/components/mission-control/team-home/blocks/ActiveMissionsTable.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/ActiveMissionsTable.tsx
@@ -51,7 +51,9 @@ export function ActiveMissionsTable({ missions }: ActiveMissionsTableProps) {
                   </span>
                 </td>
                 <td className="py-2.5 text-xs text-cafe-secondary">
-                  {mission.evidenceCount}/{mission.requiredEvidence}
+                  {mission.evidenceCount != null && mission.requiredEvidence != null
+                    ? `${mission.evidenceCount}/${mission.requiredEvidence}`
+                    : '—'}
                 </td>
                 <td className="max-w-xs truncate py-2.5 text-xs text-cafe-secondary">{mission.nextAction}</td>
               </tr>

--- a/packages/web/src/components/mission-control/team-home/blocks/ActiveMissionsTable.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/ActiveMissionsTable.tsx
@@ -1,0 +1,64 @@
+import { formatHandle } from '../cat-handle';
+import type { TeamHomeData } from '../types';
+
+interface ActiveMissionsTableProps {
+  missions: TeamHomeData['missions'];
+}
+
+const stageLabels: Record<TeamHomeData['missions'][number]['stage'], string> = {
+  kickoff: '启动',
+  impl: '实现',
+  quality_gate: '质量门禁',
+  review: 'Review',
+  merge: 'Merge',
+  completion: '完成',
+};
+
+export function ActiveMissionsTable({ missions }: ActiveMissionsTableProps) {
+  if (missions.length === 0) {
+    return (
+      <section className="rounded-2xl bg-[var(--console-card-bg)] p-6 shadow-[var(--console-card-shadow)]">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Active Missions</h2>
+        <p className="mt-4 text-center text-sm text-cafe-secondary">当前没有进行中的 mission</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Active Missions</h2>
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="text-xs text-cafe-muted">
+              <th className="pb-2 font-medium">ID</th>
+              <th className="pb-2 font-medium">Name</th>
+              <th className="pb-2 font-medium">Owner</th>
+              <th className="pb-2 font-medium">Stage</th>
+              <th className="pb-2 font-medium">Evidence</th>
+              <th className="pb-2 font-medium">Next Action</th>
+            </tr>
+          </thead>
+          <tbody className="text-cafe">
+            {missions.map((mission) => (
+              <tr key={mission.id} className="border-t border-[var(--console-border-soft)]">
+                <td className="py-2.5 font-mono text-xs text-cafe-secondary">{mission.id}</td>
+                <td className="py-2.5">{mission.name}</td>
+                <td className="py-2.5">{formatHandle(mission.owner)}</td>
+                <td className="py-2.5">
+                  <span className="rounded-md bg-[var(--console-shell-bg)] px-2 py-0.5 text-xs">
+                    {stageLabels[mission.stage]}
+                  </span>
+                </td>
+                <td className="py-2.5 text-xs text-cafe-secondary">
+                  {mission.evidenceCount}/{mission.requiredEvidence}
+                </td>
+                <td className="max-w-xs truncate py-2.5 text-xs text-cafe-secondary">{mission.nextAction}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/BatonBoard.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/BatonBoard.tsx
@@ -1,0 +1,37 @@
+import { formatHandleWithName } from '../cat-handle';
+import type { TeamHomeData } from '../types';
+
+interface BatonBoardProps {
+  baton: TeamHomeData['baton'];
+}
+
+export function BatonBoard({ baton }: BatonBoardProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-6 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Baton Board</h2>
+      <div className="mt-3 flex items-start gap-3">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-[var(--console-active-bg)] text-lg">
+          🏀
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-cafe">
+            {formatHandleWithName(baton.holder)}
+            <span className="mx-2 text-cafe-muted">·</span>
+            <span className="text-cafe-secondary">{baton.scope}</span>
+          </p>
+          <p className="mt-1 text-xs text-cafe-secondary">持球 since {new Date(baton.since).toLocaleString('zh-CN')}</p>
+          <div className="mt-3 rounded-xl bg-[var(--console-shell-bg)] px-3 py-2.5">
+            <p className="text-xs text-cafe-muted">Next Step</p>
+            <p className="mt-0.5 text-sm text-cafe">{baton.nextStep}</p>
+          </div>
+          {baton.nextOwner && (
+            <p className="mt-2 text-xs text-cafe-secondary">下一棒：{formatHandleWithName(baton.nextOwner)}</p>
+          )}
+          {baton.blocker && (
+            <p className="mt-2 text-xs font-medium text-[var(--semantic-danger)]">阻塞：{baton.blocker}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/CVODecisionQueue.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/CVODecisionQueue.tsx
@@ -1,0 +1,48 @@
+import type { TeamHomeData } from '../types';
+
+interface CVODecisionQueueProps {
+  items: TeamHomeData['cvoDecisions'];
+}
+
+const urgencyLabels: Record<TeamHomeData['cvoDecisions'][number]['urgency'], string> = {
+  now: '现在',
+  this_week: '本周',
+  later: '稍后',
+};
+
+export function CVODecisionQueue({ items }: CVODecisionQueueProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">CVO Decision Queue</h2>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm text-cafe-secondary">暂无待决策事项</p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {items.map((item) => (
+            <li key={item.id} className="rounded-xl bg-[var(--console-shell-bg)] px-3 py-2.5">
+              <div className="flex items-start justify-between gap-2">
+                <p className="text-sm font-medium text-cafe">{item.question}</p>
+                <span className="shrink-0 rounded bg-[var(--console-active-bg)] px-1.5 py-0.5 text-micro font-medium text-cafe">
+                  {urgencyLabels[item.urgency]}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-cafe-secondary">{item.context}</p>
+              {item.suggestedOptions && item.suggestedOptions.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {item.suggestedOptions.map((option) => (
+                    <span
+                      key={option}
+                      className="rounded bg-[var(--console-card-bg)] px-2 py-0.5 text-xs text-cafe-secondary"
+                    >
+                      {option}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/CultureConstitutionPanel.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/CultureConstitutionPanel.tsx
@@ -1,0 +1,31 @@
+import type { TeamHomeData } from '../types';
+
+interface CultureConstitutionPanelProps {
+  culture: TeamHomeData['culture'];
+}
+
+export function CultureConstitutionPanel({ culture }: CultureConstitutionPanelProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Culture Constitution</h2>
+      <p className="mt-2 text-sm font-medium text-cafe">今日信条：{culture.headline}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        {culture.rules.map((rule) => (
+          <span
+            key={rule.id}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              rule.active
+                ? 'bg-[var(--console-active-bg)] text-cafe'
+                : 'bg-[var(--console-shell-bg)] text-cafe-secondary'
+            }`}
+          >
+            {rule.text}
+          </span>
+        ))}
+      </div>
+      <p className="mt-4 text-xs leading-relaxed text-cafe-secondary">
+        我们不是一组被调用的模型。我们是一支有愿景、有边界、有记忆、有复盘、有交付纪律的 Agent 原生开发团队。
+      </p>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/QualityGateChecklist.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/QualityGateChecklist.tsx
@@ -1,0 +1,49 @@
+import { formatHandle } from '../cat-handle';
+import type { TeamHomeData } from '../types';
+
+interface QualityGateChecklistProps {
+  gates: TeamHomeData['qualityGates'];
+}
+
+const statusIndicator: Record<TeamHomeData['qualityGates'][number]['status'], { dot: string; label: string }> = {
+  passed: { dot: 'bg-[var(--semantic-success)]', label: '已通过' },
+  pending: { dot: 'bg-[var(--semantic-warning)]', label: '进行中' },
+  failed: { dot: 'bg-[var(--semantic-danger)]', label: '未通过' },
+  not_started: { dot: 'bg-cafe-muted', label: '未开始' },
+};
+
+export function QualityGateChecklist({ gates }: QualityGateChecklistProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Quality Gates</h2>
+      <ul className="mt-3 space-y-2">
+        {gates.map((gate) => {
+          const { dot, label } = statusIndicator[gate.status];
+          return (
+            <li
+              key={gate.name}
+              className="flex items-center justify-between rounded-xl bg-[var(--console-shell-bg)] px-3 py-2"
+            >
+              <div className="flex items-center gap-2.5">
+                <span className={`h-2 w-2 rounded-full ${dot}`} />
+                <span className="text-sm text-cafe">{gate.label}</span>
+              </div>
+              <div className="flex items-center gap-2 text-xs text-cafe-secondary">
+                <span>{label}</span>
+                {gate.owner && <span>{formatHandle(gate.owner)}</span>}
+                {gate.evidenceRef && (
+                  <a
+                    href={gate.evidenceRef}
+                    className="text-cafe-secondary underline-offset-2 hover:text-cafe hover:underline"
+                  >
+                    证据
+                  </a>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/RecentMemoryFeed.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/RecentMemoryFeed.tsx
@@ -1,0 +1,51 @@
+import type { TeamHomeData } from '../types';
+
+interface RecentMemoryFeedProps {
+  items: TeamHomeData['recentMemory'];
+}
+
+const kindLabels: Record<TeamHomeData['recentMemory'][number]['kind'], string> = {
+  lesson: 'Lesson',
+  adr: 'ADR',
+  skill: 'Skill',
+  decision: 'Decision',
+};
+
+const kindBadge: Record<TeamHomeData['recentMemory'][number]['kind'], string> = {
+  lesson: 'bg-[var(--semantic-info-surface)] text-[var(--semantic-info)]',
+  adr: 'bg-[var(--semantic-success-surface)] text-[var(--semantic-success)]',
+  skill: 'bg-[var(--semantic-warning-surface)] text-[var(--semantic-warning)]',
+  decision: 'bg-[var(--console-active-bg)] text-cafe',
+};
+
+export function RecentMemoryFeed({ items }: RecentMemoryFeedProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Recent Memory</h2>
+      {items.length === 0 ? (
+        <p className="mt-3 text-sm text-cafe-secondary">最近没有沉淀</p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className="flex items-start justify-between gap-2 rounded-xl bg-[var(--console-shell-bg)] px-3 py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <a href={item.anchor} className="text-sm font-medium text-cafe hover:underline">
+                  {item.title}
+                </a>
+                <p className="mt-0.5 text-xs text-cafe-secondary">
+                  {new Date(item.createdAt).toLocaleDateString('zh-CN')}
+                </p>
+              </div>
+              <span className={`shrink-0 rounded px-1.5 py-0.5 text-micro font-medium ${kindBadge[item.kind]}`}>
+                {kindLabels[item.kind]}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/RiskWatch.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/RiskWatch.tsx
@@ -1,0 +1,46 @@
+import type { TeamHomeData } from '../types';
+
+interface RiskWatchProps {
+  risks: TeamHomeData['risks'];
+}
+
+const severityDot: Record<TeamHomeData['risks'][number]['severity'], string> = {
+  high: 'bg-[var(--semantic-danger)]',
+  medium: 'bg-[var(--semantic-warning)]',
+  low: 'bg-cafe-muted',
+};
+
+const riskIcon: Record<TeamHomeData['risks'][number]['type'], string> = {
+  vision_drift: '⚠',
+  no_evidence: '📛',
+  cross_thread_block: '🔒',
+  unresolved_review: '👀',
+};
+
+export function RiskWatch({ risks }: RiskWatchProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Risk Watch</h2>
+      {risks.length === 0 ? (
+        <p className="mt-3 text-sm text-cafe-secondary">当前无风险告警</p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {risks.map((risk) => (
+            <li key={risk.id} className="flex items-start gap-2.5 rounded-xl bg-[var(--console-shell-bg)] px-3 py-2.5">
+              <span className="text-base">{riskIcon[risk.type]}</span>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className={`h-2 w-2 rounded-full ${severityDot[risk.severity]}`} />
+                  <span className="text-sm text-cafe">{risk.message}</span>
+                </div>
+                {risk.relatedFeatureId && (
+                  <p className="mt-0.5 text-xs text-cafe-secondary">关联：{risk.relatedFeatureId}</p>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/SharedMissionBanner.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/SharedMissionBanner.tsx
@@ -1,0 +1,41 @@
+import type { TeamHomeData } from '../types';
+
+interface SharedMissionBannerProps {
+  mission: TeamHomeData['mission'];
+}
+
+const stageLabels: Record<TeamHomeData['mission']['phase'], string> = {
+  kickoff: '启动',
+  impl: '实现',
+  quality_gate: '质量门禁',
+  review: 'Review',
+  merge: 'Merge',
+  completion: '完成',
+};
+
+export function SharedMissionBanner({ mission }: SharedMissionBannerProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-6 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Shared Mission</h2>
+      <p className="mt-2 text-lg font-medium leading-relaxed text-cafe">{mission.text}</p>
+      <div className="mt-4 flex flex-wrap items-center gap-3 text-xs text-cafe-secondary">
+        <span className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--console-shell-bg)] px-2.5 py-1">
+          Phase:
+          <span className="font-medium text-cafe">{stageLabels[mission.phase]}</span>
+        </span>
+        <span className="inline-flex items-center gap-1.5 rounded-lg bg-[var(--console-shell-bg)] px-2.5 py-1">
+          Feature:
+          <span className="font-medium text-cafe">{mission.activeFeatureId}</span>
+        </span>
+        {mission.truthSourceUrl && (
+          <a
+            href={mission.truthSourceUrl}
+            className="rounded-lg px-2.5 py-1 text-cafe-secondary underline-offset-2 hover:bg-[var(--console-hover-bg)] hover:text-cafe hover:underline"
+          >
+            真相源 →
+          </a>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/blocks/TeamStatusCards.tsx
+++ b/packages/web/src/components/mission-control/team-home/blocks/TeamStatusCards.tsx
@@ -1,0 +1,33 @@
+import { formatHandle, formatName } from '../cat-handle';
+import type { TeamHomeData } from '../types';
+
+interface TeamStatusCardsProps {
+  members: TeamHomeData['team'];
+}
+
+const roleEmoji: Record<TeamHomeData['team'][number]['role'], string> = {
+  agent: '🐱',
+  human: '👤',
+};
+
+export function TeamStatusCards({ members }: TeamStatusCardsProps) {
+  return (
+    <section className="rounded-2xl bg-[var(--console-card-bg)] p-5 shadow-[var(--console-card-shadow)]">
+      <h2 className="text-xs font-semibold uppercase tracking-wider text-cafe-muted">Team Status</h2>
+      <ul className="mt-3 space-y-2">
+        {members.map((member) => (
+          <li key={member.id} className="flex items-start gap-3 rounded-xl bg-[var(--console-shell-bg)] px-3 py-2.5">
+            <span className="text-lg">{roleEmoji[member.role]}</span>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-cafe">{formatName(member.id)}</span>
+                <span className="text-xs text-cafe-muted">{formatHandle(member.id)}</span>
+              </div>
+              <p className="mt-0.5 truncate text-xs text-cafe-secondary">{member.currentContext}</p>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/web/src/components/mission-control/team-home/cat-handle.ts
+++ b/packages/web/src/components/mission-control/team-home/cat-handle.ts
@@ -1,0 +1,36 @@
+import type { CatId } from '@cat-cafe/shared';
+import type { TeamHomeParticipantId } from './types';
+
+const DISPLAY_NAME_MAP: Record<string, string> = {
+  codex: 'Codex',
+  kiimi: 'KK',
+  claude: 'Claude',
+  opus: 'Opus',
+  gemini: 'Gemini',
+  'co-creator': '铲屎官',
+};
+
+export function formatHandle(id: TeamHomeParticipantId): string {
+  return `@${id}`;
+}
+
+export function formatName(id: TeamHomeParticipantId): string {
+  return DISPLAY_NAME_MAP[id] ?? id;
+}
+
+export function formatHandleWithName(id: TeamHomeParticipantId): string {
+  const name = formatName(id);
+  const handle = formatHandle(id);
+  return name === handle ? handle : `${name} (${handle})`;
+}
+
+export function isHuman(id: TeamHomeParticipantId): boolean {
+  return id === 'co-creator';
+}
+
+export function toCatId(id: TeamHomeParticipantId): CatId {
+  if (isHuman(id)) {
+    throw new Error(`Cannot convert human participant ${id} to CatId`);
+  }
+  return id as CatId;
+}

--- a/packages/web/src/components/mission-control/team-home/fixture.ts
+++ b/packages/web/src/components/mission-control/team-home/fixture.ts
@@ -1,0 +1,69 @@
+import type { CatId } from '@cat-cafe/shared';
+import type { TeamHomeData } from './types';
+
+const now = new Date().toISOString();
+
+export const teamHomeFixture: TeamHomeData = {
+  mission: {
+    text: '让每个有想法的人，都能带着一支 Agent 原生团队，把想法做成能运行的世界。',
+    phase: 'impl',
+    activeFeatureId: '—',
+    truthSourceUrl: undefined,
+  },
+  baton: {
+    holder: 'co-creator',
+    scope: '当前无明确持球任务',
+    since: now,
+    nextStep: '等待新的 mission 被领取或分配',
+    nextOwner: undefined,
+    blocker: null,
+  },
+  qualityGates: [],
+  team: [
+    {
+      id: 'codex' as CatId,
+      name: 'Codex',
+      role: 'agent',
+      currentContext: '等待任务',
+      lastActiveAt: now,
+      capabilities: ['spec', 'review', 'architecture'],
+    },
+    {
+      id: 'kiimi' as CatId,
+      name: 'KK',
+      role: 'agent',
+      currentContext: '等待任务',
+      lastActiveAt: now,
+      capabilities: ['impl', 'tdd', 'frontend'],
+    },
+    {
+      id: 'claude' as CatId,
+      name: 'Claude',
+      role: 'agent',
+      currentContext: '等待任务',
+      lastActiveAt: now,
+      capabilities: ['design', 'frontend', 'ux'],
+    },
+    {
+      id: 'co-creator',
+      name: '铲屎官',
+      role: 'human',
+      currentContext: '愿景守护 / CVO 决策',
+      lastActiveAt: now,
+      capabilities: ['cvo_decision', 'vision_guard'],
+    },
+  ],
+  missions: [],
+  culture: {
+    headline: '方向正确 > 执行速度',
+    rules: [
+      { id: 'p1', text: '面向终态，不绕路', active: true },
+      { id: 'state', text: '状态高于消息', active: true },
+      { id: 'root_cause', text: '根因大于补丁', active: false },
+      { id: 'evidence', text: '可验证才算完成', active: true },
+    ],
+  },
+  cvoDecisions: [],
+  risks: [],
+  recentMemory: [],
+};

--- a/packages/web/src/components/mission-control/team-home/types.ts
+++ b/packages/web/src/components/mission-control/team-home/types.ts
@@ -39,8 +39,8 @@ export interface TeamHomeMissionSummary {
   name: string;
   owner: TeamHomeParticipantId;
   stage: TeamHomeSOPStage;
-  evidenceCount: number;
-  requiredEvidence: number;
+  evidenceCount?: number;
+  requiredEvidence?: number;
   nextAction: string;
   updatedAt: string;
 }

--- a/packages/web/src/components/mission-control/team-home/types.ts
+++ b/packages/web/src/components/mission-control/team-home/types.ts
@@ -1,0 +1,96 @@
+import type { CatId } from '@cat-cafe/shared';
+
+export type TeamHomeParticipantId = CatId | 'co-creator';
+
+export type TeamHomeSOPStage = 'kickoff' | 'impl' | 'quality_gate' | 'review' | 'merge' | 'completion';
+
+export type TeamHomeGateStatus = 'passed' | 'pending' | 'failed' | 'not_started';
+
+export type TeamHomeRiskType = 'vision_drift' | 'no_evidence' | 'cross_thread_block' | 'unresolved_review';
+
+export interface TeamHomeBaton {
+  holder: TeamHomeParticipantId;
+  scope: string;
+  since: string;
+  nextStep: string;
+  nextOwner?: TeamHomeParticipantId;
+  blocker: string | null;
+}
+
+export interface TeamHomeQualityGate {
+  name: string;
+  label: string;
+  status: TeamHomeGateStatus;
+  evidenceRef?: string;
+  owner?: TeamHomeParticipantId;
+}
+
+export interface TeamHomeMember {
+  id: TeamHomeParticipantId;
+  name: string;
+  role: 'agent' | 'human';
+  currentContext: string;
+  lastActiveAt: string;
+  capabilities: string[];
+}
+
+export interface TeamHomeMissionSummary {
+  id: string;
+  name: string;
+  owner: TeamHomeParticipantId;
+  stage: TeamHomeSOPStage;
+  evidenceCount: number;
+  requiredEvidence: number;
+  nextAction: string;
+  updatedAt: string;
+}
+
+export interface TeamHomeCultureRule {
+  id: string;
+  text: string;
+  active: boolean;
+}
+
+export interface TeamHomeDecisionItem {
+  id: string;
+  question: string;
+  context: string;
+  urgency: 'now' | 'this_week' | 'later';
+  suggestedOptions?: string[];
+}
+
+export interface TeamHomeRisk {
+  id: string;
+  type: TeamHomeRiskType;
+  message: string;
+  relatedFeatureId?: string;
+  severity: 'high' | 'medium' | 'low';
+}
+
+export interface TeamHomeMemoryItem {
+  id: string;
+  kind: 'lesson' | 'adr' | 'skill' | 'decision';
+  title: string;
+  anchor: string;
+  createdAt: string;
+}
+
+export interface TeamHomeData {
+  mission: {
+    text: string;
+    phase: TeamHomeSOPStage;
+    activeFeatureId: string;
+    truthSourceUrl?: string;
+  };
+  baton: TeamHomeBaton;
+  qualityGates: TeamHomeQualityGate[];
+  team: TeamHomeMember[];
+  missions: TeamHomeMissionSummary[];
+  culture: {
+    headline: string;
+    rules: TeamHomeCultureRule[];
+  };
+  cvoDecisions: TeamHomeDecisionItem[];
+  risks: TeamHomeRisk[];
+  recentMemory: TeamHomeMemoryItem[];
+}


### PR DESCRIPTION
## PR Type

- [x] ✨ **Feature** — New capability or behavior change (requires Feature Doc)

## Related Issue

Tracked in #982 (parent: F049 / F058 Mission Hub).

## Feature Doc (Feature PRs only)

docs/features/F049-mission-control-backlog-center.md
docs/features/F058-mission-control-enhancements.md

## What

Add a "今日团队" (Team Home) tab to `/mission-hub` that shows the team's current focus, baton holder, active missions, and member status derived from real backlog + thread state.

Key files changed:
- `packages/web/src/components/mission-control/MissionControlPage.tsx` — add `today` tab
- `packages/web/src/components/mission-control/team-home/` — new panel, adapter, blocks, types, fixture
- `packages/web/src/components/__tests__/team-home-adapter.test.ts` — adapter regression tests
- `packages/web/src/app/console-tokens.css` — dashboard card shadow tokens

This PR now contains **only** the Team Home scoped changes. The unrelated runtime/install/governance commits and the `review-notes/` artifacts have been removed by rebasing onto current `main`.

## Why

The review packet noted that `threadsByBacklogId` was passed through but unused, so the page could not answer "球在谁手里 / 哪些猫参与了". This PR wires the real backlog lease and thread state into the Team Home view while keeping modules without reliable sources (quality gates, risks, memory, CVO decisions) empty rather than inventing data.

## Tradeoff

- Hangs inside existing `/mission-hub` instead of a new app to keep MVP scope small.
- No Shadcn; uses existing Tailwind + custom CSS tokens.
- Evidence count is left undefined until a reliable source exists, rather than misusing the audit log.

## Test Evidence

Rebased onto current `origin/main` and scoped to Team Home files only.

```
cd packages/web
pnpm exec vitest run src/components/__tests__/team-home-adapter.test.ts
# Test Files  1 passed (1) / Tests 5 passed
pnpm exec vitest run src/components/__tests__/mission-control-page.test.ts
# Test Files  1 passed (1) / Tests 35 passed
```

## AC Checklist (Feature PRs only)

- [x] AC: `今日团队` tab renders on `/mission-hub`
- [x] AC: Baton holder and team cards derive from active lease + thread state
- [x] AC: Active missions list derives from approved/dispatched backlog items
- [x] AC: Feature doc link derives from `feature:F049` tags
- [x] AC: No unrelated runtime/install/governance changes included
- [x] AC: No `review-notes/` or screenshot artifacts included

---

@zts212653 — this has been rebased and split per your triage feedback. Please review/confirm #982 scope and remove `triage`/`needs-info` labels when ready.
