### PR TITLE
fix(api): add MiniMax-M3 context window fallback

### DIFF
--- a/packages/api/scripts/with-test-home.sh
+++ b/packages/api/scripts/with-test-home.sh
@@ -30,6 +30,11 @@ unset CAT_CAFE_RUNTIME_ROOT
 unset CAT_CAFE_MCP_SERVER_PATH
 unset CAT_CAFE_WORKSPACE_ROOT
 
+# API_SERVER_HOST is a runtime binding choice. LAN/dev invocations commonly set
+# it to 0.0.0.0, but capability write tests expect localhost-only defaults unless
+# an individual test explicitly sets the host under test.
+unset API_SERVER_HOST
+
 # DEFAULT_CAT_ID is user/runtime preference, not test fixture state. Leaving it
 # inherited makes routing tests depend on which cat launched the test command.
 unset DEFAULT_CAT_ID

--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -19,6 +19,8 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
   'gpt-5.1-codex': 400_000,
   o3: 200_000,
   'o4-mini': 200_000,
+  // MiniMax
+  'MiniMax-M3': 1_000_000,
   // Gemini
   'gemini-2.5-pro': 1_000_000,
   'gemini-2.5-flash': 1_000_000,

--- a/packages/api/test/context-window-sizes.test.js
+++ b/packages/api/test/context-window-sizes.test.js
@@ -20,6 +20,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('claude-opus-4-6'), 200_000);
     assert.equal(getContextWindowFallback('claude-sonnet-4-5'), 200_000);
     assert.equal(getContextWindowFallback('gpt-5.3'), 128_000);
+    assert.equal(getContextWindowFallback('MiniMax-M3'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-2.5-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3.1-pro-preview'), 1_000_000);
@@ -47,6 +48,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('anthropic/claude-sonnet-4-5'), 200_000);
     assert.equal(getContextWindowFallback('openai-compat/gpt-5.3'), 128_000);
     assert.equal(getContextWindowFallback('openai-compat/gpt-5.1-codex'), 400_000);
+    assert.equal(getContextWindowFallback('minimax/MiniMax-M3'), 1_000_000);
     assert.equal(getContextWindowFallback('google/gemini-2.5-pro'), 1_000_000);
     // Prefix match after strip (versioned model behind provider prefix)
     assert.equal(getContextWindowFallback('anthropic/claude-opus-4-6-20260101'), 200_000);

--- a/packages/api/test/with-test-home.test.js
+++ b/packages/api/test/with-test-home.test.js
@@ -34,3 +34,17 @@ test('with-test-home strips runtime default cat override from outer shell', () =
   assert.equal(result.status, 0, result.stderr);
   assert.equal(result.stdout.trim(), '');
 });
+
+test('with-test-home strips runtime API host binding from outer shell', () => {
+  const result = spawnSync('bash', [withTestHome, 'node', '-p', 'process.env.API_SERVER_HOST ?? ""'], {
+    cwd: resolve(__dirname, '..'),
+    env: {
+      ...process.env,
+      API_SERVER_HOST: '0.0.0.0',
+    },
+    encoding: 'utf8',
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), '');
+});


### PR DESCRIPTION
## What

- Add `MiniMax-M3` to the context-window fallback table with a 1,000,000 token window.
- Add regression coverage for bare and provider-prefixed MiniMax-M3 model IDs.
- Isolate `API_SERVER_HOST` in the test-home harness so LAN runtime bindings do not pollute localhost-only capability write tests.

## Why

OpenCode does not emit `contextWindowSize`. Without a table fallback, MiniMax-M3 falls through to the OpenCode default of 128,000 tokens, so session health treats a 1M model as 128K and triggers premature handoff.

The test-harness change is a gate fix found while validating against current mainline: it prevents an outer development shell bound to `0.0.0.0` from making localhost-only capability write tests fail with false 403s.

## Issue Closure

Closes #990

## Original Requirements

- Public issue: #990
- Original public issue excerpt:
  > MiniMax-M3 supports a 1,000,000-token context window, but Cat Cafe session health can display and enforce the OpenCode default 128,000-token window for MiniMax-M3 sessions.
  > MiniMax-M3 sessions should use a 1,000,000-token context-window fallback when OpenCode does not report a window size.
- User-facing pain: MiniMax-M3 is configured as a large-context model, but Cat Cafe session health can display and enforce the 128K fallback.
- Please review against issue #990: does this PR make Cat Cafe recognize MiniMax-M3 as a 1M context model when OpenCode omits `contextWindowSize`?

## Plan / ADR

- Plan: none, scoped bug fix
- ADR: none
- BACKLOG: none

## Tradeoff

This is a narrow fallback-table fix. A broader long-term option is to ingest OpenCode or models.dev provider metadata dynamically, but that is not required to fix the current false 128K cap. I intentionally did not add MiniMax-M2.7-highspeed or DeepSeek fallback entries because their true windows were not verified for this issue.

## Test Evidence

- Current rebased HEAD: `d86e8c5a`.
- Focused local tests passed: context-window fallback, OpenCode event transform, and test-home isolation, 30 tests.
- `git diff --check origin/main...HEAD` passed.
- GitHub checks are expected to rerun on the rebased head and are the merge source of truth.

## Open Questions

Reviewer should focus on:

- Whether hard-coding `MiniMax-M3` as 1,000,000 is appropriate for public issue #990.
- Whether unsetting `API_SERVER_HOST` in `with-test-home.sh` is properly scoped to test isolation and does not weaken runtime capability write guards.
- Whether this PR should remain narrow instead of adding unverified fallback entries for other OpenCode models.

---

**Local Review**: previous reviews covered the pre-rebase head; current head `d86e8c5a` needs review continuity.
**Maintainer Intake**: #990 accepted as `bug`, `triaged`, and `accepted`.
**Cloud Review**: unavailable; connector requested Codex account connection instead of producing a review.

<!-- Cat signature: Maine Coon / GPT-5.5 -->