### PR TITLE
fix(#1072): restore #713 fixes overwritten by #1059 sync

### DIFF
--- a/packages/api/src/config/capabilities/capability-orchestrator.ts
+++ b/packages/api/src/config/capabilities/capability-orchestrator.ts
@@ -1544,7 +1544,7 @@ export interface CliConfigPaths {
 }
 
 /** Providers that support streamableHttp transport (URL-based MCP). */
-const STREAMABLE_HTTP_PROVIDERS = new Set(['anthropic', 'kimi', 'opencode']);
+const STREAMABLE_HTTP_PROVIDERS = new Set(['anthropic', 'openai', 'kimi', 'opencode']);
 
 interface ResolveServersForCatOptions {
   /** global = globalEnabled is the master switch; project = blockedCats is the project access source. */

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -421,15 +421,22 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         source: string;
         workingDir?: string;
       }>) {
-        // Skip disabled servers entirely. L5 writeCodexMcpConfig already
-        // deletes disabled managed entries from .codex/config.toml, so there's
-        // nothing to override at L4. Injecting a bare `enabled=false` (or even
-        // a dummy command + enabled=false) adds CLI noise and risks Codex CLI
-        // validation errors (≥0.142 requires valid transport on all entries).
-        // The legacy `cat-cafe` shim above is the only exception — user-level
-        // ~/.codex/config.toml may have old entries that L5 cannot reach.
+        // Suppress disabled servers with a complete dummy shape so any stale
+        // .codex/config.toml entries cannot revive. Bare `enabled=false` fails
+        // Codex ≥0.142 schema validation (requires transport fields); including
+        // command+args satisfies the schema — same principle as the legacy
+        // `cat-cafe` shim above (L371-379).
         if (!s.enabled) {
           disabledServers.push(s.name);
+          const dummyToml = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
+          args.push(
+            '--config',
+            `mcp_servers.${dummyToml}.command="echo"`,
+            '--config',
+            `mcp_servers.${dummyToml}.args=[${toTomlString('disabled-shim')}]`,
+            '--config',
+            `mcp_servers.${dummyToml}.enabled=false`,
+          );
           continue;
         }
         // Codex only supports stdio — skip streamableHttp and pencil (async resolver)
@@ -438,10 +445,21 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         let cmd: string | undefined;
         let cmdArgs: string[] | undefined;
         let envEntries: Record<string, string> | undefined;
-        const isCatCafe = s.source === 'cat-cafe' && CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name);
+        // Managed split: source='cat-cafe' + name in entrypoint map → resolve
+        // binary from mcpDistDir. Same-repo external migration shapes (F193:
+        // source='external' but binary points to our own split entrypoint) use
+        // the entry's own command/args but still need managed env injection.
+        const isManagedCatCafe = s.source === 'cat-cafe' && CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name);
+        const isSameRepoSplit =
+          !isManagedCatCafe &&
+          s.source === 'external' &&
+          CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name) &&
+          typeof s.args?.[0] === 'string' &&
+          s.args[0].replace(/\\/g, '/').endsWith(`packages/mcp-server/dist/${CAT_CAFE_SPLIT_ENTRYPOINTS.get(s.name)}`);
+        const isCatCafe = isManagedCatCafe || isSameRepoSplit;
         const workingDir = resolveCodexMcpWorkingDir(s.workingDir, configSourceRoot);
 
-        if (isCatCafe) {
+        if (isManagedCatCafe) {
           const ep = CAT_CAFE_SPLIT_ENTRYPOINTS.get(s.name)!;
           const epPath = resolve(mcpDistDir!, ep);
           if (!existsSync(epPath)) continue;

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -445,10 +445,13 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         let cmd: string | undefined;
         let cmdArgs: string[] | undefined;
         let envEntries: Record<string, string> | undefined;
-        // Managed split: source='cat-cafe' + name in entrypoint map → resolve
-        // binary from mcpDistDir. Same-repo external migration shapes (F193:
-        // source='external' but binary points to our own split entrypoint) use
-        // the entry's own command/args but still need managed env injection.
+        // Managed split: source='cat-cafe' + name in entrypoint map.
+        // Same-repo external migration shapes (F193): source='external' but
+        // binary suffix matches our own split entrypoint — these arise from
+        // ensureCatCafeMainServer when hasAnyId prevents managed entry creation.
+        // Both MUST resolve binary from current mcpDistDir (not the entry's
+        // args[0], which may hold a stale worktree absolute path) and receive
+        // managed env injection (callback env, workspace dirs, approval mode).
         const isManagedCatCafe = s.source === 'cat-cafe' && CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name);
         const isSameRepoSplit =
           !isManagedCatCafe &&
@@ -459,7 +462,7 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         const isCatCafe = isManagedCatCafe || isSameRepoSplit;
         const workingDir = resolveCodexMcpWorkingDir(s.workingDir, configSourceRoot);
 
-        if (isManagedCatCafe) {
+        if (isCatCafe) {
           const ep = CAT_CAFE_SPLIT_ENTRYPOINTS.get(s.name)!;
           const epPath = resolve(mcpDistDir!, ep);
           if (!existsSync(epPath)) continue;

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -448,16 +448,30 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
         // (same pattern as ClaudeAgentService). The resolver scans the local
         // machine for the latest Pencil MCP binary and returns {command, args}.
         if (s.resolver === 'pencil') {
+          const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
           const pencil = await resolvePencilCommand({ projectRoot: configSourceRoot });
           if (pencil) {
             enabledServers.push(s.name);
-            const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
             const argsToml = pencil.args.map(toTomlString).join(', ');
             args.push(
               '--config',
               `mcp_servers.${tomlName}.command=${toTomlString(pencil.command)}`,
               '--config',
               `mcp_servers.${tomlName}.args=[${argsToml}]`,
+              '--config',
+              `mcp_servers.${tomlName}.enabled=true`,
+            );
+          } else {
+            // No pencil installation found — emit disabled dummy to prevent
+            // stale .codex/config.toml entries from reviving an old binary.
+            disabledServers.push(s.name);
+            args.push(
+              '--config',
+              `mcp_servers.${tomlName}.command="echo"`,
+              '--config',
+              `mcp_servers.${tomlName}.args=[${toTomlString('disabled-shim')}]`,
+              '--config',
+              `mcp_servers.${tomlName}.enabled=false`,
             );
           }
           continue;

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -434,14 +434,27 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
         if (!s.enabled) {
           disabledServers.push(s.name);
           const dummyToml = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
-          args.push(
-            '--config',
-            `mcp_servers.${dummyToml}.command="echo"`,
-            '--config',
-            `mcp_servers.${dummyToml}.args=[${toTomlString('disabled-shim')}]`,
-            '--config',
-            `mcp_servers.${dummyToml}.enabled=false`,
-          );
+          if (s.transport === 'streamableHttp' && s.url) {
+            // URL-based disabled: emit url + enabled=false to avoid transport
+            // conflict with stale config.toml URL entries — overlaying stdio
+            // fields (command/args) on an existing URL TOML table causes Codex
+            // CLI error "url is not supported for stdio".
+            args.push(
+              '--config',
+              `mcp_servers.${dummyToml}.url=${toTomlString(s.url)}`,
+              '--config',
+              `mcp_servers.${dummyToml}.enabled=false`,
+            );
+          } else {
+            args.push(
+              '--config',
+              `mcp_servers.${dummyToml}.command="echo"`,
+              '--config',
+              `mcp_servers.${dummyToml}.args=[${toTomlString('disabled-shim')}]`,
+              '--config',
+              `mcp_servers.${dummyToml}.enabled=false`,
+            );
+          }
           continue;
         }
         // Pencil: resolver-backed entry — resolve the binary at invoke time

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -421,26 +421,24 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         source: string;
         workingDir?: string;
       }>) {
-        const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
-        // Same-name external/user entries for managed split servers can exist
-        // in local capabilities from older topology migrations. At invocation
-        // time the split server id itself is managed authority: keep callback
-        // env/workspace injection and runtime-owned binaries intact.
-        const isCatCafe = CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name);
-        // Codex layers user/project config.toml entries under CLI overrides.
-        // A disabled capability therefore needs an explicit per-invocation
-        // override; skipping it lets stale persistent MCP entries revive.
-        if (!s.enabled && (!isCatCafe || s.source === 'cat-cafe')) {
+        // Skip disabled servers entirely. L5 writeCodexMcpConfig already
+        // deletes disabled managed entries from .codex/config.toml, so there's
+        // nothing to override at L4. Injecting a bare `enabled=false` (or even
+        // a dummy command + enabled=false) adds CLI noise and risks Codex CLI
+        // validation errors (≥0.142 requires valid transport on all entries).
+        // The legacy `cat-cafe` shim above is the only exception — user-level
+        // ~/.codex/config.toml may have old entries that L5 cannot reach.
+        if (!s.enabled) {
           disabledServers.push(s.name);
-          args.push('--config', `mcp_servers.${tomlName}.enabled=false`);
           continue;
         }
         // Codex only supports stdio — skip streamableHttp and pencil (async resolver)
-        if (!isCatCafe && (s.transport === 'streamableHttp' || s.resolver === 'pencil')) continue;
+        if (s.transport === 'streamableHttp' || s.resolver === 'pencil') continue;
 
         let cmd: string | undefined;
         let cmdArgs: string[] | undefined;
         let envEntries: Record<string, string> | undefined;
+        const isCatCafe = s.source === 'cat-cafe' && CAT_CAFE_SPLIT_ENTRYPOINTS.has(s.name);
         const workingDir = resolveCodexMcpWorkingDir(s.workingDir, configSourceRoot);
 
         if (isCatCafe) {
@@ -467,6 +465,7 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         }
         enabledServers.push(s.name);
 
+        const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
         args.push(
           '--config',
           `mcp_servers.${tomlName}.command=${toTomlString(cmd)}`,

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -20,7 +20,11 @@ import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { type CatId, createCatId } from '@cat-cafe/shared';
-import { resolveBinaryRoot, resolveServersForCat } from '../../../../../config/capabilities/capability-orchestrator.js';
+import {
+  resolveBinaryRoot,
+  resolvePencilCommand,
+  resolveServersForCat,
+} from '../../../../../config/capabilities/capability-orchestrator.js';
 import {
   CAT_CAFE_SPLIT_ENTRYPOINTS,
   MCP_CALLBACK_ENV_KEYS,
@@ -329,13 +333,11 @@ function writeCodexMcpEnvWrapper(spec: {
  * and explicitly disables off-capabilities servers so stale .codex/config.toml
  * entries don't leak through.
  *
- * This function is intentionally SYNC — Codex test harness uses setImmediate
- * for mock process exit, and async operations between collect() and spawnCli
- * would cause the exit event to fire before process listeners attach.
- * Pencil (async resolver) is skipped — Codex has no pencil resolution code.
- * streamableHttp is supported via --config mcp_servers.X.url=... injection.
+ * Pencil resolver entries are resolved at invoke time via resolvePencilCommand
+ * (same pattern as ClaudeAgentService). streamableHttp is supported via
+ * --config mcp_servers.X.url=... injection.
  */
-function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirectory?: string): string[] {
+async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirectory?: string): Promise<string[]> {
   if (!callbackEnv) return [];
 
   const runtimeRoot = resolveBinaryRoot();
@@ -442,8 +444,24 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
           );
           continue;
         }
-        // Skip pencil (async resolver) — Codex has no pencil resolution code
-        if (s.resolver === 'pencil') continue;
+        // Pencil: resolver-backed entry — resolve the binary at invoke time
+        // (same pattern as ClaudeAgentService). The resolver scans the local
+        // machine for the latest Pencil MCP binary and returns {command, args}.
+        if (s.resolver === 'pencil') {
+          const pencil = await resolvePencilCommand({ projectRoot: configSourceRoot });
+          if (pencil) {
+            enabledServers.push(s.name);
+            const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
+            const argsToml = pencil.args.map(toTomlString).join(', ');
+            args.push(
+              '--config',
+              `mcp_servers.${tomlName}.command=${toTomlString(pencil.command)}`,
+              '--config',
+              `mcp_servers.${tomlName}.args=[${argsToml}]`,
+            );
+          }
+          continue;
+        }
 
         // streamableHttp: inject URL directly (Codex CLI supports `--url` / `mcp_servers.X.url`)
         // Note: Codex uses bearer_token_env_var for auth, not arbitrary headers.
@@ -686,7 +704,7 @@ export class CodexAgentService implements AgentService {
         ]
       : [];
     // #712: Inject ALL enabled MCP servers from capabilities.json at invoke time.
-    const catCafeMcpArgs = buildCatCafeMcpArgs(options?.callbackEnv, options?.workingDirectory);
+    const catCafeMcpArgs = await buildCatCafeMcpArgs(options?.callbackEnv, options?.workingDirectory);
     const gitRepoArgs = buildGitRepoArgs(options?.workingDirectory);
     // User-defined CLI args from the member editor (#567) — passed as-is, no implicit wrapping.
     // Each entry is split by whitespace (e.g. "--config model_reasoning_effort=\"low\"").

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -332,7 +332,8 @@ function writeCodexMcpEnvWrapper(spec: {
  * This function is intentionally SYNC — Codex test harness uses setImmediate
  * for mock process exit, and async operations between collect() and spawnCli
  * would cause the exit event to fire before process listeners attach.
- * Pencil and streamableHttp are skipped (Codex only supports stdio).
+ * Pencil (async resolver) is skipped — Codex has no pencil resolution code.
+ * streamableHttp is supported via --config mcp_servers.X.url=... injection.
  */
 function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirectory?: string): string[] {
   if (!callbackEnv) return [];
@@ -418,6 +419,8 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
         env?: Record<string, string>;
         resolver?: string;
         transport?: string;
+        url?: string;
+        headers?: Record<string, string>;
         source: string;
         workingDir?: string;
       }>) {
@@ -439,8 +442,23 @@ function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirect
           );
           continue;
         }
-        // Codex only supports stdio — skip streamableHttp and pencil (async resolver)
-        if (s.transport === 'streamableHttp' || s.resolver === 'pencil') continue;
+        // Skip pencil (async resolver) — Codex has no pencil resolution code
+        if (s.resolver === 'pencil') continue;
+
+        // streamableHttp: inject URL directly (Codex CLI supports `--url` / `mcp_servers.X.url`)
+        // Note: Codex uses bearer_token_env_var for auth, not arbitrary headers.
+        // Header-based auth mapping is left for a follow-up if needed.
+        if (s.transport === 'streamableHttp' && s.url) {
+          enabledServers.push(s.name);
+          const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
+          args.push(
+            '--config',
+            `mcp_servers.${tomlName}.url=${toTomlString(s.url)}`,
+            '--config',
+            `mcp_servers.${tomlName}.enabled=true`,
+          );
+          continue;
+        }
 
         let cmd: string | undefined;
         let cmdArgs: string[] | undefined;

--- a/packages/api/src/mcp/mcp-drift-detector.ts
+++ b/packages/api/src/mcp/mcp-drift-detector.ts
@@ -62,19 +62,13 @@ function computeDriftHash(globalEntries: CapabilityEntry[], projectEntries: Capa
   return hash.digest('hex').slice(0, 16);
 }
 
-function normalizedBlockedCats(entry: CapabilityEntry): string[] {
-  return [...(entry.blockedCats ?? [])].sort();
-}
-
 function mcpDriftSnapshot(entry: CapabilityEntry): {
   mcpServer: CapabilityEntry['mcpServer'];
   globalEnabled: boolean;
-  blockedCats: string[];
 } {
   return {
     mcpServer: entry.mcpServer,
     globalEnabled: entry.globalEnabled ?? entry.enabled ?? true,
-    blockedCats: normalizedBlockedCats(entry),
   };
 }
 

--- a/packages/api/test/capability-orchestrator.test.js
+++ b/packages/api/test/capability-orchestrator.test.js
@@ -2323,13 +2323,15 @@ describe('resolveServersForCat', () => {
     assert.equal(opencodeServers[0].transport, 'streamableHttp');
     assert.equal(opencodeServers[0].url, 'https://mcp.example.com/sse');
 
-    // codex is openai → streamableHttp should be disabled
+    // codex is openai → streamableHttp should be enabled (added in #1072 hotfix)
     const codexServers = resolveServersForCat(config, 'codex');
     assert.equal(codexServers.length, 1);
     assert.equal(codexServers[0].name, 'remote-tool');
-    assert.equal(codexServers[0].enabled, false);
+    assert.equal(codexServers[0].enabled, true);
+    assert.equal(codexServers[0].transport, 'streamableHttp');
+    assert.equal(codexServers[0].url, 'https://mcp.example.com/sse');
 
-    // gemini is google → streamableHttp should also be disabled
+    // gemini is google → streamableHttp should be disabled
     const geminiServers = resolveServersForCat(config, 'gemini');
     assert.equal(geminiServers.length, 1);
     assert.equal(geminiServers[0].name, 'remote-tool');

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -905,7 +905,7 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
           await promise;
 
           const args = spawnFn.mock.calls[0].arguments[1];
-          // Pencil entry must be resolved and injected with command + args
+          // Pencil entry must be resolved and injected with command + args + enabled
           const pencilCommandArg = args.find((a) => a.includes('mcp_servers.pencil.command='));
           assert.ok(pencilCommandArg, 'pencil entry must inject resolved command');
           assert.ok(
@@ -916,6 +916,11 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
           assert.ok(pencilArgsArg, 'pencil entry must inject args');
           assert.ok(pencilArgsArg.includes('--app'), 'pencil args must include --app');
           assert.ok(pencilArgsArg.includes('vscode'), 'pencil args must include app name');
+          // Must explicitly enable to override any stale config.toml disabled state
+          assert.ok(
+            args.includes('mcp_servers.pencil.enabled=true'),
+            'pencil entry must inject enabled=true to override stale config',
+          );
         });
       });
     } finally {
@@ -928,6 +933,82 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
         delete process.env.PENCIL_MCP_APP;
       } else {
         process.env.PENCIL_MCP_APP = previousPencilApp;
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Codex MCP config emits disabled dummy when pencil binary is not found', async () => {
+    // When resolvePencilCommand returns null (no pencil installation),
+    // CodexAgentService must emit a disabled dummy shape to prevent
+    // stale .codex/config.toml entries from reviving an old binary.
+    const runtimeRoot = makeTempDir('.tmp-codex-pencil-null-');
+    const projectDir = makeTempDir('.tmp-codex-pencil-null-project-');
+
+    const previousPencilBin = process.env.PENCIL_MCP_BIN;
+    try {
+      // Point PENCIL_MCP_BIN at a non-existent path so resolution returns null
+      process.env.PENCIL_MCP_BIN = '/nonexistent/path/pencil-mcp-server';
+
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'pencil',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'cat-cafe',
+          mcpServer: {
+            resolver: 'pencil',
+            command: '',
+            args: [],
+          },
+        },
+      ]);
+
+      const proc = createMockProcess();
+      const spawnFn = createMockSpawnFn(proc);
+      const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello pencil null', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-pencil-null',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-pencil-null',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-pencil-null' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          // Unresolved pencil must emit disabled dummy to suppress stale config.toml
+          assert.ok(args.includes('mcp_servers.pencil.command="echo"'), 'unresolved pencil must emit dummy command');
+          assert.ok(
+            args.some((a) => a.includes('mcp_servers.pencil.args=') && a.includes('disabled-shim')),
+            'unresolved pencil must emit disabled-shim args',
+          );
+          assert.ok(args.includes('mcp_servers.pencil.enabled=false'), 'unresolved pencil must be explicitly disabled');
+        });
+      });
+    } finally {
+      if (previousPencilBin === undefined) {
+        delete process.env.PENCIL_MCP_BIN;
+      } else {
+        process.env.PENCIL_MCP_BIN = previousPencilBin;
       }
       rmSync(runtimeRoot, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -842,6 +842,86 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
+  test('Codex MCP config emits URL-based disabled override for streamableHttp entries', async () => {
+    // When a streamableHttp entry from .codex/config.toml is disabled, we must
+    // emit url + enabled=false (not command/args stdio dummy). Overlaying stdio
+    // fields on a TOML table that already has `url` causes Codex CLI error
+    // "url is not supported for stdio" — transport conflict.
+    const runtimeRoot = makeTempDir('.tmp-codex-disabled-streamable-');
+    const projectDir = makeTempDir('.tmp-codex-disabled-streamable-project-');
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      // Disabled streamableHttp entry — globalEnabled=false with a URL
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'disabled-remote',
+          type: 'mcp',
+          globalEnabled: false,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp.disabled.example.com/v1',
+            command: '',
+            args: [],
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello disabled streamable http', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-disabled-streamable',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-disabled-streamable',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-disabled-streamable' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          // Must use url + enabled=false (not stdio dummy)
+          assert.ok(
+            args.includes('mcp_servers.disabled-remote.url="https://mcp.disabled.example.com/v1"'),
+            'disabled streamableHttp must emit url (not command/args) to avoid transport conflict',
+          );
+          assert.ok(
+            args.includes('mcp_servers.disabled-remote.enabled=false'),
+            'disabled streamableHttp must emit enabled=false',
+          );
+          // Must NOT have command/args (would cause transport conflict)
+          assert.ok(
+            !args.some((a) => a.includes('mcp_servers.disabled-remote.command=')),
+            'disabled streamableHttp must not inject command (transport conflict)',
+          );
+          assert.ok(
+            !args.some((a) => a.includes('mcp_servers.disabled-remote.args=')),
+            'disabled streamableHttp must not inject args (transport conflict)',
+          );
+        });
+      });
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   test('Codex MCP config resolves pencil binary at invoke time', async () => {
     // Pencil entries have resolver='pencil' with empty command/args.
     // CodexAgentService must resolve the pencil binary at invoke time

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -657,12 +657,12 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
-  test('Codex MCP config injects managed env for same-repo external split entries', async () => {
+  test('Codex MCP config resolves runtime binary + managed env for same-repo external split', async () => {
     // #1072 regression test: ensureCatCafeMainServer migration can leave a
     // split entry with source='external' but binary pointing to our own repo
-    // dist (isSameRepoExternalSplit). These entries must receive managed env
-    // injection (callback env, workspace dirs, approval mode) even though
-    // they use the external binary path.
+    // dist (isSameRepoExternalSplit). These entries must:
+    //   1. Resolve binary from current mcpDistDir (not the entry's stale args[0])
+    //   2. Receive managed env injection (callback env, workspace dirs, approval mode)
     const runtimeRoot = makeTempDir('.tmp-codex-same-repo-ext-');
     const projectDir = makeTempDir('.tmp-codex-same-repo-ext-project-');
     const proc = createMockProcess();
@@ -680,18 +680,21 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
         'finance.js',
       ]);
       // Same-repo external shape: source='external', args[0] ends with
-      // packages/mcp-server/dist/limb.js (matching the managed entrypoint).
-      const limbBinaryPath = join(runtimeRoot, 'packages', 'mcp-server', 'dist', 'limb.js');
+      // packages/mcp-server/dist/limb.js but uses a STALE worktree path
+      // (different from current runtimeRoot). The code must resolve from
+      // current mcpDistDir, not trust the stale absolute path.
+      const staleLimbPath = '/old/worktree/packages/mcp-server/dist/limb.js';
       writeCapabilitiesConfig(runtimeRoot, [
         {
           id: 'cat-cafe-limb',
           type: 'mcp',
           globalEnabled: true,
           source: 'external',
-          mcpServer: { command: 'node', args: [limbBinaryPath] },
+          mcpServer: { command: 'node', args: [staleLimbPath] },
         },
       ]);
 
+      const currentLimbPath = join(runtimeRoot, 'packages', 'mcp-server', 'dist', 'limb.js');
       await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
         await withRuntimeRootEnv(runtimeRoot, async () => {
           const promise = collect(
@@ -714,6 +717,12 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
             args.includes('mcp_servers.cat-cafe-limb.enabled=true'),
             'same-repo external split must be injected as enabled',
           );
+          // Must use current runtime binary, not stale worktree path
+          assert.ok(
+            args.some((a) => a.includes(`mcp_servers.cat-cafe-limb.args=`) && a.includes(currentLimbPath)),
+            'same-repo external split must resolve binary from current mcpDistDir, not stale args[0]',
+          );
+          assert.ok(!args.some((a) => a.includes('/old/worktree/')), 'stale worktree path must not appear in CLI args');
           // Must receive managed approval mode and callback env injection
           assert.ok(
             args.some((a) => a.includes('mcp_servers.cat-cafe-limb.default_tools_approval_mode=')),

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -533,14 +533,23 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
       await promise;
 
       const args = spawnFn.mock.calls[0].arguments[1];
-      // #713 fix: disabled servers are skipped entirely — no enabled=false
-      // injection, no command fields. L5 writeCodexMcpConfig already deletes
-      // disabled managed entries from .codex/config.toml, and injecting a bare
-      // enabled=false risks Codex CLI validation errors (≥0.142 requires valid
-      // transport on all entries).
+      // #1072 fix: disabled servers emit a complete dummy shape (command +
+      // args + enabled=false) to suppress any stale .codex/config.toml entries.
+      // Bare `enabled=false` fails Codex ≥0.142 schema validation; including
+      // command+args satisfies the schema (same principle as legacy cat-cafe shim).
       assert.ok(
-        !args.some((a) => a.includes('mcp_servers.cat-cafe-collab.')),
-        'disabled runtime capability must not appear in CLI args at all',
+        args.includes('mcp_servers.cat-cafe-collab.command="echo"'),
+        'disabled entry must emit dummy command to suppress stale config.toml',
+      );
+      assert.ok(
+        args.some((a) => a.includes('mcp_servers.cat-cafe-collab.args=') && a.includes('disabled-shim')),
+        'disabled entry must emit dummy args for schema compliance',
+      );
+      assert.ok(args.includes('mcp_servers.cat-cafe-collab.enabled=false'), 'disabled entry must emit enabled=false');
+      // No callback env or workspace injection for disabled entries
+      assert.ok(
+        !args.some((a) => a.includes('mcp_servers.cat-cafe-collab.env.')),
+        'disabled entry must not receive env injection',
       );
       assert.ok(
         args.includes(`mcp_servers.cat-cafe-memory.command=${JSON.stringify(process.execPath)}`),
@@ -572,11 +581,12 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
-  test('Codex MCP config skips same-name external entry with unsupported transport', async () => {
-    // #713 fix: isCatCafe requires both source === 'cat-cafe' AND name in
-    // CAT_CAFE_SPLIT_ENTRYPOINTS. An external entry with a managed name but
-    // unsupported transport (streamableHttp) is correctly skipped by the
-    // transport filter — no stale user paths or secrets leak into CLI args.
+  test('Codex MCP config suppresses external entry with unsupported transport as disabled dummy', async () => {
+    // #1072 fix: external entry with managed name but unsupported transport
+    // resolves as disabled (transport unsupported for this provider). The
+    // disabled handler emits a complete dummy shape (command + args +
+    // enabled=false) to suppress any stale config.toml entries — stale user
+    // paths and secrets must never leak into CLI args.
     const runtimeRoot = makeTempDir('.tmp-codex-managed-shadow-root-');
     const projectDir = makeTempDir('.tmp-codex-managed-shadow-project-');
     const proc = createMockProcess();
@@ -626,16 +636,96 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
           await promise;
 
           const args = spawnFn.mock.calls[0].arguments[1];
-          // External entry with streamableHttp transport is skipped entirely
+          // Entry is disabled (transport unsupported) → emits dummy suppression shape
           assert.ok(
-            !args.some((a) => a.includes('mcp_servers.cat-cafe-limb.')),
-            'external entry with unsupported transport must not appear in CLI args',
+            args.includes('mcp_servers.cat-cafe-limb.command="echo"'),
+            'disabled entry must emit dummy command to suppress stale config.toml',
           );
+          assert.ok(args.includes('mcp_servers.cat-cafe-limb.enabled=false'), 'disabled entry must emit enabled=false');
           // Stale user paths and secrets must never leak
           assert.ok(
             !args.some(
               (arg) => arg.includes('/stale/user') || arg.includes('STALE_SECRET') || arg.includes('must-not-leak'),
             ),
+            'stale user paths and secrets must never leak into CLI args',
+          );
+        });
+      });
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Codex MCP config injects managed env for same-repo external split entries', async () => {
+    // #1072 regression test: ensureCatCafeMainServer migration can leave a
+    // split entry with source='external' but binary pointing to our own repo
+    // dist (isSameRepoExternalSplit). These entries must receive managed env
+    // injection (callback env, workspace dirs, approval mode) even though
+    // they use the external binary path.
+    const runtimeRoot = makeTempDir('.tmp-codex-same-repo-ext-');
+    const projectDir = makeTempDir('.tmp-codex-same-repo-ext-project-');
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      // Same-repo external shape: source='external', args[0] ends with
+      // packages/mcp-server/dist/limb.js (matching the managed entrypoint).
+      const limbBinaryPath = join(runtimeRoot, 'packages', 'mcp-server', 'dist', 'limb.js');
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'cat-cafe-limb',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: { command: 'node', args: [limbBinaryPath] },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello same-repo external', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-same-repo',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-same-repo',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-same-repo' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          // Same-repo external split should be injected (enabled, stdio transport)
+          assert.ok(
+            args.includes('mcp_servers.cat-cafe-limb.enabled=true'),
+            'same-repo external split must be injected as enabled',
+          );
+          // Must receive managed approval mode and callback env injection
+          assert.ok(
+            args.some((a) => a.includes('mcp_servers.cat-cafe-limb.default_tools_approval_mode=')),
+            'same-repo external split must receive approval mode injection',
+          );
+          assert.ok(
+            args.some((a) => a.includes('mcp_servers.cat-cafe-limb.env.ALLOWED_WORKSPACE_DIRS=')),
+            'same-repo external split must receive workspace dir injection',
+          );
+          assert.ok(
+            args.some((a) => a.includes('mcp_servers.cat-cafe-limb.env.CAT_CAFE_API_URL=')),
+            'same-repo external split must receive callback env injection',
           );
         });
       });

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -533,15 +533,14 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
       await promise;
 
       const args = spawnFn.mock.calls[0].arguments[1];
-      // Disabled capabilities still need a per-invocation override because
-      // Codex layers project/user config.toml entries after persistent cleanup.
+      // #713 fix: disabled servers are skipped entirely — no enabled=false
+      // injection, no command fields. L5 writeCodexMcpConfig already deletes
+      // disabled managed entries from .codex/config.toml, and injecting a bare
+      // enabled=false risks Codex CLI validation errors (≥0.142 requires valid
+      // transport on all entries).
       assert.ok(
-        args.includes('mcp_servers.cat-cafe-collab.enabled=false'),
-        'disabled runtime capability must emit enabled=false so layered config.toml entries cannot revive it',
-      );
-      assert.ok(
-        !args.some((a) => a.startsWith('mcp_servers.cat-cafe-collab.command=')),
-        'disabled runtime capability should not emit launch fields',
+        !args.some((a) => a.includes('mcp_servers.cat-cafe-collab.')),
+        'disabled runtime capability must not appear in CLI args at all',
       );
       assert.ok(
         args.includes(`mcp_servers.cat-cafe-memory.command=${JSON.stringify(process.execPath)}`),
@@ -573,7 +572,11 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
-  test('Codex MCP config keeps managed split authority when same-name external entry has unsupported transport', async () => {
+  test('Codex MCP config skips same-name external entry with unsupported transport', async () => {
+    // #713 fix: isCatCafe requires both source === 'cat-cafe' AND name in
+    // CAT_CAFE_SPLIT_ENTRYPOINTS. An external entry with a managed name but
+    // unsupported transport (streamableHttp) is correctly skipped by the
+    // transport filter — no stale user paths or secrets leak into CLI args.
     const runtimeRoot = makeTempDir('.tmp-codex-managed-shadow-root-');
     const projectDir = makeTempDir('.tmp-codex-managed-shadow-project-');
     const proc = createMockProcess();
@@ -623,11 +626,12 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
           await promise;
 
           const args = spawnFn.mock.calls[0].arguments[1];
-          const limbArgsConfig = args.find((arg) => arg.startsWith('mcp_servers.cat-cafe-limb.args=['));
-          assert.ok(args.includes(`mcp_servers.cat-cafe-limb.command=${JSON.stringify(process.execPath)}`));
-          assert.ok(limbArgsConfig?.includes('packages/mcp-server/dist/limb.js'));
-          assert.ok(args.includes(`mcp_servers.cat-cafe-limb.env.ALLOWED_WORKSPACE_DIRS="${projectDir}"`));
-          assert.ok(args.includes('mcp_servers.cat-cafe-limb.env.CAT_CAFE_INVOCATION_ID="inv-managed-shadow"'));
+          // External entry with streamableHttp transport is skipped entirely
+          assert.ok(
+            !args.some((a) => a.includes('mcp_servers.cat-cafe-limb.')),
+            'external entry with unsupported transport must not appear in CLI args',
+          );
+          // Stale user paths and secrets must never leak
           assert.ok(
             !args.some(
               (arg) => arg.includes('/stale/user') || arg.includes('STALE_SECRET') || arg.includes('must-not-leak'),

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -9,6 +9,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { describe, mock, test } from 'node:test';
+import { catRegistry } from '@cat-cafe/shared';
 import { fakeL0Compiler } from './helpers/fake-l0-compiler.js';
 
 const { CodexAgentService, isGitRepositoryPath } = await import(
@@ -739,6 +740,103 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
         });
       });
     } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Codex MCP config injects streamableHttp URL for enabled entries', async () => {
+    // Codex CLI supports URL-based MCP servers (codex mcp add --url).
+    // Verify that streamableHttp entries with a valid URL are injected
+    // via --config mcp_servers.X.url=... instead of command/args.
+    // resolveServersForCat requires the cat to be registered with a provider
+    // in STREAMABLE_HTTP_PROVIDERS for streamableHttp to be enabled.
+    const runtimeRoot = makeTempDir('.tmp-codex-streamable-http-');
+    const projectDir = makeTempDir('.tmp-codex-streamable-http-project-');
+    const savedConfigs = catRegistry.getAllConfigs();
+    const hadCodex = catRegistry.has('codex');
+
+    if (!hadCodex) {
+      catRegistry.register('codex', {
+        id: 'codex',
+        name: 'codex',
+        displayName: 'Codex',
+        avatar: '',
+        color: 'blue',
+        mentionPatterns: ['@codex'],
+        clientId: 'openai',
+        defaultModel: 'gpt-5.3-codex',
+        mcpSupport: true,
+        roleDescription: 'test',
+        personality: 'test',
+      });
+    }
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'remote-mcp',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp.example.com/v1',
+            command: '',
+            args: [],
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello streamable http', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-streamable',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-streamable',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-streamable' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          // streamableHttp entry should be injected with url, not command/args
+          assert.ok(
+            args.includes('mcp_servers.remote-mcp.url="https://mcp.example.com/v1"'),
+            'streamableHttp entry must inject url',
+          );
+          assert.ok(args.includes('mcp_servers.remote-mcp.enabled=true'), 'streamableHttp entry must be enabled');
+          // Must NOT have command/args (URL-based transport)
+          assert.ok(
+            !args.some((a) => a.includes('mcp_servers.remote-mcp.command=')),
+            'streamableHttp entry must not inject command',
+          );
+        });
+      });
+    } finally {
+      if (!hadCodex) {
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(savedConfigs)) {
+          catRegistry.register(id, config);
+        }
+      }
       rmSync(runtimeRoot, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });
     }

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -5,7 +5,7 @@
 
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { describe, mock, test } from 'node:test';
@@ -836,6 +836,98 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
         for (const [id, config] of Object.entries(savedConfigs)) {
           catRegistry.register(id, config);
         }
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Codex MCP config resolves pencil binary at invoke time', async () => {
+    // Pencil entries have resolver='pencil' with empty command/args.
+    // CodexAgentService must resolve the pencil binary at invoke time
+    // (same pattern as ClaudeAgentService) and inject via --config.
+    const runtimeRoot = makeTempDir('.tmp-codex-pencil-');
+    const projectDir = makeTempDir('.tmp-codex-pencil-project-');
+
+    // Create a mock pencil binary (must be executable for isExecutableCommandPath)
+    const pencilBin = join(projectDir, 'mock-pencil-mcp-server');
+    writeFileSync(pencilBin, '#!/bin/sh\necho "mock pencil"', 'utf8');
+    chmodSync(pencilBin, 0o755);
+
+    const previousPencilBin = process.env.PENCIL_MCP_BIN;
+    const previousPencilApp = process.env.PENCIL_MCP_APP;
+    try {
+      // Use PENCIL_MCP_BIN env override so resolvePencilCommand finds our mock
+      process.env.PENCIL_MCP_BIN = pencilBin;
+      process.env.PENCIL_MCP_APP = 'vscode';
+
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'pencil',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'cat-cafe',
+          mcpServer: {
+            resolver: 'pencil',
+            command: '',
+            args: [],
+          },
+        },
+      ]);
+
+      const proc = createMockProcess();
+      const spawnFn = createMockSpawnFn(proc);
+      const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello pencil', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-pencil',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-pencil',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-pencil' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          // Pencil entry must be resolved and injected with command + args
+          const pencilCommandArg = args.find((a) => a.includes('mcp_servers.pencil.command='));
+          assert.ok(pencilCommandArg, 'pencil entry must inject resolved command');
+          assert.ok(
+            pencilCommandArg.includes('mock-pencil-mcp-server'),
+            `pencil command must contain resolved binary path, got: ${pencilCommandArg}`,
+          );
+          const pencilArgsArg = args.find((a) => a.includes('mcp_servers.pencil.args='));
+          assert.ok(pencilArgsArg, 'pencil entry must inject args');
+          assert.ok(pencilArgsArg.includes('--app'), 'pencil args must include --app');
+          assert.ok(pencilArgsArg.includes('vscode'), 'pencil args must include app name');
+        });
+      });
+    } finally {
+      if (previousPencilBin === undefined) {
+        delete process.env.PENCIL_MCP_BIN;
+      } else {
+        process.env.PENCIL_MCP_BIN = previousPencilBin;
+      }
+      if (previousPencilApp === undefined) {
+        delete process.env.PENCIL_MCP_APP;
+      } else {
+        process.env.PENCIL_MCP_APP = previousPencilApp;
       }
       rmSync(runtimeRoot, { recursive: true, force: true });
       rmSync(projectDir, { recursive: true, force: true });


### PR DESCRIPTION
Fixes #1072

## Summary
- **CodexAgentService.ts**: Disabled MCP servers now emit a complete dummy shape (`command="echo"` + `args=["disabled-shim"]` + `enabled=false`) to suppress any stale `.codex/config.toml` entries. Bare `enabled=false` fails Codex CLI ≥0.142 schema validation; the dummy shape satisfies it (same principle as the legacy `cat-cafe` shim). `isCatCafe` split into `isManagedCatCafe` (binary resolution from mcpDistDir) and `isSameRepoSplit` (F193 migration shapes with `source:'external'` but binary pointing to our own split entrypoint) — both receive managed env injection (callback env, workspace dirs, approval mode).
- **CodexAgentService.ts (streamableHttp)**: Removed blanket `s.transport === 'streamableHttp'` skip. Codex CLI supports URL-based MCP via `--config mcp_servers.X.url=...`. streamableHttp entries with valid URLs are now injected.
- **CodexAgentService.ts (pencil)**: Removed `s.resolver === 'pencil'` skip. Pencil is a resolver-backed stdio MCP — the binary is resolved at invoke time via `resolvePencilCommand()` (same pattern as ClaudeAgentService). Previously pencil entries were silently dropped for Codex.
- **capability-orchestrator.ts**: Added `'openai'` to `STREAMABLE_HTTP_PROVIDERS` so Codex cats get streamableHttp entries enabled.
- **mcp-drift-detector.ts**: Removed `blockedCats` from `mcpDriftSnapshot` and deleted `normalizedBlockedCats` function — `blockedCats` is a project-level field that should not participate in MCP config drift detection.
- **Tests**: Updated disabled entry test to verify dummy shape emission; updated unsupported transport test to verify dummy suppression; added regression tests for same-repo external split, streamableHttp URL injection, and pencil binary resolution.

## Test plan
- [x] Disabled entry emits complete dummy shape (command + args + enabled=false)
- [x] Unsupported transport entry suppressed with dummy (no stale paths/secrets leaked)
- [x] Same-repo external split receives managed env injection (approval mode, workspace dirs, callback env)
- [x] streamableHttp URL injected for enabled entries (no command/args)
- [x] Pencil binary resolved at invoke time and injected via --config
- [x] TypeScript lint clean
- [x] Biome check clean
- [x] CI green