### PR TITLE
fix(web): prevent PWA online hard reload

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -85,7 +85,7 @@ const nextConfig = {
 module.exports = withPWA({
   dest: 'public',
   disable: process.env.NODE_ENV === 'development' && !enablePwaInDev,
-  reloadOnOnline: true,
+  reloadOnOnline: false,
   // Start URL is a static shell; precache it so PWA cold-open does not block on network.
   dynamicStartUrl: false,
   // Keep default page/document runtime caching and only override what we need.

--- a/packages/web/test/next-config.test.cjs
+++ b/packages/web/test/next-config.test.cjs
@@ -1,5 +1,6 @@
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
+const Module = require('node:module');
 const path = require('node:path');
 const { describe, it } = require('node:test');
 
@@ -24,6 +25,31 @@ function withEnv(overrides, run) {
         process.env[key] = value;
       }
     }
+  }
+}
+
+function loadConfigWithPwaCapture() {
+  let capturedPwaOptions;
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === '@ducanh2912/next-pwa') {
+      return {
+        default: (pwaOptions) => {
+          capturedPwaOptions = pwaOptions;
+          return (config) => config;
+        },
+      };
+    }
+    return originalLoad.call(this, request, parent, isMain);
+  };
+
+  try {
+    delete require.cache[configPath];
+    require(configPath);
+    return capturedPwaOptions;
+  } finally {
+    delete require.cache[configPath];
+    Module._load = originalLoad;
   }
 }
 
@@ -70,5 +96,15 @@ describe('next.config rewrites', () => {
       'next.config.js requires @ducanh2912/next-pwa during next build, so it cannot live in devDependencies',
     );
     assert.equal(packageJson.devDependencies?.['@ducanh2912/next-pwa'], undefined);
+  });
+
+  it('does not hard reload the PWA when network connectivity returns', () => {
+    const pwaOptions = loadConfigWithPwaCapture();
+
+    assert.equal(
+      pwaOptions?.reloadOnOnline,
+      false,
+      'Realtime chat must reconnect without next-pwa injecting location.reload() on the online event',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- disable next-pwa's `reloadOnOnline` behavior so transient connectivity recovery does not inject `location.reload()`
- add a focused next.config regression test that captures the PWA wrapper options

## Scope
This intentionally covers the first accepted slice from #1032: the true hard page reload on the browser `online` event. The render cascade/performance work should stay in a follow-up PR.

Refs #1032

## Tests
- `node --test test/next-config.test.cjs`
- `node scripts/run-with-node-env-test.mjs node --test test/next-config.test.cjs`

[宪宪/gpt-5.5🐾]