### PR TITLE
fix: make opencode follow thread workspace

### DIFF
--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -8,6 +8,25 @@ You are an OpenCode-runtime cat. Project files are resolved relative to your
 working directory (cwd) — there is **no** silent fallback to a host/runtime path
 like Claude or Codex have.
 
+## Interaction Channel
+
+The native `question` tool is **denied** for OpenCode (enforced in the generated
+opencode config: `permission.question = "deny"`). Do not prompt the user through
+`question` — the call is rejected.
+
+To ask the user for a choice or confirmation, emit an interactive rich block via
+`cat_cafe_create_rich_block` (e.g. a select / confirm block). That is the supported
+interaction channel for OpenCode cats.
+
+## Memory Recall (three entry points)
+
+Recall is not one tool — pick the entry by scenario:
+- Precise anchor / relationships → `cat_cafe_graph_resolve`
+- Zero prior / scan recent → `cat_cafe_list_recent`
+- Semantic / fuzzy → `cat_cafe_search_evidence` (unsure → `mode=hybrid`)
+
+Full decision tree: `cat-cafe-skills/refs/memory-routing-partial.md`.
+
 ## Workspace Binding
 
 OpenCode **requires** the thread to be bound to a concrete project workspace

--- a/OPENCODE.md
+++ b/OPENCODE.md
@@ -1,0 +1,40 @@
+# Clowder AI — OpenCode Agent Guide
+
+> OpenCode-specific addendum, injected alongside the compiled L0 system prompt.
+> Applies to cats running through the OpenCode CLI (e.g. minimax-m3).
+
+## Identity
+You are an OpenCode-runtime cat. Project files are resolved relative to your
+working directory (cwd) — there is **no** silent fallback to a host/runtime path
+like Claude or Codex have.
+
+## Workspace Binding
+
+OpenCode **requires** the thread to be bound to a concrete project workspace
+before it can spawn. Because OpenCode resolves every project path relative to its
+cwd, a missing or invalid workspace means project-blindness. To avoid silently
+inheriting the runtime directory (`cat-cafe-runtime/packages/api`), OpenCode
+**fails loud** in these cases instead of spawning project-blind (clowder-ai#1000):
+
+- The thread has no `projectPath`, or it is `default` / unbound.
+- The thread `projectPath` does not resolve to an existing directory under an
+  allowed root (deleted / moved / typo).
+- The thread uses a virtual game `projectPath` (e.g. `games/werewolf`), which is a
+  category label, not a real filesystem directory.
+
+You will see an error such as:
+
+> `OpenCode requires a thread projectPath for <threadId>. Bind the thread to a
+> project workspace before spawning OpenCode.`
+
+### How to bind a project workspace
+- **New thread**: create it bound to a concrete `projectPath` — an absolute path
+  to an existing directory under an allowed root.
+- **Existing thread**: set or repoint its `projectPath` from thread settings to a
+  valid project directory.
+- **Game / virtual threads**: cannot run OpenCode — route OpenCode work to a
+  project-bound thread instead.
+
+A **transient** filesystem error (mount flake / NFS / temporary permission loss)
+is reported separately ("Retry; if it persists, re-bind...") and is safe to retry;
+only re-bind the workspace if the error persists.

--- a/packages/api/src/config/account-resolver.ts
+++ b/packages/api/src/config/account-resolver.ts
@@ -45,6 +45,22 @@ export function resolveBuiltinClientForProvider(provider: ClientId): BuiltinAcco
   return builtinAccountFamilyForClient(provider);
 }
 
+/**
+ * Whether a provider's CLI must spawn with a concrete, validated thread workspace (cwd).
+ *
+ * OpenCode resolves project files relative to its working directory and — unlike
+ * Claude/Codex — has no silent fallback: without a validated workspace it inherits the
+ * runtime cwd and goes project-blind (clowder-ai#1000). Returning true makes the
+ * invocation layer fail loud instead of silently inheriting the runtime cwd.
+ *
+ * Provider-level capability (not a per-variant config field): this is a CLI trait, not
+ * per-cat data — every OpenCode variant needs it, and a second workspace-strict CLI only
+ * adds one branch here, keeping the invocation layer a pure reader (no hardcoded check).
+ */
+export function providerRequiresThreadWorkspace(provider: ClientId | undefined): boolean {
+  return provider === 'opencode';
+}
+
 export function resolveAnthropicRuntimeProfile(
   projectRoot: string,
   preferredAccountRef?: string,

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -23,6 +23,7 @@ import {
 } from '@cat-cafe/shared';
 import { context, SpanStatusCode, trace } from '@opentelemetry/api';
 import {
+  providerRequiresThreadWorkspace,
   resolveBuiltinClientForProvider,
   resolveForClient,
   validateRuntimeProviderBinding,
@@ -972,7 +973,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
 
     const catConfig = catRegistry.tryGet(catId as string)?.config;
     const provider = catConfig?.clientId;
-    const requiresThreadWorkspace = provider === 'opencode';
+    const requiresThreadWorkspace = providerRequiresThreadWorkspace(provider);
 
     // Resolve workingDirectory from thread's projectPath
     let workingDirectory: string | undefined;
@@ -1028,7 +1029,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
             if (!validatedProjectPath.ok) {
               const isTransient = validatedProjectPath.reason === 'io_error';
               workspaceResolutionFailureMessage = isTransient
-                ? `Unable to validate thread projectPath for ${threadId}: ${thread.projectPath}. ${validatedProjectPath.message ?? 'Transient filesystem error.'}`
+                ? `Unable to validate thread projectPath for ${threadId}: ${thread.projectPath}. ${validatedProjectPath.message ?? 'Transient filesystem error.'} Retry; if it persists, re-bind the thread's project workspace.`
                 : `Invalid thread projectPath for ${threadId}: ${thread.projectPath}. Expected an existing directory under allowed roots.`;
               log.warn(
                 {

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -71,7 +71,7 @@ import { resolveActiveProjectRoot } from '../../../../../utils/active-project-ro
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
 import { findMonorepoRoot, isSameProject } from '../../../../../utils/monorepo-root.js';
-import { isUnderAllowedRoot } from '../../../../../utils/project-path.js';
+import { validateProjectPath } from '../../../../../utils/project-path.js';
 import { tcpProbe } from '../../../../../utils/tcp-probe.js';
 import type { AgentPaneRegistry } from '../../../../terminal/agent-pane-registry.js';
 import type { TmuxGateway } from '../../../../terminal/tmux-gateway.js';
@@ -970,13 +970,26 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       }
     }
 
+    const catConfig = catRegistry.tryGet(catId as string)?.config;
+    const provider = catConfig?.clientId;
+    const requiresThreadWorkspace = provider === 'opencode';
+
     // Resolve workingDirectory from thread's projectPath
     let workingDirectory: string | undefined;
     let bootcampWorkspaceError: Error | undefined;
+    let workspaceResolutionError: Error | undefined;
     if (threadStore) {
+      let thread: Awaited<ReturnType<IThreadStore['get']>> | null | undefined;
       try {
-        const thread = await preflightRace(Promise.resolve(threadStore.get(threadId)), 'threadStore.get', signal);
-        if (thread?.createdAt) threadCreatedAt = thread.createdAt;
+        thread = await preflightRace(Promise.resolve(threadStore.get(threadId)), 'threadStore.get', signal);
+      } catch (err) {
+        log.warn(
+          { catId, threadId, err },
+          'threadStore.get failed during workspace resolution — proceeding without workingDirectory',
+        );
+      }
+      if (thread) {
+        if (thread.createdAt) threadCreatedAt = thread.createdAt;
         // #836: Reborn session strategy — force new session every invocation.
         // Uses store lookup (isRebornSession) instead of thread field because
         // Redis stores strategy in separate hash fields not hydrated by get().
@@ -1006,8 +1019,21 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           // F101: Game threads use virtual projectPaths (e.g. 'games/werewolf') for
           // categorization only — they are not real filesystem directories. Skip them
           // to avoid triggering the F070 governance gate on a non-existent path.
-          if (!thread.projectPath.startsWith('games/') && isUnderAllowedRoot(thread.projectPath)) {
-            workingDirectory = thread.projectPath;
+          if (!thread.projectPath.startsWith('games/')) {
+            const validatedProjectPath = await validateProjectPath(thread.projectPath);
+            if (!validatedProjectPath) {
+              log.warn(
+                { catId, threadId, projectPath: thread.projectPath },
+                'thread projectPath failed validation during workspace resolution',
+              );
+              if (requiresThreadWorkspace) {
+                workspaceResolutionError = new Error(
+                  `Invalid thread projectPath for ${threadId}: ${thread.projectPath}. Expected an existing directory under allowed roots.`,
+                );
+              }
+            } else {
+              workingDirectory = validatedProjectPath;
+            }
           }
         } else if (thread?.bootcampState) {
           const bootcampWorkspace = await resolveBootcampWorkspaceRoot();
@@ -1016,13 +1042,18 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           } else {
             bootcampWorkspaceError = new Error(bootcampWorkspace.error);
           }
+        } else if (requiresThreadWorkspace) {
+          workspaceResolutionError = new Error(
+            `OpenCode requires a thread projectPath for ${threadId}. Bind the thread to a project workspace before spawning OpenCode.`,
+          );
         }
-      } catch {
-        // Thread store timeout or error — proceed without workingDirectory
       }
     }
     if (bootcampWorkspaceError) {
       throw bootcampWorkspaceError;
+    }
+    if (workspaceResolutionError) {
+      throw workspaceResolutionError;
     }
     const workingProjectRoot = workingDirectory ? findMonorepoRoot(workingDirectory) : undefined;
 
@@ -1150,8 +1181,6 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
 
     // F127 account injection:
     // Members bind to a concrete accountRef (builtin oauth account or generic api_key account).
-    const catConfig = catRegistry.tryGet(catId as string)?.config;
-    const provider = catConfig?.clientId;
     const builtinClient = provider ? resolveBuiltinClientForProvider(provider) : null;
     const defaultModel = catConfig?.defaultModel?.trim() || undefined;
     // Account resolution, proxy registration, and runtime config always use the
@@ -1468,6 +1497,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     }
 
     const openCodeExternalDirs: string[] = [];
+    const openCodeAllowedWorkspaceDirs = workingDirectory ? resolve(workingDirectory) : undefined;
     if (provider === 'opencode') {
       if (workingDirectory && !isSameProject(workingDirectory, hostProjectRoot)) {
         // External project — grant access to Clowder AI host root (configs, MCP, etc.)
@@ -1508,6 +1538,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
         hasBaseUrl: Boolean(resolvedAccount.baseUrl),
         omitProviderAuth: !isApiKey,
         mcpServerPath,
+        ...(openCodeAllowedWorkspaceDirs ? { allowedWorkspaceDirs: openCodeAllowedWorkspaceDirs } : {}),
         // F203 Phase I: inject compiled L0 + OPENCODE.md into instructions.
         instructions: openCodeL0InstructionPaths,
         // #935: External directory permissions for Windows/cross-project access.

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -71,7 +71,7 @@ import { resolveActiveProjectRoot } from '../../../../../utils/active-project-ro
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
 import { findMonorepoRoot, isSameProject } from '../../../../../utils/monorepo-root.js';
-import { validateProjectPath } from '../../../../../utils/project-path.js';
+import { validateProjectPathDetailed } from '../../../../../utils/project-path.js';
 import { tcpProbe } from '../../../../../utils/tcp-probe.js';
 import type { AgentPaneRegistry } from '../../../../terminal/agent-pane-registry.js';
 import type { TmuxGateway } from '../../../../terminal/tmux-gateway.js';
@@ -978,11 +978,13 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     let workingDirectory: string | undefined;
     let bootcampWorkspaceError: Error | undefined;
     let workspaceResolutionError: Error | undefined;
+    let workspaceResolutionFailureMessage: string | undefined;
     if (threadStore) {
       let thread: Awaited<ReturnType<IThreadStore['get']>> | null | undefined;
       try {
         thread = await preflightRace(Promise.resolve(threadStore.get(threadId)), 'threadStore.get', signal);
       } catch (err) {
+        workspaceResolutionFailureMessage = `Unable to resolve thread workspace for ${threadId}: ${err instanceof Error ? err.message : String(err)}`;
         log.warn(
           { catId, threadId, err },
           'threadStore.get failed during workspace resolution — proceeding without workingDirectory',
@@ -1019,20 +1021,27 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           // F101: Game threads use virtual projectPaths (e.g. 'games/werewolf') for
           // categorization only — they are not real filesystem directories. Skip them
           // to avoid triggering the F070 governance gate on a non-existent path.
-          if (!thread.projectPath.startsWith('games/')) {
-            const validatedProjectPath = await validateProjectPath(thread.projectPath);
-            if (!validatedProjectPath) {
+          if (thread.projectPath.startsWith('games/')) {
+            workspaceResolutionFailureMessage = `OpenCode requires a filesystem thread projectPath for ${threadId}; virtual game projectPath ${thread.projectPath} cannot be used as a working directory.`;
+          } else {
+            const validatedProjectPath = await validateProjectPathDetailed(thread.projectPath);
+            if (!validatedProjectPath.ok) {
+              const isTransient = validatedProjectPath.reason === 'io_error';
+              workspaceResolutionFailureMessage = isTransient
+                ? `Unable to validate thread projectPath for ${threadId}: ${thread.projectPath}. ${validatedProjectPath.message ?? 'Transient filesystem error.'}`
+                : `Invalid thread projectPath for ${threadId}: ${thread.projectPath}. Expected an existing directory under allowed roots.`;
               log.warn(
-                { catId, threadId, projectPath: thread.projectPath },
+                {
+                  catId,
+                  threadId,
+                  projectPath: thread.projectPath,
+                  reason: validatedProjectPath.reason,
+                  message: validatedProjectPath.message,
+                },
                 'thread projectPath failed validation during workspace resolution',
               );
-              if (requiresThreadWorkspace) {
-                workspaceResolutionError = new Error(
-                  `Invalid thread projectPath for ${threadId}: ${thread.projectPath}. Expected an existing directory under allowed roots.`,
-                );
-              }
             } else {
-              workingDirectory = validatedProjectPath;
+              workingDirectory = validatedProjectPath.path;
             }
           }
         } else if (thread?.bootcampState) {
@@ -1043,11 +1052,15 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
             bootcampWorkspaceError = new Error(bootcampWorkspace.error);
           }
         } else if (requiresThreadWorkspace) {
-          workspaceResolutionError = new Error(
-            `OpenCode requires a thread projectPath for ${threadId}. Bind the thread to a project workspace before spawning OpenCode.`,
-          );
+          workspaceResolutionFailureMessage = `OpenCode requires a thread projectPath for ${threadId}. Bind the thread to a project workspace before spawning OpenCode.`;
         }
       }
+    }
+    if (requiresThreadWorkspace && threadStore && !workingDirectory && !bootcampWorkspaceError) {
+      workspaceResolutionError = new Error(
+        workspaceResolutionFailureMessage ??
+          `OpenCode requires a thread projectPath for ${threadId}. Bind the thread to a project workspace before spawning OpenCode.`,
+      );
     }
     if (bootcampWorkspaceError) {
       throw bootcampWorkspaceError;

--- a/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
@@ -14,7 +14,6 @@
  *   error       → error
  */
 
-import { resolve } from 'node:path';
 import { type CatId, createCatId } from '@cat-cafe/shared';
 import { getCatModel } from '../../../../../config/cat-models.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
@@ -100,11 +99,6 @@ export function summarizeOpenCodeEnvForDebug(env: Record<string, string | null> 
 /** F203 Phase I: env var signaling that OPENCODE_CONFIG is instructions-only (no custom provider). */
 export const OC_INSTRUCTIONS_ONLY_ENV = 'CAT_CAFE_OC_INSTRUCTIONS_ONLY';
 
-function resolveAllowedWorkspaceDirs(workingDirectory?: string): string | undefined {
-  const threadWorkspace = workingDirectory?.trim();
-  return threadWorkspace ? resolve(threadWorkspace) : undefined;
-}
-
 export class OpenCodeAgentService implements L0InjectableAgentService {
   readonly catId: CatId;
   private readonly model: string;
@@ -145,11 +139,15 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     const effectiveModel = options?.callbackEnv?.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE ?? this.model;
     const args = this.buildArgs(prompt, options?.sessionId, effectiveModel, options?.cliConfigArgs);
     const cwd = options?.workingDirectory;
-    const childEnv = this.buildEnv(options?.callbackEnv, cwd);
+    const childEnv = this.buildEnv(options?.callbackEnv);
     // F171: Account env vars applied LAST — user overrides provider-injected values
     if (options?.accountEnv) {
       for (const [k, v] of Object.entries(options.accountEnv)) childEnv[k] = v;
     }
+    // The Cat Cafe MCP workspace is authoritative in OPENCODE_CONFIG
+    // mcp.cat-cafe.environment. Do not leak stale account-level workspace env into
+    // the parent OpenCode process and let it race the invocation-scoped config.
+    delete childEnv.ALLOWED_WORKSPACE_DIRS;
     const envSummary = summarizeOpenCodeEnvForDebug(childEnv);
     const metadata: MessageMetadata = { provider: 'opencode', model: effectiveModel };
     let sessionInitEmitted = false;
@@ -438,10 +436,8 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     return deduped;
   }
 
-  private buildEnv(callbackEnv?: Record<string, string>, workingDirectory?: string): Record<string, string | null> {
+  private buildEnv(callbackEnv?: Record<string, string>): Record<string, string | null> {
     const env: Record<string, string | null> = { ...callbackEnv };
-    const allowedWorkspaceDirs = resolveAllowedWorkspaceDirs(workingDirectory);
-    if (allowedWorkspaceDirs) env.ALLOWED_WORKSPACE_DIRS = allowedWorkspaceDirs;
 
     // clowder-ai#223: When OPENCODE_CONFIG is set (custom provider via runtime config file),
     // credentials are injected via {env:CAT_CAFE_OC_*} substitution in the config.

--- a/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
@@ -14,6 +14,7 @@
  *   error       → error
  */
 
+import { resolve } from 'node:path';
 import { type CatId, createCatId } from '@cat-cafe/shared';
 import { getCatModel } from '../../../../../config/cat-models.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
@@ -99,6 +100,11 @@ export function summarizeOpenCodeEnvForDebug(env: Record<string, string | null> 
 /** F203 Phase I: env var signaling that OPENCODE_CONFIG is instructions-only (no custom provider). */
 export const OC_INSTRUCTIONS_ONLY_ENV = 'CAT_CAFE_OC_INSTRUCTIONS_ONLY';
 
+function resolveAllowedWorkspaceDirs(workingDirectory?: string): string | undefined {
+  const threadWorkspace = workingDirectory?.trim();
+  return threadWorkspace ? resolve(threadWorkspace) : undefined;
+}
+
 export class OpenCodeAgentService implements L0InjectableAgentService {
   readonly catId: CatId;
   private readonly model: string;
@@ -139,7 +145,7 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     const effectiveModel = options?.callbackEnv?.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE ?? this.model;
     const args = this.buildArgs(prompt, options?.sessionId, effectiveModel, options?.cliConfigArgs);
     const cwd = options?.workingDirectory;
-    const childEnv = this.buildEnv(options?.callbackEnv);
+    const childEnv = this.buildEnv(options?.callbackEnv, cwd);
     // F171: Account env vars applied LAST — user overrides provider-injected values
     if (options?.accountEnv) {
       for (const [k, v] of Object.entries(options.accountEnv)) childEnv[k] = v;
@@ -432,8 +438,10 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     return deduped;
   }
 
-  private buildEnv(callbackEnv?: Record<string, string>): Record<string, string | null> {
+  private buildEnv(callbackEnv?: Record<string, string>, workingDirectory?: string): Record<string, string | null> {
     const env: Record<string, string | null> = { ...callbackEnv };
+    const allowedWorkspaceDirs = resolveAllowedWorkspaceDirs(workingDirectory);
+    if (allowedWorkspaceDirs) env.ALLOWED_WORKSPACE_DIRS = allowedWorkspaceDirs;
 
     // clowder-ai#223: When OPENCODE_CONFIG is set (custom provider via runtime config file),
     // credentials are injected via {env:CAT_CAFE_OC_*} substitution in the config.

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -107,17 +107,15 @@ export interface OpenCodeRuntimeConfigOptions {
   omitProviderAuth?: boolean;
   /** Absolute path to Clowder AI MCP server entry (packages/mcp-server/dist/index.js). */
   mcpServerPath?: string;
+  /** Workspace exposed to Clowder AI MCP servers for this invocation. */
+  allowedWorkspaceDirs?: string;
   /**
    * F203 Phase I: Instruction file paths injected into OpenCode's `instructions` config.
    * These are loaded by OpenCode every turn into `role: "system"` messages — compression-immune.
    * Typical contents: [compiledL0Path, "OPENCODE.md"].
    */
   instructions?: readonly string[];
-  /**
-   * #935: Directories outside the OpenCode working directory that should be
-   * granted `permission.external_directory` access. Typically includes the
-   * Clowder AI host project root when the thread's working directory is external.
-   */
+  /** #935: Directories outside cwd granted `permission.external_directory` access. */
   externalDirectories?: readonly string[];
 }
 
@@ -187,6 +185,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
     hasBaseUrl = false,
     omitProviderAuth = false,
     mcpServerPath,
+    allowedWorkspaceDirs,
     instructions,
     externalDirectories,
   } = options;
@@ -225,6 +224,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
       'cat-cafe': {
         type: 'local',
         command: ['node', mcpServerPath],
+        ...(allowedWorkspaceDirs ? { environment: { ALLOWED_WORKSPACE_DIRS: allowedWorkspaceDirs } } : {}),
       },
     };
   }

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -14,4 +14,5 @@ export type {
 } from './cli-types.js';
 export { isParseError, parseNDJSON } from './ndjson-parser.js';
 export { normalizeErrorMessage } from './normalize-error.js';
-export { isUnderAllowedRoot, validateProjectPath } from './project-path.js';
+export type { ProjectPathValidationFailureReason, ProjectPathValidationResult } from './project-path.js';
+export { isUnderAllowedRoot, validateProjectPath, validateProjectPathDetailed } from './project-path.js';

--- a/packages/api/src/utils/project-path.ts
+++ b/packages/api/src/utils/project-path.ts
@@ -97,30 +97,69 @@ export function isDenylistMode(): boolean {
   return LEGACY_ALLOWED_ROOTS() === null;
 }
 
+export type ProjectPathValidationFailureReason = 'not_found' | 'not_directory' | 'denied_root' | 'io_error';
+
+export type ProjectPathValidationResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: ProjectPathValidationFailureReason; message?: string };
+
+interface ProjectPathValidationDeps {
+  realpath?: typeof realpath;
+  stat?: typeof stat;
+}
+
+function errorCode(err: unknown): string | undefined {
+  return typeof err === 'object' && err !== null && 'code' in err
+    ? String((err as { code?: unknown }).code)
+    : undefined;
+}
+
+function errorMessage(err: unknown): string | undefined {
+  return err instanceof Error ? err.message : undefined;
+}
+
+function isMissingPathError(err: unknown): boolean {
+  return ['ENOENT', 'ENOTDIR'].includes(errorCode(err) ?? '');
+}
+
 /**
- * Check if a path is an allowed project directory.
+ * Check if a path is an allowed project directory and return diagnostic detail.
  *
  * 1. Resolves the path to absolute
  * 2. Uses realpath() to follow symlinks and canonicalize
  * 3. Checks the real path against denylist (or allowlist in legacy mode)
  * 4. Verifies the path is an existing directory
+ */
+export async function validateProjectPathDetailed(
+  rawPath: string,
+  deps: ProjectPathValidationDeps = {},
+): Promise<ProjectPathValidationResult> {
+  const realpathFn = deps.realpath ?? realpath;
+  const statFn = deps.stat ?? stat;
+  try {
+    const absPath = resolve(rawPath);
+    const realPath = await realpathFn(absPath);
+
+    if (!isUnderAllowedRoot(realPath)) return { ok: false, reason: 'denied_root' };
+
+    const info = await statFn(realPath);
+    if (!info.isDirectory()) return { ok: false, reason: 'not_directory' };
+
+    return { ok: true, path: realPath };
+  } catch (err) {
+    if (isMissingPathError(err)) return { ok: false, reason: 'not_found', message: errorMessage(err) };
+    return { ok: false, reason: 'io_error', message: errorMessage(err) };
+  }
+}
+
+/**
+ * Check if a path is an allowed project directory.
  *
  * @returns The canonicalized real path if valid, or null if rejected.
  */
 export async function validateProjectPath(rawPath: string): Promise<string | null> {
-  try {
-    const absPath = resolve(rawPath);
-    const realPath = await realpath(absPath);
-
-    if (!isUnderAllowedRoot(realPath)) return null;
-
-    const info = await stat(realPath);
-    if (!info.isDirectory()) return null;
-
-    return realPath;
-  } catch {
-    return null;
-  }
+  const result = await validateProjectPathDetailed(rawPath);
+  return result.ok ? result.path : null;
 }
 
 export function isPathUnderRoots(absPath: string, roots: string[], platformName = process.platform): boolean {

--- a/packages/api/test/account-resolver.test.js
+++ b/packages/api/test/account-resolver.test.js
@@ -58,6 +58,20 @@ describe('account-resolver (4b unified runtime resolution)', () => {
     return writeFile(join(projectRoot, '.cat-cafe', 'credentials.json'), JSON.stringify(creds, null, 2), 'utf-8');
   }
 
+  it('providerRequiresThreadWorkspace: only OpenCode requires a thread workspace (provider-level capability, not hardcoded in invocation layer)', async () => {
+    const { providerRequiresThreadWorkspace } = await import(`../dist/config/account-resolver.js?t=${Date.now()}-rtw`);
+    // OpenCode resolves project files relative to cwd and has no silent fallback like
+    // Claude/Codex — without a validated workspace it would inherit the runtime cwd.
+    assert.equal(providerRequiresThreadWorkspace('opencode'), true);
+    // Providers with their own cwd sources / silent fallback must NOT be forced.
+    assert.equal(providerRequiresThreadWorkspace('anthropic'), false);
+    assert.equal(providerRequiresThreadWorkspace('openai'), false);
+    assert.equal(providerRequiresThreadWorkspace('google'), false);
+    assert.equal(providerRequiresThreadWorkspace('kimi'), false);
+    // Unknown / undefined provider must default to false (no surprise hard-fail).
+    assert.equal(providerRequiresThreadWorkspace(undefined), false);
+  });
+
   it('resolveByAccountRef returns RuntimeProviderProfile from accounts + credentials', async () => {
     const { resolveByAccountRef } = await import(`../dist/config/account-resolver.js?t=${Date.now()}`);
     await writeCatalog({

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6,7 +6,7 @@
 import './helpers/setup-cat-registry.js';
 import assert from 'node:assert/strict';
 import { existsSync } from 'node:fs';
-import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readdir, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -6760,8 +6760,44 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(optionsSeen[0]?.workingDirectory, undefined, 'workingDirectory must be undefined for game threads');
   });
 
+  it('fails loud for OpenCode when thread projectPath is a virtual game path', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        invokedService = true;
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: 'games/werewolf', createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opencode',
+        service,
+        prompt: 'test game briefing',
+        userId: 'user1',
+        threadId: 'thread-opencode-game-werewolf',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, false, 'OpenCode must not inherit runtime cwd for virtual game projectPaths');
+    assert.ok(
+      msgs.some((m) => m.type === 'error' && String(m.error).includes('virtual game projectPath games/werewolf')),
+      `expected virtual game projectPath error, got: ${msgs.map((m) => m.type).join(',')}`,
+    );
+  });
+
   it('passes a valid thread projectPath as OpenCode workingDirectory', async () => {
-    const projectRoot = process.cwd();
+    const projectRoot = await realpath(join(__dirname, '..', '..', '..'));
 
     const optionsSeen = [];
     const service = {
@@ -6952,6 +6988,44 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.ok(
       !msgs.some((m) => m.type === 'error' && String(m.error).includes('Unable to resolve thread workspace')),
       'threadStore transient failure must not hard-fail invocation',
+    );
+  });
+
+  it('fails loud for OpenCode when thread workspace lookup fails before spawn', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        invokedService = true;
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => {
+          throw new Error('thread store unavailable');
+        },
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opencode',
+        service,
+        prompt: 'test opencode workspace lookup failure',
+        userId: 'user1',
+        threadId: 'thread-opencode-workspace-lookup-fails',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, false, 'OpenCode must not inherit runtime cwd when workspace lookup fails');
+    assert.ok(
+      msgs.some((m) => m.type === 'error' && String(m.error).includes('Unable to resolve thread workspace')),
+      `expected OpenCode workspace lookup error, got: ${msgs.map((m) => m.type).join(',')}`,
     );
   });
 

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6760,6 +6760,201 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(optionsSeen[0]?.workingDirectory, undefined, 'workingDirectory must be undefined for game threads');
   });
 
+  it('passes a valid thread projectPath as OpenCode workingDirectory', async () => {
+    const projectRoot = process.cwd();
+
+    const optionsSeen = [];
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        optionsSeen.push(options ?? {});
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: projectRoot, createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opencode',
+        service,
+        prompt: 'test project cwd',
+        userId: 'user1',
+        threadId: 'thread-opencode-project-cwd',
+        isLastCat: true,
+      }),
+    );
+
+    assert.ok(
+      msgs.some((m) => m.type === 'done'),
+      'service should complete',
+    );
+    assert.equal(optionsSeen.length, 1, `service should be invoked once, got messages: ${JSON.stringify(msgs)}`);
+    assert.equal(optionsSeen[0]?.workingDirectory, projectRoot);
+  });
+
+  it('fails loud for OpenCode when thread projectPath is default', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        invokedService = true;
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: 'default', createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opencode',
+        service,
+        prompt: 'test missing project path',
+        userId: 'user1',
+        threadId: 'thread-default-project-path',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, false, 'OpenCode must not inherit runtime cwd when projectPath is default');
+    assert.ok(
+      msgs.some((m) => m.type === 'error' && String(m.error).includes('OpenCode requires a thread projectPath')),
+      `expected missing projectPath error, got: ${msgs.map((m) => m.type).join(',')}`,
+    );
+  });
+
+  it('fails loud for OpenCode when thread projectPath is rejected by project-path validation', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        invokedService = true;
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: '/dev', createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opencode',
+        service,
+        prompt: 'test invalid project path',
+        userId: 'user1',
+        threadId: 'thread-invalid-project-path',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, false, 'OpenCode must not spawn when projectPath is invalid');
+    assert.ok(
+      msgs.some((m) => m.type === 'error' && String(m.error).includes('Invalid thread projectPath')),
+      `expected invalid projectPath error, got: ${msgs.map((m) => m.type).join(',')}`,
+    );
+  });
+
+  it('degrades for non-OpenCode when thread projectPath is rejected by project-path validation', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        invokedService = true;
+        assert.equal(options?.workingDirectory, undefined);
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: '/dev', createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test invalid project path degrade',
+        userId: 'user1',
+        threadId: 'thread-invalid-project-path-non-opencode',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, true, 'non-OpenCode providers keep best-effort fallback');
+    assert.ok(
+      msgs.some((m) => m.type === 'done'),
+      'should reach done',
+    );
+    assert.ok(
+      !msgs.some((m) => m.type === 'error' && String(m.error).includes('Invalid thread projectPath')),
+      'non-OpenCode provider must not hard-fail historical invalid projectPath',
+    );
+  });
+
+  it('degrades when thread workspace lookup fails before spawn', async () => {
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        invokedService = true;
+        assert.equal(options?.workingDirectory, undefined);
+        yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+      },
+    };
+
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => {
+          throw new Error('thread store unavailable');
+        },
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test workspace lookup failure degrade',
+        userId: 'user1',
+        threadId: 'thread-workspace-lookup-fails',
+        isLastCat: true,
+      }),
+    );
+
+    assert.equal(invokedService, true, 'threadStore transient failure should keep best-effort fallback');
+    assert.ok(
+      msgs.some((m) => m.type === 'done'),
+      'should reach done',
+    );
+    assert.ok(
+      !msgs.some((m) => m.type === 'error' && String(m.error).includes('Unable to resolve thread workspace')),
+      'threadStore transient failure must not hard-fail invocation',
+    );
+  });
+
   it('bug-fix: account resolution uses runtime root (process.cwd()), not thread.projectPath', async () => {
     // Regression: thread.projectPath points to dev worktree which lacks runtime-only accounts.
     // Account resolution must always use process.cwd() (the runtime root).

--- a/packages/api/test/opencode-agent-service.test.js
+++ b/packages/api/test/opencode-agent-service.test.js
@@ -425,6 +425,18 @@ describe('OpenCodeAgentService', () => {
     assert.strictEqual(opts.cwd, '/tmp/project');
   });
 
+  test('derives child workspace env from workingDirectory', async () => {
+    const proc = createMockProcess();
+    const spawnFn = mock.fn(() => proc);
+    const service = new OpenCodeAgentService({ catId: 'opencode', spawnFn, model: 'claude-haiku-4-5' });
+    const promise = collect(service.invoke('Test', { workingDirectory: '/tmp/project' }));
+    emitOpenCodeEvents(proc, [STEP_START, TEXT_RESPONSE, STEP_FINISH]);
+    await promise;
+
+    const opts = spawnFn.mock.calls[0].arguments[2];
+    assert.strictEqual(opts.env.ALLOWED_WORKSPACE_DIRS, '/tmp/project');
+  });
+
   test('yields error + done on CLI exit failure', async () => {
     const proc = createMockProcess(1);
     const spawnFn = mock.fn(() => proc);

--- a/packages/api/test/opencode-agent-service.test.js
+++ b/packages/api/test/opencode-agent-service.test.js
@@ -425,7 +425,7 @@ describe('OpenCodeAgentService', () => {
     assert.strictEqual(opts.cwd, '/tmp/project');
   });
 
-  test('derives child workspace env from workingDirectory', async () => {
+  test('does not put invocation workspace into the parent OpenCode env', async () => {
     const proc = createMockProcess();
     const spawnFn = mock.fn(() => proc);
     const service = new OpenCodeAgentService({ catId: 'opencode', spawnFn, model: 'claude-haiku-4-5' });
@@ -434,7 +434,32 @@ describe('OpenCodeAgentService', () => {
     await promise;
 
     const opts = spawnFn.mock.calls[0].arguments[2];
-    assert.strictEqual(opts.env.ALLOWED_WORKSPACE_DIRS, '/tmp/project');
+    assert.strictEqual(
+      opts.env.ALLOWED_WORKSPACE_DIRS,
+      undefined,
+      'mcp.cat-cafe.environment in OPENCODE_CONFIG is the workspace source of truth',
+    );
+  });
+
+  test('does not let stale account ALLOWED_WORKSPACE_DIRS override the invocation workspace', async () => {
+    const proc = createMockProcess();
+    const spawnFn = mock.fn(() => proc);
+    const service = new OpenCodeAgentService({ catId: 'opencode', spawnFn, model: 'claude-haiku-4-5' });
+    const promise = collect(
+      service.invoke('Test', {
+        workingDirectory: '/tmp/project',
+        accountEnv: { ALLOWED_WORKSPACE_DIRS: '/stale/account/workspace' },
+      }),
+    );
+    emitOpenCodeEvents(proc, [STEP_START, TEXT_RESPONSE, STEP_FINISH]);
+    await promise;
+
+    const opts = spawnFn.mock.calls[0].arguments[2];
+    assert.equal(
+      opts.env.ALLOWED_WORKSPACE_DIRS,
+      undefined,
+      'OpenCode parent env must not carry a stale workspace; mcp.cat-cafe.environment is the authoritative child env',
+    );
   });
 
   test('yields error + done on CLI exit failure', async () => {

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -3,6 +3,7 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import { resolveWorkspaceRoot } from '../dist/config/capabilities/mcp-config-adapters.js';
 import { prepareOpenCodeAcpSpawnConfig } from '../dist/domains/cats/services/agents/providers/opencode-acp-spawn-config.js';
 import {
   deriveOpenCodeApiType,
@@ -449,6 +450,36 @@ describe('generateOpenCodeRuntimeConfig', () => {
         ALLOWED_WORKSPACE_DIRS: '/tmp/project',
       },
     });
+  });
+
+  test('mcp.cat-cafe environment drives MCP workspace resolution', () => {
+    const originalAwd = process.env.ALLOWED_WORKSPACE_DIRS;
+    const originalWorkspace = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    try {
+      process.env.ALLOWED_WORKSPACE_DIRS = '/stale/parent/workspace';
+      delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      const config = generateOpenCodeRuntimeConfig({
+        providerName: 'anthropic',
+        models: ['anthropic/claude-opus-4-6'],
+        defaultModel: 'anthropic/claude-opus-4-6',
+        apiType: 'anthropic',
+        mcpServerPath: '/absolute/path/to/packages/mcp-server/dist/index.js',
+        allowedWorkspaceDirs: '/tmp/project',
+      });
+
+      process.env.ALLOWED_WORKSPACE_DIRS = config.mcp['cat-cafe'].environment.ALLOWED_WORKSPACE_DIRS;
+
+      assert.equal(
+        resolveWorkspaceRoot(),
+        '/tmp/project',
+        'OpenCode MCP child env must make Cat Cafe MCP resolve the invocation workspace',
+      );
+    } finally {
+      if (originalAwd === undefined) delete process.env.ALLOWED_WORKSPACE_DIRS;
+      else process.env.ALLOWED_WORKSPACE_DIRS = originalAwd;
+      if (originalWorkspace === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = originalWorkspace;
+    }
   });
 
   test('#871: non-api_key runtime config can omit provider auth placeholders', () => {

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -432,6 +432,25 @@ describe('generateOpenCodeRuntimeConfig', () => {
     });
   });
 
+  test('mcp.cat-cafe environment uses the invocation workspace', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'anthropic',
+      models: ['anthropic/claude-opus-4-6'],
+      defaultModel: 'anthropic/claude-opus-4-6',
+      apiType: 'anthropic',
+      mcpServerPath: '/absolute/path/to/packages/mcp-server/dist/index.js',
+      allowedWorkspaceDirs: '/tmp/project',
+    });
+
+    assert.deepStrictEqual(config.mcp['cat-cafe'], {
+      type: 'local',
+      command: ['node', '/absolute/path/to/packages/mcp-server/dist/index.js'],
+      environment: {
+        ALLOWED_WORKSPACE_DIRS: '/tmp/project',
+      },
+    });
+  });
+
   test('#871: non-api_key runtime config can omit provider auth placeholders', () => {
     const config = generateOpenCodeRuntimeConfig({
       providerName: 'anthropic',

--- a/packages/api/test/project-path.test.js
+++ b/packages/api/test/project-path.test.js
@@ -7,6 +7,7 @@ import { after, before, describe, it } from 'node:test';
 
 const {
   validateProjectPath,
+  validateProjectPathDetailed,
   isUnderAllowedRoot,
   getAllowedRoots,
   getDefaultDeniedRoots,
@@ -125,6 +126,25 @@ describe('validateProjectPath', () => {
   it('returns null for nonexistent path', async () => {
     const result = await validateProjectPath('/nonexistent/path/xxx');
     assert.strictEqual(result, null);
+  });
+
+  it('classifies transient filesystem errors separately from invalid paths', async () => {
+    const result = await validateProjectPathDetailed('/tmp/project', {
+      realpath: async () => {
+        const err = new Error('disk not ready');
+        err.code = 'EIO';
+        throw err;
+      },
+      stat: async () => {
+        throw new Error('stat should not be reached');
+      },
+    });
+
+    assert.deepStrictEqual(result, {
+      ok: false,
+      reason: 'io_error',
+      message: 'disk not ready',
+    });
   });
 
   it('returns null for denied system path', async () => {


### PR DESCRIPTION
## Summary
- fail loud before spawning OpenCode when thread workspace lookup or projectPath validation cannot produce a real filesystem workspace
- keep the existing `games/*` virtual projectPath exemption for non-OpenCode providers, but reject it for OpenCode so it never inherits runtime cwd
- make generated OpenCode MCP config the single workspace source of truth: `mcp.cat-cafe.environment.ALLOWED_WORKSPACE_DIRS` is derived from the validated invocation `workingDirectory`
- clear parent-process `ALLOWED_WORKSPACE_DIRS` from OpenCode child env so stale account env cannot override the invocation workspace
- expose detailed projectPath validation reasons so transient I/O is distinguishable from invalid/denied paths

Fixes #1000

## Original requirements
Source: dispatch mission + lawplatform incident `docs/incidents/2026-06-22-opencode-cwd-not-following-project-dir.md`

> OpenCode/minimax-m3 first launch should see the thread project worktree, not `cat-cafe-runtime/packages/api`. Relative paths/default workspace must align with Claude/Codex behavior, and failures should not silently inherit runtime cwd.

## OpenCode MCP env evidence
Primary-source check against anomalyco/opencode `dev` at `7b750a8f20e72d9842a3a18e00544fb9e43b0b7c`:
- `packages/core/src/v1/config/mcp.ts` defines local MCP `environment` as environment variables for the MCP server process: https://github.com/anomalyco/opencode/blob/7b750a8f20e72d9842a3a18e00544fb9e43b0b7c/packages/core/src/v1/config/mcp.ts#L14-L16
- `packages/opencode/src/mcp/index.ts` starts local MCP stdio transport with `env: { ...process.env, ..., ...mcp.environment }`, so `mcp.cat-cafe.environment.ALLOWED_WORKSPACE_DIRS` overrides any parent/account env value for the spawned MCP child: https://github.com/anomalyco/opencode/blob/7b750a8f20e72d9842a3a18e00544fb9e43b0b7c/packages/opencode/src/mcp/index.ts#L331-L343
- Local regression evidence: `opencode-config-template.test.js` applies the generated `mcp.cat-cafe.environment` to `resolveWorkspaceRoot()` and proves the Cat Cafe MCP workspace resolves to the invocation project path.

## Architecture ownership
- Architecture cell: agent invocation / provider spawn boundary
- Map delta: none
- Why: this extends existing `invoke-single-cat` workspace resolution and OpenCode provider config/env behavior; it does not add a new Store, Queue, Router, Adapter, Dispatcher, or Binding.

## Quality gate evidence
Rebased on `origin/main` (`4241932f`) and pushed at `a4390810`.

- `pnpm --filter @cat-cafe/api run build` -> pass
- targeted OpenCode/workspace tests -> 203/203 pass
- `pnpm check` -> pass (advisory warnings only; no errors)
- `git diff --check` -> pass
- `pnpm --filter @cat-cafe/api run test:public` before rebase -> 15300 tests, 15273 pass, 27 skipped, 0 fail
- `pnpm --filter @cat-cafe/api run test:public` after rebase -> OpenCode-related coverage passed; local run failed 4 unrelated F237 `prompt-injection-yaml-validation.test.js` tests because this runtime shell sets `DEFAULT_OWNER_USER_ID=default-user` while those new session-auth fixtures use `sessionUserId=test-user`. `git diff --exit-code origin/main -- packages/api/test/prompt-injection-yaml-validation.test.js packages/api/src/routes/prompt-injection.ts` is clean. The same targeted prompt-injection test passes 12/12 with `DEFAULT_OWNER_USER_ID` unset and fails the same 4/12 with the inherited owner env.

## Reviewer focus
- Re-check the final OpenCode invariant guard: if `provider === 'opencode'` and thread workspace resolution leaves `workingDirectory` empty, invocation fails before provider spawn. This covers default/unbound, `games/*`, invalid path, transient validation failure, and `threadStore.get` failure.
- Re-check OpenCode MCP env semantics against the upstream source links and local `resolveWorkspaceRoot()` regression test.
- Re-check account env precedence: stale parent `ALLOWED_WORKSPACE_DIRS` is removed; MCP child env is authoritative.

[砚砚/gpt-5.5🐾]
