### PR TITLE
[codex] 修复 Windows Codex 入口解析

### DIFF
--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -93,8 +93,11 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
           .split('\n')
           .map((l) => l.trim())
           .filter(Boolean);
-        // On Windows, prefer the .cmd shim (more reliable for shim resolution)
-        const resolved = (IS_WINDOWS && lines.find((l) => /\.cmd$/i.test(l))) || lines[0];
+        // On Windows, prefer native/shim entrypoints over extensionless
+        // binaries. Windows Store Codex exposes both `codex` (ELF) and
+        // `codex.exe` (PE); spawning the ELF path falls through to bash.
+        const resolved =
+          (IS_WINDOWS && (lines.find((l) => /\.cmd$/i.test(l)) || lines.find((l) => /\.exe$/i.test(l)))) || lines[0];
         resolvedCache.set(command, resolved);
         return resolved;
       }

--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -6,7 +6,7 @@
 
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, win32 } from 'node:path';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -40,6 +40,25 @@ function collectNvmBinDirs(): string[] {
 }
 
 const resolvedCache = new Map<string, string>();
+
+function normalizeWindowsDir(path: string): string {
+  return win32.dirname(path).replace(/[\\/]+$/, '').toLowerCase();
+}
+
+/**
+ * Select the effective Windows PATH hit while preserving directory order.
+ *
+ * `where <command>` can return multiple entries from the same directory
+ * (for example `codex` and `codex.exe` from the Windows Store alias dir).
+ * We only apply `.cmd` / `.exe` preference within the first directory bucket;
+ * later directories must not override an earlier PATH wrapper/version pin.
+ */
+export function selectWindowsPathEntry(lines: readonly string[]): string | null {
+  if (lines.length === 0) return null;
+  const firstDir = normalizeWindowsDir(lines[0]);
+  const firstDirHits = lines.filter((line) => normalizeWindowsDir(line) === firstDir);
+  return firstDirHits.find((line) => /\.cmd$/i.test(line)) || firstDirHits.find((line) => /\.exe$/i.test(line)) || firstDirHits[0];
+}
 
 /**
  * Drop a cache entry. Accepts EITHER the bare command name (cache key) OR the
@@ -93,11 +112,7 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
           .split('\n')
           .map((l) => l.trim())
           .filter(Boolean);
-        // On Windows, prefer native/shim entrypoints over extensionless
-        // binaries. Windows Store Codex exposes both `codex` (ELF) and
-        // `codex.exe` (PE); spawning the ELF path falls through to bash.
-        const resolved =
-          (IS_WINDOWS && (lines.find((l) => /\.cmd$/i.test(l)) || lines.find((l) => /\.exe$/i.test(l)))) || lines[0];
+        const resolved = (IS_WINDOWS && selectWindowsPathEntry(lines)) || lines[0];
         resolvedCache.set(command, resolved);
         return resolved;
       }

--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -42,7 +42,10 @@ function collectNvmBinDirs(): string[] {
 const resolvedCache = new Map<string, string>();
 
 function normalizeWindowsDir(path: string): string {
-  return win32.dirname(path).replace(/[\\/]+$/, '').toLowerCase();
+  return win32
+    .dirname(path)
+    .replace(/[\\/]+$/, '')
+    .toLowerCase();
 }
 
 /**
@@ -57,7 +60,11 @@ export function selectWindowsPathEntry(lines: readonly string[]): string | null 
   if (lines.length === 0) return null;
   const firstDir = normalizeWindowsDir(lines[0]);
   const firstDirHits = lines.filter((line) => normalizeWindowsDir(line) === firstDir);
-  return firstDirHits.find((line) => /\.cmd$/i.test(line)) || firstDirHits.find((line) => /\.exe$/i.test(line)) || firstDirHits[0];
+  return (
+    firstDirHits.find((line) => /\.cmd$/i.test(line)) ||
+    firstDirHits.find((line) => /\.exe$/i.test(line)) ||
+    firstDirHits[0]
+  );
 }
 
 /**

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -4,9 +4,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-const { resolveCliCommand, resolveCliCommandOrBare, formatCliNotFoundError, invalidateCliCommand } = await import(
-  '../dist/utils/cli-resolve.js'
-);
+const { resolveCliCommand, resolveCliCommandOrBare, formatCliNotFoundError, invalidateCliCommand, selectWindowsPathEntry } =
+  await import('../dist/utils/cli-resolve.js');
 
 // --- formatCliNotFoundError ---
 
@@ -58,6 +57,16 @@ test('resolveCliCommandOrBare returns bare name when CLI not found', () => {
 test('resolveCliCommand returns null for non-existent CLI', () => {
   const result = resolveCliCommand('nonexistent-cli-tool-abc-99999');
   assert.equal(result, null);
+});
+
+test('selectWindowsPathEntry prefers .exe over extensionless hits from the same directory', () => {
+  const selected = selectWindowsPathEntry(['C:\\Users\\me\\bin\\codex', 'C:\\Users\\me\\bin\\codex.exe']);
+  assert.equal(selected, 'C:\\Users\\me\\bin\\codex.exe');
+});
+
+test('selectWindowsPathEntry preserves an earlier PATH wrapper over a later .exe in another directory', () => {
+  const selected = selectWindowsPathEntry(['C:\\Users\\me\\bin\\codex.bat', 'C:\\Program Files\\Codex\\codex.exe']);
+  assert.equal(selected, 'C:\\Users\\me\\bin\\codex.bat');
 });
 
 test(

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -19,7 +19,11 @@ test('formatCliNotFoundError returns install hint for known CLI', () => {
 test('formatCliNotFoundError returns native installer hint for agy', () => {
   const msg = formatCliNotFoundError('agy');
   assert.match(msg, /agy CLI 未找到/);
-  assert.match(msg, /https:\/\/antigravity\.google\/cli\/install\.sh/);
+  if (process.platform === 'win32') {
+    assert.match(msg, /install\.cmd/);
+  } else {
+    assert.match(msg, /https:\/\/antigravity\.google\/cli\/install\.sh/);
+  }
 });
 
 test('formatCliNotFoundError points opencode users at the npm package that installs the opencode binary', () => {
@@ -55,6 +59,40 @@ test('resolveCliCommand returns null for non-existent CLI', () => {
   const result = resolveCliCommand('nonexistent-cli-tool-abc-99999');
   assert.equal(result, null);
 });
+
+test(
+  'resolveCliCommand prefers .exe over extensionless Windows PATH hits',
+  { skip: process.platform !== 'win32' && 'Windows-only (.exe PATH preference)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-exe-prefer-'));
+    const binDir = join(tempRoot, 'bin');
+    mkdirSync(binDir, { recursive: true });
+
+    const cmdName = `fake-cliresolve-exe-prefer-${process.pid}-${Date.now()}`;
+    const extensionless = join(binDir, cmdName);
+    const exePath = join(binDir, `${cmdName}.exe`);
+    writeFileSync(extensionless, 'ELF fake linux binary', 'utf8');
+    writeFileSync(exePath, 'MZ fake windows binary', 'utf8');
+
+    const originalPath = process.env.PATH;
+    const originalPathMixed = process.env.Path;
+    try {
+      process.env.PATH = `${binDir};${originalPath ?? ''}`;
+      process.env.Path = `${binDir};${originalPathMixed ?? originalPath ?? ''}`;
+      invalidateCliCommand(cmdName);
+
+      const result = resolveCliCommand(cmdName);
+      assert.equal(result, exePath, 'Windows resolver must prefer the native .exe over extensionless PATH hits');
+    } finally {
+      invalidateCliCommand(cmdName);
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      if (originalPathMixed === undefined) delete process.env.Path;
+      else process.env.Path = originalPathMixed;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
 
 // --- Windows APPDATA fallback ---
 

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -4,8 +4,13 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
-const { resolveCliCommand, resolveCliCommandOrBare, formatCliNotFoundError, invalidateCliCommand, selectWindowsPathEntry } =
-  await import('../dist/utils/cli-resolve.js');
+const {
+  resolveCliCommand,
+  resolveCliCommandOrBare,
+  formatCliNotFoundError,
+  invalidateCliCommand,
+  selectWindowsPathEntry,
+} = await import('../dist/utils/cli-resolve.js');
 
 // --- formatCliNotFoundError ---
 


### PR DESCRIPTION
## 变更

修复 Windows 下 Codex provider 解析 CLI 时误选 extensionless `codex` 的问题。

Windows Store Codex 会同时暴露 `codex` 和 `codex.exe`。此前解析逻辑只优先 `.cmd`，否则直接使用 `where codex` 的第一个结果，可能选中 ELF 入口并退到 bash/shell 启动路径，最终触发：

```text
unexpected EOF while looking for matching `''
```

现在 Windows 解析顺序调整为：`.cmd` -> `.exe` -> 其他第一个结果。

## 验证

- `node --test packages/api/test/cli-resolve.test.js`
- `node --test packages/api/test/cli-spawn-native-exe.test.js packages/api/test/cli-spawn-win.test.js`
- `pnpm --filter @cat-cafe/api run build`
- 本地运行时探针确认 `codex` 解析到 `codex.exe`，spawn mode 为 `native-exe`
- 本地重启后 `/api/health`、`/api/ready`、`/settings` 返回 200

Closes #1084
