### PR TITLE
fix(F210): hotfix Gemini AGY carrier config

### DIFF
--- a/cat-template.json
+++ b/cat-template.json
@@ -98,7 +98,7 @@
     },
     "gemini": {
       "defaultModel": "gemini-2.5-pro",
-      "models": ["gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-pro-preview"]
+      "models": ["gemini-2.5-pro", "gemini-3-flash-preview", "gemini-3.1-pro"]
     }
   },
   "coCreator": {
@@ -524,19 +524,15 @@
         {
           "id": "gemini-default",
           "clientId": "google",
-          "defaultModel": "gemini-3.1-pro-preview",
+          "defaultModel": "gemini-3.1-pro",
           "mcpSupport": true,
           "cli": {
             "command": "gemini",
             "outputFormat": "stream-json",
             "defaultArgs": []
           },
-          "acp": {
-            "command": "gemini",
-            "startupArgs": ["--acp", "--approval-mode", "yolo"],
-            "mcpWhitelist": ["cat-cafe", "cat-cafe-memory", "cat-cafe-collab", "cat-cafe-signals", "pencil"],
-            "supportsMultiplexing": true
-          },
+          "acp": null,
+          "cliConfigArgs": ["--model gemini-3.1-pro"],
           "personality": "热血奔放，善用富文本语音，表达力最强",
           "strengths": ["visual-design", "ui-ux", "creativity"],
           "contextBudget": {
@@ -574,12 +570,8 @@
             "outputFormat": "stream-json",
             "defaultArgs": []
           },
-          "acp": {
-            "command": "gemini",
-            "startupArgs": ["--acp", "--approval-mode", "yolo"],
-            "mcpWhitelist": ["cat-cafe", "cat-cafe-memory", "cat-cafe-collab", "cat-cafe-signals", "pencil"],
-            "supportsMultiplexing": true
-          },
+          "acp": null,
+          "cliConfigArgs": ["--model gemini-3.5-flash"],
           "caution": "强review，禁自合",
           "restrictions": [],
           "personality": "经典版，创意丰富",

--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -26,6 +26,8 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
   'gemini-2.5-pro': 1_000_000,
   'gemini-2.5-flash': 1_000_000,
   'gemini-3-pro': 1_000_000,
+  'gemini-3.1-pro': 1_000_000,
+  // Historical ACP-era id retained for old sessions and imported metadata.
   'gemini-3.1-pro-preview': 1_000_000,
 };
 

--- a/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/GeminiAgentService.ts
@@ -814,8 +814,8 @@ export class GeminiAgentService implements AgentService {
           type: 'antigravity_cli_model_override_unsupported',
           requestedModel: requestedModelOverride,
           reason: agyProfile
-            ? 'AGY CLI profile model selection is configured through isolated settings; no verified per-call --model/env override exists.'
-            : 'AGY CLI uses the account-side selected model; no verified per-call --model/env override exists.',
+            ? 'AGY CLI profile model selection is configured through isolated settings; CAT_CAFE_GEMINI_MODEL_OVERRIDE is ignored. Use the profile model setting instead.'
+            : 'AGY CLI does not accept CAT_CAFE_GEMINI_MODEL_OVERRIDE; use catalog cliConfigArgs such as --model <model>, or the account-side selected model.',
         }),
         metadata,
         timestamp: Date.now(),

--- a/packages/api/test/cat-config-loader.test.js
+++ b/packages/api/test/cat-config-loader.test.js
@@ -1,6 +1,6 @@
 import './helpers/setup-cat-registry.js';
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -21,6 +21,9 @@ const {
   getCatFamily,
   _resetCachedConfig,
 } = await import('../dist/config/cat-config-loader.js');
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_TEMPLATE_PATH = resolve(__dirname, '..', '..', '..', 'cat-template.json');
 
 /** Create a temp JSON file with given content, return path */
 function writeTempConfig(data) {
@@ -68,6 +71,38 @@ describe('cat-config-loader', () => {
       assert.equal(config.version, 1);
       assert.equal(config.breeds.length, 1);
       assert.equal(config.breeds[0].id, 'ragdoll');
+    });
+
+    it('keeps gemini25 template off the retired Gemini ACP carrier', () => {
+      const config = loadCatConfig(REPO_TEMPLATE_PATH);
+      const rawConfig = JSON.parse(readFileSync(REPO_TEMPLATE_PATH, 'utf-8'));
+      const breed = config.breeds.find((b) => b.id === 'siamese');
+      assert.ok(breed, 'siamese breed should exist in repo template');
+      const variant = breed.variants.find((v) => v.catId === 'gemini25');
+      assert.ok(variant, 'gemini25 variant should exist in repo template');
+      const rawBreed = rawConfig.breeds.find((b) => b.id === 'siamese');
+      const rawVariant = rawBreed.variants.find((v) => v.catId === 'gemini25');
+
+      assert.equal(variant.defaultModel, 'gemini-3.5-flash');
+      assert.deepEqual(rawVariant.acp, null);
+      assert.deepEqual(variant.cliConfigArgs, ['--model gemini-3.5-flash']);
+    });
+
+    it('keeps gemini31 template off the retired Gemini ACP carrier', () => {
+      const config = loadCatConfig(REPO_TEMPLATE_PATH);
+      const rawConfig = JSON.parse(readFileSync(REPO_TEMPLATE_PATH, 'utf-8'));
+      const breed = config.breeds.find((b) => b.id === 'siamese');
+      assert.ok(breed, 'siamese breed should exist in repo template');
+      const variant = breed.variants.find((v) => v.id === breed.defaultVariantId);
+      assert.ok(variant, 'default gemini31 variant should exist in repo template');
+      const rawBreed = rawConfig.breeds.find((b) => b.id === 'siamese');
+      const rawVariant = rawBreed.variants.find((v) => v.id === rawBreed.defaultVariantId);
+
+      assert.equal(variant.defaultModel, 'gemini-3.1-pro');
+      assert.deepEqual(rawVariant.acp, null);
+      assert.deepEqual(variant.cliConfigArgs, ['--model gemini-3.1-pro']);
+      assert.ok(rawConfig.clientDefaults.gemini.models.includes('gemini-3.1-pro'));
+      assert.equal(rawConfig.clientDefaults.gemini.models.includes('gemini-3.1-pro-preview'), false);
     });
 
     it('loads default project config when no path/env provided', () => {

--- a/packages/api/test/context-window-sizes.test.js
+++ b/packages/api/test/context-window-sizes.test.js
@@ -24,6 +24,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('minimax-m3'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-2.5-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3-pro'), 1_000_000);
+    assert.equal(getContextWindowFallback('gemini-3.1-pro'), 1_000_000);
     assert.equal(getContextWindowFallback('gemini-3.1-pro-preview'), 1_000_000);
   });
 
@@ -52,6 +53,7 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('minimax/MiniMax-M3'), 1_000_000);
     assert.equal(getContextWindowFallback('minimax/minimax-m3'), 1_000_000);
     assert.equal(getContextWindowFallback('google/gemini-2.5-pro'), 1_000_000);
+    assert.equal(getContextWindowFallback('google/gemini-3.1-pro'), 1_000_000);
     // Prefix match after strip (versioned model behind provider prefix)
     assert.equal(getContextWindowFallback('anthropic/claude-opus-4-6-20260101'), 200_000);
     assert.equal(getContextWindowFallback('openai-compat/gpt-5.3-turbo'), 128_000);

--- a/packages/api/test/gemini-agent-service.test.js
+++ b/packages/api/test/gemini-agent-service.test.js
@@ -500,7 +500,7 @@ describe('GeminiAgentService (antigravity-cli adapter)', () => {
     assert.ok(args.includes('--add-dir'));
     assert.equal(args[args.indexOf('--add-dir') + 1], workDir);
     assert.equal(args[args.indexOf('--print') + 1], 'System identity\n\nSay hi');
-    assert.equal(args.includes('--model'), false, 'agy 1.0.1 has no verified --model flag');
+    assert.equal(args.includes('--model'), false, 'default antigravity-cli must not pass --model without config');
   });
 
   test('F212: AGY empty plain-text completion yields user-visible silent_completion diagnostics', async () => {
@@ -1337,6 +1337,27 @@ describe('GeminiAgentService (antigravity-cli adapter)', () => {
     assert.ok(args.includes('/tmp/extra-agy-dir'), 'unrelated user --add-dir should remain');
   });
 
+  test('allows catalog AGY model selection through cliConfigArgs', async () => {
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new GeminiAgentService({
+      spawnFn,
+      adapter: 'antigravity-cli',
+      model: 'gemini-3.5-flash',
+    });
+
+    const promise = collect(
+      service.invoke('Say hi', {
+        cliConfigArgs: ['--model gemini-3.5-flash'],
+      }),
+    );
+    emitPlainText(proc, 'AGY_MODEL_ARG_OK\n');
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.equal(args[args.indexOf('--model') + 1], 'gemini-3.5-flash');
+  });
+
   test('uses isolated AGY profile HOME and gates yolo on sandbox proof', async () => {
     const proc = createMockProcess();
     const profileRoot = mkdtempSync(join(tmpdir(), 'agy-service-profile-root-'));
@@ -1750,7 +1771,7 @@ describe('GeminiAgentService (antigravity-cli adapter)', () => {
   test('reports per-call model override as unsupported without passing --model to agy', async () => {
     const proc = createMockProcess();
     const spawnFn = createMockSpawnFn(proc);
-    const service = new GeminiAgentService({ spawnFn, adapter: 'antigravity-cli' });
+    const service = new GeminiAgentService({ spawnFn, adapter: 'antigravity-cli', model: 'gemini-3.5-flash' });
 
     const promise = collect(
       service.invoke('model override check', {
@@ -1767,7 +1788,8 @@ describe('GeminiAgentService (antigravity-cli adapter)', () => {
     assert.ok(info, 'unsupported model override should be explicit system_info');
     const payload = JSON.parse(info.content);
     assert.equal(payload.requestedModel, 'gemini-override-should-not-be-used');
-    assert.match(payload.reason, /account-side selected model/);
+    assert.match(payload.reason, /CAT_CAFE_GEMINI_MODEL_OVERRIDE/);
+    assert.match(payload.reason, /cliConfigArgs/);
 
     const done = msgs.find((m) => m.type === 'done');
     assert.equal(done?.metadata?.modelVerified, false);

--- a/packages/web/src/components/UnifiedAuthModal.tsx
+++ b/packages/web/src/components/UnifiedAuthModal.tsx
@@ -21,7 +21,7 @@ const MODEL_SUGGESTIONS: Partial<Record<BuiltinAccountClient, string[]>> = {
     'claude-opus-4-5-20251101',
   ],
   openai: ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5.3-codex-spark'],
-  google: ['gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3.1-pro-preview'],
+  google: ['gemini-2.5-pro', 'gemini-3-flash-preview', 'gemini-3.1-pro'],
   dare: ['claude-sonnet-4-6'],
   opencode: ['claude-sonnet-4-6', 'claude-opus-4-6'],
 };

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -2111,7 +2111,7 @@ describe('HubCatEditor', () => {
                 authType: 'oauth',
                 protocol: 'google',
                 mode: 'subscription',
-                models: ['gemini-2.5-pro', 'gemini-3.1-pro-preview'],
+                models: ['gemini-2.5-pro', 'gemini-3.1-pro'],
                 hasApiKey: false,
                 createdAt: '2026-03-18T00:00:00.000Z',
                 updatedAt: '2026-03-18T00:00:00.000Z',

--- a/scripts/install-auth-config.mjs
+++ b/scripts/install-auth-config.mjs
@@ -20,7 +20,7 @@ const BUILTIN_ACCOUNT_SPECS = [
     models: ['claude-opus-4-6', 'claude-sonnet-4-6', 'claude-opus-4-5-20251101'],
   },
   { id: 'codex', displayName: 'Codex', client: 'openai', models: ['gpt-5.3-codex', 'gpt-5.4', 'gpt-5.3-codex-spark'] },
-  { id: 'gemini', displayName: 'Gemini', client: 'google', models: ['gemini-3.1-pro-preview', 'gemini-2.5-pro'] },
+  { id: 'gemini', displayName: 'Gemini', client: 'google', models: ['gemini-3.1-pro', 'gemini-2.5-pro'] },
   { id: 'kimi', displayName: 'Kimi', client: 'kimi', models: ['kimi-code/kimi-for-coding'] },
   { id: 'dare', displayName: 'Dare', client: 'dare', models: ['z-ai/glm-4.7'] },
   { id: 'opencode', displayName: 'OpenCode', client: 'opencode', models: ['claude-opus-4-6', 'claude-sonnet-4-5'] },


### PR DESCRIPTION
## Summary
- Switch Gemini catalog defaults away from the retired Gemini ACP path and pin AGY CLI model args for gemini/gemini25.
- Align gemini31 model IDs across template, context-window fallback, auth UI suggestions, and install defaults.
- Add regressions that keep Gemini template entries off ACP and cover AGY cliConfigArgs model selection.

## Verification
- env PATH=/opt/homebrew/Cellar/node@24/24.18.0/bin:$PATH pnpm --dir packages/api run build
- env PATH=/opt/homebrew/Cellar/node@24/24.18.0/bin:$PATH CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import /Users/tianyiliang/Projects/cat-cafe-runtime/packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cat-config-loader.test.js packages/api/test/context-window-sizes.test.js packages/api/test/gemini-agent-service.test.js
- env PATH=/opt/homebrew/Cellar/node@24/24.18.0/bin:$PATH pnpm --dir packages/web exec vitest run src/components/__tests__/hub-cat-editor.test.tsx

Runtime check: PATCH /api/cats/gemini returned 200 and persisted defaultModel=gemini-3.1-pro, acp=null, cliConfigArgs=["--model gemini-3.1-pro"].