### PR TITLE
Fix Windows bootcamp workspace root startup

### DIFF
--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -633,6 +633,11 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
       'Windows production starts must default CAT_CAFE_WORKSPACE_ROOT to $ProjectRoot while preserving explicit env overrides',
     );
     assert.match(
+      ps1,
+      /\$workspaceRootMarker\s*=\s*if\s*\(-not\s*\$Dev\)\s*\{\s*if\s*\(\$env:CAT_CAFE_WORKSPACE_ROOT\)\s*\{\s*\$env:CAT_CAFE_WORKSPACE_ROOT\s*\}\s*else\s*\{\s*\$ProjectRoot\s*\}\s*\}/,
+      'Windows production CAT_CAFE_WORKSPACE_ROOT must prefer explicit $env override before falling back to $ProjectRoot (guards against accidental override-stripping refactors)',
+    );
+    assert.match(
       overridesBlock,
       /CAT_CAFE_WORKSPACE_ROOT\s*=\s*\$workspaceRootMarker/,
       'runtimeEnvOverrides must pass CAT_CAFE_WORKSPACE_ROOT into the API job after dotenv reload',

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -627,6 +627,16 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
       /CAT_CAFE_RUNTIME_ROOT\s*=\s*\$runtimeRootMarker/,
       'runtimeEnvOverrides must pass CAT_CAFE_RUNTIME_ROOT into the API job after dotenv reload',
     );
+    assert.match(
+      ps1,
+      /\$workspaceRootMarker\s*=\s*if\s*\(-not\s*\$Dev\)\s*\{\s*[\s\S]*\$ProjectRoot[\s\S]*\}\s*else\s*\{\s*\$env:CAT_CAFE_WORKSPACE_ROOT\s*\}/,
+      'Windows production starts must default CAT_CAFE_WORKSPACE_ROOT to $ProjectRoot while preserving explicit env overrides',
+    );
+    assert.match(
+      overridesBlock,
+      /CAT_CAFE_WORKSPACE_ROOT\s*=\s*\$workspaceRootMarker/,
+      'runtimeEnvOverrides must pass CAT_CAFE_WORKSPACE_ROOT into the API job after dotenv reload',
+    );
   });
 
   it('start-windows.ps1 assigns NODE_ENV inside the API Start-Job', () => {

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -499,6 +499,11 @@ try {
     $apiNodeEnv = if ($Dev) { 'development' } else { 'production' }
     $globalSidecarOwner = if ($useRedis -and -not $Dev) { "1" } else { $null }
     $runtimeRootMarker = if (-not $Dev) { $ProjectRoot } else { $null }
+    $workspaceRootMarker = if (-not $Dev) {
+        if ($env:CAT_CAFE_WORKSPACE_ROOT) { $env:CAT_CAFE_WORKSPACE_ROOT } else { $ProjectRoot }
+    } else {
+        $env:CAT_CAFE_WORKSPACE_ROOT
+    }
     $runtimeEnvOverrides = @{
         REDIS_URL = $env:REDIS_URL
         MEMORY_STORE = $env:MEMORY_STORE
@@ -517,6 +522,7 @@ try {
         CAT_CAFE_SERVICE_AUDIO_ENABLED = $env:CAT_CAFE_SERVICE_AUDIO_ENABLED
         CAT_CAFE_PROVISION_GLOBAL_SIDECAR = $globalSidecarOwner
         CAT_CAFE_RUNTIME_ROOT = $runtimeRootMarker
+        CAT_CAFE_WORKSPACE_ROOT = $workspaceRootMarker
     }
 
     # Embedding sidecar (and other Cat Cafe ML services) are reconciled by the


### PR DESCRIPTION
## Summary

- Set `CAT_CAFE_WORKSPACE_ROOT` for Windows production/runtime startup when the API job is marked with `CAT_CAFE_RUNTIME_ROOT`.
- Default the workspace root to `$ProjectRoot`, while preserving an explicit `CAT_CAFE_WORKSPACE_ROOT` from the environment or `.env`.
- Extend the existing `start-windows.ps1` regression test to assert that the workspace root marker is passed into the API job, and lock the explicit-env-first ordering inside the production branch (added in follow-up commit per local review nit).

## Why

PR #1024 fixed the bootcamp modal UI and frontend error feedback, but it did not change `scripts/start-windows.ps1`. On Windows production/runtime startup, the API job still received `CAT_CAFE_RUNTIME_ROOT` without `CAT_CAFE_WORKSPACE_ROOT`, so bootcamp thread creation could still fail with:

```text
Bootcamp workspace root is not configured; refusing to use runtime cwd
```

This aligns the Windows startup path with `scripts/runtime-worktree.sh`, which already exports both runtime root and workspace root.

Closes #1023.

## Validation

- `node --test --test-name-pattern "start-windows.ps1 marks production API job as connector runtime" scripts/start-dev-profile-isolation.test.mjs`
- `pnpm.cmd exec biome check scripts/start-dev-profile-isolation.test.mjs --formatter-enabled=false --diagnostic-level=error`
- `git diff --check`
- Local node regex dry-run confirms both the existing greedy assert and the new strict `explicit-env-first` assert match the current `scripts/start-windows.ps1` production branch.

Note: running the full `node --test scripts/start-dev-profile-isolation.test.mjs` on this Windows shell still fails in unrelated bash-dependent subtests with `status=null`; the targeted Windows startup assertions pass.