### PR TITLE
fix(api): add OpenRouter MiniMax-M3 slug alias

### DIFF
--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -21,6 +21,7 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
   'o4-mini': 200_000,
   // MiniMax
   'MiniMax-M3': 1_000_000,
+  'minimax-m3': 1_000_000,
   // Gemini
   'gemini-2.5-pro': 1_000_000,
   'gemini-2.5-flash': 1_000_000,

--- a/packages/api/test/context-window-sizes.test.js
+++ b/packages/api/test/context-window-sizes.test.js
@@ -21,6 +21,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('claude-sonnet-4-5'), 200_000);
     assert.equal(getContextWindowFallback('gpt-5.3'), 128_000);
     assert.equal(getContextWindowFallback('MiniMax-M3'), 1_000_000);
+    assert.equal(getContextWindowFallback('minimax-m3'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-2.5-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3.1-pro-preview'), 1_000_000);
@@ -49,6 +50,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('openai-compat/gpt-5.3'), 128_000);
     assert.equal(getContextWindowFallback('openai-compat/gpt-5.1-codex'), 400_000);
     assert.equal(getContextWindowFallback('minimax/MiniMax-M3'), 1_000_000);
+    assert.equal(getContextWindowFallback('minimax/minimax-m3'), 1_000_000);
     assert.equal(getContextWindowFallback('google/gemini-2.5-pro'), 1_000_000);
     // Prefix match after strip (versioned model behind provider prefix)
     assert.equal(getContextWindowFallback('anthropic/claude-opus-4-6-20260101'), 200_000);


### PR DESCRIPTION
## What

- Add the verified OpenRouter lowercase slug alias `minimax-m3` for MiniMax-M3.
- Add regression coverage for both bare `minimax-m3` and provider-prefixed `minimax/minimax-m3`.

## Why

Follow-up to #989 / #990. OpenRouter exposes MiniMax-M3 as `minimax/minimax-m3`; the fallback resolver strips provider prefixes and then performs a case-sensitive lookup. Without the lowercase alias, OpenRouter-routed MiniMax-M3 sessions can still fall back to the conservative 128K default instead of the intended 1M context window.

## Validation

```bash
pnpm --filter @cat-cafe/api run build
bash packages/api/scripts/with-test-home.sh node --test packages/api/test/context-window-sizes.test.js
pnpm check
```

No unverified MiniMax variants are added.

[砚砚/gpt-5.5🐾]