### PR TITLE
Fix bootcamp modal create feedback

### DIFF
--- a/packages/web/src/components/BootcampListModal.tsx
+++ b/packages/web/src/components/BootcampListModal.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { type Thread, useChatStore } from '@/stores/chatStore';
+import { useToastStore } from '@/stores/toastStore';
 import { apiFetch } from '@/utils/api-client';
 import { BootcampIcon } from './icons/BootcampIcon';
 import { pushThreadRouteWithHistory } from './ThreadSidebar/thread-navigation';
@@ -42,6 +43,33 @@ function phaseProgress(phase: string | undefined): number {
   const idx = PHASE_ORDER.indexOf(phase);
   if (idx < 0) return 0;
   return Math.round(((idx + 1) / PHASE_ORDER.length) * 100);
+}
+
+async function readApiError(res: Response, fallback: string): Promise<string> {
+  try {
+    const data = (await res.json()) as { error?: unknown; message?: unknown };
+    const message = typeof data.error === 'string' ? data.error : typeof data.message === 'string' ? data.message : '';
+    if (message.trim()) return message.trim();
+  } catch {
+    // fall through to fallback
+  }
+  return fallback;
+}
+
+function normalizeCreateError(message: string): string {
+  if (message.includes('Bootcamp workspace root')) {
+    return '训练营工作区未配置。请在启动环境中设置 CAT_CAFE_WORKSPACE_ROOT 后重启服务。';
+  }
+  return message;
+}
+
+function showCreateError(message: string) {
+  useToastStore.getState().addToast({
+    type: 'error',
+    title: '创建训练营失败',
+    message,
+    duration: 7000,
+  });
 }
 
 interface BootcampListModalProps {
@@ -104,11 +132,17 @@ export function BootcampListModal({ open, onClose, currentThreadId }: BootcampLi
           bootcampState: { v: 1, phase: 'phase-1-intro', startedAt: Date.now() },
         }),
       });
-      if (!res.ok) return;
+      if (!res.ok) {
+        const message = await readApiError(res, `请求失败 (${res.status})`);
+        showCreateError(normalizeCreateError(message));
+        return;
+      }
       const thread: Thread = await res.json();
       setThreads([thread, ...storeThreads]);
       pushThreadRouteWithHistory(thread.id, typeof window !== 'undefined' ? window : undefined);
       onClose();
+    } catch (err) {
+      showCreateError(err instanceof Error ? err.message : '网络请求失败，请稍后重试。');
     } finally {
       setIsCreating(false);
     }
@@ -221,10 +255,10 @@ export function BootcampListModal({ open, onClose, currentThreadId }: BootcampLi
             type="button"
             onClick={handleCreate}
             disabled={isCreating}
-            className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-cafe-accent text-[var(--cafe-surface)] font-semibold hover:opacity-90 disabled:opacity-40 transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 rounded-xl bg-cafe-accent text-[var(--cafe-surface)] font-semibold hover:opacity-90 disabled:opacity-40 transition-colors whitespace-nowrap"
             data-testid="bootcamp-list-create"
           >
-            <svg className="w-4.5 h-4.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <svg className="w-5 h-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
             </svg>
             {isCreating ? '创建中...' : '开始新训练营'}

--- a/packages/web/src/components/__tests__/bootcamp-list-modal-navigation.test.tsx
+++ b/packages/web/src/components/__tests__/bootcamp-list-modal-navigation.test.tsx
@@ -5,6 +5,7 @@ import { CHAT_THREAD_ROUTE_EVENT } from '../ThreadSidebar/thread-navigation';
 
 const apiFetchMock = vi.hoisted(() => vi.fn());
 const routerPushMock = vi.hoisted(() => vi.fn());
+const toastAddMock = vi.hoisted(() => vi.fn());
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: routerPushMock }),
@@ -13,6 +14,10 @@ vi.mock('next/navigation', () => ({
 vi.mock('../../stores/chatStore', () => ({
   useChatStore: (selector: (state: { threads: unknown[]; setThreads: ReturnType<typeof vi.fn> }) => unknown) =>
     selector({ threads: [], setThreads: vi.fn() }),
+}));
+
+vi.mock('../../stores/toastStore', () => ({
+  useToastStore: { getState: () => ({ addToast: toastAddMock }) },
 }));
 
 vi.mock('../../utils/api-client', () => ({
@@ -32,6 +37,7 @@ describe('BootcampListModal navigation', () => {
   beforeEach(() => {
     apiFetchMock.mockReset();
     routerPushMock.mockReset();
+    toastAddMock.mockReset();
     window.history.replaceState({}, '', '/');
     container = document.createElement('div');
     document.body.appendChild(container);
@@ -78,5 +84,55 @@ describe('BootcampListModal navigation', () => {
     expect(dispatchSpy.mock.calls.some(([event]) => event.type === CHAT_THREAD_ROUTE_EVENT)).toBe(true);
     expect(routerPushMock).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps the create button compact and surfaces bootcamp creation errors', async () => {
+    apiFetchMock.mockImplementation(async (path: string) => {
+      if (path === '/api/bootcamp/threads') {
+        return {
+          ok: true,
+          json: async () => ({ threads: [] }),
+        };
+      }
+      if (path === '/api/threads') {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ error: 'Bootcamp workspace root is not configured; refusing to use runtime cwd' }),
+        };
+      }
+      throw new Error(`Unexpected API call: ${path}`);
+    });
+    const onClose = vi.fn();
+
+    await act(async () => {
+      root.render(React.createElement(BootcampListModal, { open: true, onClose, currentThreadId: 'default' }));
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const createButton = container.querySelector('[data-testid="bootcamp-list-create"]') as HTMLButtonElement | null;
+    expect(createButton).toBeTruthy();
+    expect(createButton!.className).toContain('whitespace-nowrap');
+    const iconClass = createButton!.querySelector('svg')?.getAttribute('class') ?? '';
+    expect(iconClass).toContain('w-5');
+    expect(iconClass).toContain('h-5');
+    expect(iconClass).toContain('shrink-0');
+    expect(iconClass).not.toContain('w-4.5');
+
+    await act(async () => {
+      createButton!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        title: '创建训练营失败',
+        message: expect.stringContaining('CAT_CAFE_WORKSPACE_ROOT'),
+      }),
+    );
+    expect(onClose).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## 关联 Issue

Closes zts212653/clowder-ai#1023

## Summary

Fixes the bootcamp list modal create button UI and surfaces errors when bootcamp thread creation fails.

## Changes

- Replace invalid Tailwind classes `w-4.5 h-4.5` with stable SVG sizing.
- Add `whitespace-nowrap` and `shrink-0` so the create button stays compact.
- Read non-2xx API error responses from `POST /api/threads`.
- Show a toast when bootcamp creation fails.
- Normalize `Bootcamp workspace root` failures into a clearer `CAT_CAFE_WORKSPACE_ROOT` setup message.
- Add coverage for the compact button classes and create-failure toast path.

## Root Cause

The create button SVG used unsupported Tailwind size classes, so the browser rendered it at its default SVG size and pushed the button layout apart.

Separately, the create handler silently returned on non-OK responses, which made backend failures appear as if the button click did nothing.

## Validation

- `pnpm.cmd --dir packages/web exec vitest run src/components/__tests__/bootcamp-list-modal-navigation.test.tsx`
- `pnpm.cmd exec biome check packages/web/src/components/BootcampListModal.tsx packages/web/src/components/__tests__/bootcamp-list-modal-navigation.test.tsx --diagnostic-level=error`

Note: full `tsc --noEmit` currently fails on unrelated existing F231/F232/capability-tip type drift.

