### PR TITLE
fix: update Inno Chinese language source for v0.11.1

### DIFF
--- a/.sync-provenance.json
+++ b/.sync-provenance.json
@@ -1,12 +1,12 @@
 {
-  "source_commit_sha": "3ca74e0371d4a6a6697b1e9aa9b538ed12410662",
-  "target_head_sha": "5bbdf430294fdf35601f9cd858338e5bcec301f9",
-  "release_tag": "v0.11.0",
-  "source_snapshot_tag": "clowder-v0.11.0-source",
+  "source_commit_sha": "ee24fc528aa35bd6e576c79296ea32992dfcd093",
+  "target_head_sha": "ee6ae7df25ffd8c77d7e972840bc7f6af23b6cc9",
+  "release_tag": "v0.11.1",
+  "source_snapshot_tag": "clowder-v0.11.1-source",
   "manifest_version": 3,
   "included_file_count": 4958,
   "excluded_file_count": 14,
   "transform_count": 34,
   "secret_scan_result": "clean",
-  "synced_at": "2026-06-25T07:49:52Z"
+  "synced_at": "2026-06-29T03:29:56Z"
 }

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Builds the Cat Cafe Windows installer package.
+  Builds the Clowder AI Windows installer package.
 
 .DESCRIPTION
   Full pipeline:
@@ -266,7 +266,7 @@ Install it with the official bootstrapper:
 
   powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri https://antigravity.google/cli/install.cmd -OutFile `$env:TEMP\antigravity-cli-install.cmd; & `$env:TEMP\antigravity-cli-install.cmd"
 
-Offline Cat Cafe packages intentionally do not vendor agy until Google
+Offline Clowder AI packages intentionally do not vendor agy until Google
 publishes a redistributable native binary contract.
 "@ | Set-Content -Path $agyInstructionsPath -Encoding ascii
 Write-Ok "agy-install-instructions.txt written"
@@ -396,7 +396,7 @@ if (-not $SkipInstaller) {
         if (Test-Path $unofficial) {
             Copy-Item $unofficial $zhIsl
         } else {
-            $url = "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/Unofficial/ChineseSimplified.isl"
+            $url = "https://raw.githubusercontent.com/jrsoftware/issrc/main/Files/Languages/ChineseSimplified.isl"
             Invoke-WebRequest -Uri $url -OutFile $zhIsl -ErrorAction Stop
         }
         Write-Host "  Installed ChineseSimplified.isl" -ForegroundColor Gray

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -57,6 +57,20 @@ test('windows desktop build script retries pnpm deploy on EPERM', async () => {
   assert.match(buildScript, /Remove-Item \$out -Recurse -Force/);
 });
 
+test('windows desktop build script downloads official Inno Setup ChineseSimplified language file', async () => {
+  const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
+
+  assert.match(
+    buildScript,
+    /https:\/\/raw\.githubusercontent\.com\/jrsoftware\/issrc\/main\/Files\/Languages\/ChineseSimplified\.isl/,
+  );
+  assert.doesNotMatch(
+    buildScript,
+    /Files\/Languages\/Unofficial\/ChineseSimplified\.isl/,
+    'ChineseSimplified.isl is now an official Inno Setup language file; the old Unofficial URL 404s',
+  );
+});
+
 test('windows desktop build script Defender cleanup runs in finally block', async () => {
   const buildScript = await readFile(desktopBuildScriptPath, 'utf8');
 


### PR DESCRIPTION
## Summary
- Update the Windows installer build script to download `ChineseSimplified.isl` from the current official Inno Setup language path.
- Add the matching release-pipeline regression test.
- Record `v0.11.1` release provenance against `clowder-v0.11.1-source`.

## Why
`v0.11.0` release asset generation failed because the old `Files/Languages/Unofficial/ChineseSimplified.isl` URL now returns 404. The patch keeps the already-published `v0.11.0` tag immutable and publishes a follow-up patch release.

## Verification
- `node --test packages/api/test/build-script-cross-platform.test.js`
- hotfix dry-run drift check passed for both changed files

[砚砚/GPT-5.5🐾]