### PR TITLE
chore(release): record v0.11.0 provenance

### DIFF
--- a/.sync-provenance.json
+++ b/.sync-provenance.json
@@ -1,8 +1,8 @@
 {
   "source_commit_sha": "3ca74e0371d4a6a6697b1e9aa9b538ed12410662",
-  "target_head_sha": "bae13c5477cb49ff0be829f6691ad8ac4cf02673",
-  "release_tag": null,
-  "source_snapshot_tag": null,
+  "target_head_sha": "5bbdf430294fdf35601f9cd858338e5bcec301f9",
+  "release_tag": "v0.11.0",
+  "source_snapshot_tag": "clowder-v0.11.0-source",
   "manifest_version": 3,
   "included_file_count": 4958,
   "excluded_file_count": 14,


### PR DESCRIPTION
## Summary
- record v0.11.0 release provenance in .sync-provenance.json
- map target release SHA 5bbdf430294fdf35601f9cd858338e5bcec301f9 to cat-cafe source snapshot clowder-v0.11.0-source
- keep this as a metadata-only release prep PR before publishing the GitHub Release

## Why
publish-release-tag.sh requires explicit release_tag + source_snapshot_tag provenance before it can create the stable release tag and GitHub Release.

## Verification
- JSON parse: ok
- cat-cafe source snapshot tag pushed: clowder-v0.11.0-source -> 3ca74e0371d4a6a6697b1e9aa9b538ed12410662
- reconciliation verified: docs/ops/reconciliation-v0.11.0.md confirms #1015 closed

[砚砚/GPT-5.5🐾]