### PR TITLE
fix(runtime): preserve install exit code + align lockfile-class regex

### DIFF
--- a/packages/api/test/runtime-worktree-script.test.js
+++ b/packages/api/test/runtime-worktree-script.test.js
@@ -80,6 +80,7 @@ function createPnpmStub(projectDir, options = {}) {
   const {
     failFrozenInstall = false,
     frozenInstallFailure = 'ERR_PNPM_OUTDATED_LOCKFILE simulated frozen lockfile failure',
+    frozenInstallExitCode = 1,
   } = options;
   const binDir = join(projectDir, 'bin');
   const logFile = join(projectDir, 'pnpm.log');
@@ -98,7 +99,7 @@ fi
 if [ "\${1:-}" = "install" ] && [ "\${2:-}" = "--frozen-lockfile" ]; then
   if [ "${failFrozenInstall ? '1' : '0'}" = "1" ]; then
     printf '%s\\n' "${frozenInstallFailure}" >&2
-    exit 1
+    exit ${frozenInstallExitCode}
   fi
   mkdir -p "$target_dir/node_modules/.pnpm"
   mkdir -p "$target_dir/packages/web/node_modules/next"
@@ -485,6 +486,78 @@ server.listen(3010,'127.0.0.1',()=>setInterval(()=>{},1000));`,
     assert.doesNotMatch(result.stdout, /retrying pnpm install --no-frozen-lockfile/);
     const pnpmLog = readFileSync(env.RUNTIME_TEST_PNPM_LOG, 'utf8').trim().split('\n');
     assert.deepEqual(pnpmLog, ['-C ' + projectDir + ' install --frozen-lockfile']);
+  });
+
+  it('additional pnpm 9 lockfile-class failure phrases trigger no-frozen-lockfile retry', () => {
+    // Align with scripts/install.ps1::Test-LockfileMismatchFailure — Windows
+    // installer already treats these phrases as retryable; the bash runtime
+    // classifier must agree so cross-platform self-heal stays symmetric.
+    const additionalPatterns = [
+      {
+        slug: 'breaking-change',
+        failure: 'ERR_PNPM_LOCKFILE_BREAKING_CHANGE: lockfile is at an incompatible version',
+      },
+      {
+        slug: 'incompatible',
+        failure: 'pnpm error: lockfile is incompatible with this version of pnpm',
+      },
+      {
+        slug: 'cannot-install-frozen',
+        failure: 'Cannot install with "frozen-lockfile" because lockfile is out of sync',
+      },
+      {
+        slug: 'cannot-proceed-without-lockfile',
+        failure: 'Cannot proceed with audit without the lockfile present',
+      },
+    ];
+
+    for (const { slug, failure } of additionalPatterns) {
+      const projectDir = createTempProject(`runtime-self-heal-install-${slug}`);
+      const env = withStubbedPnpmEnv(projectDir, {
+        failFrozenInstall: true,
+        frozenInstallFailure: failure,
+      });
+
+      const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
+        cwd: projectDir,
+        encoding: 'utf8',
+        env,
+      });
+
+      assert.equal(
+        result.status,
+        0,
+        `[${slug}] expected retry to succeed; exit=${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+      assert.match(
+        result.stdout,
+        /retrying pnpm install --no-frozen-lockfile/,
+        `[${slug}] expected classified retry to fire on "${failure}"`,
+      );
+    }
+  });
+
+  it('preserves original frozen install exit code on non-retry-able generic failure', () => {
+    // The non-retry path captures pnpm's exit code via ${PIPESTATUS[0]} so
+    // interrupts / OOM-style exits stay distinguishable from a generic exit 1.
+    const projectDir = createTempProject('runtime-self-heal-install-preserves-exit-code');
+    const env = withStubbedPnpmEnv(projectDir, {
+      failFrozenInstall: true,
+      frozenInstallFailure: 'simulated network failure',
+      frozenInstallExitCode: 42,
+    });
+
+    const result = spawnSync('bash', [join(projectDir, 'scripts', 'runtime-worktree.sh'), 'start', '--no-sync'], {
+      cwd: projectDir,
+      encoding: 'utf8',
+      env,
+    });
+
+    assert.equal(
+      result.status,
+      42,
+      `expected stub pnpm exit 42 to reach the caller; got ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
   });
 
   it('fails with guidance when auto-install is disabled and prerequisites are missing', () => {

--- a/scripts/runtime-worktree.sh
+++ b/scripts/runtime-worktree.sh
@@ -215,27 +215,43 @@ runtime_quick_mode() {
 
 runtime_install_can_retry_without_frozen_lockfile() {
   local log_file="$1"
+  # Kept in sync with scripts/install.ps1::Test-LockfileMismatchFailure — the
+  # Windows installer is the single source of truth for which pnpm 9 lockfile-
+  # class failures justify a `pnpm install --no-frozen-lockfile` retry. Any
+  # phrase added here MUST also be reflected in install.ps1 (and vice versa)
+  # so Linux/macOS bash and Windows PowerShell self-heal stay symmetric.
   grep -Eiq \
-    'ERR_PNPM_OUTDATED_LOCKFILE|ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE|ERR_PNPM_LOCKFILE_CONFIG_MISMATCH|frozen[- ]lockfile|lockfile.*(outdated|not up to date)' \
+    'ERR_PNPM_OUTDATED_LOCKFILE|ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE|ERR_PNPM_LOCKFILE_BREAKING_CHANGE|ERR_PNPM_LOCKFILE_CONFIG_MISMATCH|Cannot install with .frozen-lockfile|Cannot proceed .*without the lockfile|frozen[- ]lockfile|lockfile.*(outdated|not up to date|incompatible)' \
     "$log_file"
 }
 
 install_runtime_dependencies() {
   local install_log
+  local install_status
 
   info "runtime prerequisites missing; running pnpm install --frozen-lockfile"
   # Always clear production env flags — Claude Code shell often has NODE_ENV=production,
   # which causes pnpm to skip devDependencies and break builds.
   install_log="$(mktemp "${TMPDIR:-/tmp}/cat-cafe-runtime-install.XXXXXX")"
+  # Wrap the pnpm pipeline in `if` so set -e + pipefail don't kill us on a
+  # non-zero exit, then capture pnpm's original exit code via ${PIPESTATUS[0]}.
+  # This preserves the caller-visible exit semantics on the non-retry path;
+  # interrupts / OOM-style failures stay distinguishable from a generic exit 1.
   if env -u NODE_ENV -u npm_config_production -u NPM_CONFIG_PRODUCTION \
     pnpm -C "$RUNTIME_DIR" install --frozen-lockfile 2>&1 | tee "$install_log"; then
+    install_status=0
+  else
+    install_status="${PIPESTATUS[0]}"
+  fi
+
+  if [ "$install_status" -eq 0 ]; then
     rm -f "$install_log"
     return 0
   fi
 
   if ! runtime_install_can_retry_without_frozen_lockfile "$install_log"; then
     rm -f "$install_log"
-    return 1
+    return "$install_status"
   fi
   rm -f "$install_log"
 


### PR DESCRIPTION
Follow-up to #978. Two related issues that surfaced when the same fix was reviewed and absorbed downstream in Cat Café.

## 1. Exit code regression in `install_runtime_dependencies` (P1)

The `2>&1 | tee "$install_log"` pipeline added in #978 dropped pnpm's original exit status on the non-retry branch — every non-lockfile failure (network, EPERM, disk full, interrupt, OOM) was hard-returned as exit `1`, hiding the real cause from the caller.

**Fix**: capture pnpm's exit code via `${PIPESTATUS[0]}` right after the `tee` pipeline, then `return "$install_status"` on the non-retry branch. The `if` wrapper still neutralizes `set -e + pipefail`, but no longer discards the original status.

**Red→Green**: new test `preserves original frozen install exit code on non-retry-able generic failure` — stubbed pnpm exits `42` with a non-lockfile error → `install_runtime_dependencies()` now returns `42` (was: `1`).

## 2. Lockfile-class regex missing 4 patterns (P2 + audit sweep)

`runtime_install_can_retry_without_frozen_lockfile()` only matched 5 of the 8 phrases that `scripts/install.ps1::Test-LockfileMismatchFailure` already treats as retryable, so cross-platform self-heal was asymmetric — Windows recovered from a pnpm lockfile-format upgrade or "lockfile incompatible" error, but Linux/macOS bash did not.

Missing patterns now added:

- `ERR_PNPM_LOCKFILE_BREAKING_CHANGE` (pnpm 9 schema upgrade)
- `lockfile.*is incompatible` (cross-version mismatch)
- `Cannot install with .frozen-lockfile` (frozen-lockfile gate)
- `Cannot proceed .*without the lockfile` (pnpm audit/install gate)

The bash classifier now matches all 8 phrases the PowerShell helper recognises. Comment names `install.ps1` as the single source of truth so future divergence is caught at review.

**Red→Green**: new parametrized test `additional pnpm 9 lockfile-class failure phrases trigger no-frozen-lockfile retry` with 4 sub-cases, one per added pattern.

## Validation

```bash
pnpm --filter @cat-cafe/api run build
cd packages/api && bash scripts/with-test-home.sh node --test \
  test/runtime-worktree-script.test.js
# → ℹ tests 23 / ℹ pass 23 / ℹ fail 0
```

## Provenance

Both findings caught by downstream review of the same patch:
- exit-code regression: independent peer review (P1)
- lockfile-class regex gap: independent cloud Codex review (P2) + sibling-call-site audit against `install.ps1::Test-LockfileMismatchFailure`

Closes: none (these are follow-ups to #978's accepted issue #954, no separate filer)