### PR TITLE
fix: add UUID guard for --resume in ClaudeAgentService

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/ClaudeAgentService.ts
@@ -47,6 +47,12 @@ const RESERVED_SYSTEM_PROMPT_FLAGS = new Set([
   '--append-system-prompt-file',
 ]);
 
+// F198 Bug #3: `claude --resume <id>` requires a valid session UUID when
+// used with --print. Guard sessionId before forwarding it as --resume.
+// Consumers (ClaudeBgCarrierService) should import from here for single
+// source of truth.
+export const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // F198: exported so other Claude carriers (e.g. ClaudeBgCarrierService) can
 // reuse the single source of truth for profile mode routing.
 export const ANTHROPIC_PROFILE_MODE_KEY = 'CAT_CAFE_ANTHROPIC_PROFILE_MODE';
@@ -366,7 +372,12 @@ export class ClaudeAgentService implements AgentService {
       '--chrome',
     ];
 
-    if (options?.sessionId) {
+    // F198 Bug #3 + Coffee regression 2026-07-02: catagent-XXX from
+    // CatAgentService (or any non-UUID source) must NOT be forwarded as
+    // --resume — Claude Code rejects non-UUID values when used with --print.
+    // Mirror ClaudeBgCarrierService UUID guard so resume never enters Claude
+    // Code with a stale / wrong-format id.
+    if (options?.sessionId && UUID_PATTERN.test(options.sessionId)) {
       args.push('--resume', options.sessionId);
     }
     for (const dir of imageAccessDirs) {

--- a/packages/api/test/claude-agent-service.test.js
+++ b/packages/api/test/claude-agent-service.test.js
@@ -496,18 +496,18 @@ test('handles mixed text and tool_use in single assistant message', async () => 
   assert.equal(contentMsgs[2].content, 'Done reading.');
 });
 
-test('passes --resume flag when sessionId is provided', async () => {
+test('passes --resume flag when sessionId is a valid UUID', async () => {
   const proc = createMockProcess();
   const spawnFn = createMockSpawnFn(proc);
   const service = createClaudeAgentService({ spawnFn });
 
-  const promise = collect(service.invoke('continue', { sessionId: 'resume-123' }));
+  const promise = collect(service.invoke('continue', { sessionId: '550e8400-e29b-41d4-a716-446655440000' }));
   emitClaudeEvents(proc, [{ type: 'result', subtype: 'success' }]);
   await promise;
 
   const args = spawnFn.mock.calls[0].arguments[1];
   assert.ok(args.includes('--resume'));
-  assert.ok(args.includes('resume-123'));
+  assert.ok(args.includes('550e8400-e29b-41d4-a716-446655440000'));
 });
 
 test('does not include --resume when no sessionId', async () => {
@@ -521,6 +521,20 @@ test('does not include --resume when no sessionId', async () => {
 
   const args = spawnFn.mock.calls[0].arguments[1];
   assert.ok(!args.includes('--resume'));
+});
+
+test('skips --resume when sessionId is not a UUID (e.g. catagent-XXX)', async () => {
+  const proc = createMockProcess();
+  const spawnFn = createMockSpawnFn(proc);
+  const service = createClaudeAgentService({ spawnFn });
+
+  const promise = collect(service.invoke('continue', { sessionId: 'catagent-1782963968527-9hw36e' }));
+  emitClaudeEvents(proc, [{ type: 'result', subtype: 'success' }]);
+  await promise;
+
+  const args = spawnFn.mock.calls[0].arguments[1];
+  assert.ok(!args.includes('--resume'));
+  assert.ok(!args.includes('catagent-'));
 });
 
 test('passes cwd from workingDirectory option', async () => {
@@ -781,7 +795,7 @@ test('yields actionable rescue hint on invalid thinking signature resume failure
   const spawnFn = createMockSpawnFn(proc);
   const service = createClaudeAgentService({ spawnFn });
 
-  const promise = collect(service.invoke('resume me', { sessionId: 'sess-bad-thinking' }));
+  const promise = collect(service.invoke('resume me', { sessionId: '550e8400-e29b-41d4-a716-446655440000' }));
 
   proc.stderr.write(
     'API Error: 400 {"type":"error","error":{"type":"invalid_request_error","message":"messages.1.content.0: Invalid `signature` in `thinking` block"}}\n',
@@ -794,7 +808,7 @@ test('yields actionable rescue hint on invalid thinking signature resume failure
   assert.ok(errMsg);
   assert.ok(errMsg.error.includes('thinking signature'));
   assert.ok(errMsg.error.includes('pnpm rescue:claude:thinking'));
-  assert.ok(errMsg.error.includes('sess-bad-thinking'));
+  assert.ok(errMsg.error.includes('550e8400-e29b-41d4-a716-446655440000'));
   assert.ok(!errMsg.error.includes('messages.1.content.0'));
 });
 


### PR DESCRIPTION
## Description

Fixes #1063

`ClaudeAgentService` was passing non-UUID sessionIds (e.g. `catagent-<ts>-<random>` from CatAgentService) directly to `claude --resume`, which Claude CLI rejects.

`ClaudeBgCarrierService` already had the correct UUID guard — this fix brings `ClaudeAgentService` in line.

## Changes

- **ClaudeAgentService.ts**: Added `UUID_PATTERN` guard before `--resume`. Non-UUID sessionIds skip resume and start fresh.
- **Tests**: Updated existing test to use valid UUID; added new test verifying non-UUID is skipped.

## Testing

54/55 tests pass (1 pre-existing env config issue unrelated).