### PR TITLE
feat(#872): Thread Metadata MCP — persist low-frequency thread anchors

### DIFF
--- a/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
@@ -423,6 +423,42 @@ export function mergeThreadMetadata(
   return base;
 }
 
+/**
+ * #872: Post-merge total caps.
+ * Per-request schema caps only bound a single patch; accumulated totals can grow unbounded.
+ * This validator rejects (throws) when the merged result exceeds contract limits.
+ * Callers invoke this AFTER merge, BEFORE write — no silent truncation.
+ */
+export const METADATA_TOTAL_LIMITS = {
+  worktrees: 100,
+  prs: 200,
+  issues: 200,
+  features: 200,
+  notes: 200,
+} as const;
+
+export function validateMergedTotals(merged: ThreadMetadataV1): void {
+  const violations: string[] = [];
+  if (merged.worktrees && merged.worktrees.length > METADATA_TOTAL_LIMITS.worktrees) {
+    violations.push(`worktrees: ${merged.worktrees.length}/${METADATA_TOTAL_LIMITS.worktrees}`);
+  }
+  if (merged.prs && merged.prs.length > METADATA_TOTAL_LIMITS.prs) {
+    violations.push(`prs: ${merged.prs.length}/${METADATA_TOTAL_LIMITS.prs}`);
+  }
+  if (merged.issues && merged.issues.length > METADATA_TOTAL_LIMITS.issues) {
+    violations.push(`issues: ${merged.issues.length}/${METADATA_TOTAL_LIMITS.issues}`);
+  }
+  if (merged.features && merged.features.length > METADATA_TOTAL_LIMITS.features) {
+    violations.push(`features: ${merged.features.length}/${METADATA_TOTAL_LIMITS.features}`);
+  }
+  if (merged.notes && Object.keys(merged.notes).length > METADATA_TOTAL_LIMITS.notes) {
+    violations.push(`notes: ${Object.keys(merged.notes).length}/${METADATA_TOTAL_LIMITS.notes}`);
+  }
+  if (violations.length > 0) {
+    throw new Error(`Thread metadata total limits exceeded: ${violations.join(', ')}`);
+  }
+}
+
 /** #872: Parse threadMetadata JSON from Redis with fail-open semantics. */
 export function parseThreadMetadataJson(raw: string): ThreadMetadataV1 | null {
   try {
@@ -1075,6 +1111,7 @@ export class ThreadStore implements IThreadStore {
   atomicMergeThreadMetadata(threadId: string, patch: ThreadMetadataPatch): ThreadMetadataV1 {
     const existing = this.getThreadMetadata(threadId);
     const merged = mergeThreadMetadata(existing ?? undefined, patch);
+    validateMergedTotals(merged);
     this.updateThreadMetadata(threadId, merged);
     return merged;
   }

--- a/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
@@ -459,14 +459,48 @@ export function validateMergedTotals(merged: ThreadMetadataV1): void {
   }
 }
 
-/** #872: Parse threadMetadata JSON from Redis with fail-open semantics. */
+/** #872: Validate a PR/issue ref shape: { repo: string, number: positive int } */
+function isValidRef(r: unknown): boolean {
+  return (
+    !!r &&
+    typeof r === 'object' &&
+    typeof (r as Record<string, unknown>).repo === 'string' &&
+    Number.isInteger((r as Record<string, unknown>).number) &&
+    ((r as Record<string, unknown>).number as number) > 0
+  );
+}
+
+/**
+ * #872: Parse threadMetadata JSON with shape validation.
+ * Returns null for anything that isn't a well-formed ThreadMetadataV1:
+ * malformed JSON, wrong version, or fields with wrong types.
+ * Read path: fail-open (caller treats null as "no metadata").
+ * Write path: fail-closed (caller rejects merge when raw exists but parse returns null).
+ */
 export function parseThreadMetadataJson(raw: string): ThreadMetadataV1 | null {
   try {
     const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === 'object' && parsed.v === 1) {
-      return parsed as ThreadMetadataV1;
+    if (!parsed || typeof parsed !== 'object' || parsed.v !== 1) return null;
+
+    // Shape validation — reject malformed v1 to prevent merge corruption
+    if (parsed.worktrees !== undefined) {
+      if (!Array.isArray(parsed.worktrees) || parsed.worktrees.some((w: unknown) => typeof w !== 'string')) return null;
     }
-    return null;
+    if (parsed.prs !== undefined) {
+      if (!Array.isArray(parsed.prs) || parsed.prs.some((p: unknown) => !isValidRef(p))) return null;
+    }
+    if (parsed.issues !== undefined) {
+      if (!Array.isArray(parsed.issues) || parsed.issues.some((i: unknown) => !isValidRef(i))) return null;
+    }
+    if (parsed.features !== undefined) {
+      if (!Array.isArray(parsed.features) || parsed.features.some((f: unknown) => typeof f !== 'string')) return null;
+    }
+    if (parsed.notes !== undefined) {
+      if (!parsed.notes || typeof parsed.notes !== 'object' || Array.isArray(parsed.notes)) return null;
+      if (Object.values(parsed.notes).some((v: unknown) => typeof v !== 'string')) return null;
+    }
+
+    return parsed as ThreadMetadataV1;
   } catch {
     return null;
   }

--- a/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
@@ -345,22 +345,25 @@ export function refKey(ref: { repo: string; number: number }): string {
   return `${ref.repo.toLowerCase()}#${ref.number}`;
 }
 
+/** #872: Patch shape for thread metadata merge operations. */
+export type ThreadMetadataPatch = {
+  worktrees?: string[];
+  prs?: Array<{ repo: string; number: number }>;
+  issues?: Array<{ repo: string; number: number }>;
+  features?: string[];
+  notes?: Record<string, string | null>;
+  removeWorktrees?: string[];
+  removePrs?: Array<{ repo: string; number: number }>;
+  removeIssues?: Array<{ repo: string; number: number }>;
+  removeFeatures?: string[];
+};
+
 /** #872: Merge thread metadata with append-dedupe semantics for arrays and merge semantics for notes.
  *  - Arrays: incoming items appended, deduped; removeX items removed.
  *  - Notes: incoming keys overwrite, null deletes, absent keys unchanged. */
 export function mergeThreadMetadata(
   existing: ThreadMetadataV1 | undefined,
-  patch: {
-    worktrees?: string[];
-    prs?: Array<{ repo: string; number: number }>;
-    issues?: Array<{ repo: string; number: number }>;
-    features?: string[];
-    notes?: Record<string, string | null>;
-    removeWorktrees?: string[];
-    removePrs?: Array<{ repo: string; number: number }>;
-    removeIssues?: Array<{ repo: string; number: number }>;
-    removeFeatures?: string[];
-  },
+  patch: ThreadMetadataPatch,
 ): ThreadMetadataV1 {
   const base: ThreadMetadataV1 = existing ? { ...existing } : { v: 1 };
 
@@ -550,6 +553,8 @@ export interface IThreadStore {
   getThreadMetadata(threadId: string): ThreadMetadataV1 | null | Promise<ThreadMetadataV1 | null>;
   /** #872: Update thread metadata (replace entire object). Use mergeThreadMetadata() to build the merged value. */
   updateThreadMetadata(threadId: string, metadata: ThreadMetadataV1 | null): void | Promise<void>;
+  /** #872 P2: Atomically read-merge-write thread metadata so concurrent callers cannot lose appends. */
+  atomicMergeThreadMetadata(threadId: string, patch: ThreadMetadataPatch): ThreadMetadataV1 | Promise<ThreadMetadataV1>;
   /** #836: Update per-cat session strategy for a thread member. `null` clears. */
   updateMemberSessionStrategy(
     threadId: string,
@@ -1065,6 +1070,13 @@ export class ThreadStore implements IThreadStore {
     } else {
       thread.threadMetadata = metadata;
     }
+  }
+
+  atomicMergeThreadMetadata(threadId: string, patch: ThreadMetadataPatch): ThreadMetadataV1 {
+    const existing = this.getThreadMetadata(threadId);
+    const merged = mergeThreadMetadata(existing ?? undefined, patch);
+    this.updateThreadMetadata(threadId, merged);
+    return merged;
   }
 
   updateMemberSessionStrategy(threadId: string, catId: string, strategy: 'resume' | 'reborn' | null): void {

--- a/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/ThreadStore.ts
@@ -183,6 +183,8 @@ export interface Thread {
     | 'trajectory';
   /** F187: User-defined label IDs for thread categorization. */
   labels?: string[];
+  /** #872: Thread metadata anchor for session recovery (worktrees, PRs, issues, features, notes). */
+  threadMetadata?: ThreadMetadataV1;
   /** F229 / F167: Thread kind marker.
    *  'concierge' = 专属前台猫载体（per-user，sidebar 默认隐藏，F229）
    *  'gate-keeping' = 守门 thread (per-repo inbox / community ops 看板载体，F167 trigger-time guard)
@@ -321,6 +323,116 @@ export interface GuideStateV1 {
   offeredBy?: string;
 }
 
+/** #872: Thread-level metadata anchor for session recovery.
+ *  Low-frequency anchors (worktree paths, PR/issue refs, feature links, free-form notes)
+ *  that survive session seal / handoff / new-member join. */
+export interface ThreadMetadataV1 {
+  v: 1;
+  /** Dev worktree absolute paths */
+  worktrees?: string[];
+  /** Associated PRs — dedupe key: `${repo.toLowerCase()}#${number}` */
+  prs?: Array<{ repo: string; number: number }>;
+  /** Associated issues — dedupe key: `${repo.toLowerCase()}#${number}` */
+  issues?: Array<{ repo: string; number: number }>;
+  /** Associated feature IDs (e.g. "F095", "F187") */
+  features?: string[];
+  /** Free-form stable KV for any thread type */
+  notes?: Record<string, string>;
+}
+
+/** #872: Dedupe key for PR/issue refs */
+export function refKey(ref: { repo: string; number: number }): string {
+  return `${ref.repo.toLowerCase()}#${ref.number}`;
+}
+
+/** #872: Merge thread metadata with append-dedupe semantics for arrays and merge semantics for notes.
+ *  - Arrays: incoming items appended, deduped; removeX items removed.
+ *  - Notes: incoming keys overwrite, null deletes, absent keys unchanged. */
+export function mergeThreadMetadata(
+  existing: ThreadMetadataV1 | undefined,
+  patch: {
+    worktrees?: string[];
+    prs?: Array<{ repo: string; number: number }>;
+    issues?: Array<{ repo: string; number: number }>;
+    features?: string[];
+    notes?: Record<string, string | null>;
+    removeWorktrees?: string[];
+    removePrs?: Array<{ repo: string; number: number }>;
+    removeIssues?: Array<{ repo: string; number: number }>;
+    removeFeatures?: string[];
+  },
+): ThreadMetadataV1 {
+  const base: ThreadMetadataV1 = existing ? { ...existing } : { v: 1 };
+
+  // --- worktrees: append + dedupe, then remove ---
+  if (patch.worktrees || patch.removeWorktrees) {
+    const set = new Set(base.worktrees ?? []);
+    for (const w of patch.worktrees ?? []) set.add(w);
+    for (const w of patch.removeWorktrees ?? []) set.delete(w);
+    base.worktrees = set.size > 0 ? [...set] : undefined;
+  }
+
+  // --- prs: append + dedupe by repo#number, then remove ---
+  if (patch.prs || patch.removePrs) {
+    const map = new Map<string, { repo: string; number: number }>();
+    for (const pr of base.prs ?? []) map.set(refKey(pr), pr);
+    for (const pr of patch.prs ?? []) {
+      const key = refKey(pr);
+      if (!map.has(key)) map.set(key, { repo: pr.repo.toLowerCase(), number: pr.number });
+    }
+    for (const pr of patch.removePrs ?? []) map.delete(refKey(pr));
+    base.prs = map.size > 0 ? [...map.values()] : undefined;
+  }
+
+  // --- issues: append + dedupe by repo#number, then remove ---
+  if (patch.issues || patch.removeIssues) {
+    const map = new Map<string, { repo: string; number: number }>();
+    for (const issue of base.issues ?? []) map.set(refKey(issue), issue);
+    for (const issue of patch.issues ?? []) {
+      const key = refKey(issue);
+      if (!map.has(key)) map.set(key, { repo: issue.repo.toLowerCase(), number: issue.number });
+    }
+    for (const issue of patch.removeIssues ?? []) map.delete(refKey(issue));
+    base.issues = map.size > 0 ? [...map.values()] : undefined;
+  }
+
+  // --- features: append + dedupe, then remove ---
+  if (patch.features || patch.removeFeatures) {
+    const set = new Set(base.features ?? []);
+    for (const f of patch.features ?? []) set.add(f);
+    for (const f of patch.removeFeatures ?? []) set.delete(f);
+    base.features = set.size > 0 ? [...set] : undefined;
+  }
+
+  // --- notes: merge with null-delete ---
+  if (patch.notes) {
+    const merged = { ...(base.notes ?? {}) };
+    for (const [k, v] of Object.entries(patch.notes)) {
+      if (v === null) {
+        delete merged[k];
+      } else {
+        merged[k] = v;
+      }
+    }
+    base.notes = Object.keys(merged).length > 0 ? merged : undefined;
+  }
+
+  return base;
+}
+
+/** #872: Parse threadMetadata JSON from Redis with fail-open semantics. */
+export function parseThreadMetadataJson(raw: string): ThreadMetadataV1 | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && parsed.v === 1) {
+      return parsed as ThreadMetadataV1;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 /** F079: Voting state stored in thread metadata */
 export interface VotingStateV1 {
   v: 1;
@@ -434,6 +546,10 @@ export interface IThreadStore {
   ): void | Promise<void>;
   /** F187: Update thread labels (replaces entire array). */
   updateLabels(threadId: string, labelIds: string[]): void | Promise<void>;
+  /** #872: Get thread metadata anchor. */
+  getThreadMetadata(threadId: string): ThreadMetadataV1 | null | Promise<ThreadMetadataV1 | null>;
+  /** #872: Update thread metadata (replace entire object). Use mergeThreadMetadata() to build the merged value. */
+  updateThreadMetadata(threadId: string, metadata: ThreadMetadataV1 | null): void | Promise<void>;
   /** #836: Update per-cat session strategy for a thread member. `null` clears. */
   updateMemberSessionStrategy(
     threadId: string,
@@ -934,6 +1050,21 @@ export class ThreadStore implements IThreadStore {
   updateLabels(threadId: string, labelIds: string[]): void {
     const thread = this.get(threadId);
     if (thread) thread.labels = labelIds;
+  }
+
+  getThreadMetadata(threadId: string): ThreadMetadataV1 | null {
+    const thread = this.get(threadId);
+    return thread?.threadMetadata ?? null;
+  }
+
+  updateThreadMetadata(threadId: string, metadata: ThreadMetadataV1 | null): void {
+    const thread = this.get(threadId);
+    if (!thread) return;
+    if (metadata === null) {
+      delete thread.threadMetadata;
+    } else {
+      thread.threadMetadata = metadata;
+    }
   }
 
   updateMemberSessionStrategy(threadId: string, catId: string, strategy: 'resume' | 'reborn' | null): void {

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -22,6 +22,7 @@ import type {
   Thread,
   ThreadMemoryV1,
   ThreadMentionRoutingFeedback,
+  ThreadMetadataPatch,
   ThreadMetadataV1,
   ThreadParticipantActivity,
   ThreadRoutingPolicyV1,
@@ -30,6 +31,7 @@ import type {
 import {
   buildExternalRuntimeAnchorThreadId,
   DEFAULT_THREAD_ID,
+  mergeThreadMetadata,
   parseThreadMetadataJson,
 } from '../ports/ThreadStore.js';
 import { MessageKeys } from '../redis-keys/message-keys.js';
@@ -48,6 +50,25 @@ if redis.call('HEXISTS', KEYS[1], 'id') == 0 then
 end
 redis.call('HSET', KEYS[1], unpack(ARGV))
 return 1
+`;
+
+/**
+ * #872 P2: Compare-And-Swap guard for thread metadata merge atomicity.
+ * Only writes if (a) thread exists (has `id`) AND (b) current field value
+ * matches the snapshot the caller read. Returns 1 on success, 0 on conflict.
+ * KEYS[1] = detail key, ARGV[1] = field, ARGV[2] = expected, ARGV[3] = new.
+ */
+const CAS_HSET_IF_HAS_ID_LUA = `
+if redis.call('HEXISTS', KEYS[1], 'id') == 0 then
+  return 0
+end
+local cur = redis.call('HGET', KEYS[1], ARGV[1])
+if cur == false then cur = '' end
+if cur == ARGV[2] then
+  redis.call('HSET', KEYS[1], ARGV[1], ARGV[3])
+  return 1
+end
+return 0
 `;
 
 /**
@@ -1270,6 +1291,37 @@ export class RedisThreadStore implements IThreadStore {
     } else {
       await this.setDetailFields(key, 'threadMetadata', JSON.stringify(metadata));
     }
+  }
+
+  /**
+   * #872 P2: Atomically read-merge-write thread metadata using CAS.
+   * Prevents concurrent callers from losing each other's appends.
+   * Retries up to 5 times on CAS conflict before falling through.
+   */
+  async atomicMergeThreadMetadata(threadId: string, patch: ThreadMetadataPatch): Promise<ThreadMetadataV1> {
+    const key = ThreadKeys.detail(threadId);
+    const maxRetries = 5;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const raw = await this.redis.hget(key, 'threadMetadata');
+      const existing = raw ? parseThreadMetadataJson(raw) : null;
+      const merged = mergeThreadMetadata(existing ?? undefined, patch);
+      const newJson = JSON.stringify(merged);
+      const ok = (await this.redis.eval(
+        CAS_HSET_IF_HAS_ID_LUA,
+        1,
+        key,
+        'threadMetadata',
+        raw ?? '',
+        newJson,
+      )) as number;
+      if (ok === 1) return merged;
+    }
+    // Exhausted CAS retries — fall back to non-atomic write (best-effort)
+    const raw = await this.redis.hget(key, 'threadMetadata');
+    const existing = raw ? parseThreadMetadataJson(raw) : null;
+    const merged = mergeThreadMetadata(existing ?? undefined, patch);
+    await this.setDetailFields(key, 'threadMetadata', JSON.stringify(merged));
+    return merged;
   }
 
   async updateMemberSessionStrategy(

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -1321,7 +1321,12 @@ export class RedisThreadStore implements IThreadStore {
         raw ?? '',
         newJson,
       )) as number;
-      if (ok === 1) return merged;
+      if (ok === 1) {
+        // #872 cloud-review P2: CAS bypasses setDetailFields, so refresh retention
+        // explicitly — otherwise metadata-only writes leave TTL stale when THREAD_TTL_SECONDS is set.
+        await this.applyKeyRetention([key]);
+        return merged;
+      }
     }
     // P1-1: No fallback write — throwing preserves the concurrent-safety guarantee.
     throw new Error(`Thread metadata CAS conflict after ${maxRetries} retries for thread ${threadId}`);

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -33,6 +33,7 @@ import {
   DEFAULT_THREAD_ID,
   mergeThreadMetadata,
   parseThreadMetadataJson,
+  validateMergedTotals,
 } from '../ports/ThreadStore.js';
 import { MessageKeys } from '../redis-keys/message-keys.js';
 import { ThreadKeys } from '../redis-keys/thread-keys.js';
@@ -1312,6 +1313,7 @@ export class RedisThreadStore implements IThreadStore {
         );
       }
       const merged = mergeThreadMetadata(existing ?? undefined, patch);
+      validateMergedTotals(merged);
       const newJson = JSON.stringify(merged);
       const ok = (await this.redis.eval(
         CAS_HSET_IF_HAS_ID_LUA,

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -1303,14 +1303,14 @@ export class RedisThreadStore implements IThreadStore {
     const maxRetries = 5;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       const raw = await this.redis.hget(key, 'threadMetadata');
+      const existing = raw ? parseThreadMetadataJson(raw) : null;
       // P1-2: if stored data exists but cannot be parsed (malformed / future version),
       // refuse to merge rather than silently overwriting it with a fresh v:1 object.
-      if (raw && !parseThreadMetadataJson(raw)) {
+      if (raw && !existing) {
         throw new Error(
           `Thread ${threadId} has unparseable metadata (${raw.length} bytes); refusing merge to prevent data loss`,
         );
       }
-      const existing = raw ? parseThreadMetadataJson(raw) : null;
       const merged = mergeThreadMetadata(existing ?? undefined, patch);
       const newJson = JSON.stringify(merged);
       const ok = (await this.redis.eval(

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -1296,13 +1296,20 @@ export class RedisThreadStore implements IThreadStore {
   /**
    * #872 P2: Atomically read-merge-write thread metadata using CAS.
    * Prevents concurrent callers from losing each other's appends.
-   * Retries up to 5 times on CAS conflict before falling through.
+   * Retries up to 5 times on CAS conflict; throws on exhaustion (no fallback).
    */
   async atomicMergeThreadMetadata(threadId: string, patch: ThreadMetadataPatch): Promise<ThreadMetadataV1> {
     const key = ThreadKeys.detail(threadId);
     const maxRetries = 5;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       const raw = await this.redis.hget(key, 'threadMetadata');
+      // P1-2: if stored data exists but cannot be parsed (malformed / future version),
+      // refuse to merge rather than silently overwriting it with a fresh v:1 object.
+      if (raw && !parseThreadMetadataJson(raw)) {
+        throw new Error(
+          `Thread ${threadId} has unparseable metadata (${raw.length} bytes); refusing merge to prevent data loss`,
+        );
+      }
       const existing = raw ? parseThreadMetadataJson(raw) : null;
       const merged = mergeThreadMetadata(existing ?? undefined, patch);
       const newJson = JSON.stringify(merged);
@@ -1316,12 +1323,8 @@ export class RedisThreadStore implements IThreadStore {
       )) as number;
       if (ok === 1) return merged;
     }
-    // Exhausted CAS retries — fall back to non-atomic write (best-effort)
-    const raw = await this.redis.hget(key, 'threadMetadata');
-    const existing = raw ? parseThreadMetadataJson(raw) : null;
-    const merged = mergeThreadMetadata(existing ?? undefined, patch);
-    await this.setDetailFields(key, 'threadMetadata', JSON.stringify(merged));
-    return merged;
+    // P1-1: No fallback write — throwing preserves the concurrent-safety guarantee.
+    throw new Error(`Thread metadata CAS conflict after ${maxRetries} retries for thread ${threadId}`);
   }
 
   async updateMemberSessionStrategy(

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -1304,10 +1304,11 @@ export class RedisThreadStore implements IThreadStore {
     const maxRetries = 5;
     for (let attempt = 0; attempt < maxRetries; attempt++) {
       const raw = await this.redis.hget(key, 'threadMetadata');
-      const existing = raw ? parseThreadMetadataJson(raw) : null;
-      // P1-2: if stored data exists but cannot be parsed (malformed / future version),
+      const existing = raw != null ? parseThreadMetadataJson(raw) : null;
+      // P1-2: if stored data exists but cannot be parsed (malformed / future version / empty string),
       // refuse to merge rather than silently overwriting it with a fresh v:1 object.
-      if (raw && !existing) {
+      // Uses `raw != null` (not truthy) so empty-string fields are correctly rejected.
+      if (raw != null && !existing) {
         throw new Error(
           `Thread ${threadId} has unparseable metadata (${raw.length} bytes); refusing merge to prevent data loss`,
         );

--- a/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisThreadStore.ts
@@ -22,11 +22,16 @@ import type {
   Thread,
   ThreadMemoryV1,
   ThreadMentionRoutingFeedback,
+  ThreadMetadataV1,
   ThreadParticipantActivity,
   ThreadRoutingPolicyV1,
   VotingStateV1,
 } from '../ports/ThreadStore.js';
-import { buildExternalRuntimeAnchorThreadId, DEFAULT_THREAD_ID } from '../ports/ThreadStore.js';
+import {
+  buildExternalRuntimeAnchorThreadId,
+  DEFAULT_THREAD_ID,
+  parseThreadMetadataJson,
+} from '../ports/ThreadStore.js';
 import { MessageKeys } from '../redis-keys/message-keys.js';
 import { ThreadKeys } from '../redis-keys/thread-keys.js';
 
@@ -1065,6 +1070,9 @@ export class RedisThreadStore implements IThreadStore {
     if (thread.labels && thread.labels.length > 0) {
       result.labels = JSON.stringify(thread.labels);
     }
+    if (thread.threadMetadata) {
+      result.threadMetadata = JSON.stringify(thread.threadMetadata);
+    }
     // F229: Concierge thread marker (set separately via updateThreadKind; also persisted here for
     // cold-create paths where the full thread object is serialized before updateThreadKind is called)
     if (thread.threadKind) {
@@ -1231,6 +1239,11 @@ export class RedisThreadStore implements IThreadStore {
         /* ignore malformed JSON */
       }
     }
+    // #872: Thread metadata anchor
+    if (data.threadMetadata) {
+      const meta = parseThreadMetadataJson(data.threadMetadata);
+      if (meta) result.threadMetadata = meta;
+    }
     // F229 / F167: Restore thread kind marker (written by updateThreadKind; validate value)
     if (data.threadKind === 'concierge' || data.threadKind === 'gate-keeping') {
       result.threadKind = data.threadKind;
@@ -1241,6 +1254,22 @@ export class RedisThreadStore implements IThreadStore {
   async updateLabels(threadId: string, labelIds: string[]): Promise<void> {
     const key = ThreadKeys.detail(threadId);
     await this.redis.hset(key, { labels: JSON.stringify(labelIds) });
+  }
+
+  async getThreadMetadata(threadId: string): Promise<ThreadMetadataV1 | null> {
+    const key = ThreadKeys.detail(threadId);
+    const raw = await this.redis.hget(key, 'threadMetadata');
+    if (!raw) return null;
+    return parseThreadMetadataJson(raw);
+  }
+
+  async updateThreadMetadata(threadId: string, metadata: ThreadMetadataV1 | null): Promise<void> {
+    const key = ThreadKeys.detail(threadId);
+    if (metadata === null) {
+      await this.deleteDetailFields(key, 'threadMetadata');
+    } else {
+      await this.setDetailFields(key, 'threadMetadata', JSON.stringify(metadata));
+    }
   }
 
   async updateMemberSessionStrategy(

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2510,6 +2510,9 @@ async function main(): Promise<void> {
     ...(workflowSopStore ? { workflowSopStore } : {}),
     queueProcessor,
     invocationQueue,
+    indexBuilder: memoryServices.indexBuilder as
+      | { markThreadDirty(threadId: string): void; flushDirtyThreads?(): number | Promise<number> }
+      | undefined,
     evidenceStore: memoryServices.evidenceStore,
     markerQueue: memoryServices.markerQueue,
     reflectionService: memoryServices.reflectionService,

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -608,8 +608,9 @@ const listLabelsQuerySchema = z.object({
 
 const refItemSchema = z.object({ repo: z.string().min(1), number: z.number().int().positive() });
 const setThreadMetadataSchema = z.object({
-  title: z.string().min(1).optional(),
-  labels: z.array(z.string()).optional(),
+  // P2: match PATCH /api/threads/:id invariants — trim + min(1) + max
+  title: z.string().trim().min(1).max(200).optional(),
+  labels: z.array(z.string().trim().min(1).max(50)).max(20).optional(),
   worktrees: z.array(z.string()).optional(),
   prs: z.array(refItemSchema).optional(),
   issues: z.array(refItemSchema).optional(),

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2776,6 +2776,20 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       await threadStore.updateTitle(effectiveThreadId, title);
     }
     if (labels !== undefined) {
+      // #872 P2 fix: reuse label validation from PATCH /api/threads/:id
+      if (labels.length > 20) {
+        reply.status(400);
+        return { error: 'Too many labels (max 20)' };
+      }
+      if (labels.length > 0 && opts.labelStore) {
+        const userLabels = await opts.labelStore.list(principal.userId);
+        const validIds = new Set(userLabels.map((l) => l.id));
+        const invalid = labels.filter((lid: string) => !validIds.has(lid));
+        if (invalid.length > 0) {
+          reply.status(400);
+          return { error: 'Invalid label IDs', invalidIds: invalid };
+        }
+      }
       await threadStore.updateLabels(effectiveThreadId, labels);
     }
 

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2803,7 +2803,18 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     // a throw doesn't leave visible fields partially committed.
     const hasMetadataUpdate = Object.keys(metadataFields).length > 0;
     if (hasMetadataUpdate) {
-      await threadStore.atomicMergeThreadMetadata(effectiveThreadId, metadataFields);
+      try {
+        await threadStore.atomicMergeThreadMetadata(effectiveThreadId, metadataFields);
+      } catch (err) {
+        // #872: total-limits rejection is a client error (deterministic, not retryable).
+        // Surface as 422 so MCP retry helpers don't retry a request that can never succeed.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('total limits exceeded')) {
+          reply.code(422);
+          return { error: msg };
+        }
+        throw err; // CAS exhaustion / unparseable data → still 500
+      }
     }
     if (title !== undefined) {
       await threadStore.updateTitle(effectiveThreadId, title);

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -53,7 +53,6 @@ import {
 } from '../domains/cats/services/stores/ports/MessageStore.js';
 import { type ITaskStore, isSubjectOwnershipConflictError } from '../domains/cats/services/stores/ports/TaskStore.js';
 import type { IThreadStore, VotingStateV1 } from '../domains/cats/services/stores/ports/ThreadStore.js';
-import { mergeThreadMetadata } from '../domains/cats/services/stores/ports/ThreadStore.js';
 import {
   canViewMessage,
   isInternalNonQuotableParent,
@@ -522,6 +521,8 @@ export interface CallbackRoutesOptions {
   featIndexProvider?: () => Promise<FeatIndexEntry[]>;
   /** F073 P1: workflow SOP store for bulletin board */
   workflowSopStore?: import('../domains/cats/services/stores/ports/WorkflowSopStore.js').IWorkflowSopStore;
+  /** #872 P2: keep evidence index in sync when set-thread-metadata changes title. */
+  indexBuilder?: { markThreadDirty(threadId: string): void; flushDirtyThreads?(): number | Promise<number> };
   /** F102: DI memory services — SQLite-backed evidence store */
   evidenceStore: IEvidenceStore;
   markerQueue: IMarkerQueue;
@@ -2774,6 +2775,13 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     // Update existing thread-level fields
     if (title !== undefined) {
       await threadStore.updateTitle(effectiveThreadId, title);
+      // #872 P2: refresh evidence index after title change (same as PATCH /api/threads/:id)
+      try {
+        opts.indexBuilder?.markThreadDirty(effectiveThreadId);
+        await opts.indexBuilder?.flushDirtyThreads?.();
+      } catch {
+        // Best-effort: evidence index refresh must not block metadata write
+      }
     }
     if (labels !== undefined) {
       // #872 P2 fix: reuse label validation from PATCH /api/threads/:id
@@ -2793,12 +2801,10 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       await threadStore.updateLabels(effectiveThreadId, labels);
     }
 
-    // Merge new metadata fields
+    // #872 P2: Atomically merge metadata to prevent concurrent write races
     const hasMetadataUpdate = Object.keys(metadataFields).length > 0;
     if (hasMetadataUpdate) {
-      const existing = await threadStore.getThreadMetadata(effectiveThreadId);
-      const merged = mergeThreadMetadata(existing ?? undefined, metadataFields);
-      await threadStore.updateThreadMetadata(effectiveThreadId, merged);
+      await threadStore.atomicMergeThreadMetadata(effectiveThreadId, metadataFields);
     }
 
     // Return the updated state

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -53,6 +53,7 @@ import {
 } from '../domains/cats/services/stores/ports/MessageStore.js';
 import { type ITaskStore, isSubjectOwnershipConflictError } from '../domains/cats/services/stores/ports/TaskStore.js';
 import type { IThreadStore, VotingStateV1 } from '../domains/cats/services/stores/ports/ThreadStore.js';
+import { mergeThreadMetadata } from '../domains/cats/services/stores/ports/ThreadStore.js';
 import {
   canViewMessage,
   isInternalNonQuotableParent,
@@ -602,6 +603,21 @@ const listThreadsQuerySchema = z.object({
 
 const listLabelsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional(),
+});
+
+const refItemSchema = z.object({ repo: z.string().min(1), number: z.number().int().positive() });
+const setThreadMetadataSchema = z.object({
+  title: z.string().min(1).optional(),
+  labels: z.array(z.string()).optional(),
+  worktrees: z.array(z.string()).optional(),
+  prs: z.array(refItemSchema).optional(),
+  issues: z.array(refItemSchema).optional(),
+  features: z.array(z.string()).optional(),
+  notes: z.record(z.string(), z.string().nullable()).optional(),
+  removeWorktrees: z.array(z.string()).optional(),
+  removePrs: z.array(refItemSchema).optional(),
+  removeIssues: z.array(refItemSchema).optional(),
+  removeFeatures: z.array(z.string()).optional(),
 });
 
 const featIndexQuerySchema = z.object({
@@ -2688,6 +2704,102 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     }));
 
     return { labels: result };
+  });
+
+  // #872: Thread Metadata MCP — read
+  app.get('/api/callbacks/thread-metadata', async (request, reply) => {
+    const principal = requireCallbackPrincipal(request, reply);
+    if (!principal) return;
+
+    if (!threadStore) {
+      reply.status(503);
+      return { error: 'Thread store not configured' };
+    }
+
+    const effectiveThreadId = principal.kind === 'invocation' ? principal.threadId : undefined;
+    if (!effectiveThreadId) {
+      reply.status(400);
+      return { error: 'Agent-key callers must use invocation auth for thread metadata' };
+    }
+
+    const thread = await threadStore.get(effectiveThreadId);
+    if (!thread) {
+      reply.status(404);
+      return { error: 'Thread not found' };
+    }
+
+    const meta = thread.threadMetadata;
+    return {
+      threadId: effectiveThreadId,
+      title: thread.title,
+      labels: thread.labels ?? [],
+      ...(meta?.worktrees ? { worktrees: meta.worktrees } : {}),
+      ...(meta?.prs ? { prs: meta.prs } : {}),
+      ...(meta?.issues ? { issues: meta.issues } : {}),
+      ...(meta?.features ? { features: meta.features } : {}),
+      ...(meta?.notes ? { notes: meta.notes } : {}),
+    };
+  });
+
+  // #872: Thread Metadata MCP — write (merge semantics)
+  app.post('/api/callbacks/set-thread-metadata', async (request, reply) => {
+    const principal = requireCallbackPrincipal(request, reply);
+    if (!principal) return;
+
+    const parsed = setThreadMetadataSchema.safeParse(request.body);
+    if (!parsed.success) {
+      reply.status(400);
+      return { error: 'Invalid request body', details: parsed.error.issues };
+    }
+
+    if (!threadStore) {
+      reply.status(503);
+      return { error: 'Thread store not configured' };
+    }
+
+    const effectiveThreadId = principal.kind === 'invocation' ? principal.threadId : undefined;
+    if (!effectiveThreadId) {
+      reply.status(400);
+      return { error: 'Agent-key callers must use invocation auth for thread metadata' };
+    }
+
+    const thread = await threadStore.get(effectiveThreadId);
+    if (!thread) {
+      reply.status(404);
+      return { error: 'Thread not found' };
+    }
+
+    const { title, labels, ...metadataFields } = parsed.data;
+
+    // Update existing thread-level fields
+    if (title !== undefined) {
+      await threadStore.updateTitle(effectiveThreadId, title);
+    }
+    if (labels !== undefined) {
+      await threadStore.updateLabels(effectiveThreadId, labels);
+    }
+
+    // Merge new metadata fields
+    const hasMetadataUpdate = Object.keys(metadataFields).length > 0;
+    if (hasMetadataUpdate) {
+      const existing = await threadStore.getThreadMetadata(effectiveThreadId);
+      const merged = mergeThreadMetadata(existing ?? undefined, metadataFields);
+      await threadStore.updateThreadMetadata(effectiveThreadId, merged);
+    }
+
+    // Return the updated state
+    const updated = await threadStore.get(effectiveThreadId);
+    const meta = updated?.threadMetadata;
+    return {
+      threadId: effectiveThreadId,
+      title: updated?.title ?? thread.title,
+      labels: updated?.labels ?? thread.labels ?? [],
+      ...(meta?.worktrees ? { worktrees: meta.worktrees } : {}),
+      ...(meta?.prs ? { prs: meta.prs } : {}),
+      ...(meta?.issues ? { issues: meta.issues } : {}),
+      ...(meta?.features ? { features: meta.features } : {}),
+      ...(meta?.notes ? { notes: meta.notes } : {}),
+    };
   });
 
   app.get('/api/callbacks/feat-index', async (request, reply) => {

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2792,7 +2792,14 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       }
     }
 
-    // All validation passed — apply mutations
+    // All validation passed — apply mutations.
+    // #872 cloud-review P2 (R3): failable operations first. atomicMergeThreadMetadata can
+    // throw on CAS exhaustion or unparseable stored data; run it before title/labels so
+    // a throw doesn't leave visible fields partially committed.
+    const hasMetadataUpdate = Object.keys(metadataFields).length > 0;
+    if (hasMetadataUpdate) {
+      await threadStore.atomicMergeThreadMetadata(effectiveThreadId, metadataFields);
+    }
     if (title !== undefined) {
       await threadStore.updateTitle(effectiveThreadId, title);
       // #872 P2: refresh evidence index after title change (same as PATCH /api/threads/:id)
@@ -2805,12 +2812,6 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
     }
     if (labels !== undefined) {
       await threadStore.updateLabels(effectiveThreadId, labels);
-    }
-
-    // #872 P2: Atomically merge metadata to prevent concurrent write races
-    const hasMetadataUpdate = Object.keys(metadataFields).length > 0;
-    if (hasMetadataUpdate) {
-      await threadStore.atomicMergeThreadMetadata(effectiveThreadId, metadataFields);
     }
 
     // Return the updated state

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -2773,19 +2773,10 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
     const { title, labels, ...metadataFields } = parsed.data;
 
-    // Update existing thread-level fields
-    if (title !== undefined) {
-      await threadStore.updateTitle(effectiveThreadId, title);
-      // #872 P2: refresh evidence index after title change (same as PATCH /api/threads/:id)
-      try {
-        opts.indexBuilder?.markThreadDirty(effectiveThreadId);
-        await opts.indexBuilder?.flushDirtyThreads?.();
-      } catch {
-        // Best-effort: evidence index refresh must not block metadata write
-      }
-    }
+    // #872 cloud-review P2: validate all rejectable inputs BEFORE applying any mutations.
+    // Without this gate, a request with valid title + invalid labels would commit the title
+    // change and then return 400, leaving the thread in a partially-mutated state.
     if (labels !== undefined) {
-      // #872 P2 fix: reuse label validation from PATCH /api/threads/:id
       if (labels.length > 20) {
         reply.status(400);
         return { error: 'Too many labels (max 20)' };
@@ -2799,6 +2790,20 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
           return { error: 'Invalid label IDs', invalidIds: invalid };
         }
       }
+    }
+
+    // All validation passed — apply mutations
+    if (title !== undefined) {
+      await threadStore.updateTitle(effectiveThreadId, title);
+      // #872 P2: refresh evidence index after title change (same as PATCH /api/threads/:id)
+      try {
+        opts.indexBuilder?.markThreadDirty(effectiveThreadId);
+        await opts.indexBuilder?.flushDirtyThreads?.();
+      } catch {
+        // Best-effort: evidence index refresh must not block metadata write
+      }
+    }
+    if (labels !== undefined) {
       await threadStore.updateLabels(effectiveThreadId, labels);
     }
 

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -606,20 +606,25 @@ const listLabelsQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).optional(),
 });
 
-const refItemSchema = z.object({ repo: z.string().min(1), number: z.number().int().positive() });
+const refItemSchema = z.object({ repo: z.string().min(1).max(200), number: z.number().int().positive() });
 const setThreadMetadataSchema = z.object({
   // P2: match PATCH /api/threads/:id invariants — trim + min(1) + max
   title: z.string().trim().min(1).max(200).optional(),
   labels: z.array(z.string().trim().min(1).max(50)).max(20).optional(),
-  worktrees: z.array(z.string()).optional(),
-  prs: z.array(refItemSchema).optional(),
-  issues: z.array(refItemSchema).optional(),
-  features: z.array(z.string()).optional(),
-  notes: z.record(z.string(), z.string().nullable()).optional(),
-  removeWorktrees: z.array(z.string()).optional(),
-  removePrs: z.array(refItemSchema).optional(),
-  removeIssues: z.array(refItemSchema).optional(),
-  removeFeatures: z.array(z.string()).optional(),
+  // #872 cloud-review P2 (R4): cap per-request payload sizes to prevent unbounded growth.
+  // These are low-frequency anchors; generous caps that no real usage should hit.
+  worktrees: z.array(z.string().max(500)).max(20).optional(),
+  prs: z.array(refItemSchema).max(50).optional(),
+  issues: z.array(refItemSchema).max(50).optional(),
+  features: z.array(z.string().max(50)).max(50).optional(),
+  notes: z
+    .record(z.string().max(100), z.string().max(2000).nullable())
+    .refine((r) => Object.keys(r).length <= 50, { message: 'Too many notes (max 50)' })
+    .optional(),
+  removeWorktrees: z.array(z.string().max(500)).max(20).optional(),
+  removePrs: z.array(refItemSchema).max(50).optional(),
+  removeIssues: z.array(refItemSchema).max(50).optional(),
+  removeFeatures: z.array(z.string().max(50)).max(50).optional(),
 });
 
 const featIndexQuerySchema = z.object({

--- a/packages/api/src/routes/threads.ts
+++ b/packages/api/src/routes/threads.ts
@@ -237,8 +237,11 @@ export function sanitizeThreadForResponse(thread: Thread, _userId: string): Thre
   //   hash storage (not hydrated by `.get()`); this strip protects the in-memory path.
   const hasPendingContinuation = !!thread.pendingContinuation;
   const hasCloudCatBindings = !!thread.cloudCatBindings;
-  if (!hasPendingContinuation && !hasCloudCatBindings) return thread;
-  const { pendingContinuation: _pc, cloudCatBindings: _ccb, ...sanitized } = thread;
+  // #872: threadMetadata is accessed via dedicated MCP tools only — strip from general APIs
+  // to avoid bloating thread list responses with worktree paths and notes.
+  const hasThreadMetadata = !!thread.threadMetadata;
+  if (!hasPendingContinuation && !hasCloudCatBindings && !hasThreadMetadata) return thread;
+  const { pendingContinuation: _pc, cloudCatBindings: _ccb, threadMetadata: _tm, ...sanitized } = thread;
   return sanitized as Thread;
 }
 

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -285,20 +285,23 @@ describe('setThreadMetadataSchema validation (P2 PATCH-parity)', () => {
   // Import the schema from the built callbacks module isn't practical,
   // so we replicate the exact Zod schema definition to test it in isolation.
   let z;
-  const refItemSchema = () => z.object({ repo: z.string(), number: z.number().int().positive() });
+  const refItemSchema = () => z.object({ repo: z.string().min(1).max(200), number: z.number().int().positive() });
   const buildSchema = () =>
     z.object({
       title: z.string().trim().min(1).max(200).optional(),
       labels: z.array(z.string().trim().min(1).max(50)).max(20).optional(),
-      worktrees: z.array(z.string()).optional(),
-      prs: z.array(refItemSchema()).optional(),
-      issues: z.array(refItemSchema()).optional(),
-      features: z.array(z.string()).optional(),
-      notes: z.record(z.string(), z.string().nullable()).optional(),
-      removeWorktrees: z.array(z.string()).optional(),
-      removePrs: z.array(refItemSchema()).optional(),
-      removeIssues: z.array(refItemSchema()).optional(),
-      removeFeatures: z.array(z.string()).optional(),
+      worktrees: z.array(z.string().max(500)).max(20).optional(),
+      prs: z.array(refItemSchema()).max(50).optional(),
+      issues: z.array(refItemSchema()).max(50).optional(),
+      features: z.array(z.string().max(50)).max(50).optional(),
+      notes: z
+        .record(z.string().max(100), z.string().max(2000).nullable())
+        .refine((r) => Object.keys(r).length <= 50, { message: 'Too many notes (max 50)' })
+        .optional(),
+      removeWorktrees: z.array(z.string().max(500)).max(20).optional(),
+      removePrs: z.array(refItemSchema()).max(50).optional(),
+      removeIssues: z.array(refItemSchema()).max(50).optional(),
+      removeFeatures: z.array(z.string().max(50)).max(50).optional(),
     });
 
   test('rejects whitespace-only title', async () => {
@@ -343,6 +346,47 @@ describe('setThreadMetadataSchema validation (P2 PATCH-parity)', () => {
     const schema = buildSchema();
     const result = schema.safeParse({ labels: Array.from({ length: 21 }, (_, i) => `l${i}`) });
     assert.equal(result.success, false);
+  });
+
+  test('rejects more than 20 worktrees per request', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ worktrees: Array.from({ length: 21 }, (_, i) => `/path/${i}`) });
+    assert.equal(result.success, false);
+  });
+
+  test('rejects worktree path exceeding 500 chars', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ worktrees: ['/' + 'a'.repeat(501)] });
+    assert.equal(result.success, false);
+  });
+
+  test('rejects more than 50 features per request', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ features: Array.from({ length: 51 }, (_, i) => `F${i}`) });
+    assert.equal(result.success, false);
+  });
+
+  test('rejects more than 50 notes', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const notes = Object.fromEntries(Array.from({ length: 51 }, (_, i) => [`k${i}`, `v${i}`]));
+    const result = schema.safeParse({ notes });
+    assert.equal(result.success, false);
+  });
+
+  test('accepts payload within all caps', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({
+      worktrees: ['/path/a'],
+      prs: [{ repo: 'owner/repo', number: 1 }],
+      features: ['F001'],
+      notes: { branch: 'main' },
+    });
+    assert.equal(result.success, true);
   });
 });
 

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -196,6 +196,73 @@ describe('parseThreadMetadataJson', () => {
     assert.equal(parseThreadMetadataJson('42'), null);
     assert.equal(parseThreadMetadataJson('null'), null);
   });
+
+  test('empty string returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(''), null);
+  });
+
+  // Shape validation regression tests (P2: malformed v1 shapes must return null)
+  test('worktrees as non-array returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, worktrees: 'abc' })), null);
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, worktrees: 123 })), null);
+  });
+
+  test('worktrees with non-string elements returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, worktrees: ['/ok', 42] })), null);
+  });
+
+  test('prs with invalid ref shape returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    // Not an array
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, prs: 'bad' })), null);
+    // Missing repo
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, prs: [{ number: 1 }] })), null);
+    // Non-positive number
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, prs: [{ repo: 'a/b', number: -1 }] })), null);
+    // Non-integer number
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, prs: [{ repo: 'a/b', number: 1.5 }] })), null);
+  });
+
+  test('issues with invalid ref shape returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, issues: [{ repo: 'a', number: 'x' }] })), null);
+  });
+
+  test('features with non-string elements returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, features: [123, 'F001'] })), null);
+  });
+
+  test('notes as non-object returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, notes: [123] })), null);
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, notes: 'bad' })), null);
+  });
+
+  test('notes with non-string values returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 1, notes: { ok: 'fine', bad: 42 } })), null);
+  });
+
+  test('valid v1 with all fields passes shape validation', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const result = parseThreadMetadataJson(
+      JSON.stringify({
+        v: 1,
+        worktrees: ['/a', '/b'],
+        prs: [{ repo: 'o/r', number: 1 }],
+        issues: [{ repo: 'o/r', number: 2 }],
+        features: ['F001'],
+        notes: { key: 'value' },
+      }),
+    );
+    assert.ok(result);
+    assert.equal(result.v, 1);
+    assert.deepEqual(result.worktrees, ['/a', '/b']);
+  });
 });
 
 describe('ThreadStore (in-memory) — threadMetadata', () => {

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -1,0 +1,262 @@
+/**
+ * #872: Thread Metadata MCP Tests
+ *
+ * Tests for ThreadMetadataV1 type, merge semantics, in-memory store,
+ * and parseThreadMetadataJson fail-open behavior.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+describe('ThreadMetadataV1 merge semantics', () => {
+  test('mergeThreadMetadata — empty patch on undefined returns v:1 skeleton', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const result = mergeThreadMetadata(undefined, {});
+    assert.deepEqual(result, { v: 1 });
+  });
+
+  test('mergeThreadMetadata — append worktrees with dedupe', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, worktrees: ['/path/a'] };
+    const result = mergeThreadMetadata(existing, {
+      worktrees: ['/path/a', '/path/b'],
+    });
+    assert.deepEqual(result.worktrees, ['/path/a', '/path/b']);
+  });
+
+  test('mergeThreadMetadata — removeWorktrees removes items', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, worktrees: ['/path/a', '/path/b'] };
+    const result = mergeThreadMetadata(existing, {
+      removeWorktrees: ['/path/a'],
+    });
+    assert.deepEqual(result.worktrees, ['/path/b']);
+  });
+
+  test('mergeThreadMetadata — worktrees set to undefined when all removed', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, worktrees: ['/path/a'] };
+    const result = mergeThreadMetadata(existing, {
+      removeWorktrees: ['/path/a'],
+    });
+    assert.equal(result.worktrees, undefined);
+  });
+
+  test('mergeThreadMetadata — append PRs with dedupe by repo#number (case insensitive)', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = {
+      v: 1,
+      prs: [{ repo: 'owner/repo', number: 1 }],
+    };
+    const result = mergeThreadMetadata(existing, {
+      prs: [
+        { repo: 'Owner/Repo', number: 1 }, // duplicate (case-insensitive)
+        { repo: 'owner/repo', number: 2 }, // new
+      ],
+    });
+    assert.equal(result.prs?.length, 2);
+    assert.deepEqual(result.prs?.[0], { repo: 'owner/repo', number: 1 });
+    assert.deepEqual(result.prs?.[1], { repo: 'owner/repo', number: 2 });
+  });
+
+  test('mergeThreadMetadata — removePrs removes by key', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = {
+      v: 1,
+      prs: [
+        { repo: 'owner/repo', number: 1 },
+        { repo: 'owner/repo', number: 2 },
+      ],
+    };
+    const result = mergeThreadMetadata(existing, {
+      removePrs: [{ repo: 'Owner/Repo', number: 1 }],
+    });
+    assert.equal(result.prs?.length, 1);
+    assert.deepEqual(result.prs?.[0], { repo: 'owner/repo', number: 2 });
+  });
+
+  test('mergeThreadMetadata — append issues with dedupe', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const result = mergeThreadMetadata(undefined, {
+      issues: [
+        { repo: 'zts212653/clowder-ai', number: 872 },
+        { repo: 'zts212653/clowder-ai', number: 872 }, // dup
+      ],
+    });
+    assert.equal(result.issues?.length, 1);
+    assert.deepEqual(result.issues?.[0], {
+      repo: 'zts212653/clowder-ai',
+      number: 872,
+    });
+  });
+
+  test('mergeThreadMetadata — append features with dedupe', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, features: ['F001'] };
+    const result = mergeThreadMetadata(existing, {
+      features: ['F001', 'F002'],
+    });
+    assert.deepEqual(result.features, ['F001', 'F002']);
+  });
+
+  test('mergeThreadMetadata — removeFeatures removes items', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, features: ['F001', 'F002'] };
+    const result = mergeThreadMetadata(existing, {
+      removeFeatures: ['F001'],
+    });
+    assert.deepEqual(result.features, ['F002']);
+  });
+
+  test('mergeThreadMetadata — notes merge: string sets, null deletes', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = {
+      v: 1,
+      notes: { key1: 'value1', key2: 'value2' },
+    };
+    const result = mergeThreadMetadata(existing, {
+      notes: { key1: null, key3: 'value3' },
+    });
+    assert.deepEqual(result.notes, { key2: 'value2', key3: 'value3' });
+  });
+
+  test('mergeThreadMetadata — notes set to undefined when all deleted', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = { v: 1, notes: { key1: 'value1' } };
+    const result = mergeThreadMetadata(existing, {
+      notes: { key1: null },
+    });
+    assert.equal(result.notes, undefined);
+  });
+
+  test('mergeThreadMetadata — does not mutate existing object', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = {
+      v: 1,
+      worktrees: ['/path/a'],
+      notes: { k: 'v' },
+    };
+    const snapshot = JSON.stringify(existing);
+    mergeThreadMetadata(existing, {
+      worktrees: ['/path/b'],
+      notes: { k: null },
+    });
+    assert.equal(JSON.stringify(existing), snapshot);
+  });
+
+  test('mergeThreadMetadata — combined add and remove in single call', async () => {
+    const { mergeThreadMetadata } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const existing = {
+      v: 1,
+      worktrees: ['/old'],
+      prs: [{ repo: 'a/b', number: 1 }],
+      features: ['F001'],
+    };
+    const result = mergeThreadMetadata(existing, {
+      worktrees: ['/new'],
+      removeWorktrees: ['/old'],
+      prs: [{ repo: 'c/d', number: 2 }],
+      removePrs: [{ repo: 'a/b', number: 1 }],
+      features: ['F002'],
+      removeFeatures: ['F001'],
+    });
+    assert.deepEqual(result.worktrees, ['/new']);
+    assert.deepEqual(result.prs, [{ repo: 'c/d', number: 2 }]);
+    assert.deepEqual(result.features, ['F002']);
+  });
+});
+
+describe('parseThreadMetadataJson', () => {
+  test('valid v1 JSON parses correctly', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const raw = JSON.stringify({
+      v: 1,
+      worktrees: ['/path'],
+      prs: [{ repo: 'a/b', number: 1 }],
+    });
+    const result = parseThreadMetadataJson(raw);
+    assert.ok(result);
+    assert.equal(result.v, 1);
+    assert.deepEqual(result.worktrees, ['/path']);
+  });
+
+  test('malformed JSON returns null (fail-open)', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson('not-json'), null);
+  });
+
+  test('wrong version returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson(JSON.stringify({ v: 2 })), null);
+  });
+
+  test('non-object returns null', async () => {
+    const { parseThreadMetadataJson } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(parseThreadMetadataJson('"string"'), null);
+    assert.equal(parseThreadMetadataJson('42'), null);
+    assert.equal(parseThreadMetadataJson('null'), null);
+  });
+});
+
+describe('ThreadStore (in-memory) — threadMetadata', () => {
+  test('getThreadMetadata returns null for thread without metadata', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    assert.equal(store.getThreadMetadata(thread.id), null);
+  });
+
+  test('updateThreadMetadata sets and getThreadMetadata reads', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    const meta = {
+      v: 1,
+      worktrees: ['/path/a'],
+      prs: [{ repo: 'owner/repo', number: 1 }],
+      features: ['F001'],
+      notes: { branch: 'feat/872' },
+    };
+    store.updateThreadMetadata(thread.id, meta);
+    const result = store.getThreadMetadata(thread.id);
+    assert.deepEqual(result, meta);
+  });
+
+  test('updateThreadMetadata(null) clears metadata', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    store.updateThreadMetadata(thread.id, { v: 1, worktrees: ['/x'] });
+    assert.ok(store.getThreadMetadata(thread.id));
+    store.updateThreadMetadata(thread.id, null);
+    assert.equal(store.getThreadMetadata(thread.id), null);
+  });
+
+  test('updateThreadMetadata on nonexistent thread is no-op', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    // Should not throw
+    store.updateThreadMetadata('nonexistent', { v: 1 });
+    assert.equal(store.getThreadMetadata('nonexistent'), null);
+  });
+
+  test('threadMetadata persists through get()', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    store.updateThreadMetadata(thread.id, {
+      v: 1,
+      issues: [{ repo: 'zts212653/clowder-ai', number: 872 }],
+    });
+    const loaded = store.get(thread.id);
+    assert.ok(loaded?.threadMetadata);
+    assert.deepEqual(loaded.threadMetadata.issues, [{ repo: 'zts212653/clowder-ai', number: 872 }]);
+  });
+});
+
+describe('refKey', () => {
+  test('generates lowercase dedupe key', async () => {
+    const { refKey } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.equal(refKey({ repo: 'Owner/Repo', number: 42 }), 'owner/repo#42');
+  });
+});

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -390,6 +390,73 @@ describe('setThreadMetadataSchema validation (P2 PATCH-parity)', () => {
   });
 });
 
+describe('validateMergedTotals — post-merge rejection', () => {
+  test('accepts metadata within limits', async () => {
+    const { validateMergedTotals } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    // Should not throw
+    validateMergedTotals({ v: 1, worktrees: Array.from({ length: 100 }, (_, i) => `/w/${i}`) });
+  });
+
+  test('rejects worktrees exceeding 100', async () => {
+    const { validateMergedTotals, METADATA_TOTAL_LIMITS } = await import(
+      '../dist/domains/cats/services/stores/ports/ThreadStore.js'
+    );
+    assert.equal(METADATA_TOTAL_LIMITS.worktrees, 100);
+    assert.throws(
+      () => validateMergedTotals({ v: 1, worktrees: Array.from({ length: 101 }, (_, i) => `/w/${i}`) }),
+      /total limits exceeded.*worktrees: 101\/100/,
+    );
+  });
+
+  test('rejects prs exceeding 200', async () => {
+    const { validateMergedTotals } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const prs = Array.from({ length: 201 }, (_, i) => ({ repo: 'r', number: i + 1 }));
+    assert.throws(() => validateMergedTotals({ v: 1, prs }), /total limits exceeded.*prs: 201\/200/);
+  });
+
+  test('rejects notes exceeding 200 keys', async () => {
+    const { validateMergedTotals } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const notes = Object.fromEntries(Array.from({ length: 201 }, (_, i) => [`k${i}`, `v${i}`]));
+    assert.throws(() => validateMergedTotals({ v: 1, notes }), /total limits exceeded.*notes: 201\/200/);
+  });
+
+  test('reports all violations at once', async () => {
+    const { validateMergedTotals } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    assert.throws(
+      () =>
+        validateMergedTotals({
+          v: 1,
+          worktrees: Array.from({ length: 101 }, (_, i) => `/w/${i}`),
+          features: Array.from({ length: 201 }, (_, i) => `F${i}`),
+        }),
+      /worktrees: 101\/100.*features: 201\/200/,
+    );
+  });
+
+  test('in-memory atomicMerge rejects when accumulated patches exceed limits', async () => {
+    const { ThreadStore: MemStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new MemStore();
+    const thread = store.create('u1', 'test');
+    // Accumulate 6 batches × 20 worktrees each = 120 > 100 limit
+    for (let batch = 0; batch < 5; batch++) {
+      store.atomicMergeThreadMetadata(thread.id, {
+        worktrees: Array.from({ length: 20 }, (_, i) => `/w/${batch * 20 + i}`),
+      });
+    }
+    // 6th batch pushes to 120, should reject
+    assert.throws(
+      () =>
+        store.atomicMergeThreadMetadata(thread.id, {
+          worktrees: Array.from({ length: 20 }, (_, i) => `/w/${100 + i}`),
+        }),
+      /total limits exceeded/,
+    );
+    // Verify the 5th batch (100 worktrees) was the last successful write
+    const meta = store.getThreadMetadata(thread.id);
+    assert.equal(meta.worktrees.length, 100);
+  });
+});
+
 describe('refKey', () => {
   test('generates lowercase dedupe key', async () => {
     const { refKey } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -281,6 +281,71 @@ describe('atomicMergeThreadMetadata (in-memory)', () => {
   });
 });
 
+describe('setThreadMetadataSchema validation (P2 PATCH-parity)', () => {
+  // Import the schema from the built callbacks module isn't practical,
+  // so we replicate the exact Zod schema definition to test it in isolation.
+  let z;
+  const refItemSchema = () => z.object({ repo: z.string(), number: z.number().int().positive() });
+  const buildSchema = () =>
+    z.object({
+      title: z.string().trim().min(1).max(200).optional(),
+      labels: z.array(z.string().trim().min(1).max(50)).max(20).optional(),
+      worktrees: z.array(z.string()).optional(),
+      prs: z.array(refItemSchema()).optional(),
+      issues: z.array(refItemSchema()).optional(),
+      features: z.array(z.string()).optional(),
+      notes: z.record(z.string(), z.string().nullable()).optional(),
+      removeWorktrees: z.array(z.string()).optional(),
+      removePrs: z.array(refItemSchema()).optional(),
+      removeIssues: z.array(refItemSchema()).optional(),
+      removeFeatures: z.array(z.string()).optional(),
+    });
+
+  test('rejects whitespace-only title', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ title: '   ' });
+    assert.equal(result.success, false);
+  });
+
+  test('trims title and accepts valid trimmed result', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ title: '  Hello  ' });
+    assert.equal(result.success, true);
+    assert.equal(result.data.title, 'Hello');
+  });
+
+  test('rejects title exceeding 200 chars', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ title: 'x'.repeat(201) });
+    assert.equal(result.success, false);
+  });
+
+  test('rejects empty-string label after trim', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ labels: ['valid', '  '] });
+    assert.equal(result.success, false);
+  });
+
+  test('trims label strings', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ labels: ['  abc  '] });
+    assert.equal(result.success, true);
+    assert.deepEqual(result.data.labels, ['abc']);
+  });
+
+  test('rejects more than 20 labels at schema level', async () => {
+    z = (await import('zod')).z;
+    const schema = buildSchema();
+    const result = schema.safeParse({ labels: Array.from({ length: 21 }, (_, i) => `l${i}`) });
+    assert.equal(result.success, false);
+  });
+});
+
 describe('refKey', () => {
   test('generates lowercase dedupe key', async () => {
     const { refKey } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');

--- a/packages/api/test/thread-metadata.test.js
+++ b/packages/api/test/thread-metadata.test.js
@@ -254,6 +254,33 @@ describe('ThreadStore (in-memory) — threadMetadata', () => {
   });
 });
 
+describe('atomicMergeThreadMetadata (in-memory)', () => {
+  test('merges patch into empty metadata and returns result', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    const result = store.atomicMergeThreadMetadata(thread.id, {
+      worktrees: ['/path/a'],
+      prs: [{ repo: 'owner/repo', number: 1 }],
+    });
+    assert.deepEqual(result.worktrees, ['/path/a']);
+    assert.deepEqual(result.prs, [{ repo: 'owner/repo', number: 1 }]);
+    // Verify persisted
+    assert.deepEqual(store.getThreadMetadata(thread.id), result);
+  });
+
+  test('merges into existing metadata with append+dedupe', async () => {
+    const { ThreadStore } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');
+    const store = new ThreadStore();
+    const thread = store.create('user-1', 'Test');
+    store.updateThreadMetadata(thread.id, { v: 1, worktrees: ['/a'] });
+    const result = store.atomicMergeThreadMetadata(thread.id, {
+      worktrees: ['/a', '/b'],
+    });
+    assert.deepEqual(result.worktrees, ['/a', '/b']);
+  });
+});
+
 describe('refKey', () => {
   test('generates lowercase dedupe key', async () => {
     const { refKey } = await import('../dist/domains/cats/services/stores/ports/ThreadStore.js');

--- a/packages/mcp-server/src/server-toolsets.ts
+++ b/packages/mcp-server/src/server-toolsets.ts
@@ -375,6 +375,8 @@ export const EXPLICIT_TOOL_ANNOTATIONS: Record<string, Annotation> = {
   cat_cafe_publish_verdict: A_WRITE_SAFE,
   cat_cafe_register_pr_tracking: A_WRITE_SAFE,
   cat_cafe_register_issue_tracking: A_WRITE_SAFE,
+  cat_cafe_get_thread_metadata: A_READ_LOCAL,
+  cat_cafe_set_thread_metadata: A_WRITE_SAFE,
   cat_cafe_register_scheduled_task: A_WRITE_SAFE,
   cat_cafe_remove_scheduled_task: A_DESTRUCTIVE, // R8.2: "stops the task and deletes it permanently" (schedule-tools.ts:217)
   cat_cafe_register_external_runtime_session: A_WRITE_SAFE,

--- a/packages/mcp-server/src/tools/callback-tools.ts
+++ b/packages/mcp-server/src/tools/callback-tools.ts
@@ -2009,6 +2009,73 @@ export async function handleSetReadMode(input: { mode: 'anchor' | 'full' }): Pro
   }
 }
 
+// #872: Thread Metadata MCP — get/set low-frequency metadata anchors
+export async function handleGetThreadMetadata(): Promise<ToolResult> {
+  return callbackGet('/api/callbacks/thread-metadata');
+}
+
+export const setThreadMetadataInputSchema = {
+  title: z.string().min(1).optional().describe('Update thread title (replaces existing)'),
+  labels: z.array(z.string()).optional().describe('Update thread labels (replaces entire array)'),
+  worktrees: z.array(z.string()).optional().describe('Worktree paths to add (append + dedupe)'),
+  prs: z
+    .array(z.object({ repo: z.string().min(1), number: z.number().int().positive() }))
+    .optional()
+    .describe('PRs to add (append + dedupe by repo#number)'),
+  issues: z
+    .array(z.object({ repo: z.string().min(1), number: z.number().int().positive() }))
+    .optional()
+    .describe('Issues to add (append + dedupe by repo#number)'),
+  features: z.array(z.string()).optional().describe('Feature IDs to add (append + dedupe)'),
+  notes: z
+    .record(z.string(), z.string().nullable())
+    .optional()
+    .describe('Free-form KV notes: string value sets key, null deletes key'),
+  removeWorktrees: z.array(z.string()).optional().describe('Worktree paths to remove'),
+  removePrs: z
+    .array(z.object({ repo: z.string().min(1), number: z.number().int().positive() }))
+    .optional()
+    .describe('PRs to remove (matched by repo#number)'),
+  removeIssues: z
+    .array(z.object({ repo: z.string().min(1), number: z.number().int().positive() }))
+    .optional()
+    .describe('Issues to remove (matched by repo#number)'),
+  removeFeatures: z.array(z.string()).optional().describe('Feature IDs to remove'),
+};
+
+export async function handleSetThreadMetadata(input: {
+  title?: string;
+  labels?: string[];
+  worktrees?: string[];
+  prs?: Array<{ repo: string; number: number }>;
+  issues?: Array<{ repo: string; number: number }>;
+  features?: string[];
+  notes?: Record<string, string | null>;
+  removeWorktrees?: string[];
+  removePrs?: Array<{ repo: string; number: number }>;
+  removeIssues?: Array<{ repo: string; number: number }>;
+  removeFeatures?: string[];
+}): Promise<ToolResult> {
+  return withDegradation({
+    toolName: 'set_thread_metadata',
+    primary: () =>
+      callbackPost('/api/callbacks/set-thread-metadata', {
+        ...(input.title !== undefined ? { title: input.title } : {}),
+        ...(input.labels !== undefined ? { labels: input.labels } : {}),
+        ...(input.worktrees !== undefined ? { worktrees: input.worktrees } : {}),
+        ...(input.prs !== undefined ? { prs: input.prs } : {}),
+        ...(input.issues !== undefined ? { issues: input.issues } : {}),
+        ...(input.features !== undefined ? { features: input.features } : {}),
+        ...(input.notes !== undefined ? { notes: input.notes } : {}),
+        ...(input.removeWorktrees !== undefined ? { removeWorktrees: input.removeWorktrees } : {}),
+        ...(input.removePrs !== undefined ? { removePrs: input.removePrs } : {}),
+        ...(input.removeIssues !== undefined ? { removeIssues: input.removeIssues } : {}),
+        ...(input.removeFeatures !== undefined ? { removeFeatures: input.removeFeatures } : {}),
+      }),
+    policy: { kind: 'none' },
+  });
+}
+
 export const callbackTools = [
   {
     name: 'cat_cafe_post_message',
@@ -2493,5 +2560,25 @@ export const callbackTools = [
       'GOTCHA: Requires Clowder AI managed session (CAT_CAFE_INVOCATION_ID).',
     inputSchema: setReadModeInputSchema,
     handler: handleSetReadMode,
+  },
+  {
+    name: 'cat_cafe_get_thread_metadata',
+    description:
+      'Read low-frequency metadata anchors for the current thread: worktree paths, associated PRs/issues, ' +
+      'feature links, labels, title, and free-form notes. Call at session start or handoff to recover context. ' +
+      'Returns all metadata fields; missing fields are omitted (not null).',
+    inputSchema: {},
+    handler: handleGetThreadMetadata,
+  },
+  {
+    name: 'cat_cafe_set_thread_metadata',
+    description:
+      'Write low-frequency metadata anchors for the current thread. Merge semantics: ' +
+      'title/labels REPLACE; worktrees/prs/issues/features APPEND with dedupe (use remove* fields to remove); ' +
+      'notes MERGE (string sets, null deletes key). ' +
+      'WHEN: after creating a worktree, PR, or issue association — NOT for dynamic state. ' +
+      'SCOPE: current thread only (no threadId param); cross-thread writes are impossible.',
+    inputSchema: setThreadMetadataInputSchema,
+    handler: handleSetThreadMetadata,
   },
 ] as const;

--- a/packages/mcp-server/test/tool-registration.test.js
+++ b/packages/mcp-server/test/tool-registration.test.js
@@ -125,6 +125,9 @@ const EXPECTED_TOOLS = [
   'cat_cafe_shell_exec',
   // F236 Phase C: cc native Read/Grep/Glob anchor mode control
   'cat_cafe_set_read_mode',
+  // #872: Thread Metadata MCP
+  'cat_cafe_get_thread_metadata',
+  'cat_cafe_set_thread_metadata',
   // F195 Phase B: Audio capture + transcription tools
   'cat_cafe_audio_list_sources',
   'cat_cafe_audio_capture_start',
@@ -204,6 +207,9 @@ const EXPECTED_COLLAB_TOOLS = [
   'cat_cafe_shell_exec',
   // F236 Phase C: cc native Read/Grep/Glob anchor mode control
   'cat_cafe_set_read_mode',
+  // #872: Thread Metadata MCP
+  'cat_cafe_get_thread_metadata',
+  'cat_cafe_set_thread_metadata',
   // F168 Phase B Task 6: declare awaiting_external state for a community case
   'cat_cafe_community_await_external',
 ];
@@ -515,6 +521,8 @@ const KNOWN_WRITE_TOOLS = [
   'cat_cafe_feat_index', // requires callback credentials unavailable in readonly
   // F236 Phase C: set_read_mode writes mode file via callbackPost
   'cat_cafe_set_read_mode',
+  // #872: set_thread_metadata writes via callbackPost
+  'cat_cafe_set_thread_metadata',
   'signal_mark_read',
   'signal_summarize',
   'signal_start_study',

--- a/packages/mcp-server/test/tool-registration.test.js
+++ b/packages/mcp-server/test/tool-registration.test.js
@@ -144,6 +144,9 @@ const EXPECTED_TOOLS = [
   'cat_cafe_publish_verdict',
   // F168 Phase B Task 6: declare awaiting_external state for a community case
   'cat_cafe_community_await_external',
+  // #872: Thread Metadata MCP
+  'cat_cafe_get_thread_metadata',
+  'cat_cafe_set_thread_metadata',
 ];
 
 const EXPECTED_COLLAB_TOOLS = [
@@ -212,6 +215,9 @@ const EXPECTED_COLLAB_TOOLS = [
   'cat_cafe_set_thread_metadata',
   // F168 Phase B Task 6: declare awaiting_external state for a community case
   'cat_cafe_community_await_external',
+  // #872: Thread Metadata MCP
+  'cat_cafe_get_thread_metadata',
+  'cat_cafe_set_thread_metadata',
 ];
 
 const EXPECTED_MEMORY_TOOLS = [

--- a/packages/mcp-server/test/tool-registration.test.js
+++ b/packages/mcp-server/test/tool-registration.test.js
@@ -144,9 +144,6 @@ const EXPECTED_TOOLS = [
   'cat_cafe_publish_verdict',
   // F168 Phase B Task 6: declare awaiting_external state for a community case
   'cat_cafe_community_await_external',
-  // #872: Thread Metadata MCP
-  'cat_cafe_get_thread_metadata',
-  'cat_cafe_set_thread_metadata',
 ];
 
 const EXPECTED_COLLAB_TOOLS = [
@@ -215,9 +212,6 @@ const EXPECTED_COLLAB_TOOLS = [
   'cat_cafe_set_thread_metadata',
   // F168 Phase B Task 6: declare awaiting_external state for a community case
   'cat_cafe_community_await_external',
-  // #872: Thread Metadata MCP
-  'cat_cafe_get_thread_metadata',
-  'cat_cafe_set_thread_metadata',
 ];
 
 const EXPECTED_MEMORY_TOOLS = [


### PR DESCRIPTION
## Summary

Closes #872.

- Add `ThreadMetadataV1` type with versioned schema (`v:1`) for low-frequency thread anchors: worktrees, PRs, issues, features, notes
- Implement merge semantics: arrays APPEND+dedupe with `remove*` counterparts; notes MERGE with `null`-delete; labels/title REPLACE
- Add two MCP tools: `cat_cafe_get_thread_metadata` (read) and `cat_cafe_set_thread_metadata` (write with merge)
- Current-thread-only auth scope via `requireCallbackPrincipal()` — no threadId parameter exposed
- Redis hash JSON serialization (same pattern as `threadMemory`, `votingState`)
- `parseThreadMetadataJson()` fail-open parsing (malformed → null, not throw)
- Label validation in set-thread-metadata reuses same invariant as `PATCH /api/threads/:id` (max 20 + userId ownership)

## Files changed (8 files, +645 lines)

| File | What |
|------|------|
| `ThreadStore.ts` | Core types, merge logic, parse, in-memory store methods |
| `RedisThreadStore.ts` | Redis serialization/deserialization + store methods |
| `callbacks.ts` | GET/POST routes with invocation auth + label validation |
| `callback-tools.ts` | MCP tool handlers (get/set) |
| `server-toolsets.ts` | Tool annotation declarations |
| `tool-registration.test.js` | Added to EXPECTED_TOOLS + EXPECTED_COLLAB_TOOLS |
| `thread-metadata.test.js` | 23 tests: merge semantics, parse fail-open, in-memory store, refKey |
| `package.json` | `check:biome-version` script for pre-commit hook |

## Design decisions (per #872 discussion)

- **Merge semantics over replace**: arrays append+dedupe so concurrent MCP callers don't overwrite each other
- **PR/issue dedupe key**: `repo.toLowerCase()#number` for case-insensitive matching
- **No `phase`/`preferredCats`**: excluded per maintainer feedback — these belong to thread-level config, not metadata
- **No session bootstrap**: deferred to separate issue — metadata is persisted but not auto-loaded into MCP session context
- **`withDegradation({ kind: 'none' })`**: write tool has no local fallback (consistent with other write callbacks)

## Test plan

- [x] 23/23 thread-metadata unit tests (merge, parse, store, refKey)
- [x] 45/45 thread-store tests (no regression)
- [x] 20/20 MCP tool-registration tests
- [x] 32/32 MCP annotation tests
- [x] 367/367 full MCP test suite
- [x] Biome check clean (pre-commit hook)
- [x] Cross-cat review by @缅因猫/砚砚 (gpt-5.5) — approved, no P1/P2

🐾 Developed by 布偶猫/宪宪 (claude-opus-4-6), reviewed by 缅因猫/砚砚 (gpt-5.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)