### PR TITLE
fix(codex): map streamableHttp bearer auth to Codex bearer_token_env_var (#1074)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -337,8 +337,14 @@ function writeCodexMcpEnvWrapper(spec: {
  * (same pattern as ClaudeAgentService). streamableHttp is supported via
  * --config mcp_servers.X.url=... injection.
  */
-async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, workingDirectory?: string): Promise<string[]> {
-  if (!callbackEnv) return [];
+async function buildCatCafeMcpArgs(
+  callbackEnv?: Record<string, string>,
+  workingDirectory?: string,
+): Promise<{ args: string[]; bearerEnv: Record<string, string> }> {
+  if (!callbackEnv) return { args: [], bearerEnv: {} };
+
+  /** Bearer tokens extracted from headers — keyed by env var name, valued by token. */
+  const bearerEnv: Record<string, string> = {};
 
   const runtimeRoot = resolveBinaryRoot();
   const fileDir = dirname(fileURLToPath(import.meta.url));
@@ -363,7 +369,7 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
       break;
     }
   }
-  if (!mcpDistDir) return [];
+  if (!mcpDistDir) return { args: [], bearerEnv: {} };
 
   const binaryProjectRoot = resolve(mcpDistDir, '../../..');
   const capabilitiesProjectRoot = binaryProjectRoot;
@@ -490,9 +496,10 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
           continue;
         }
 
-        // streamableHttp: inject URL directly (Codex CLI supports `--url` / `mcp_servers.X.url`)
-        // Note: Codex uses bearer_token_env_var for auth, not arbitrary headers.
-        // Header-based auth mapping is left for a follow-up if needed.
+        // streamableHttp: inject URL directly (Codex CLI supports `--url` / `mcp_servers.X.url`).
+        // Auth: Codex uses `bearer_token_env_var` (not arbitrary headers). If the
+        // descriptor has an `Authorization: Bearer <token>` header, we extract
+        // the token into an env var and point `bearer_token_env_var` at it.
         if (s.transport === 'streamableHttp' && s.url) {
           enabledServers.push(s.name);
           const tomlName = /^[A-Za-z0-9_-]+$/.test(s.name) ? s.name : `"${s.name}"`;
@@ -502,6 +509,16 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
             '--config',
             `mcp_servers.${tomlName}.enabled=true`,
           );
+          // Map Authorization: Bearer <token> → bearer_token_env_var (#1074)
+          const authHeader = s.headers?.Authorization ?? s.headers?.authorization;
+          if (authHeader) {
+            const bearerMatch = /^Bearer\s+(.+)$/i.exec(authHeader);
+            if (bearerMatch) {
+              const envVarName = `CLOWDER_MCP_BEARER_${s.name.replace(/[^A-Za-z0-9]/g, '_').toUpperCase()}`;
+              bearerEnv[envVarName] = bearerMatch[1];
+              args.push('--config', `mcp_servers.${tomlName}.bearer_token_env_var=${toTomlString(envVarName)}`);
+            }
+          }
           continue;
         }
 
@@ -612,7 +629,7 @@ async function buildCatCafeMcpArgs(callbackEnv?: Record<string, string>, working
     },
     '#712: MCP invoke-time injection',
   );
-  return args;
+  return { args, bearerEnv };
 }
 
 export function isGitRepositoryPath(workingDirectory: string): boolean {
@@ -731,7 +748,10 @@ export class CodexAgentService implements AgentService {
         ]
       : [];
     // #712: Inject ALL enabled MCP servers from capabilities.json at invoke time.
-    const catCafeMcpArgs = await buildCatCafeMcpArgs(options?.callbackEnv, options?.workingDirectory);
+    const { args: catCafeMcpArgs, bearerEnv: mcpBearerEnv } = await buildCatCafeMcpArgs(
+      options?.callbackEnv,
+      options?.workingDirectory,
+    );
     const gitRepoArgs = buildGitRepoArgs(options?.workingDirectory);
     // User-defined CLI args from the member editor (#567) — passed as-is, no implicit wrapping.
     // Each entry is split by whitespace (e.g. "--config model_reasoning_effort=\"low\"").
@@ -941,6 +961,12 @@ export class CodexAgentService implements AgentService {
           if (customBaseUrl && (k === 'OPENAI_BASE_URL' || k === 'OPENAI_API_BASE')) continue;
           codexEnv[k] = v;
         }
+      }
+
+      // #1074: Inject bearer token env vars extracted from streamableHttp headers.
+      // Codex CLI reads bearer_token_env_var from process env at connect time.
+      for (const [k, v] of Object.entries(mcpBearerEnv)) {
+        codexEnv[k] = v;
       }
 
       const semanticCompletionController = new AbortController();

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -512,10 +512,13 @@ async function buildCatCafeMcpArgs(
           );
           // Map Authorization: Bearer <token> → bearer_token_env_var (#1074)
           // Header lookup is case-insensitive (HTTP headers are case-insensitive per RFC 7230).
-          const authHeader = s.headers
+          const rawAuthHeader = s.headers
             ? Object.entries(s.headers).find(([k]) => k.toLowerCase() === 'authorization')?.[1]
             : undefined;
-          if (authHeader) {
+          if (rawAuthHeader) {
+            // Resolve ${ENV_VAR} placeholders before extraction — same semantics as
+            // mcp-probe.ts resolveEnvVarsInRecord (supports `Bearer ${TOKEN}` patterns).
+            const authHeader = rawAuthHeader.replace(/\$\{([^}]+)\}/g, (_, name) => process.env[name] ?? '');
             const bearerMatch = /^Bearer\s+(.+)$/i.exec(authHeader);
             if (bearerMatch) {
               // Env var name must be collision-proof: distinct MCP names that differ

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -15,6 +15,7 @@
  *   turn.started / turn.completed / 其余 item 事件 → 跳过
  */
 
+import { createHash } from 'node:crypto';
 import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
@@ -510,11 +511,20 @@ async function buildCatCafeMcpArgs(
             `mcp_servers.${tomlName}.enabled=true`,
           );
           // Map Authorization: Bearer <token> → bearer_token_env_var (#1074)
-          const authHeader = s.headers?.Authorization ?? s.headers?.authorization;
+          // Header lookup is case-insensitive (HTTP headers are case-insensitive per RFC 7230).
+          const authHeader = s.headers
+            ? Object.entries(s.headers).find(([k]) => k.toLowerCase() === 'authorization')?.[1]
+            : undefined;
           if (authHeader) {
             const bearerMatch = /^Bearer\s+(.+)$/i.exec(authHeader);
             if (bearerMatch) {
-              const envVarName = `CLOWDER_MCP_BEARER_${s.name.replace(/[^A-Za-z0-9]/g, '_').toUpperCase()}`;
+              // Env var name must be collision-proof: distinct MCP names that differ
+              // only by punctuation (e.g. `foo-bar` vs `foo_bar`) would otherwise
+              // map to the same env var, routing one server's token to another.
+              // Append a short stable hash of the raw name for uniqueness.
+              const sanitized = s.name.replace(/[^A-Za-z0-9]/g, '_').toUpperCase();
+              const hash = createHash('sha256').update(s.name).digest('hex').slice(0, 8);
+              const envVarName = `CLOWDER_MCP_BEARER_${sanitized}_${hash}`;
               bearerEnv[envVarName] = bearerMatch[1];
               args.push('--config', `mcp_servers.${tomlName}.bearer_token_env_var=${toTomlString(envVarName)}`);
             }

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -921,17 +921,21 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
             'authed streamableHttp must inject url',
           );
           assert.ok(args.includes('mcp_servers.authed-remote.enabled=true'), 'authed streamableHttp must be enabled');
-          // bearer_token_env_var must reference the generated env var
+          // bearer_token_env_var must reference the generated env var (includes hash suffix)
           const bearerArg = args.find((a) => a.includes('bearer_token_env_var'));
           assert.ok(bearerArg, 'must inject bearer_token_env_var config');
           assert.ok(
-            bearerArg.includes('CLOWDER_MCP_BEARER_AUTHED_REMOTE'),
-            'bearer_token_env_var must reference CLOWDER_MCP_BEARER_AUTHED_REMOTE',
+            bearerArg.includes('CLOWDER_MCP_BEARER_AUTHED_REMOTE_'),
+            'bearer_token_env_var must reference CLOWDER_MCP_BEARER_AUTHED_REMOTE_<hash>',
           );
+          // Extract actual env var name from the config arg
+          const envVarMatch = bearerArg.match(/CLOWDER_MCP_BEARER_[A-Za-z0-9_]+/);
+          assert.ok(envVarMatch, 'bearer env var name must be extractable');
+          const actualEnvVar = envVarMatch[0];
           // Token must be in process env (Codex reads bearer_token_env_var from process env)
           assert.ok(spawnOpts?.env, 'spawn options must include env');
           assert.strictEqual(
-            spawnOpts.env.CLOWDER_MCP_BEARER_AUTHED_REMOTE,
+            spawnOpts.env[actualEnvVar],
             'sk-test-secret-token-123',
             'bearer token must be in child process env',
           );
@@ -939,6 +943,229 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
           assert.ok(
             !args.some((a) => a.includes('mcp_servers.authed-remote.command=')),
             'authed streamableHttp must not inject command',
+          );
+        });
+      });
+    } finally {
+      if (!hadCodex) {
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(savedConfigs)) {
+          catRegistry.register(id, config);
+        }
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Bearer env var names are collision-proof for MCP ids that normalize identically', async () => {
+    // Regression: `foo-bar` and `foo_bar` both sanitize to `FOO_BAR`.
+    // Without a hash suffix the second overwrites the first in bearerEnv,
+    // routing one MCP's token to another — a secret misrouting bug.
+    const runtimeRoot = makeTempDir('.tmp-codex-bearer-collision-');
+    const projectDir = makeTempDir('.tmp-codex-bearer-collision-project-');
+    const savedConfigs = catRegistry.getAllConfigs();
+    const hadCodex = catRegistry.has('codex');
+
+    if (!hadCodex) {
+      catRegistry.register('codex', {
+        id: 'codex',
+        name: 'codex',
+        displayName: 'Codex',
+        avatar: '',
+        color: 'blue',
+        mentionPatterns: ['@codex'],
+        clientId: 'openai',
+        defaultModel: 'gpt-5.3-codex',
+        mcpSupport: true,
+        roleDescription: 'test',
+        personality: 'test',
+      });
+    }
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'foo-bar',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp-a.example.com',
+            command: '',
+            args: [],
+            headers: { Authorization: 'Bearer token-A' },
+          },
+        },
+        {
+          id: 'foo_bar',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp-b.example.com',
+            command: '',
+            args: [],
+            headers: { Authorization: 'Bearer token-B' },
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('test collision', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-collision',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-collision',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-collision' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          const spawnOpts = spawnFn.mock.calls[0].arguments[2];
+
+          // Both MCPs must have distinct bearer_token_env_var configs
+          const bearerArgs = args.filter((a) => a.includes('bearer_token_env_var'));
+          assert.strictEqual(bearerArgs.length, 2, 'must have two distinct bearer_token_env_var configs');
+
+          // Extract env var names from the config args
+          const envVarNames = bearerArgs.map((a) => {
+            const m = a.match(/CLOWDER_MCP_BEARER_[A-Za-z0-9_]+/);
+            return m ? m[0] : null;
+          });
+          assert.ok(envVarNames[0] && envVarNames[1], 'both env var names must be extractable');
+          assert.notStrictEqual(envVarNames[0], envVarNames[1], 'env var names must differ (collision-proof)');
+
+          // Each env var must carry the correct token
+          assert.ok(spawnOpts?.env, 'spawn options must include env');
+          const tokenA = spawnOpts.env[envVarNames[0]];
+          const tokenB = spawnOpts.env[envVarNames[1]];
+          // Determine which env var goes with which MCP by checking the args ordering
+          const fooBarDashIdx = args.findIndex((a) => a.includes('mcp_servers.foo-bar.bearer'));
+          const fooBarUnderIdx = args.findIndex((a) => a.includes('mcp_servers.foo_bar.bearer'));
+          if (fooBarDashIdx < fooBarUnderIdx) {
+            assert.strictEqual(tokenA, 'token-A', 'foo-bar must carry token-A');
+            assert.strictEqual(tokenB, 'token-B', 'foo_bar must carry token-B');
+          } else {
+            assert.strictEqual(tokenA, 'token-B', 'foo_bar must carry token-B');
+            assert.strictEqual(tokenB, 'token-A', 'foo-bar must carry token-A');
+          }
+        });
+      });
+    } finally {
+      if (!hadCodex) {
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(savedConfigs)) {
+          catRegistry.register(id, config);
+        }
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Bearer auth maps case-insensitive Authorization header', async () => {
+    // HTTP headers are case-insensitive per RFC 7230. A descriptor with
+    // `AUTHORIZATION` or `authorization` must still be mapped.
+    const runtimeRoot = makeTempDir('.tmp-codex-bearer-case-');
+    const projectDir = makeTempDir('.tmp-codex-bearer-case-project-');
+    const savedConfigs = catRegistry.getAllConfigs();
+    const hadCodex = catRegistry.has('codex');
+
+    if (!hadCodex) {
+      catRegistry.register('codex', {
+        id: 'codex',
+        name: 'codex',
+        displayName: 'Codex',
+        avatar: '',
+        color: 'blue',
+        mentionPatterns: ['@codex'],
+        clientId: 'openai',
+        defaultModel: 'gpt-5.3-codex',
+        mcpSupport: true,
+        roleDescription: 'test',
+        personality: 'test',
+      });
+    }
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      // Use AUTHORIZATION (all-caps) — must still be recognized
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'upper-auth',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp.upper.example.com',
+            command: '',
+            args: [],
+            headers: { AUTHORIZATION: 'Bearer sk-upper-token' },
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('test upper auth', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-upper',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-upper',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-upper' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          const spawnOpts = spawnFn.mock.calls[0].arguments[2];
+
+          const bearerArg = args.find((a) => a.includes('bearer_token_env_var'));
+          assert.ok(bearerArg, 'AUTHORIZATION (all-caps) must still map to bearer_token_env_var');
+
+          const envVarMatch = bearerArg.match(/CLOWDER_MCP_BEARER_[A-Za-z0-9_]+/);
+          assert.ok(envVarMatch, 'env var name must be extractable');
+          assert.strictEqual(
+            spawnOpts.env[envVarMatch[0]],
+            'sk-upper-token',
+            'bearer token must be in child process env',
           );
         });
       });

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -842,6 +842,118 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
+  test('Codex MCP config maps Authorization Bearer header to bearer_token_env_var', async () => {
+    // #1074: When a streamableHttp entry has an Authorization: Bearer header,
+    // CodexAgentService must extract the token into a process env var and
+    // inject bearer_token_env_var pointing at it — Codex CLI does not accept
+    // arbitrary headers, only bearer_token_env_var.
+    const runtimeRoot = makeTempDir('.tmp-codex-bearer-');
+    const projectDir = makeTempDir('.tmp-codex-bearer-project-');
+    const savedConfigs = catRegistry.getAllConfigs();
+    const hadCodex = catRegistry.has('codex');
+
+    if (!hadCodex) {
+      catRegistry.register('codex', {
+        id: 'codex',
+        name: 'codex',
+        displayName: 'Codex',
+        avatar: '',
+        color: 'blue',
+        mentionPatterns: ['@codex'],
+        clientId: 'openai',
+        defaultModel: 'gpt-5.3-codex',
+        mcpSupport: true,
+        roleDescription: 'test',
+        personality: 'test',
+      });
+    }
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'authed-remote',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp.secure.example.com/v1',
+            command: '',
+            args: [],
+            headers: { Authorization: 'Bearer sk-test-secret-token-123' },
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('hello authed streamable', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-bearer',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-bearer',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-bearer' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          const spawnOpts = spawnFn.mock.calls[0].arguments[2];
+          // URL must still be injected
+          assert.ok(
+            args.includes('mcp_servers.authed-remote.url="https://mcp.secure.example.com/v1"'),
+            'authed streamableHttp must inject url',
+          );
+          assert.ok(args.includes('mcp_servers.authed-remote.enabled=true'), 'authed streamableHttp must be enabled');
+          // bearer_token_env_var must reference the generated env var
+          const bearerArg = args.find((a) => a.includes('bearer_token_env_var'));
+          assert.ok(bearerArg, 'must inject bearer_token_env_var config');
+          assert.ok(
+            bearerArg.includes('CLOWDER_MCP_BEARER_AUTHED_REMOTE'),
+            'bearer_token_env_var must reference CLOWDER_MCP_BEARER_AUTHED_REMOTE',
+          );
+          // Token must be in process env (Codex reads bearer_token_env_var from process env)
+          assert.ok(spawnOpts?.env, 'spawn options must include env');
+          assert.strictEqual(
+            spawnOpts.env.CLOWDER_MCP_BEARER_AUTHED_REMOTE,
+            'sk-test-secret-token-123',
+            'bearer token must be in child process env',
+          );
+          // Must NOT have command/args
+          assert.ok(
+            !args.some((a) => a.includes('mcp_servers.authed-remote.command=')),
+            'authed streamableHttp must not inject command',
+          );
+        });
+      });
+    } finally {
+      if (!hadCodex) {
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(savedConfigs)) {
+          catRegistry.register(id, config);
+        }
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   test('Codex MCP config emits URL-based disabled override for streamableHttp entries', async () => {
     // When a streamableHttp entry from .codex/config.toml is disabled, we must
     // emit url + enabled=false (not command/args stdio dummy). Overlaying stdio

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -1181,6 +1181,116 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
+  test('Bearer auth resolves ${ENV_VAR} placeholders in Authorization header', async () => {
+    // Regression: mcp-probe.ts resolves ${ENV} in headers before connecting.
+    // Codex invoke must do the same — otherwise probe succeeds but Codex sends
+    // the literal placeholder string as the bearer token.
+    const runtimeRoot = makeTempDir('.tmp-codex-bearer-envref-');
+    const projectDir = makeTempDir('.tmp-codex-bearer-envref-project-');
+    const savedConfigs = catRegistry.getAllConfigs();
+    const hadCodex = catRegistry.has('codex');
+
+    if (!hadCodex) {
+      catRegistry.register('codex', {
+        id: 'codex',
+        name: 'codex',
+        displayName: 'Codex',
+        avatar: '',
+        color: 'blue',
+        mentionPatterns: ['@codex'],
+        clientId: 'openai',
+        defaultModel: 'gpt-5.3-codex',
+        mcpSupport: true,
+        roleDescription: 'test',
+        personality: 'test',
+      });
+    }
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.3-codex' });
+
+    // Set a real env var for the placeholder to resolve against
+    const envKey = 'TEST_MCP_BEARER_PLACEHOLDER_TOKEN';
+    const originalEnv = process.env[envKey];
+    process.env[envKey] = 'resolved-secret-token-456';
+
+    try {
+      writeMcpDistStubs(runtimeRoot, [
+        'index.js',
+        'collab.js',
+        'memory.js',
+        'signals.js',
+        'limb.js',
+        'audio.js',
+        'finance.js',
+      ]);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'env-backed-remote',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: {
+            transport: 'streamableHttp',
+            url: 'https://mcp.envbacked.example.com',
+            command: '',
+            args: [],
+            headers: { Authorization: `Bearer \${${envKey}}` },
+          },
+        },
+      ]);
+
+      await withWorkspaceEnv({ ALLOWED_WORKSPACE_DIRS: undefined, CAT_CAFE_WORKSPACE_ROOT: undefined }, async () => {
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke('test env-backed bearer', {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_API_URL: 'http://127.0.0.1:3004',
+                CAT_CAFE_INVOCATION_ID: 'inv-envref',
+                CAT_CAFE_CALLBACK_TOKEN: 'tok-envref',
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-envref' }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          const spawnOpts = spawnFn.mock.calls[0].arguments[2];
+
+          const bearerArg = args.find((a) => a.includes('bearer_token_env_var'));
+          assert.ok(bearerArg, 'env-backed header must still map to bearer_token_env_var');
+
+          const envVarMatch = bearerArg.match(/CLOWDER_MCP_BEARER_[A-Za-z0-9_]+/);
+          assert.ok(envVarMatch, 'env var name must be extractable');
+
+          // The child env var must contain the RESOLVED token, not the placeholder
+          assert.strictEqual(
+            spawnOpts.env[envVarMatch[0]],
+            'resolved-secret-token-456',
+            'bearer token must be the resolved value, not the ${} placeholder',
+          );
+        });
+      });
+    } finally {
+      // Restore original env
+      if (originalEnv === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = originalEnv;
+      }
+      if (!hadCodex) {
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(savedConfigs)) {
+          catRegistry.register(id, config);
+        }
+      }
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
   test('Codex MCP config emits URL-based disabled override for streamableHttp entries', async () => {
     // When a streamableHttp entry from .codex/config.toml is disabled, we must
     // emit url + enabled=false (not command/args stdio dummy). Overlaying stdio


### PR DESCRIPTION
## Summary

- Maps `Authorization: Bearer <token>` headers from Cat Café MCP descriptors into Codex CLI's `bearer_token_env_var` config
- Extracts the bearer token into a collision-proof `CLOWDER_MCP_BEARER_<SANITIZED>_<HASH>` process env var (sha256-suffixed to prevent token misrouting between MCPs with similar names)
- Codex CLI reads the token from process env at connect time
- Changes `buildCatCafeMcpArgs` return type to `{ args, bearerEnv }` to support env injection
- Authorization header lookup is case-insensitive per RFC 7230

### Non-scope
- OAuth mapping (`--oauth-client-id`, `--oauth-resource`) deferred — Cat Café MCP descriptors don't have OAuth fields yet
- Non-bearer auth headers are not mapped (Codex CLI only supports `bearer_token_env_var`)

## Test plan

- [x] New test: bearer env var mapping (happy path)
- [x] New test: collision-proof env var names for MCPs with identical sanitized names (`foo-bar` vs `foo_bar`)
- [x] New test: case-insensitive Authorization header (`AUTHORIZATION` all-caps)
- [x] All existing MCP injection tests pass (URL, disabled, pencil, dummy)
- [x] 61 tests pass, 0 fail
- [x] Build + biome clean

Ref #1074