### PR TITLE
fix: read connector gateway registries lazily

### DIFF
--- a/packages/api/src/routes/connector-hub.ts
+++ b/packages/api/src/routes/connector-hub.ts
@@ -914,10 +914,10 @@ export const connectorHubRoutes: FastifyPluginAsync<ConnectorHubRoutesOptions> =
   // Implementation in connector-plugin-routes.ts for file size discipline.
   connectorActionRoutes({
     getManifests: getConnectorManifests,
-    pluginRegistry: opts.pluginRegistry,
-    adapterRegistry: opts.adapterRegistry,
-    activateConnector: opts.activateConnector,
-    deactivateConnector: opts.deactivateConnector,
+    getPluginRegistry: () => opts.pluginRegistry,
+    getAdapterRegistry: () => opts.adapterRegistry,
+    getActivateConnector: () => opts.activateConnector,
+    getDeactivateConnector: () => opts.deactivateConnector,
     redis: opts.redis,
   })(app);
 

--- a/packages/api/src/routes/connector-plugin-routes.ts
+++ b/packages/api/src/routes/connector-plugin-routes.ts
@@ -37,14 +37,18 @@ import {
 export interface ConnectorActionRoutesOptions {
   /** Manifest lookup by connector ID (built-in + installed plugins). */
   getManifests: () => Map<string, ConnectorManifest>;
-  /** F240 A-3: Plugin registry for generic action endpoint (includes unconfigured plugins) */
-  pluginRegistry?: ReadonlyMap<string, IMConnectorPlugin>;
-  /** F240 A-3: Adapter registry for generic action endpoint (only configured+started connectors) */
-  adapterRegistry?: ReadonlyMap<string, IOutboundAdapter>;
-  /** F240 A-3: Activate a connector after credentials acquired via action */
-  activateConnector?: (connectorId: string) => Promise<void>;
-  /** F240 A-3: Deactivate a connector on disconnect */
-  deactivateConnector?: (connectorId: string) => Promise<void>;
+  /**
+   * F240 A-3: Live plugin registry getter (resolves after gateway start).
+   * wireGatewayHooks mutates connectorHubOpts.pluginRegistry post-register;
+   * a register-time value would snapshot undefined. Getter reads latest at request time.
+   */
+  getPluginRegistry?: () => ReadonlyMap<string, IMConnectorPlugin> | undefined;
+  /** F240 A-3: Live adapter registry getter (same timing reason as getPluginRegistry) */
+  getAdapterRegistry?: () => ReadonlyMap<string, IOutboundAdapter> | undefined;
+  /** F240 A-3: Live activate hook getter */
+  getActivateConnector?: () => ((connectorId: string) => Promise<void>) | undefined;
+  /** F240 A-3: Live deactivate hook getter */
+  getDeactivateConnector?: () => ((connectorId: string) => Promise<void>) | undefined;
   /** Shared Redis dependency for external connector action handlers. */
   redis?: RedisClient | undefined;
 }
@@ -177,13 +181,13 @@ export const connectorActionRoutes: (opts: ConnectorActionRoutesOptions) => (app
         return { error: `Unknown connector: ${connectorId}` };
       }
 
-      const plugin = opts.pluginRegistry?.get(connectorId);
+      const plugin = opts.getPluginRegistry?.()?.get(connectorId);
       if (!plugin) {
         reply.status(503);
         return { error: `Connector '${connectorId}' plugin not loaded` };
       }
       // Adapter is optional — unconfigured connectors (e.g. pre-QR-login) have no adapter yet
-      const adapter = opts.adapterRegistry?.get(connectorId);
+      const adapter = opts.getAdapterRegistry?.()?.get(connectorId);
 
       const projectRoot = resolveActiveProjectRoot();
       // Resolve actual env (stored > env > default) so action handlers see real values
@@ -226,9 +230,11 @@ export const connectorActionRoutes: (opts: ConnectorActionRoutesOptions) => (app
 
       // Lifecycle: activate after credential backfill, deactivate on explicit disconnect.
       let activationStatus: 'activated' | 'deactivated' | 'failed' | undefined;
-      if (result.activate === false && opts.deactivateConnector) {
+      const deactivateConnector = opts.getDeactivateConnector?.();
+      const activateConnector = opts.getActivateConnector?.();
+      if (result.activate === false && deactivateConnector) {
         try {
-          await opts.deactivateConnector(connectorId);
+          await deactivateConnector(connectorId);
           activationStatus = 'deactivated';
           app.log.info({ connectorId }, '[ConnectorHub] Connector deactivated after disconnect');
         } catch (err) {
@@ -254,10 +260,10 @@ export const connectorActionRoutes: (opts: ConnectorActionRoutesOptions) => (app
         }
       } else if (
         (result.activate === true || (result.backfilledKeys && result.backfilledKeys.length > 0)) &&
-        opts.activateConnector
+        activateConnector
       ) {
         try {
-          await opts.activateConnector(connectorId);
+          await activateConnector(connectorId);
           activationStatus = 'activated';
           app.log.info(
             { connectorId, backfilledKeys: result.backfilledKeys },


### PR DESCRIPTION
## Summary
- make connector action routes read gateway registries/hooks through request-time getters
- avoid capturing `pluginRegistry`, `adapterRegistry`, `activateConnector`, and `deactivateConnector` as `undefined` before gateway startup wiring
- fixes the Weixin action endpoint returning `Connector 'weixin' plugin not loaded` after the plugin is registered later by the gateway\n\nCloses #1033\n\n## Verification\n- `pnpm exec biome check packages/api/src/routes/connector-hub.ts packages/api/src/routes/connector-plugin-routes.ts` exited 0; existing complexity warnings remain in pre-existing handlers\n- `pnpm exec tsc --noEmit` reported pre-existing SessionRecord/SessionChainStore errors; modified files had 0 TypeScript errors\n- Full local test run was not completed because local Node 26/better-sqlite3 native install is currently failing; pushed to GitHub so CI can validate in the upstream environment