### PR TITLE
feat: redesign thread sidebar tabs (v1-v19)

### DIFF
--- a/docs/design/sidebar-proposals.html
+++ b/docs/design/sidebar-proposals.html
@@ -1,0 +1,877 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>对话列表面板 — 改版方案 v9</title>
+<style>
+  :root {
+    --console-panel-bg: #f2ede6;
+    --console-card-soft-bg: #e6e0d6;
+    --console-hover-bg: rgba(0,0,0,0.04);
+    --console-active-bg: #fdf6e8;
+    --console-field-bg: #f4f0ea;
+    --console-input-stroke: #d4cbc0;
+    --console-border-soft: #d4cbc0;
+
+    --cafe-black: #2d2825;
+    --cafe-secondary: #6e655e;
+    --cafe-muted: #8a8078;
+    --cafe-accent: #b8842a;
+    --cafe-subtle: #e8e2d8;
+    --cafe-surface: #f2ede6;
+    --cafe-surface-elevated: #fcfaf7;
+
+    --conn-amber-bg: #fdf6e8;
+    --conn-amber-text: #966a22;
+    --conn-amber-ring: #f5d88e;
+    --conn-red-text: #c53030;
+    --conn-red-bg: #fef2f2;
+    --conn-emerald-text: #38a169;
+    --conn-blue-text: #3b82f6;
+    --conn-purple-text: #8b5cf6;
+
+    --cat-blue: #7eb8da;
+    --cat-pink: #d4a0b9;
+    --cat-gold: #d4b483;
+  }
+  * { margin:0; padding:0; box-sizing:border-box; }
+  body { font-family:"Inter",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; background:#e8e2d8; color:var(--cafe-black); -webkit-font-smoothing:antialiased; }
+
+  .layout { display:flex; justify-content:center; gap:32px; padding:24px 32px; max-width:1280px; margin:0 auto; flex-wrap:wrap; }
+  .panel-wrap { width:248px; flex-shrink:0; }
+  .panel-label { font-size:13px; font-weight:600; margin-bottom:8px; color:var(--cafe-secondary); display:flex; align-items:center; gap:6px; }
+  .panel-label .tag { font-size:10px; font-weight:500; padding:1px 6px; border-radius:99px; background:var(--conn-amber-bg); color:var(--conn-amber-text); }
+
+  .sidebar { width:100%; height:660px; background:var(--console-panel-bg); display:flex; flex-direction:column; border-radius:12px; overflow:hidden; box-shadow:0 1px 4px rgba(0,0,0,0.06); }
+
+  /* 头部（不变） */
+  .sidebar .head { padding:12px 12px 8px; display:flex; align-items:center; justify-content:space-between; }
+  .sidebar .head h2 { font-size:14px; font-weight:600; color:var(--cafe-black); }
+  .sidebar .head .actions { display:flex; align-items:center; gap:6px; }
+  .sidebar .head .btn-icon { padding:6px; border-radius:8px; color:var(--cafe-accent); background:none; border:none; cursor:pointer; display:flex; }
+  .sidebar .head .btn-icon:hover { background:var(--conn-amber-bg); }
+  .sidebar .head .btn-primary { font-size:12px; background:var(--cafe-accent); color:white; border:none; padding:5px 10px; border-radius:6px; cursor:pointer; font-weight:500; }
+
+  /* 搜索（不变） */
+  .sidebar .search-wrap { padding:0 12px 8px; display:flex; align-items:center; gap:6px; }
+  .sidebar .search-wrap input { flex:1; min-width:0; border-radius:8px; background:var(--console-card-soft-bg); border:none; padding:6px 10px; font-size:12px; color:var(--cafe-secondary); outline:none; }
+  .sidebar .search-wrap input::placeholder { color:var(--cafe-muted); }
+  .sidebar .search-wrap input:focus { box-shadow:0 0 0 1px var(--console-input-stroke); }
+  .sidebar .search-wrap .btn-read { font-size:10px; color:var(--cafe-secondary); background:none; border:none; cursor:pointer; white-space:nowrap; padding:2px 6px; border-radius:4px; }
+
+  /* 标签筛选条（不变 —— 标签是筛选器，不是 Tab） */
+  .sidebar .tags { padding:0 12px 8px; display:flex; align-items:center; gap:4px; flex-wrap:wrap; }
+  .sidebar .tags button { font-size:10px; padding:2px 8px; border-radius:99px; border:1px solid transparent; color:var(--cafe-muted); background:none; cursor:pointer; display:flex; align-items:center; gap:3px; }
+  .sidebar .tags button:hover { background:var(--console-hover-bg); color:var(--cafe-secondary); }
+  .sidebar .tags button.on { border-color:var(--console-border-soft); background:var(--console-field-bg); color:var(--cafe-black); }
+  .sidebar .tags .icon-btn { padding:2px 6px; border-radius:99px; }
+  .sidebar .tags .tag-dot { width:6px; height:6px; border-radius:50%; display:inline-block; }
+  .sidebar .tags .clear-btn { margin-left:auto; border-radius:99px; color:var(--conn-red-text); font-size:10px; padding:2px 6px; background:none; border:none; cursor:pointer; }
+
+  /* 【改动】大厅：在 Tab 之上，独立于 Tab（与现有代码一致——大厅不归任何 Tab 管） */
+  .sidebar .lobby { margin:4px 8px 2px; padding:8px 10px; border-radius:12px; background:var(--console-active-bg); cursor:pointer; }
+  .sidebar .lobby .row1 { display:flex; align-items:center; gap:5px; }
+  .sidebar .lobby .hub-icon { color:var(--cafe-accent); flex-shrink:0; display:flex; }
+  .sidebar .lobby .title { font-size:12px; color:var(--cafe-black); font-weight:500; flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .sidebar .lobby .more-btn { font-size:14px; color:var(--cafe-muted); background:none; border:none; cursor:pointer; padding:0 4px; border-radius:4px; opacity:0; transition:opacity .15s; flex-shrink:0; }
+  .sidebar .lobby:hover .more-btn { opacity:1; }
+  .sidebar .lobby .row2 { display:flex; align-items:center; justify-content:space-between; margin-top:3px; }
+  .sidebar .lobby .avatars { display:flex; align-items:center; gap:3px; }
+  .sidebar .lobby .time { font-size:10px; color:var(--cafe-muted); }
+
+  /* 【改动】Tab 行：右侧放展开/收起图标按钮 */
+  /* v9: Tab 行 — 选中 tab 始终完整可见（横向滚动 + scroll-into-view） */
+  .sidebar .tabs-row { display:flex; align-items:stretch; padding:0 8px 0 12px; border-bottom:1px solid var(--cafe-subtle); gap:0; }
+  .sidebar .tabs { display:flex; gap:2px; flex:1; min-width:0; overflow-x:auto; overflow-y:hidden; scrollbar-width:none; }
+  .sidebar .tabs::-webkit-scrollbar { display:none; }
+  .sidebar .tab { padding:6px 8px; font-size:11px; font-weight:500; color:var(--cafe-muted); cursor:pointer; border:none; border-bottom:2px solid transparent; background:none; white-space:nowrap; display:flex; align-items:center; gap:4px; border-radius:6px 6px 0 0; transition:all .12s; flex-shrink:0; scroll-snap-align:end; }
+  .sidebar .tab:hover { color:var(--cafe-secondary); background:var(--console-hover-bg); }
+  .sidebar .tab.on { color:var(--cafe-accent); border-bottom-color:var(--cafe-accent); font-weight:600; }
+  .sidebar .tab .count { font-size:10px; color:var(--cafe-muted); font-weight:400; }
+  .sidebar .tab.on .count { color:var(--cafe-accent); }
+  /* 溢出"更多"tab：当 tab 数超过容器宽度时出现，收起溢出的 tab */
+  .sidebar .tab-more { padding:6px 8px; font-size:11px; color:var(--cafe-muted); cursor:pointer; border:none; background:none; display:flex; align-items:center; gap:3px; border-radius:6px; flex-shrink:0; }
+  .sidebar .tab-more:hover { color:var(--cafe-secondary); background:var(--console-hover-bg); }
+  .sidebar .tab-more .has-overflow { width:4px; height:4px; border-radius:50%; background:var(--cafe-accent); }
+  /* 分隔线：把 tab 区和展开/折叠区视觉分开 */
+  .sidebar .tabs-row .divider { width:1px; align-self:center; height:16px; background:var(--cafe-subtle); margin:0 4px; flex-shrink:0; }
+  /* v7: 展开/收起只用图标，不要中文 */
+  .sidebar .tabs-row .ctrl { display:flex; align-items:center; gap:2px; flex-shrink:0; }
+  .sidebar .tabs-row .ctrl button { width:22px; height:22px; padding:0; display:flex; align-items:center; justify-content:center; border:none; background:none; cursor:pointer; border-radius:5px; color:var(--cafe-muted); transition:all .12s; }
+  .sidebar .tabs-row .ctrl button:hover { background:var(--console-hover-bg); color:var(--cafe-accent); }
+
+  /* v9: list 顶部加边距，第一个 item 不紧贴 tab 分割线 */
+  .sidebar .list { flex:1; overflow-y:auto; scrollbar-width: thin; scrollbar-color: transparent transparent; padding-top:6px; }
+  .sidebar .list:hover { scrollbar-color: var(--cafe-muted) transparent; }
+  .sidebar .list::-webkit-scrollbar { width: 6px; }
+  .sidebar .list::-webkit-scrollbar-track { background: transparent; }
+  .sidebar .list::-webkit-scrollbar-thumb { background: transparent; border-radius: 3px; }
+  .sidebar .list:hover::-webkit-scrollbar-thumb { background: var(--cafe-muted); }
+
+  /* 项目分组标题（与现 SectionGroup 一致） */
+  .section-head { padding:6px 12px; display:flex; align-items:center; gap:6px; cursor:pointer; }
+  .section-head:hover { background:var(--cafe-surface-elevated); }
+  .section-head .chevron { color:var(--cafe-muted); transition:transform .15s; display:flex; }
+  .section-head .chevron.open { transform:rotate(90deg); }
+  /* 【改动】项目路径：完整路径显示，超长中间省略 */
+  .section-head .sec-label { font-size:11px; font-weight:500; color:var(--cafe-secondary); flex:1; min-width:0; white-space:nowrap; overflow:hidden; }
+  .section-head .gov-dot { width:7px; height:7px; border-radius:50%; flex-shrink:0; }
+  .section-head .sec-count { font-size:10px; color:var(--cafe-muted); margin-left:auto; flex-shrink:0; }
+  .section-head .sec-action { color:var(--cafe-muted); padding:2px; border-radius:4px; background:none; border:none; cursor:pointer; opacity:0; transition:opacity .15s; display:flex; }
+  .section-head:hover .sec-action { opacity:1; }
+  .section-head .sec-action:hover { color:var(--cafe-accent); }
+  /* 置顶项目名称染 accent */
+  .section-head.pinned-proj .sec-label { color:var(--cafe-accent); }
+
+  /* 对话条目 */
+  .item { position:relative; margin:0 8px; padding:7px 10px; border-radius:12px; cursor:pointer; transition:background .1s; }
+  .item:hover { background:var(--console-hover-bg); }
+  .item.active { background:var(--console-active-bg); }
+  .item.indented { padding-left:18px; }
+
+  .item .row1 { display:flex; align-items:center; gap:5px; }
+  .item .hub-icon { color:var(--cafe-accent); flex-shrink:0; display:flex; }
+  .item .bootcamp-icon { color:var(--conn-purple-text); flex-shrink:0; display:flex; }
+  .item .title { font-size:12px; color:var(--cafe-secondary); flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; line-height:1.4; }
+  .item.active .title { color:var(--cafe-black); font-weight:500; }
+
+  .item .pin-mark { color:var(--cafe-accent); flex-shrink:0; display:flex; align-items:center; }
+  /* v7: 删除 proj-tag——标题后不显示文件夹信息，hover 显示完整信息（与现有逻辑一致） */
+
+  .item .more-btn { font-size:14px; color:var(--cafe-muted); background:none; border:none; cursor:pointer; padding:0 4px; border-radius:4px; opacity:0; transition:opacity .15s; flex-shrink:0; }
+  .item:hover .more-btn { opacity:1; }
+
+  .item .dropdown { position:absolute; right:8px; top:32px; z-index:50; min-width:148px; background:var(--cafe-surface-elevated); border:1px solid var(--cafe-subtle); border-radius:8px; padding:4px 0; box-shadow:0 4px 12px rgba(0,0,0,0.1); font-size:12px; }
+  .item .dropdown .menu-item { padding:6px 12px; display:flex; align-items:center; gap:8px; cursor:pointer; color:var(--cafe-secondary); }
+  .item .dropdown .menu-item:hover { background:var(--console-hover-bg); }
+  .item .dropdown .menu-item.danger { color:var(--conn-red-text); }
+  .item .dropdown .sep { height:1px; background:var(--cafe-subtle); margin:4px 0; }
+  .item .dropdown .menu-item .mi-icon { font-size:12px; width:16px; text-align:center; display:flex; justify-content:center; }
+
+  .item .row2 { display:flex; align-items:center; justify-content:space-between; margin-top:3px; }
+  .item .row2 .left { display:flex; align-items:center; gap:4px; min-width:0; }
+  .item .row2 .right { display:flex; align-items:center; gap:4px; flex-shrink:0; }
+
+  .avatar { width:16px; height:16px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:7px; font-weight:600; color:white; flex-shrink:0; }
+  .avatar.b { background:var(--cat-blue); }
+  .avatar.p { background:var(--cat-pink); }
+  .avatar.g { background:var(--cat-gold); }
+
+  .status-dot { width:6px; height:6px; border-radius:50%; flex-shrink:0; }
+  .status-dot.green { background:var(--conn-emerald-text); }
+  .status-dot.amber { background:var(--conn-amber-text); }
+
+  /* 【改动】标签展示重设计：纯色点（hover tooltip 显名），最多 3 个，超出 +N */
+  /* v8: 标签按钮高度对齐猫猫头像（16px） */
+  .label-dots { display:inline-flex; align-items:center; gap:3px; flex-shrink:0; height:16px; padding:0 5px; border-radius:99px; background:var(--console-card-soft-bg); cursor:default; transition:background .12s; }
+  .label-dots:hover { background:var(--console-hover-bg); }
+  .label-dots .label-ico { color:var(--cafe-muted); display:flex; flex-shrink:0; }
+  .label-dots:hover .label-ico { color:var(--cafe-secondary); }
+  .label-dots .ldot { width:6px; height:6px; border-radius:50%; border:1px solid rgba(255,255,255,0.4); flex-shrink:0; }
+  .label-dots .ldot-more { font-size:9px; color:var(--cafe-muted); margin-left:1px; }
+  /* v8: 收藏标记——被收藏的对话在所有 tab 显示 */
+  .fav-mark { color:var(--cat-gold); display:flex; flex-shrink:0; opacity:.9; }
+
+  .paw { font-size:10px; color:var(--cafe-muted); }
+  .no-cat { font-size:10px; color:var(--cafe-muted); }
+  .pref-ring { width:5px; height:5px; border-radius:50%; display:inline-block; margin-left:1px; }
+  .time { font-size:10px; color:var(--cafe-muted); }
+  .draft { font-size:10px; font-weight:500; color:var(--conn-red-text); }
+  .unread-badge { font-size:10px; font-weight:600; color:var(--conn-red-text); padding:0 4px; border-radius:99px; background:var(--conn-red-bg); }
+
+  .empty-tab { padding:24px 16px; text-align:center; font-size:11px; color:var(--cafe-muted); line-height:1.6; }
+
+  .trash { margin:auto 8px 8px; }
+  .trash button { width:100%; display:flex; align-items:center; gap:8px; height:36px; padding:0 10px; border-radius:12px; background:var(--console-card-soft-bg); border:none; font-size:12px; color:var(--cafe-secondary); cursor:pointer; }
+  .trash button:hover { color:var(--cafe-accent); }
+</style>
+</head>
+<body>
+
+<div style="max-width:1280px;margin:0 auto;padding:24px 32px 8px">
+  <h1 style="font-size:18px;font-weight:600;margin-bottom:4px">对话列表面板改版 v9</h1>
+  <p style="font-size:12px;color:var(--cafe-muted);line-height:1.6">
+    <strong>v9 本版调整</strong>：⑯ 选中 tab 始终完整可见（横向滚动 + scroll-into-view，tab 过多时选中的不裁切） ⑰ list 顶部加边距，第一个 item 不紧贴 tab 分割线<br>
+    <strong>v8 历史</strong>：⑬ 收藏标记全局显示 ⑭ 标签按钮高度对齐头像 ⑮ item hover 信息与代码一致<br>
+    <strong>v7 历史</strong>：⑨ 标题后不显示文件夹（hover 显示） ⑩ 标签合并单按钮 ⑪ 展开/折叠只图标 ⑫ Tab 去图标+顺序最近/项目/系统/收藏+去未读点<br>
+    <strong>v6 历史</strong>：⑦ 标签前加 tag 图标 ⑧ Tab 图标+文字、溢出收"更多"、分隔线区分展开/折叠<br>
+    <strong>v5 历史</strong>：① 大厅移到 Tab <strong>之上</strong>（与现有代码一致，不归任何 Tab） ② 项目 Tab 显示完整路径，超长中间 <code>...</code>  ③ 标签重设计为纯色点（hover 显名，最多3个+N） ④ 训练营对话在「最近」Tab 按时间排，带训练营小图标 ⑤ 展开/收起按钮移到 Tab 行右侧 ⑥ 展开/收起图标换业界通用 single chevron<br>
+    <strong>置顶逻辑</strong>：对话置顶=最近+当前Tab子目录双重置顶（pushpin 标识）；项目置顶=只项目Tab（项目名染 accent）
+  </p>
+</div>
+
+<svg width="0" height="0" style="position:absolute" aria-hidden="true">
+  <symbol id="i-pin" viewBox="0 0 24 24"><path d="M12 17v5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/><path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-star" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="currentColor"/></symbol>
+  <!-- 展开/收起：业界通用的单 chevron（VS Code / JetBrains / 文件管理器通用） -->
+  <symbol id="i-expand" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-collapse" viewBox="0 0 24 24"><path d="M18 15l-6-6-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-chev" viewBox="0 0 12 12"><path d="M4 2l4 4-4 4V2z" fill="currentColor"/></symbol>
+  <symbol id="i-lobby" viewBox="0 0 24 24"><path d="M12 3l-9 7h2v9h5v-6h4v6h5v-9h2z" fill="currentColor"/></symbol>
+  <!-- 训练营：毕业帽 -->
+  <symbol id="i-bootcamp" viewBox="0 0 24 24"><path d="M12 3L1 9l11 6 9-4.91V17h2V9L12 3z" fill="currentColor"/><path d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82z" fill="currentColor"/></symbol>
+  <symbol id="i-plus" viewBox="0 0 16 16"><path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" fill="currentColor"/></symbol>
+  <symbol id="i-more" viewBox="0 0 16 16"><path d="M8 4a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2z" fill="currentColor"/></symbol>
+  <!-- v6 新增：标签前缀图标（Lucide tag 形状） -->
+  <symbol id="i-tag" viewBox="0 0 24 24"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/><circle cx="7" cy="7" r="1.2" fill="currentColor"/></symbol>
+  <!-- v6 新增：Tab 图标（最近=时钟、系统=齿轮、项目=文件夹、收藏=星、更多=下拉） -->
+  <symbol id="i-tab-recent" viewBox="0 0 24 24"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/><path d="M12 7v5l3 2" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-tab-system" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-tab-project" viewBox="0 0 24 24"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-tab-star" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <symbol id="i-tab-more" viewBox="0 0 24 24"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/></symbol>
+  <symbol id="i-chev-down" viewBox="0 0 24 24"><path d="M6 9l6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/></symbol>
+  <!-- v8: 收藏标记（实心小星，与现有 StarIcon filled 一致） -->
+  <symbol id="i-fav" viewBox="0 0 24 24"><path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" fill="currentColor"/></symbol>
+</svg>
+
+<div class="layout">
+
+<!-- ====== A. 最近 Tab ====== -->
+<div class="panel-wrap">
+  <div class="panel-label">A. <span class="tag">最近 Tab</span></div>
+  <div class="sidebar">
+    <div class="head">
+      <h2>对话</h2>
+      <div class="actions">
+        <button class="btn-icon" title="猫猫训练营"><svg width="14" height="14"><use href="#i-lobby"/></svg></button>
+        <button class="btn-primary">+ 新对话</button>
+      </div>
+    </div>
+
+    <div class="search-wrap">
+      <input placeholder="搜索对话、项目或 ID..." />
+      <button class="btn-read">全部已读</button>
+    </div>
+
+    <div class="tags">
+      <button class="on">未分类 (3)</button>
+      <button class="icon-btn">✨</button>
+      <button><span class="tag-dot" style="background:#7eb8da"></span>前端</button>
+      <button><span class="tag-dot" style="background:#d4a0b9"></span>设计</button>
+      <button class="clear-btn">✕</button>
+    </div>
+
+    <!-- 【改动】大厅：在 Tab 之上 -->
+    <div class="lobby">
+      <div class="row1">
+        <span class="hub-icon"><svg width="13" height="13"><use href="#i-lobby"/></svg></span>
+        <span class="title">🎉 大厅</span>
+        <button class="more-btn">⋯</button>
+      </div>
+      <div class="row2">
+        <div class="avatars">
+          <span class="avatar b">宪</span>
+          <span class="avatar p">砚</span>
+          <span class="avatar g">金</span>
+        </div>
+        <span class="time">公共入口</span>
+      </div>
+    </div>
+
+    <!-- 【v7 改动】Tab 行：纯文字、顺序 最近/项目/系统/收藏，溢出收"更多"，分隔线区分展开/折叠 -->
+    <div class="tabs-row">
+      <div class="tabs">
+        <button class="tab on">最近 <span class="count">8</span></button>
+        <button class="tab">项目 <span class="count">5</span></button>
+        <button class="tab">系统 <span class="count">2</span></button>
+        <button class="tab">收藏 <span class="count">3</span></button>
+        <button class="tab-more" title="更多对话类型">更多<svg width="10" height="10" style="opacity:.6"><use href="#i-chev-down"/></svg><span class="has-overflow"></span></button>
+      </div>
+      <div class="divider"></div>
+      <div class="ctrl">
+        <button title="全部展开"><svg width="14" height="14"><use href="#i-expand"/></svg></button>
+        <button title="全部折叠"><svg width="14" height="14"><use href="#i-collapse"/></svg></button>
+      </div>
+    </div>
+
+    <div class="list">
+      <!-- 最近 Tab：按时间倒序。置顶项用 pushpin，插时间线 -->
+      <div class="item active">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F190 视觉契约重构&#10;路径: clowder-ai">F190 视觉契约重构</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left">
+            <span class="avatar b">宪</span>
+            <span class="status-dot green"></span>
+            <!-- 标签：纯色点，hover tooltip 显名 -->
+            <span class="label-dots" title="标签: 前端, 重构">
+              <span class="label-ico"><svg width="11" height="11"><use href="#i-tag"/></svg></span>
+              <span class="ldot" style="background:#7eb8da" title="前端"></span>
+              <span class="ldot" style="background:#d4a0b9" title="重构"></span>
+            </span>
+            <span class="unread-badge">3</span>
+          </div>
+          <div class="right"><span class="time">3分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F237 注入追踪可观测性&#10;路径: clowder-ai">F237 注入追踪可观测性</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar p">砚</span><span class="status-dot green"></span></div>
+          <div class="right"><span class="time">25分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="title" title="Redis 连接池优化&#10;路径: clowder-ai">Redis 连接池优化</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left">
+            <span class="avatar g">金</span>
+            <!-- 3个标签 + 超出显示 +N -->
+            <span class="label-dots" title="标签: 后端, 性能, Redis, 数据库, 运维">
+              <span class="label-ico"><svg width="11" height="11"><use href="#i-tag"/></svg></span>
+              <span class="ldot" style="background:#d4b483" title="后端"></span>
+              <span class="ldot" style="background:#38a169" title="性能"></span>
+              <span class="ldot" style="background:#8b5cf6" title="Redis"></span>
+              <span class="ldot-more">+2</span>
+            </span>
+          </div>
+          <div class="right"><span class="draft">[草稿]</span><span class="time">1小时前</span></div>
+        </div>
+      </div>
+
+      <!-- 【改动】训练营对话：在最近 Tab 按时间排，带训练营小图标 -->
+      <div class="item">
+        <div class="row1">
+          <span class="bootcamp-icon" title="训练营对话"><svg width="11" height="11"><use href="#i-bootcamp"/></svg></span>
+          <span class="title" title="训练营 Task 7: 实现侧栏改版&#10;路径: clowder-ai">训练营 Task 7: 实现侧栏改版</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar g">金</span></div>
+          <div class="right"><span class="time">2小时前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="title" title="Codex 流式认证修复&#10;路径: clowder-ai">Codex 流式认证修复</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span></div>
+          <div class="right"><span class="time">3小时前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="title" title="安全审计追踪日志系统设计&#10;路径: cat-cafe-docs">安全审计追踪日志系统设计</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="status-dot amber"></span></div>
+          <div class="right"><span class="time">8小时前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="title" title="移动端适配调研&#10;路径: clowder-ai">移动端适配调研</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar g">金</span></div>
+          <div class="right"><span class="time">2天前</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="trash">
+      <button><span>🗑</span><span style="flex:1;text-align:left">回收站 (2)</span><span style="font-size:10px;color:var(--cafe-muted)">▼</span></button>
+    </div>
+  </div>
+</div>
+
+<!-- ====== B. 项目 Tab（完整路径 + 中间省略） ====== -->
+<div class="panel-wrap">
+  <div class="panel-label">B. <span class="tag">项目 Tab · 完整路径</span></div>
+  <div class="sidebar">
+    <div class="head">
+      <h2>对话</h2>
+      <div class="actions">
+        <button class="btn-icon"><svg width="14" height="14"><use href="#i-lobby"/></svg></button>
+        <button class="btn-primary">+ 新对话</button>
+      </div>
+    </div>
+
+    <div class="search-wrap">
+      <input placeholder="搜索对话、项目或 ID..." />
+    </div>
+
+    <div class="tags">
+      <button class="on">未分类 (3)</button>
+      <button class="icon-btn">✨</button>
+      <button><span class="tag-dot" style="background:#7eb8da"></span>前端</button>
+    </div>
+
+    <!-- 大厅在 Tab 之上 -->
+    <div class="lobby">
+      <div class="row1">
+        <span class="hub-icon"><svg width="13" height="13"><use href="#i-lobby"/></svg></span>
+        <span class="title">🎉 大厅</span>
+        <button class="more-btn">⋯</button>
+      </div>
+      <div class="row2">
+        <div class="avatars"><span class="avatar b">宪</span><span class="avatar p">砚</span><span class="avatar g">金</span></div>
+        <span class="time">公共入口</span>
+      </div>
+    </div>
+
+    <div class="tabs-row">
+      <div class="tabs">
+        <button class="tab">最近 <span class="count">8</span></button>
+        <button class="tab on">项目 <span class="count">5</span></button>
+        <button class="tab">系统 <span class="count">2</span></button>
+        <button class="tab">收藏 <span class="count">3</span></button>
+        <button class="tab-more" title="更多对话类型">更多<svg width="10" height="10" style="opacity:.6"><use href="#i-chev-down"/></svg><span class="has-overflow"></span></button>
+      </div>
+      <div class="divider"></div>
+      <div class="ctrl">
+        <button title="全部展开"><svg width="14" height="14"><use href="#i-expand"/></svg></button>
+        <button title="全部折叠"><svg width="14" height="14"><use href="#i-collapse"/></svg></button>
+      </div>
+    </div>
+
+    <div class="list">
+      <!-- 置顶项目（染 accent） -->
+      <div class="section-head pinned-proj">
+        <span class="chevron open"><svg width="10" height="10"><use href="#i-chev"/></svg></span>
+        <span class="pin-mark" title="项目已置顶"><svg width="10" height="10"><use href="#i-pin"/></svg></span>
+        <!-- 完整路径，超长中间省略 -->
+        <span class="sec-label" title="D:\AI\TRUE_CAT\work\clowder-ai">D:\AI\TRUE_CAT\work\clowder-ai</span>
+        <span class="gov-dot" style="background:var(--conn-emerald-text)" title="治理正常"></span>
+        <span class="sec-count">4</span>
+        <button class="sec-action" title="新建对话"><svg width="11" height="11"><use href="#i-plus"/></svg></button>
+        <button class="sec-action" title="更多操作"><svg width="11" height="11"><use href="#i-more"/></svg></button>
+      </div>
+
+      <!-- 项目内：置顶对话排前（pushpin），其余字典序 -->
+      <div class="item indented">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="title">F204 微信公众号插件</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="label-dots" title="前端"><span class="label-ico"><svg width="11" height="11"><use href="#i-tag"/></svg></span><span class="ldot" style="background:#7eb8da"></span></span></div>
+          <div class="right"><span class="time">10分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item indented">
+        <div class="row1">
+          <span class="title">Codex 流式认证修复</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span></div>
+          <div class="right"><span class="time">3小时前</span></div>
+        </div>
+      </div>
+
+      <div class="item indented">
+        <div class="row1">
+          <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F237 注入追踪可观测性&#10;路径: clowder-ai">F237 注入追踪可观测性</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar p">砚</span><span class="status-dot green"></span></div>
+          <div class="right"><span class="time">25分钟前</span></div>
+        </div>
+      </div>
+
+      <!-- 超长路径项目：中间省略 -->
+      <div class="section-head">
+        <span class="chevron open"><svg width="10" height="10"><use href="#i-chev"/></svg></span>
+        <!-- 完整路径超长，中间 ... 显示 -->
+        <span class="sec-label" title="D:\docs\projects\archive\2024\cat-cafe-docs">D:\docs\...ve\cat-cafe-docs</span>
+        <span class="gov-dot" style="background:var(--conn-amber-text)" title="治理过期"></span>
+        <span class="sec-count">2</span>
+        <button class="sec-action" title="更多操作"><svg width="11" height="11"><use href="#i-more"/></svg></button>
+        <button class="sec-action" title="固定项目"><svg width="10" height="10"><use href="#i-pin"/></svg></button>
+      </div>
+
+      <div class="item indented">
+        <div class="row1">
+          <span class="title">安全审计追踪日志系统设计</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span></div>
+          <div class="right"><span class="time">8小时前</span></div>
+        </div>
+      </div>
+
+      <div class="item indented">
+        <div class="row1">
+          <span class="title">用户权限重构方案讨论</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="avatar p">砚</span></div>
+          <div class="right"><span class="time">昨天</span></div>
+        </div>
+      </div>
+
+      <div class="section-head">
+        <span class="chevron"><svg width="10" height="10"><use href="#i-chev"/></svg></span>
+        <span class="sec-label" style="color:var(--cafe-muted)">其他项目 (1)</span>
+        <span class="sec-count">1</span>
+      </div>
+    </div>
+
+    <div class="trash">
+      <button><span>🗑</span><span style="flex:1;text-align:left">回收站 (2)</span><span style="font-size:10px;color:var(--cafe-muted)">▼</span></button>
+    </div>
+  </div>
+</div>
+
+</div>
+
+<!-- 第二行：系统 Tab + 收藏 Tab + 菜单展开 -->
+<div class="layout" style="padding-top:0">
+
+<!-- ====== C. 系统 Tab（字典序） ====== -->
+<div class="panel-wrap">
+  <div class="panel-label">C. <span class="tag">系统 Tab</span></div>
+  <div class="sidebar">
+    <div class="head">
+      <h2>对话</h2>
+      <div class="actions">
+        <button class="btn-icon"><svg width="14" height="14"><use href="#i-lobby"/></svg></button>
+        <button class="btn-primary">+ 新对话</button>
+      </div>
+    </div>
+
+    <div class="search-wrap"><input placeholder="搜索对话、项目或 ID..." /></div>
+    <div class="tags">
+      <button class="on">未分类 (3)</button>
+      <button class="icon-btn">✨</button>
+      <button><span class="tag-dot" style="background:#7eb8da"></span>前端</button>
+    </div>
+
+    <div class="lobby">
+      <div class="row1">
+        <span class="hub-icon"><svg width="13" height="13"><use href="#i-lobby"/></svg></span>
+        <span class="title">🎉 大厅</span>
+        <button class="more-btn">⋯</button>
+      </div>
+      <div class="row2">
+        <div class="avatars"><span class="avatar b">宪</span><span class="avatar p">砚</span></div>
+        <span class="time">公共入口</span>
+      </div>
+    </div>
+
+    <div class="tabs-row">
+      <div class="tabs">
+        <button class="tab">最近 <span class="count">8</span></button>
+        <button class="tab">项目 <span class="count">5</span></button>
+        <button class="tab on">系统 <span class="count">2</span></button>
+        <button class="tab">收藏 <span class="count">3</span></button>
+        <button class="tab-more" title="更多对话类型">更多<svg width="10" height="10" style="opacity:.6"><use href="#i-chev-down"/></svg><span class="has-overflow"></span></button>
+      </div>
+      <div class="divider"></div>
+      <div class="ctrl">
+        <button title="全部展开"><svg width="14" height="14"><use href="#i-expand"/></svg></button>
+        <button title="全部折叠"><svg width="14" height="14"><use href="#i-collapse"/></svg></button>
+      </div>
+    </div>
+
+    <div class="list">
+      <!-- 置顶系统对话排前 -->
+      <div class="item active">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="hub-icon"><svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7v10l10 5 10-5V7L12 2zm0 2.18L19.5 8 12 11.82 4.5 8 12 4.18z"/></svg></span>
+          <span class="title">Eval 任务调度器</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar p">砚</span><span class="status-dot amber"></span></div>
+          <div class="right"><span class="time">15分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="hub-icon"><svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2L2 7v10l10 5 10-5V7L12 2zm0 2.18L19.5 8 12 11.82 4.5 8 12 4.18z"/></svg></span>
+          <span class="title">微信连接器中枢</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="status-dot green"></span><span class="unread-badge">12</span></div>
+          <div class="right"><span class="time">2分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="empty-tab">系统对话由平台维护</div>
+    </div>
+
+    <div class="trash">
+      <button><span>🗑</span><span style="flex:1;text-align:left">回收站 (2)</span><span style="font-size:10px;color:var(--cafe-muted)">▼</span></button>
+    </div>
+  </div>
+</div>
+
+<!-- ====== D. 收藏 Tab（字典序） ====== -->
+<div class="panel-wrap">
+  <div class="panel-label">D. <span class="tag">收藏 Tab</span></div>
+  <div class="sidebar">
+    <div class="head">
+      <h2>对话</h2>
+      <div class="actions">
+        <button class="btn-icon"><svg width="14" height="14"><use href="#i-lobby"/></svg></button>
+        <button class="btn-primary">+ 新对话</button>
+      </div>
+    </div>
+
+    <div class="search-wrap"><input placeholder="搜索对话、项目或 ID..." /></div>
+    <div class="tags">
+      <button class="on">未分类 (3)</button>
+      <button class="icon-btn">✨</button>
+      <button><span class="tag-dot" style="background:#7eb8da"></span>前端</button>
+    </div>
+
+    <div class="lobby">
+      <div class="row1">
+        <span class="hub-icon"><svg width="13" height="13"><use href="#i-lobby"/></svg></span>
+        <span class="title">🎉 大厅</span>
+        <button class="more-btn">⋯</button>
+      </div>
+      <div class="row2">
+        <div class="avatars"><span class="avatar b">宪</span><span class="avatar p">砚</span></div>
+        <span class="time">公共入口</span>
+      </div>
+    </div>
+
+    <div class="tabs-row">
+      <div class="tabs">
+        <button class="tab">最近 <span class="count">8</span></button>
+        <button class="tab">项目 <span class="count">5</span></button>
+        <button class="tab">系统 <span class="count">2</span></button>
+        <button class="tab on">收藏 <span class="count">3</span></button>
+        <button class="tab-more" title="更多对话类型">更多<svg width="10" height="10" style="opacity:.6"><use href="#i-chev-down"/></svg><span class="has-overflow"></span></button>
+      </div>
+      <div class="divider"></div>
+      <div class="ctrl">
+        <button title="全部展开"><svg width="14" height="14"><use href="#i-expand"/></svg></button>
+        <button title="全部折叠"><svg width="14" height="14"><use href="#i-collapse"/></svg></button>
+      </div>
+    </div>
+
+    <div class="list">
+      <!-- 置顶收藏排前 -->
+      <div class="item active">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+                    <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F190 视觉契约重构&#10;路径: clowder-ai">F190 视觉契约重构</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="status-dot green"></span><span class="unread-badge">3</span></div>
+          <div class="right"><span class="time">3分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+                    <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="架构决策记录合集&#10;路径: cat-cafe-docs">架构决策记录合集</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar p">砚</span></div>
+          <div class="right"><span class="time">昨天</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+                    <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="家规与决策漏斗&#10;路径: cat-cafe-docs">家规与决策漏斗</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="avatar g">金</span></div>
+          <div class="right"><span class="time">3天前</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="trash">
+      <button><span>🗑</span><span style="flex:1;text-align:left">回收站 (2)</span><span style="font-size:10px;color:var(--cafe-muted)">▼</span></button>
+    </div>
+  </div>
+</div>
+
+<!-- ====== E. 最近 Tab + 菜单展开 ====== -->
+<div class="panel-wrap">
+  <div class="panel-label">E. <span class="tag">最近 Tab · 菜单展开</span></div>
+  <div class="sidebar">
+    <div class="head">
+      <h2>对话</h2>
+      <div class="actions">
+        <button class="btn-icon"><svg width="14" height="14"><use href="#i-lobby"/></svg></button>
+        <button class="btn-primary">+ 新对话</button>
+      </div>
+    </div>
+
+    <div class="search-wrap"><input placeholder="搜索对话、项目或 ID..." /></div>
+    <div class="tags">
+      <button class="on">未分类 (3)</button>
+      <button class="icon-btn">✨</button>
+      <button><span class="tag-dot" style="background:#7eb8da"></span>前端</button>
+    </div>
+
+    <div class="lobby">
+      <div class="row1">
+        <span class="hub-icon"><svg width="13" height="13"><use href="#i-lobby"/></svg></span>
+        <span class="title">🎉 大厅</span>
+        <button class="more-btn">⋯</button>
+      </div>
+      <div class="row2">
+        <div class="avatars"><span class="avatar b">宪</span><span class="avatar p">砚</span></div>
+        <span class="time">公共入口</span>
+      </div>
+    </div>
+
+    <div class="tabs-row">
+      <div class="tabs">
+        <button class="tab on">最近 <span class="count">8</span></button>
+        <button class="tab">项目 <span class="count">5</span></button>
+        <button class="tab">系统 <span class="count">2</span></button>
+        <button class="tab">收藏 <span class="count">3</span></button>
+        <button class="tab-more" title="更多对话类型">更多<svg width="10" height="10" style="opacity:.6"><use href="#i-chev-down"/></svg><span class="has-overflow"></span></button>
+      </div>
+      <div class="divider"></div>
+      <div class="ctrl">
+        <button title="全部展开"><svg width="14" height="14"><use href="#i-expand"/></svg></button>
+        <button title="全部折叠"><svg width="14" height="14"><use href="#i-collapse"/></svg></button>
+      </div>
+    </div>
+
+    <div class="list">
+      <div class="item active">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F190 视觉契约重构&#10;路径: clowder-ai">F190 视觉契约重构</span>
+          <button class="more-btn" style="opacity:1">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar b">宪</span><span class="status-dot green"></span><span class="unread-badge">3</span></div>
+          <div class="right"><span class="time">3分钟前</span></div>
+        </div>
+        <div class="dropdown">
+          <div class="menu-item"><span class="mi-icon">📌</span>取消置顶</div>
+          <div class="menu-item"><span class="mi-icon">⭐</span>取消收藏</div>
+          <div class="sep"></div>
+          <div class="menu-item"><span class="mi-icon">✏️</span>重命名对话</div>
+          <div class="menu-item"><span class="mi-icon">🐱</span>设置默认猫猫</div>
+          <div class="menu-item"><span class="mi-icon">🏷️</span>标签管理</div>
+          <div class="sep"></div>
+          <div class="menu-item"><span class="mi-icon">📋</span>导出对话</div>
+          <div class="menu-item"><span class="mi-icon">🎭</span>回放剧场</div>
+          <div class="sep"></div>
+          <div class="menu-item danger"><span class="mi-icon">🗑️</span>删除对话</div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="fav-mark" title="已收藏"><svg width="11" height="11"><use href="#i-fav"/></svg></span><span class="title" title="F237 注入追踪可观测性&#10;路径: clowder-ai">F237 注入追踪可观测性</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar p">砚</span><span class="status-dot green"></span></div>
+          <div class="right"><span class="time">25分钟前</span></div>
+        </div>
+      </div>
+
+      <div class="item">
+        <div class="row1">
+          <span class="pin-mark" title="已置顶"><svg width="11" height="11"><use href="#i-pin"/></svg></span>
+          <span class="title" title="Redis 连接池优化&#10;路径: clowder-ai">Redis 连接池优化</span>
+          <button class="more-btn">⋯</button>
+        </div>
+        <div class="row2">
+          <div class="left"><span class="avatar g">金</span></div>
+          <div class="right"><span class="draft">[草稿]</span><span class="time">1小时前</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="trash">
+      <button><span>🗑</span><span style="flex:1;text-align:left">回收站 (2)</span><span style="font-size:10px;color:var(--cafe-muted)">▼</span></button>
+    </div>
+  </div>
+</div>
+
+</div>
+
+<div style="max-width:1280px;margin:0 auto;padding:8px 32px 48px">
+  <div style="background:white;border-radius:12px;padding:18px 22px;box-shadow:0 1px 4px rgba(0,0,0,0.05);font-size:12px;line-height:1.7;color:var(--cafe-secondary)">
+    <div style="font-weight:600;color:var(--cafe-black);margin-bottom:8px">v9 调整说明</div>
+
+    <div style="margin-bottom:6px"><strong style="color:var(--cafe-accent)">⑯ 选中 tab 始终完整可见</strong>：tab 过多时，<code>.tabs</code> 改为<strong>横向滚动</strong>（<code>overflow-x:auto</code>，滚动条隐藏）。选中的 tab 用 <code>scrollIntoView({inline:'nearest'})</code> 自动滚到可见区——无论选中的是「收藏」还是其他，都完整显示不被裁切。落地到 React 时用 <code>useEffect</code> 监听 activeTab 变化 + tab ref 调 <code>scrollIntoView</code>。点击 tab 后 <code>requestAnimationFrame</code> 触发滚动，保证 class 更新后再滚。</div>
+
+    <div style="margin-bottom:6px"><strong style="color:var(--cafe-accent)">⑰ list 顶部加边距</strong>：<code>.list</code> 加 <code>padding-top:6px</code>，第一个 item 不再紧贴 tab 行的 border-bottom 分割线。</div>
+
+    <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--cafe-subtle);color:var(--cafe-muted);font-size:11px">
+      <strong>v8 历史（⑬-⑮）</strong>：收藏标记全局显示 / 标签按钮对齐头像 / item hover 信息与代码一致。
+    </div>
+
+    <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--cafe-subtle);color:var(--cafe-muted);font-size:11px">
+      <strong>v7 历史（⑨-⑫）</strong>：标题后不显示文件夹 / 标签合并单按钮 / 展开/折叠只图标 / Tab 去图标+顺序+去未读点。
+    </div>
+
+    <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--cafe-subtle);color:var(--cafe-muted);font-size:11px">
+      <strong>v6 历史（⑦-⑧）</strong>：标签前加 tag 图标 / Tab 图标+文字+溢出更多+分隔线。
+    </div>
+
+    <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--cafe-subtle);color:var(--cafe-muted);font-size:11px">
+      <strong>v5 历史（①-⑥）</strong>：大厅在 Tab 之上 / 项目完整路径 / 标签色点 / 训练营最近 Tab / 展开折叠右侧 / 单 chevron。
+    </div>
+
+    <div style="margin-top:8px;padding-top:8px;border-top:1px solid var(--cafe-subtle);color:var(--cafe-muted)">
+      <strong>置顶逻辑不变</strong>：对话置顶=最近 Tab + 当前 Tab 子目录双重置顶（pushpin 标识）；项目置顶=只项目 Tab（项目名染 accent + pushpin）。排序：最近按时间，其他 Tab 字典序。
+    </div>
+  </div>
+</div>
+
+<script>
+// v9: 选中 tab 始终完整可见——点击 tab 后滚到可见区
+// 落地到 React 时用 useEffect + ref.scrollIntoView({inline:'nearest',block:'nearest'})
+document.querySelectorAll('.sidebar').forEach(sb => {
+  const tabs = sb.querySelector('.tabs');
+  if (!tabs) return;
+  // 初始：把当前 on 的 tab 滚到可见
+  const scrollActiveIntoView = () => {
+    const on = tabs.querySelector('.tab.on');
+    if (on) on.scrollIntoView({ inline: 'nearest', block: 'nearest', behavior: 'smooth' });
+  };
+  scrollActiveIntoView();
+  tabs.addEventListener('click', e => {
+    const t = e.target.closest('.tab');
+    if (!t) return;
+    tabs.querySelectorAll('.tab').forEach(x => x.classList.remove('on'));
+    t.classList.add('on');
+    // 等 class 更新后再滚
+    requestAnimationFrame(scrollActiveIntoView);
+  });
+});
+</script>
+
+</body>
+</html>

--- a/feature-specs/2026-07-06-sidebar-tab-redesign.md
+++ b/feature-specs/2026-07-06-sidebar-tab-redesign.md
@@ -1,0 +1,243 @@
+# Sidebar Tab Redesign Implementation Plan
+
+**Feature:** Current thread request — left ThreadSidebar redesign (`thread_mr7npab0e3e87ihf`, no F-id assigned)
+**Goal:** Redesign the left conversation sidebar into a clearer tabbed navigation surface with compact rows, hidden row actions, and v9 design parity.
+**Acceptance Criteria:** AC-1 through AC-17 below, copied from `docs/design/sidebar-proposals.html` v9 and the thread handoff.
+**Architecture cell:** `thread-navigation`
+**Map delta:** none
+**Map delta why:** This changes the existing ThreadSidebar presentation and grouping selectors, without changing thread metadata ownership or API boundaries.
+**Architecture:** Add a local tab view model on top of existing thread data and pin/favorite/label state. Keep lobby and label filtering as separate surfaces, and render tab-specific thread lists with the existing `ThreadItem` / `SectionGroup` action contracts.
+**Tech Stack:** React, TypeScript, existing Zustand stores, Vitest, Playwright for visual verification.
+**前端验证:** Yes — compare against `docs/design/sidebar-proposals.html` v9 and verify in a feature worktree browser.
+
+---
+
+## Finish Line
+
+B definition: the left sidebar reads as `大厅` + label filter + tab row (`最近 / 项目 / 系统 / 收藏`) + compact thread list, matching v9 interaction rules while preserving existing create/delete/rename/pin/favorite/label/replay behavior.
+
+Not building:
+- No new backend API or persistent state.
+- No label-as-tab behavior; labels remain a filter bar.
+- No new project metadata model; project pin state remains `useProjectPins`.
+- No changes to runtime / alpha / production data stores.
+
+## Terminal Schema
+
+```ts
+type SidebarTabId = 'recent' | 'project' | 'system' | 'favorites';
+
+interface SidebarTab {
+  id: SidebarTabId;
+  label: string;
+  count: number;
+}
+
+interface SidebarThreadBucket {
+  kind: 'flat' | 'project';
+  threads: Thread[];
+  projectGroups?: ThreadGroup[];
+}
+```
+
+Derived values only. Do not store tab memberships outside React memoized selectors.
+
+## Acceptance Criteria
+
+1. Lobby stays above the tab row and is never part of any tab.
+2. Tab order is `最近 / 项目 / 系统 / 收藏`, plain text, no icons.
+3. Tabs are isolated: each tab shows only its own conversations.
+4. Recent/system/favorites tabs are flat; project tab uses project sections only.
+5. Thread title is 12px, single-line ellipsis; active row changes weight only, not size.
+6. Title row does not show folder/project chips; full info stays in hover tooltip.
+7. Delete, pin, favorite, labels, rename, export, replay, and cat settings stay under `...` menu.
+8. Pinned threads use the existing pushpin mark, with no left accent rail.
+9. Favorited threads show a gold filled star in every tab where they appear.
+10. Pinned conversations float in `最近` and inside their current tab subsection.
+11. Pinned projects only affect the project tab.
+12. Recent tab sorts by time descending; other tab subitems sort alphabetically with pinned first.
+13. Labels render as one compact tag button with tag icon, up to three color dots, and `+N`.
+14. Label button height matches the 16px cat avatar height.
+15. Expand/collapse controls live on the right side of the tab row, icon-only single chevrons.
+16. Overflowing tabs scroll horizontally and the active tab scrolls into view.
+17. The list area has top padding so the first item does not touch the tab divider.
+
+## Task 1: Selector Tests for Tab Membership and Sorting
+
+**Files:**
+- Modify: `packages/web/src/components/ThreadSidebar/thread-utils.ts`
+- Test: `packages/web/src/components/__tests__/thread-utils.test.ts`
+
+**Step 1: Write failing tests**
+
+Add tests for:
+- `recent` excludes default and system threads, includes favorites, sorts pinned first then recent time.
+- `system` contains only `systemKind` / `connectorHubState` threads.
+- `favorites` contains all favorited non-default threads, pinned first then alphabetical.
+- `project` excludes system threads, groups by full project path, pinned projects sort first, subitems pinned first then alphabetical.
+
+**Step 2: Run red**
+
+Run:
+
+```bash
+pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/thread-utils.test.ts
+```
+
+Expected: new tab selector tests fail because the selector does not exist yet.
+
+**Step 3: Implement selector**
+
+Add exported pure helpers in `thread-utils.ts`:
+- `SidebarTabId`
+- `SidebarTab`
+- `buildSidebarTabs(...)`
+- `buildSidebarTabContent(...)`
+
+Reuse existing `ThreadGroup` where possible. Keep all grouping derived and deterministic.
+
+**Step 4: Run green**
+
+Run the same test command. Expected: all `thread-utils` tests pass.
+
+## Task 2: ThreadItem Compact Row Contract
+
+**Files:**
+- Modify: `packages/web/src/components/ThreadSidebar/ThreadItem.tsx`
+- Test: `packages/web/src/components/__tests__/thread-item-actions.test.tsx`
+- Test: `packages/web/src/components/__tests__/thread-item-draft-badge.test.tsx`
+
+**Step 1: Write failing tests**
+
+Add assertions for:
+- Pin and delete controls are no longer fixed row buttons.
+- More menu still exposes pin/delete/favorite/label actions.
+- Favorited rows render a visible filled star outside the menu.
+- Label dots render as one 16px-high button/container with tag semantics and overflow count.
+- Row tooltip still contains title, participants, project path, and time.
+
+**Step 2: Run red**
+
+Run:
+
+```bash
+pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/thread-item-actions.test.tsx src/components/__tests__/thread-item-draft-badge.test.tsx
+```
+
+Expected: tests that assert compact v9 row behavior fail on current implementation.
+
+**Step 3: Implement minimal UI**
+
+Update `ThreadItem`:
+- Single-line 12px title.
+- Move pin/delete into more menu.
+- Add inline pin and favorite markers before title.
+- Replace label chips with tag-icon + dots compact label button.
+- Remove active left accent rail assumptions if present.
+
+**Step 4: Run green**
+
+Run the same test command. Expected: thread item tests pass.
+
+## Task 3: Sidebar Tab Row and Content Rendering
+
+**Files:**
+- Modify: `packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx`
+- Modify: `packages/web/src/components/ThreadSidebar/SectionGroup.tsx`
+- Test: `packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx`
+
+**Step 1: Write failing tests**
+
+Create a sidebar harness test that verifies:
+- Lobby renders before the tab list.
+- Tabs render in the required order.
+- Selecting each tab changes visible content and does not mix system/project/favorite-only views.
+- Expand/collapse buttons are icon-only controls in the tab row.
+- Active tab has a ref target for scroll-into-view behavior.
+
+**Step 2: Run red**
+
+Run:
+
+```bash
+pnpm --filter @cat-cafe/web exec vitest run src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+```
+
+Expected: test fails because the sidebar still renders grouped sections without tabs.
+
+**Step 3: Implement tab UI**
+
+Update `ThreadSidebar`:
+- Add `activeTab` state.
+- Use tab selector helpers from Task 1.
+- Keep default/lobby item above tabs.
+- Render `LabelFilterBar` as a filter above the list, not as tabs.
+- Add tab row overflow with refs and `scrollIntoView({ inline: 'nearest', block: 'nearest' })` on active tab changes.
+- Render flat tab content with `ThreadItem`; project tab with `SectionGroup`.
+
+Update `SectionGroup` only as needed for project-tab compact heading and real button separation.
+
+**Step 4: Run green**
+
+Run the new tab test plus existing sidebar tests.
+
+## Task 4: Visual Contract and Windows Path Guard
+
+**Files:**
+- Modify: `packages/web/src/components/__tests__/f190-visual-contract.test.ts`
+- Test: `packages/web/src/components/__tests__/f190-visual-contract.test.ts`
+
+**Step 1: Write failing guard if needed**
+
+If v9 styling introduces a visual-contract issue or Windows path miss, add the minimal test expectation first.
+
+**Step 2: Implement fix**
+
+Keep typography token and no raw pixel-font rules intact. If the existing `/dev/` exclusion needs Windows compatibility, use `[\\/]dev[\\/]`.
+
+**Step 3: Run**
+
+```bash
+pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/f190-visual-contract.test.ts
+```
+
+Expected: 279 visual-contract tests pass.
+
+## Task 5: Quality Gate and Dogfood
+
+**Files:**
+- Evidence only: screenshots in temp evidence dir, no root artifacts.
+
+**Step 1: Format and typecheck**
+
+```bash
+pnpm biome format --write packages/web/src/components/ThreadSidebar packages/web/src/components/__tests__/f190-visual-contract.test.ts
+pnpm --filter @cat-cafe/web exec tsc --noEmit
+```
+
+**Step 2: Run targeted tests**
+
+```bash
+pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/thread-utils.test.ts src/components/__tests__/thread-item-actions.test.tsx src/components/__tests__/thread-item-draft-badge.test.tsx src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx src/components/ThreadSidebar/__tests__/sidebar-mobile-close.test.ts src/components/ThreadSidebar/__tests__/thread-sidebar-create-error-toast.test.tsx src/components/ThreadSidebar/__tests__/thread-sidebar-mission-entry.test.tsx src/components/ThreadSidebar/__tests__/thread-sidebar-organize-flow.test.tsx src/components/ThreadSidebar/__tests__/thread-sidebar-scroll-memory.test.ts src/components/__tests__/f190-visual-contract.test.ts
+```
+
+**Step 3: Browser dogfood**
+
+Run the feature worktree dev service on an isolated non-runtime port. Do not use `3003/3004`.
+
+Verify against `docs/design/sidebar-proposals.html` v9:
+- default desktop view
+- each tab selected
+- active rightmost tab fully visible
+- first list item spacing
+- more-menu actions
+
+**Step 4: Review packet**
+
+Request review from Blue-White Cat with:
+- original requirement excerpt
+- v9 demo path
+- 17-point coverage table
+- tests and browser evidence
+- worktree path and branch
+

--- a/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
+++ b/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
@@ -9,9 +9,8 @@ const GOV_STATUS_DOT: Record<string, { color: string; title: string }> = {
   'never-synced': { color: 'bg-conn-slate-ring', title: '未同步治理' },
 };
 
-/** Section icon SVG paths (extracted to reduce JSX noise) */
+/** Section icon SVG paths (extracted to reduce JSX noise). pin uses stroke style — see PinSectionIcon. */
 const ICON_PATHS: Record<string, string> = {
-  pin: 'M4.456 2.013a.75.75 0 011.06-.034l6.5 6a.75.75 0 01-.034 1.06l-1.99 1.838.637 3.22a.75.75 0 01-1.196.693L6.5 12.526l-2.933 2.264a.75.75 0 01-1.196-.693l.637-3.22-1.99-1.838a.75.75 0 01-.034-1.06l5.472-5.966z',
   star: 'M8 1.5l2.09 4.26 4.71.68-3.41 3.32.8 4.69L8 12.26l-4.19 2.19.8-4.69L1.2 6.44l4.71-.68L8 1.5z',
   clock:
     'M8 1a7 7 0 110 14A7 7 0 018 1zm0 1.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM8 4a.75.75 0 01.75.75v2.69l1.78 1.78a.75.75 0 01-1.06 1.06l-2-2A.75.75 0 017.25 8V4.75A.75.75 0 018 4z',
@@ -71,7 +70,7 @@ export function SectionGroup({
   const inputRef = useRef<HTMLInputElement>(null);
   const ime = useIMEGuard();
 
-  const hasContextMenu = onOpenInFinder || onRenameProject || onArchiveThreads;
+  const hasContextMenu = onOpenInFinder || onRenameProject || onArchiveThreads || onToggleProjectPin;
 
   // Close menu on click outside
   useEffect(() => {
@@ -114,60 +113,46 @@ export function SectionGroup({
   const govDot = governanceStatus ? GOV_STATUS_DOT[governanceStatus] : undefined;
 
   return (
-    <div className="mt-1 relative group/section">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full text-left px-3 py-1.5 flex items-center gap-1.5 hover:bg-cafe-surface-elevated transition-colors"
-        title={projectPath && projectPath !== 'default' ? projectPath : undefined}
-      >
-        {/* Chevron */}
-        <svg
-          aria-hidden="true"
-          className={`w-3 h-3 text-cafe-muted transition-transform flex-shrink-0 ${isCollapsed ? '' : 'rotate-90'}`}
-          viewBox="0 0 12 12"
-          fill="currentColor"
-        >
-          <path d="M4 2l4 4-4 4V2z" />
-        </svg>
-
-        {/* Section icon */}
-        {iconPath && (
-          <svg
-            aria-hidden="true"
-            className={`w-3 h-3 flex-shrink-0 ${iconColor}`}
-            viewBox="0 0 16 16"
-            fill="currentColor"
-          >
-            <path d={iconPath} />
-          </svg>
-        )}
-
-        {/* Label (inline rename or static) */}
+    <div className="relative mt-1 px-2 group/section">
+      <div className="flex w-full items-center gap-1 rounded-lg px-1.5 py-1.5 transition-colors hover:bg-cafe-surface-elevated">
         {isRenaming ? (
-          <input
-            ref={inputRef}
-            value={draftName}
-            onChange={(e) => setDraftName(e.target.value)}
-            onClick={stopButton}
-            onCompositionStart={ime.onCompositionStart}
-            onCompositionEnd={ime.onCompositionEnd}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !ime.isComposing()) {
-                e.preventDefault();
-                submitRename();
-              }
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setIsRenaming(false);
-              }
-            }}
-            onBlur={submitRename}
-            maxLength={100}
-            className="text-xs font-medium px-1 py-0 rounded border border-cafe-subtle focus:outline-none focus:border-cafe-accent flex-1 min-w-0"
-          />
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <SectionChevron isCollapsed={isCollapsed} />
+            {iconPath && <SectionIcon iconPath={iconPath} iconColor={iconColor} />}
+            <input
+              ref={inputRef}
+              value={draftName}
+              onChange={(e) => setDraftName(e.target.value)}
+              onClick={stopButton}
+              onCompositionStart={ime.onCompositionStart}
+              onCompositionEnd={ime.onCompositionEnd}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !ime.isComposing()) {
+                  e.preventDefault();
+                  submitRename();
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setIsRenaming(false);
+                }
+              }}
+              onBlur={submitRename}
+              maxLength={100}
+              className="min-w-0 flex-1 rounded border border-cafe-subtle px-1 py-0 text-xs font-medium focus:border-cafe-accent focus:outline-none"
+            />
+          </div>
         ) : (
-          <span className="text-xs font-medium text-cafe-secondary truncate">{label}</span>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+            title={projectPath && projectPath !== 'default' ? projectPath : undefined}
+          >
+            <SectionChevron isCollapsed={isCollapsed} />
+            {iconPath && <SectionIcon iconPath={iconPath} iconColor={iconColor} />}
+            {isProjectPinned && <PinSectionIcon />}
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-cafe-secondary">{label}</span>
+          </button>
         )}
 
         {/* Governance dot */}
@@ -185,7 +170,6 @@ export function SectionGroup({
             }}
             title="新建对话"
             testId="quick-create-btn"
-            className="opacity-0 group-hover/section:opacity-100"
           >
             <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
           </ActionButton>
@@ -200,34 +184,29 @@ export function SectionGroup({
             }}
             title="更多操作"
             testId="project-menu-btn"
-            className="opacity-0 group-hover/section:opacity-100"
           >
             <path d="M8 4a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2z" />
           </ActionButton>
         )}
-
-        {/* Project pin button */}
-        {onToggleProjectPin && (
-          <ActionButton
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleProjectPin();
-            }}
-            title={isProjectPinned ? '取消固定项目' : '固定项目到活跃区'}
-            testId="project-pin-btn"
-            className={isProjectPinned ? 'text-cafe-accent' : 'text-cafe-muted hover:text-cafe-muted'}
-          >
-            <path d={ICON_PATHS.pin} />
-          </ActionButton>
-        )}
-      </button>
+      </div>
 
       {/* F095 Phase F: Context menu dropdown */}
       {showMenu && (
         <div
           ref={menuRef}
-          className="absolute right-2 top-8 z-50 bg-cafe-surface rounded-lg shadow-lg border border-cafe py-1 min-w-[140px]"
+          className="absolute right-2 top-8 z-50 bg-cafe-surface rounded-lg shadow-lg border border-cafe py-1 min-w-[160px]"
         >
+          {onToggleProjectPin && (
+            <MenuItem
+              onClick={() => {
+                onToggleProjectPin();
+                setShowMenu(false);
+              }}
+              icon={<PinMenuIcon active={isProjectPinned} />}
+            >
+              {isProjectPinned ? '取消固定项目' : '固定项目到活跃区'}
+            </MenuItem>
+          )}
           {onOpenInFinder && (
             <MenuItem
               onClick={() => {
@@ -258,6 +237,65 @@ export function SectionGroup({
   );
 }
 
+function SectionChevron({ isCollapsed }: { isCollapsed: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`h-3 w-3 flex-shrink-0 text-cafe-muted transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
+      viewBox="0 0 12 12"
+      fill="currentColor"
+    >
+      <path d="M4 2l4 4-4 4V2z" />
+    </svg>
+  );
+}
+
+function SectionIcon({ iconPath, iconColor }: { iconPath: string; iconColor?: string }) {
+  return (
+    <svg aria-hidden="true" className={`h-3 w-3 flex-shrink-0 ${iconColor}`} viewBox="0 0 16 16" fill="currentColor">
+      <path d={iconPath} />
+    </svg>
+  );
+}
+
+/** Pinned-section icon — demo pushpin (sidebar-proposals.html line 205), stroke style, 24x24. */
+function PinSectionIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3 w-3 flex-shrink-0 text-cafe-accent"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+    </svg>
+  );
+}
+
+/** Menu-item pushpin — accent when pinned, muted otherwise. */
+function PinMenuIcon({ active }: { active?: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`h-3 w-3 flex-shrink-0 ${active ? 'text-cafe-accent' : 'text-cafe-muted'}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+    </svg>
+  );
+}
+
 /** Small icon button used for pin / quick-create / menu actions. */
 function ActionButton({
   onClick,
@@ -273,9 +311,8 @@ function ActionButton({
   children: React.ReactNode;
 }) {
   return (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       onClick={onClick}
       onKeyDown={(e) => {
         if ((e.key === 'Enter' || e.key === ' ') && !e.repeat) {
@@ -284,27 +321,38 @@ function ActionButton({
           onClick(e as unknown as React.MouseEvent);
         }
       }}
-      className={`ml-0.5 flex-shrink-0 cursor-pointer transition-all text-cafe-muted hover:text-cafe-secondary ${className ?? ''}`}
+      className={`ml-0.5 flex-shrink-0 transition-all text-cafe-muted hover:text-cafe-secondary ${className ?? ''}`}
       title={title}
       data-testid={testId}
     >
       <svg aria-hidden="true" className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
         {children}
       </svg>
-    </span>
+    </button>
   );
 }
 
 /** Menu item for the project context menu dropdown. */
-function MenuItem({ onClick, danger, children }: { onClick: () => void; danger?: boolean; children: React.ReactNode }) {
+function MenuItem({
+  onClick,
+  danger,
+  icon,
+  children,
+}: {
+  onClick: () => void;
+  danger?: boolean;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+      className={`flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-xs transition-colors ${
         danger ? 'text-conn-red-text hover:bg-conn-red-bg' : 'text-cafe-secondary hover:bg-cafe-surface-elevated'
       }`}
     >
+      {icon && <span className="flex flex-shrink-0 items-center">{icon}</span>}
       {children}
     </button>
   );

--- a/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
@@ -183,17 +183,30 @@ export function ThreadItem({
     void onToggleFavorite(id, !isFavorited);
   }, [id, isFavorited, onToggleFavorite]);
 
+  const togglePin = useCallback(() => {
+    if (!onTogglePin) return;
+    setIsMoreOpen(false);
+    void onTogglePin(id, !isPinned);
+  }, [id, isPinned, onTogglePin]);
+
+  const deleteThread = useCallback(() => {
+    if (!onDelete) return;
+    setIsMoreOpen(false);
+    onDelete(id);
+  }, [id, onDelete]);
+
   return (
     <div
       data-thread-id={id}
-      className={`group relative mx-2 rounded-xl ${indented ? 'pl-5 pr-3' : 'px-3'} py-2.5 transition-colors cursor-pointer ${
+      aria-current={isActive ? 'page' : undefined}
+      className={`group relative mx-2 rounded-xl ${indented ? 'pl-5 pr-3' : 'px-3'} py-2 transition-colors cursor-pointer ${
         isActive ? 'bg-[var(--console-active-bg)]' : 'hover:bg-[var(--console-hover-bg)]'
       }`}
       onClick={() => onSelect(id)}
       title={tooltip}
     >
       {/* Title row */}
-      <div className="flex items-start justify-between gap-1 mb-1">
+      <div className="mb-1 flex items-center justify-between gap-1">
         {isEditing ? (
           <input
             ref={inputRef}
@@ -221,43 +234,31 @@ export function ThreadItem({
             className="text-sm px-1.5 py-0.5 rounded border border-cafe-subtle focus:outline-none focus:border-cafe-accent w-full mr-2 disabled:opacity-70"
           />
         ) : (
-          <span
-            className={`text-sm leading-snug line-clamp-2 flex-1 min-w-0 ${isActive ? 'font-semibold text-cafe-black' : 'text-cafe-secondary'}`}
-          >
+          <span className="flex min-w-0 flex-1 items-center gap-1">
+            {isPinned && (
+              <span className="inline-flex flex-shrink-0 text-cafe-accent" role="img" aria-label="已置顶">
+                <PinIcon />
+              </span>
+            )}
+            {isFavorited && (
+              <span
+                className="inline-flex flex-shrink-0 text-conn-amber-text"
+                role="img"
+                aria-label="已收藏"
+                data-testid="thread-favorite-mark"
+              >
+                <StarIcon filled />
+              </span>
+            )}
             {isHubThread && <HubIcon className="w-3.5 h-3.5 inline-block mr-1 text-cafe-accent align-text-bottom" />}
-            {title ?? (id === 'default' ? '大厅' : '未命名对话')}
+            <span
+              className={`min-w-0 flex-1 truncate text-xs leading-5 ${isActive ? 'font-medium text-cafe-black' : 'text-cafe-secondary'}`}
+            >
+              {title ?? (id === 'default' ? '大厅' : '未命名对话')}
+            </span>
           </span>
         )}
         <div className="flex items-center gap-0.5 flex-shrink-0 mt-0.5">
-          {/* Fixed thread actions: pin, delete, more. */}
-          {canPin && !isEditing && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                void onTogglePin(id, !isPinned);
-              }}
-              className={`p-0.5 rounded transition-all ${
-                isPinned
-                  ? 'text-cafe-accent'
-                  : 'opacity-0 group-hover:opacity-100 text-cafe-muted hover:text-cafe-accent'
-              }`}
-              title={isPinned ? '取消置顶' : '置顶'}
-            >
-              <PinIcon />
-            </button>
-          )}
-          {canDelete && !isEditing && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(id);
-              }}
-              className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-cafe-muted hover:bg-conn-red-bg hover:text-conn-red-text transition-all"
-              title="删除对话"
-            >
-              <DeleteIcon />
-            </button>
-          )}
           {hasMoreActions && (
             <div className="relative">
               <button
@@ -285,6 +286,11 @@ export function ThreadItem({
                   className="absolute right-0 top-5 z-50 min-w-[144px] rounded-lg border border-cafe bg-cafe-surface py-1 shadow-lg"
                   onClick={(e) => e.stopPropagation()}
                 >
+                  {canPin && (
+                    <ThreadActionMenuItem icon={<PinIcon />} onClick={togglePin}>
+                      {isPinned ? '取消置顶' : '置顶'}
+                    </ThreadActionMenuItem>
+                  )}
                   {onUpdatePreferredCats && (
                     <ThreadCatSettings
                       threadId={id}
@@ -324,6 +330,14 @@ export function ThreadItem({
                     <ThreadActionMenuItem icon={<StarIcon filled={isFavorited} />} onClick={toggleFavorite}>
                       {isFavorited ? '取消收藏' : '收藏'}
                     </ThreadActionMenuItem>
+                  )}
+                  {canDelete && (
+                    <>
+                      <div className="my-1 h-px bg-cafe-subtle" />
+                      <ThreadActionMenuItem icon={<DeleteIcon />} onClick={deleteThread} danger>
+                        删除对话
+                      </ThreadActionMenuItem>
+                    </>
                   )}
                 </div>
               )}
@@ -388,16 +402,27 @@ export function ThreadItem({
 // ─── Small icon components ───
 
 function PinIcon() {
+  // demo sidebar-proposals.html line 205 — pushpin (stroke style, 24x24)
   return (
-    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
-      <path d="M4.456 2.013a.75.75 0 011.06-.034l6.5 6a.75.75 0 01-.034 1.06l-1.99 1.838.637 3.22a.75.75 0 01-1.196.693L6.5 12.526l-2.933 2.264a.75.75 0 01-1.196-.693l.637-3.22-1.99-1.838a.75.75 0 01-.034-1.06l5.472-5.966z" />
+    <svg
+      className="w-3 h-3"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
     </svg>
   );
 }
 
 function DeleteIcon() {
   return (
-    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path
         fillRule="evenodd"
         d="M5 3.25V4H2.75a.75.75 0 000 1.5h.3l.815 8.15A1.5 1.5 0 005.357 15h5.285a1.5 1.5 0 001.493-1.35l.815-8.15h.3a.75.75 0 000-1.5H11v-.75A2.25 2.25 0 008.75 1h-1.5A2.25 2.25 0 005 3.25zm2.25-.75a.75.75 0 00-.75.75V4h3v-.75a.75.75 0 00-.75-.75h-1.5z"
@@ -480,10 +505,12 @@ function StarIcon({ filled }: { filled?: boolean }) {
 function ThreadActionMenuItem({
   icon,
   onClick,
+  danger,
   children,
 }: {
   icon: ReactNode;
   onClick: () => void;
+  danger?: boolean;
   children: ReactNode;
 }) {
   return (
@@ -491,7 +518,9 @@ function ThreadActionMenuItem({
       type="button"
       role="menuitem"
       onClick={onClick}
-      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-cafe-secondary transition-colors hover:bg-cafe-surface-elevated"
+      className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
+        danger ? 'text-conn-red-text hover:bg-conn-red-bg' : 'text-cafe-secondary hover:bg-cafe-surface-elevated'
+      }`}
     >
       <span className="inline-flex h-3 w-3 flex-shrink-0 items-center justify-center text-cafe-muted">{icon}</span>
       <span>{children}</span>
@@ -506,19 +535,21 @@ function LabelDots({ labels }: { labels?: string[] }) {
     .map((id) => allLabels.find((l) => l.id === id))
     .filter((l): l is NonNullable<typeof l> => l !== undefined);
   if (resolved.length === 0) return null;
-  const shown = resolved.slice(0, 2);
+  const shown = resolved.slice(0, 3);
   const overflow = resolved.length - shown.length;
   return (
-    <div className="flex items-center gap-0.5 ml-1" title={resolved.map((l) => l.name).join(', ')}>
+    <div
+      className="ml-1 inline-flex h-4 items-center gap-1 rounded-full bg-[var(--console-card-soft-bg)] px-1.5 text-cafe-muted"
+      title={resolved.map((l) => l.name).join(', ')}
+      data-testid="thread-label-dots"
+    >
+      <LabelIcon />
       {shown.map((l) => (
         <span
           key={l.id}
-          className="inline-flex items-center gap-0.5 rounded-full px-1 py-px text-micro leading-tight text-cafe-secondary"
-          style={{ backgroundColor: `${l.color}18` }}
-        >
-          <span className="inline-block w-1 h-1 rounded-full flex-shrink-0" style={{ backgroundColor: l.color }} />
-          <span className="max-w-[32px] truncate">{l.name}</span>
-        </span>
+          className="inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: l.color }}
+        />
       ))}
       {overflow > 0 && <span className="text-micro text-cafe-muted">+{overflow}</span>}
     </div>

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -19,10 +19,12 @@ import { ThreadItem } from './ThreadItem';
 import { ThreadOrganizerModal } from './ThreadOrganizerModal';
 import { pushThreadRouteWithHistory } from './thread-navigation';
 import {
+  buildSidebarTabContent,
+  buildSidebarTabs,
   getProjectPaths,
   mergeLiveActivityIntoThreads,
   projectDisplayName,
-  sortAndGroupThreadsWithWorkspace,
+  type SidebarTabId,
 } from './thread-utils';
 import { createToggleWithReconcile } from './toggle-with-reconcile';
 import { useCollapseState } from './use-collapse-state';
@@ -71,9 +73,16 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
   const [govHealth, setGovHealth] = useState<Record<string, string>>({});
   // F252 Phase E: Meow Theater replay state
   const [replayThreadId, setReplayThreadId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<SidebarTabId>('recent');
 
   // F095 Phase E: scroll anchor for reorder stability
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<Record<SidebarTabId, HTMLButtonElement | null>>({
+    recent: null,
+    project: null,
+    system: null,
+    favorites: null,
+  });
   // F095 Phase F: custom project display names
   const [projectNames, setProjectNames] = useState(() =>
     readProjectNames(typeof localStorage !== 'undefined' ? localStorage : { getItem: () => null, setItem: () => {} }),
@@ -156,6 +165,12 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     window.addEventListener('online', handleOnline);
     return () => window.removeEventListener('online', handleOnline);
   }, [loadThreads]);
+
+  useEffect(() => {
+    const activeButton = tabRefs.current[activeTab];
+    if (!activeButton || typeof activeButton.scrollIntoView !== 'function') return;
+    activeButton.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [activeTab]);
 
   // F070: Fetch governance health for all registered external projects
   useEffect(() => {
@@ -707,25 +722,75 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     }
   }, []);
 
-  // F095 Phase B: Active workspace grouping
+  // V9 sidebar tabs: keep grouping derived from filtered thread data.
   const { pinnedProjects, toggleProjectPin } = useProjectPins();
-  const threadGroups = useMemo(
-    () => sortAndGroupThreadsWithWorkspace(labelFilteredThreads, unreadIds, pinnedProjects),
-    [labelFilteredThreads, unreadIds, pinnedProjects],
+  const tabs = useMemo(
+    () => buildSidebarTabs(labelFilteredThreads, pinnedProjects),
+    [labelFilteredThreads, pinnedProjects],
   );
+  const activeTabContent = useMemo(
+    () => buildSidebarTabContent(activeTab, labelFilteredThreads, pinnedProjects),
+    [activeTab, labelFilteredThreads, pinnedProjects],
+  );
+  const projectThreadGroups = useMemo(
+    () => buildSidebarTabContent('project', labelFilteredThreads, pinnedProjects).projectGroups ?? [],
+    [labelFilteredThreads, pinnedProjects],
+  );
+  const threadGroups = activeTabContent.kind === 'project' ? (activeTabContent.projectGroups ?? []) : [];
   const existingProjects = useMemo(() => getProjectPaths(liveThreads), [liveThreads]);
   const showDefaultThread = (normalizedQuery.length === 0 || '大厅'.includes(normalizedQuery)) && !labelFilter;
 
   // F095 Phase E: Scroll anchor — keeps visible content in place when threads reorder
-  const { onScroll: handleScrollAnchor } = useScrollAnchor(scrollContainerRef, threadGroups);
+  const { onScroll: handleScrollAnchor } = useScrollAnchor(scrollContainerRef, projectThreadGroups);
 
   // F095: Collapse state with localStorage persistence + search/active auto-expand
   const { isCollapsed, toggleGroup, expandAll, collapseAll } = useCollapseState({
-    threadGroups,
+    threadGroups: projectThreadGroups,
     searchQuery: normalizedQuery,
     currentThreadId,
   });
   const sidebarWidthClass = className === undefined ? 'w-60' : className;
+
+  const renderThreadItem = useCallback(
+    (thread: Thread, indented = false) => (
+      <ThreadItem
+        key={thread.id}
+        id={thread.id}
+        title={thread.title}
+        participants={thread.participants}
+        lastActiveAt={thread.lastActiveAt}
+        isActive={currentThreadId === thread.id}
+        onSelect={handleSelect}
+        onDelete={handleDeleteRequest}
+        onRename={handleRename}
+        onTogglePin={handleTogglePin}
+        onToggleFavorite={handleToggleFavorite}
+        onUpdatePreferredCats={handleUpdatePreferredCats}
+        onUpdateLabels={handleUpdateLabels}
+        onReplay={handleReplay}
+        isPinned={thread.pinned}
+        isFavorited={thread.favorited}
+        threadState={getThreadState(thread.id)}
+        projectPath={thread.projectPath}
+        indented={indented}
+        preferredCats={thread.preferredCats}
+        threadLabels={thread.labels}
+        isHubThread={!!thread.connectorHubState}
+      />
+    ),
+    [
+      currentThreadId,
+      getThreadState,
+      handleDeleteRequest,
+      handleRename,
+      handleReplay,
+      handleSelect,
+      handleToggleFavorite,
+      handleTogglePin,
+      handleUpdateLabels,
+      handleUpdatePreferredCats,
+    ],
+  );
 
   return (
     <>
@@ -792,7 +857,11 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
           onManualOrganize={() => setShowOrganizer(true)}
         />
 
-        <div ref={scrollContainerRef} onScroll={handleScrollAnchor} className="flex-1 overflow-y-auto">
+        <div
+          ref={scrollContainerRef}
+          onScroll={handleScrollAnchor}
+          className="flex-1 overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:transparent_var(--console-panel-bg)] hover:[scrollbar-color:var(--cafe-muted)_var(--console-panel-bg)] [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-[var(--console-panel-bg)] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent hover:[&::-webkit-scrollbar-thumb]:bg-cafe-muted [&::-webkit-scrollbar-corner]:bg-[var(--console-panel-bg)]"
+        >
           {isLoadingThreads && threads.length === 0 && (
             <div className="text-center py-4 text-xs text-cafe-muted">加载中...</div>
           )}
@@ -809,182 +878,131 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
             />
           )}
 
-          {threadGroups.length > 0 && (
-            <div className="flex items-center justify-end px-3 pt-1.5">
-              <button
-                type="button"
-                onClick={expandAll}
-                className="text-micro text-cafe-muted hover:text-cafe-accent transition-colors"
-                data-testid="expand-all-btn"
+          {tabs.length > 0 && (
+            <div
+              className="sticky top-0 z-10 flex items-stretch gap-1 border-b border-cafe-subtle bg-[var(--console-panel-bg)] pt-2 pl-3 pr-2"
+              data-testid="sidebar-tabs-row"
+            >
+              <div
+                className="flex min-w-0 flex-1 gap-0.5 overflow-x-auto overflow-y-hidden px-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)]"
+                role="tablist"
+                aria-label="对话分类"
+                data-testid="sidebar-tabs-scroll"
               >
-                全部展开
-              </button>
-              <span className="text-micro text-cafe-muted mx-1">/</span>
-              <button
-                type="button"
-                onClick={collapseAll}
-                className="text-micro text-cafe-muted hover:text-cafe-accent transition-colors"
-                data-testid="collapse-all-btn"
-              >
-                全部折叠
-              </button>
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    ref={(node) => {
+                      tabRefs.current[tab.id] = node;
+                    }}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`flex flex-shrink-0 items-center gap-1 rounded-t-md border-b-2 px-2 py-1.5 text-micro font-medium transition-colors ${
+                      activeTab === tab.id
+                        ? 'border-cafe-accent text-cafe-accent'
+                        : 'border-transparent text-cafe-muted hover:bg-[var(--console-hover-bg)] hover:text-cafe-secondary'
+                    }`}
+                    data-testid={`sidebar-tab-${tab.id}`}
+                  >
+                    <span>{tab.label}</span>
+                    <span className={activeTab === tab.id ? 'text-cafe-accent' : 'text-cafe-muted'}>{tab.count}</span>
+                  </button>
+                ))}
+              </div>
             </div>
           )}
 
-          {threadGroups.map((group) => {
-            const groupKey = group.projectPath ?? group.type;
-            const icon =
-              group.type === 'pinned'
-                ? ('pin' as const)
-                : group.type === 'favorites'
-                  ? ('star' as const)
-                  : group.type === 'recent'
-                    ? ('clock' as const)
-                    : group.type === 'system'
-                      ? ('system' as const)
-                      : undefined;
+          <div className="pt-1.5" data-testid="sidebar-tab-content">
+            {activeTabContent.kind === 'flat' && activeTabContent.threads.map((t) => renderThreadItem(t))}
 
-            // Archived container: render nested project groups
-            if (group.type === 'archived-container') {
-              return (
-                <SectionGroup
-                  key="archived-container"
-                  label={group.label}
-                  icon="archive"
-                  count={group.archivedGroups?.length ?? 0}
-                  isCollapsed={isCollapsed('archived-container')}
-                  onToggle={() => toggleGroup('archived-container')}
+            {activeTabContent.kind === 'project' &&
+              threadGroups.length > 0 && (
+                <div
+                  className="flex items-center justify-between px-3 py-1 text-micro text-cafe-muted"
+                  data-testid="project-toolbar"
                 >
-                  {group.archivedGroups?.map((sub) => {
-                    const subKey = sub.projectPath ?? sub.type;
-                    return (
-                      <SectionGroup
-                        key={subKey}
-                        label={sub.projectPath ? (projectNames.get(sub.projectPath) ?? sub.label) : sub.label}
-                        count={sub.threads.length}
-                        isCollapsed={isCollapsed(subKey)}
-                        onToggle={() => toggleGroup(subKey)}
-                        projectPath={sub.projectPath}
-                        governanceStatus={sub.projectPath ? govHealth[sub.projectPath] : undefined}
-                        onToggleProjectPin={sub.projectPath ? () => toggleProjectPin(sub.projectPath!) : undefined}
-                        isProjectPinned={sub.projectPath ? pinnedProjects.has(sub.projectPath) : undefined}
-                        onQuickCreate={sub.projectPath ? () => handleQuickCreate(sub.projectPath!) : undefined}
-                        onOpenInFinder={
-                          sub.projectPath && sub.projectPath !== 'default'
-                            ? () => handleOpenInFinder(sub.projectPath!)
-                            : undefined
-                        }
-                        onRenameProject={
-                          sub.projectPath ? (name: string) => handleRenameProject(sub.projectPath!, name) : undefined
-                        }
-                        onArchiveThreads={sub.projectPath ? () => handleArchiveThreads(sub.projectPath!) : undefined}
+                  <span>{threadGroups.length} 个项目</span>
+                  <div className="flex items-center gap-0.5">
+                    <button
+                      type="button"
+                      onClick={expandAll}
+                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                      data-testid="expand-all-btn"
+                      aria-label="展开全部项目"
+                      title="展开全部"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
                       >
-                        {sub.threads.map((t) => (
-                          <ThreadItem
-                            key={t.id}
-                            id={t.id}
-                            title={t.title}
-                            participants={t.participants}
-                            lastActiveAt={t.lastActiveAt}
-                            isActive={currentThreadId === t.id}
-                            onSelect={handleSelect}
-                            onDelete={handleDeleteRequest}
-                            onRename={handleRename}
-                            onTogglePin={handleTogglePin}
-                            onToggleFavorite={handleToggleFavorite}
-                            onUpdatePreferredCats={handleUpdatePreferredCats}
-                            onUpdateLabels={handleUpdateLabels}
-                            onReplay={handleReplay}
-                            isPinned={t.pinned}
-                            isFavorited={t.favorited}
-                            threadState={getThreadState(t.id)}
-                            projectPath={t.projectPath}
-                            indented
-                            preferredCats={t.preferredCats}
-                            threadLabels={t.labels}
-                            isHubThread={!!t.connectorHubState}
-                          />
-                        ))}
-                      </SectionGroup>
-                    );
-                  })}
-                </SectionGroup>
-              );
-            }
+                        <path d="M6 9l6 6 6-6" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={collapseAll}
+                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                      data-testid="collapse-all-btn"
+                      aria-label="折叠全部项目"
+                      title="折叠全部"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M18 15l-6-6-6 6" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
 
-            return (
-              <SectionGroup
-                key={groupKey}
-                label={group.projectPath ? (projectNames.get(group.projectPath) ?? group.label) : group.label}
-                icon={icon}
-                count={group.threads.length}
-                isCollapsed={isCollapsed(groupKey)}
-                onToggle={() => toggleGroup(groupKey)}
-                projectPath={group.projectPath}
-                governanceStatus={group.projectPath ? govHealth[group.projectPath] : undefined}
-                onToggleProjectPin={
-                  group.type === 'project' && group.projectPath ? () => toggleProjectPin(group.projectPath!) : undefined
-                }
-                isProjectPinned={
-                  group.type === 'project' && group.projectPath ? pinnedProjects.has(group.projectPath) : undefined
-                }
-                onQuickCreate={
-                  group.type === 'project' && group.projectPath
-                    ? () => handleQuickCreate(group.projectPath!)
-                    : undefined
-                }
-                // Note: system/pinned/recent/favorites groups get undefined for all project actions
-                // because group.type !== 'project'. This is intentional — only project sections
-                // should have Open in Finder / Rename / Archive / Quick Create.
-                onOpenInFinder={
-                  group.type === 'project' && group.projectPath && group.projectPath !== 'default'
-                    ? () => handleOpenInFinder(group.projectPath!)
-                    : undefined
-                }
-                onRenameProject={
-                  group.type === 'project' && group.projectPath
-                    ? (name: string) => handleRenameProject(group.projectPath!, name)
-                    : undefined
-                }
-                onArchiveThreads={
-                  group.type === 'project' && group.projectPath
-                    ? () => handleArchiveThreads(group.projectPath!)
-                    : undefined
-                }
-              >
-                {group.threads.map((t) => (
-                  <ThreadItem
-                    key={t.id}
-                    id={t.id}
-                    title={t.title}
-                    participants={t.participants}
-                    lastActiveAt={t.lastActiveAt}
-                    isActive={currentThreadId === t.id}
-                    onSelect={handleSelect}
-                    onDelete={handleDeleteRequest}
-                    onRename={handleRename}
-                    onTogglePin={handleTogglePin}
-                    onToggleFavorite={handleToggleFavorite}
-                    onUpdatePreferredCats={handleUpdatePreferredCats}
-                    onUpdateLabels={handleUpdateLabels}
-                    onReplay={handleReplay}
-                    isPinned={t.pinned}
-                    isFavorited={t.favorited}
-                    threadState={getThreadState(t.id)}
-                    projectPath={t.projectPath}
-                    indented={group.type === 'project'}
-                    preferredCats={t.preferredCats}
-                    threadLabels={t.labels}
-                    isHubThread={!!t.connectorHubState}
-                  />
-                ))}
-              </SectionGroup>
-            );
-          })}
+            {activeTabContent.kind === 'project' &&
+              threadGroups.map((group) => {
+                const groupKey = group.projectPath ?? group.type;
+                const projectPath = group.projectPath;
 
-          {normalizedQuery.length > 0 && threadGroups.length === 0 && !showDefaultThread && (
-            <div className="px-3 py-4 text-xs text-cafe-muted">没有匹配的对话</div>
-          )}
+                return (
+                  <SectionGroup
+                    key={groupKey}
+                    label={projectPath ? (projectNames.get(projectPath) ?? group.label) : group.label}
+                    count={group.threads.length}
+                    isCollapsed={isCollapsed(groupKey)}
+                    onToggle={() => toggleGroup(groupKey)}
+                    projectPath={projectPath}
+                    governanceStatus={projectPath ? govHealth[projectPath] : undefined}
+                    onToggleProjectPin={projectPath ? () => toggleProjectPin(projectPath) : undefined}
+                    isProjectPinned={projectPath ? pinnedProjects.has(projectPath) : undefined}
+                    onQuickCreate={projectPath ? () => handleQuickCreate(projectPath) : undefined}
+                    onOpenInFinder={
+                      projectPath && projectPath !== 'default' ? () => handleOpenInFinder(projectPath) : undefined
+                    }
+                    onRenameProject={projectPath ? (name: string) => handleRenameProject(projectPath, name) : undefined}
+                    onArchiveThreads={projectPath ? () => handleArchiveThreads(projectPath) : undefined}
+                  >
+                    {group.threads.map((t) => renderThreadItem(t, true))}
+                  </SectionGroup>
+                );
+              })}
+
+            {normalizedQuery.length > 0 && activeTabContent.threads.length === 0 && !showDefaultThread && (
+              <div className="px-3 py-4 text-xs text-cafe-muted">没有匹配的对话</div>
+            )}
+          </div>
         </div>
 
         {/* F095 Phase D: Trash bin section */}

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-delete-confirm.test.ts
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-delete-confirm.test.ts
@@ -124,7 +124,17 @@ describe('Thread delete confirmation (I-1)', () => {
   }
 
   function findDeleteButton(): HTMLButtonElement | undefined {
-    return Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('title') === '删除对话');
+    return Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.trim() === '删除对话');
+  }
+
+  function openActionsMenu() {
+    const moreBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.getAttribute('title') === '更多操作',
+    );
+    expect(moreBtn, 'more actions button should exist for non-default thread').toBeTruthy();
+    act(() => {
+      moreBtn?.click();
+    });
   }
 
   /** F095 defaults all sections collapsed. Click expand-all first. */
@@ -142,9 +152,10 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
-    expect(deleteBtn, 'delete button should exist for non-default thread').toBeTruthy();
+    expect(deleteBtn, 'delete menu item should exist for non-default thread').toBeTruthy();
 
     act(() => {
       deleteBtn?.click();
@@ -168,6 +179,7 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
     act(() => {
@@ -191,6 +203,7 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
     act(() => {

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-scroll-memory.test.ts
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-scroll-memory.test.ts
@@ -82,7 +82,9 @@ function jsonOk(data: unknown) {
 
 function findScrollContainer(root: HTMLElement): HTMLDivElement {
   const scroller = Array.from(root.querySelectorAll('div')).find(
-    (el): el is HTMLDivElement => el.className.includes('overflow-y-auto') && !!el.querySelector('[data-thread-id]'),
+    (el): el is HTMLDivElement =>
+      (el.className.includes('overflow-y-auto') || el.className.includes('overflow-y:overlay')) &&
+      !!el.querySelector('[data-thread-id]'),
   );
   if (!scroller) throw new Error('scroll container not found');
   return scroller;
@@ -158,8 +160,24 @@ describe('ThreadSidebar scroll memory', () => {
   }
 
   function expandAll(rootEl: HTMLElement) {
+    // v12: variable toggle button only renders on the project tab. Switch there first.
+    const projectTab = rootEl.querySelector('[data-testid="sidebar-tab-project"]') as HTMLButtonElement | null;
+    if (projectTab) {
+      act(() => {
+        projectTab.click();
+      });
+    }
+    // Variable button: allCollapsed → "expand-all-btn", else → "collapse-all-btn".
+    // To guarantee all-expanded end state regardless of initial state: first collapse all
+    // (so we reach a known allCollapsed=true), then click expand-all.
+    const collapseBtn = rootEl.querySelector('[data-testid="collapse-all-btn"]') as HTMLButtonElement | null;
+    if (collapseBtn) {
+      act(() => {
+        collapseBtn.click();
+      });
+    }
     const expandBtn = rootEl.querySelector('[data-testid="expand-all-btn"]') as HTMLButtonElement | null;
-    if (!expandBtn) throw new Error('expand-all button not found');
+    if (!expandBtn) throw new Error('expand-all button not found after collapse');
     act(() => {
       expandBtn.click();
     });

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
@@ -1,0 +1,146 @@
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Thread } from '@/stores/chat-types';
+import {
+  createThreadSidebarHarness,
+  installThreadSidebarGlobals,
+  mockStore,
+  resetThreadSidebarGlobals,
+  resetThreadSidebarMocks,
+  type ThreadSidebarHarness,
+} from './thread-sidebar-test-helpers';
+
+const NOW = 1710000000000;
+
+function makeThread(overrides: Partial<Thread> & { id: string }): Thread {
+  return {
+    projectPath: 'default',
+    title: null,
+    createdBy: 'user',
+    participants: [],
+    lastActiveAt: NOW,
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
+function visibleThreadIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-thread-id]')).map(
+    (node) => node.getAttribute('data-thread-id') ?? '',
+  );
+}
+
+async function clickTab(container: HTMLElement, tabId: string, flush: () => Promise<void>) {
+  const tab = container.querySelector(`[data-testid="sidebar-tab-${tabId}"]`) as HTMLButtonElement;
+  await act(async () => {
+    tab.click();
+  });
+  await flush();
+}
+
+describe('ThreadSidebar v9 tab redesign', () => {
+  let harness: ThreadSidebarHarness;
+  let scrollIntoView: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    installThreadSidebarGlobals();
+    resetThreadSidebarMocks();
+    scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+    });
+    Object.assign(mockStore, {
+      threads: [
+        makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+        makeThread({ id: 'recent', title: 'Recent Thread', projectPath: '/proj/b', lastActiveAt: NOW - 1_000 }),
+        makeThread({ id: 'project', title: 'Project Thread', projectPath: '/proj/a', lastActiveAt: NOW - 2_000 }),
+        makeThread({
+          id: 'favorite',
+          title: 'Favorite Thread',
+          favorited: true,
+          projectPath: '/proj/a',
+          lastActiveAt: NOW - 3_000,
+        }),
+        makeThread({ id: 'system', title: 'System Thread', systemKind: 'eval_domain', lastActiveAt: NOW - 4_000 }),
+      ],
+      currentThreadId: 'recent',
+      threadStates: {},
+      isLoadingThreads: false,
+    });
+    harness = createThreadSidebarHarness();
+  });
+
+  afterEach(() => {
+    harness.cleanup();
+    resetThreadSidebarGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps lobby above the tab row and renders tabs in the v9 order', async () => {
+    await harness.render();
+
+    const lobby = harness.container.querySelector('[data-thread-id="default"]');
+    const tabsRow = harness.container.querySelector('[data-testid="sidebar-tabs-row"]');
+    expect(lobby).not.toBeNull();
+    expect(tabsRow).not.toBeNull();
+    const position = lobby!.compareDocumentPosition(tabsRow!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const tabs = Array.from(harness.container.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim());
+    expect(tabs).toEqual(['最近3', '项目3', '系统1', '收藏1']);
+  });
+
+  it('switches isolated tab content without mixing system/project/favorite views', async () => {
+    await harness.render();
+
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'recent', 'project', 'favorite']);
+
+    await clickTab(harness.container, 'system', harness.flush);
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'system']);
+
+    await clickTab(harness.container, 'favorites', harness.flush);
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'favorite']);
+  });
+
+  it('shows separate expand/collapse buttons in a project toolbar below the tabs', async () => {
+    await harness.render();
+
+    // Default (recent) tab is flat — no project toolbar.
+    expect(harness.container.querySelector('[data-testid="project-toolbar"]')).toBeNull();
+
+    // Project tab — toolbar appears inside the tab content, below the tabs row.
+    await clickTab(harness.container, 'project', harness.flush);
+    const tabsRow = harness.container.querySelector('[data-testid="sidebar-tabs-row"]');
+    expect(tabsRow).not.toBeNull();
+
+    const toolbar = harness.container.querySelector('[data-testid="project-toolbar"]');
+    expect(toolbar).not.toBeNull();
+
+    // Two separate buttons (not a single toggle): expand-all + collapse-all, both present.
+    const expand = harness.container.querySelector('[data-testid="expand-all-btn"]');
+    const collapse = harness.container.querySelector('[data-testid="collapse-all-btn"]');
+    expect(expand).not.toBeNull();
+    expect(collapse).not.toBeNull();
+    // Both buttons live inside the toolbar (not the tabs row).
+    expect(toolbar?.contains(expand)).toBe(true);
+    expect(toolbar?.contains(collapse)).toBe(true);
+    expect(tabsRow?.contains(expand)).toBe(false);
+    // Icon-only (no text label).
+    expect((expand as HTMLButtonElement)?.textContent?.trim()).toBe('');
+    expect((collapse as HTMLButtonElement)?.textContent?.trim()).toBe('');
+    expect((expand as HTMLButtonElement)?.getAttribute('aria-label')).toBe('展开全部项目');
+    expect((collapse as HTMLButtonElement)?.getAttribute('aria-label')).toBe('折叠全部项目');
+
+    const tabContent = harness.container.querySelector('[data-testid="sidebar-tab-content"]');
+    expect(tabContent?.className).toContain('pt-1.5');
+  });
+
+  it('scrolls the active tab into view after selection', async () => {
+    await harness.render();
+
+    await clickTab(harness.container, 'favorites', harness.flush);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+  });
+});

--- a/packages/web/src/components/ThreadSidebar/thread-utils.ts
+++ b/packages/web/src/components/ThreadSidebar/thread-utils.ts
@@ -50,6 +50,20 @@ export interface ThreadGroup {
   archivedGroups?: ThreadGroup[];
 }
 
+export type SidebarTabId = 'recent' | 'project' | 'system' | 'favorites';
+
+export interface SidebarTab {
+  id: SidebarTabId;
+  label: string;
+  count: number;
+}
+
+export interface SidebarThreadBucket {
+  kind: 'flat' | 'project';
+  threads: Thread[];
+  projectGroups?: ThreadGroup[];
+}
+
 type ThreadActivitySource = Pick<ThreadState, 'lastActivity'> | undefined;
 
 /**
@@ -77,6 +91,105 @@ function sortByUnreadThenActive(a: Thread, b: Thread, unreadIds?: Set<string>): 
     if (aUnread !== bUnread) return bUnread - aUnread;
   }
   return b.lastActiveAt - a.lastActiveAt;
+}
+
+function isSystemThread(thread: Thread): boolean {
+  return !!thread.systemKind || !!thread.connectorHubState;
+}
+
+function titleForSort(thread: Thread): string {
+  return thread.title ?? (thread.id === 'default' ? '大厅' : '未命名对话');
+}
+
+function sortPinnedThenActive(a: Thread, b: Thread): number {
+  const aPinned = a.pinned ? 1 : 0;
+  const bPinned = b.pinned ? 1 : 0;
+  if (aPinned !== bPinned) return bPinned - aPinned;
+  return b.lastActiveAt - a.lastActiveAt;
+}
+
+function sortPinnedThenTitle(a: Thread, b: Thread): number {
+  const aPinned = a.pinned ? 1 : 0;
+  const bPinned = b.pinned ? 1 : 0;
+  if (aPinned !== bPinned) return bPinned - aPinned;
+  return titleForSort(a).localeCompare(titleForSort(b), 'zh-Hans-CN');
+}
+
+function nonDefaultThreads(threads: Thread[]): Thread[] {
+  return threads.filter((thread) => thread.id !== 'default');
+}
+
+function tabRecentThreads(threads: Thread[]): Thread[] {
+  // Demo spec (sidebar-proposals.html line 200/848): 对话置顶 = 最近 Tab + 当前 Tab 双重置顶.
+  // A pinned system thread must still appear in the recent tab (additive, not exclusive).
+  // Unpinned system threads stay only in the system tab.
+  return nonDefaultThreads(threads)
+    .filter((thread) => thread.pinned || !isSystemThread(thread))
+    .sort(sortPinnedThenActive);
+}
+
+function tabSystemThreads(threads: Thread[]): Thread[] {
+  return nonDefaultThreads(threads).filter(isSystemThread).sort(sortPinnedThenTitle);
+}
+
+function tabFavoriteThreads(threads: Thread[]): Thread[] {
+  return nonDefaultThreads(threads)
+    .filter((thread) => thread.favorited)
+    .sort(sortPinnedThenTitle);
+}
+
+function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): ThreadGroup[] {
+  const grouped = new Map<string, Thread[]>();
+  for (const thread of nonDefaultThreads(threads)) {
+    if (isSystemThread(thread)) continue;
+    const projectPath = thread.projectPath ?? 'default';
+    if (!grouped.has(projectPath)) grouped.set(projectPath, []);
+    grouped.get(projectPath)?.push(thread);
+  }
+
+  return [...grouped.entries()]
+    .map(([projectPath, projectThreads]) => ({
+      type: 'project' as const,
+      label: projectDisplayName(projectPath),
+      projectPath,
+      threads: projectThreads.sort(sortPinnedThenTitle),
+    }))
+    .sort((a, b) => {
+      const aPinned = pinnedProjects.has(a.projectPath ?? '') ? 1 : 0;
+      const bPinned = pinnedProjects.has(b.projectPath ?? '') ? 1 : 0;
+      if (aPinned !== bPinned) return bPinned - aPinned;
+      if (a.projectPath === 'default') return 1;
+      if (b.projectPath === 'default') return -1;
+      return (a.projectPath ?? a.label).localeCompare(b.projectPath ?? b.label, 'zh-Hans-CN');
+    });
+}
+
+export function buildSidebarTabs(threads: Thread[], pinnedProjects: Set<string> = new Set()): SidebarTab[] {
+  const projectCount = tabProjectGroups(threads, pinnedProjects).reduce((sum, group) => sum + group.threads.length, 0);
+  return [
+    { id: 'recent', label: '最近', count: tabRecentThreads(threads).length },
+    { id: 'project', label: '项目', count: projectCount },
+    { id: 'system', label: '系统', count: tabSystemThreads(threads).length },
+    { id: 'favorites', label: '收藏', count: tabFavoriteThreads(threads).length },
+  ];
+}
+
+export function buildSidebarTabContent(
+  tabId: SidebarTabId,
+  threads: Thread[],
+  pinnedProjects: Set<string> = new Set(),
+): SidebarThreadBucket {
+  if (tabId === 'project') {
+    const projectGroups = tabProjectGroups(threads, pinnedProjects);
+    return { kind: 'project', threads: projectGroups.flatMap((group) => group.threads), projectGroups };
+  }
+  if (tabId === 'system') {
+    return { kind: 'flat', threads: tabSystemThreads(threads) };
+  }
+  if (tabId === 'favorites') {
+    return { kind: 'flat', threads: tabFavoriteThreads(threads) };
+  }
+  return { kind: 'flat', threads: tabRecentThreads(threads) };
 }
 
 /**

--- a/packages/web/src/components/__tests__/f190-visual-contract.test.ts
+++ b/packages/web/src/components/__tests__/f190-visual-contract.test.ts
@@ -506,7 +506,7 @@ describe('F190 typography guard — no hardcoded font sizes in console scope', (
   it('src-wide guard: no raw pixel font definitions outside typography tokens', () => {
     const srcRoot = resolve(testDir, '..', '..');
     /* F056: dev/ tools (OklchTuner) intentionally use dense px sizes */
-    const DEV_EXCLUDE = /\/dev\//;
+    const DEV_EXCLUDE = /[\\/]dev[\\/]/;
     const violations = collectSourceFiles(srcRoot)
       .filter((file) => !DEV_EXCLUDE.test(file))
       .flatMap((file) => {

--- a/packages/web/src/components/__tests__/section-group.test.tsx
+++ b/packages/web/src/components/__tests__/section-group.test.tsx
@@ -12,96 +12,83 @@ function renderToContainer(element: React.ReactElement) {
   return { container, root };
 }
 
-describe('SectionGroup pin button', () => {
-  // P2: pin button must respond to Space key (ARIA role="button" requirement)
-  it('fires onToggleProjectPin on Space key press', () => {
+// v12: pin moved back into the "..." context menu (per co-creator feedback).
+// Tests open the menu then click the pin MenuItem (matched by label text).
+
+/** Open the project context menu by clicking the "更多操作" trigger. */
+function openMenu(container: HTMLElement): void {
+  const menuBtn = container.querySelector<HTMLButtonElement>('[data-testid="project-menu-btn"]');
+  if (!menuBtn) throw new Error('project-menu-btn not found');
+  act(() => {
+    menuBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+/** Find a MenuItem button by its text content. Throws if absent. */
+function findMenuItemByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  const match = buttons.find((b) => b.textContent?.trim() === text);
+  if (!match) throw new Error(`MenuItem with text "${text}" not found`);
+  return match;
+}
+
+function renderPinGroup(overrides: { onToggle?: () => void; onPin?: () => void; isProjectPinned?: boolean } = {}) {
+  const onPin = overrides.onPin ?? vi.fn();
+  const { container } = renderToContainer(
+    <SectionGroup
+      label="test-project"
+      count={3}
+      isCollapsed={false}
+      onToggle={overrides.onToggle ?? (() => {})}
+      onToggleProjectPin={onPin}
+      isProjectPinned={overrides.isProjectPinned ?? false}
+    >
+      <div>child</div>
+    </SectionGroup>,
+  );
+  return { container, onPin };
+}
+
+describe('SectionGroup pin (in context menu)', () => {
+  it('fires onToggleProjectPin when pin menu item clicked', () => {
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
+    const { container } = renderPinGroup({ onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
     act(() => {
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      pinItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onPin).toHaveBeenCalledTimes(1);
   });
 
-  it('fires onToggleProjectPin on Enter key press', () => {
-    const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
-    act(() => {
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-    });
-    expect(onPin).toHaveBeenCalledTimes(1);
-  });
-
-  it('pin button click does not trigger parent onToggle', () => {
+  it('pin menu item click does not trigger parent onToggle', () => {
     const onToggle = vi.fn();
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={onToggle}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
+    const { container } = renderPinGroup({ onToggle, onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
     act(() => {
-      pinBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      pinItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onPin).toHaveBeenCalledTimes(1);
     expect(onToggle).not.toHaveBeenCalled();
   });
 
-  // Cloud P2: auto-repeat keydown should not re-trigger pin toggle
-  it('ignores repeated Space keydown events (key held down)', () => {
+  it('shows "取消固定项目" label when pinned, "固定项目到活跃区" when unpinned', () => {
+    const { container: unpinned } = renderPinGroup({ isProjectPinned: false });
+    openMenu(unpinned);
+    expect(() => findMenuItemByText(unpinned, '固定项目到活跃区')).not.toThrow();
+
+    const { container: pinned } = renderPinGroup({ isProjectPinned: true });
+    openMenu(pinned);
+    expect(() => findMenuItemByText(pinned, '取消固定项目')).not.toThrow();
+  });
+
+  it('pin menu item is a native button (keyboard-accessible by default)', () => {
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
-    act(() => {
-      // First press — should fire
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: false }));
-      // Auto-repeat events — should be ignored
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: true }));
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: true }));
-    });
-    expect(onPin).toHaveBeenCalledTimes(1);
+    const { container } = renderPinGroup({ onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
+    expect(pinItem.tagName).toBe('BUTTON');
   });
 });

--- a/packages/web/src/components/__tests__/thread-item-actions.test.tsx
+++ b/packages/web/src/components/__tests__/thread-item-actions.test.tsx
@@ -6,7 +6,7 @@ import { ThreadItem } from '@/components/ThreadSidebar/ThreadItem';
 vi.mock('@/hooks/useCatData', () => ({
   useCatData: () => ({
     cats: [],
-    getCatById: () => undefined,
+    getCatById: (catId: string) => ({ displayName: catId === 'cat-a' ? '猫甲' : catId }),
     getCatsByBreed: () => new Map(),
   }),
 }));
@@ -67,6 +67,17 @@ vi.mock('@/components/ThreadSidebar/thread-utils', () => ({
   formatRelativeTime: () => '1分',
 }));
 
+vi.mock('@/stores/label-store', () => ({
+  useLabelStore: () => ({
+    labels: [
+      { id: 'product', name: '产品体验', color: '#3b82f6' },
+      { id: 'architecture', name: '架构规划', color: '#8b5cf6' },
+      { id: 'bug', name: '缺陷排查', color: '#ef4444' },
+      { id: 'quality', name: '评测质控', color: '#10b981' },
+    ],
+  }),
+}));
+
 vi.mock('@/utils/api-client', () => ({
   API_URL: 'http://example.test',
   apiFetch: vi.fn(),
@@ -92,13 +103,13 @@ describe('ThreadItem actions', () => {
     vi.restoreAllMocks();
   });
 
-  function renderThread() {
+  function renderThread(overrides: Partial<React.ComponentProps<typeof ThreadItem>> = {}) {
     act(() => {
       root.render(
         React.createElement(ThreadItem, {
           id: 'thread-1',
           title: 'Thread 1',
-          participants: [],
+          participants: ['cat-a'],
           lastActiveAt: 1,
           isActive: false,
           onSelect: vi.fn(),
@@ -111,6 +122,8 @@ describe('ThreadItem actions', () => {
           projectPath: '/projects/cat-cafe',
           isPinned: false,
           isFavorited: false,
+          threadLabels: [],
+          ...overrides,
         }),
       );
     });
@@ -120,11 +133,11 @@ describe('ThreadItem actions', () => {
     return container.querySelector(`button[title="${title}"]`);
   }
 
-  it('keeps direct thread actions to pin, delete, and more', () => {
+  it('keeps pin and delete inside the more menu instead of fixed row buttons', () => {
     renderThread();
 
-    expect(buttonByTitle('置顶')).not.toBeNull();
-    expect(buttonByTitle('删除对话')).not.toBeNull();
+    expect(buttonByTitle('置顶')).toBeNull();
+    expect(buttonByTitle('删除对话')).toBeNull();
     expect(buttonByTitle('更多操作')).not.toBeNull();
     expect(buttonByTitle('更多操作')?.className).not.toContain('opacity-0');
 
@@ -150,6 +163,8 @@ describe('ThreadItem actions', () => {
     });
 
     const menu = container.querySelector('[role="menu"]');
+    expect(menu?.textContent).toContain('置顶');
+    expect(menu?.textContent).toContain('删除对话');
     expect(menu?.textContent).toContain('设置默认猫猫');
     expect(menu?.textContent).toContain('重命名对话');
     expect(menu?.textContent).toContain('导出对话');
@@ -167,7 +182,7 @@ describe('ThreadItem actions', () => {
     const menu = container.querySelector('[role="menu"]');
     expect(menu).not.toBeNull();
 
-    for (const label of ['设置默认猫猫', '重命名对话', '导出对话', '标签管理', '收藏']) {
+    for (const label of ['置顶', '设置默认猫猫', '重命名对话', '导出对话', '标签管理', '收藏', '删除对话']) {
       const item = Array.from(menu!.querySelectorAll('[role="menuitem"]')).find((el) =>
         el.textContent?.includes(label),
       );
@@ -176,5 +191,33 @@ describe('ThreadItem actions', () => {
       expect(first?.querySelector('svg[aria-hidden="true"]') ?? first?.matches('svg[aria-hidden="true"]')).toBeTruthy();
       expect(item!.textContent).toContain(label);
     }
+  });
+
+  it('shows a filled favorite mark next to favorited thread titles', () => {
+    renderThread({ isFavorited: true });
+
+    const mark = container.querySelector('[data-testid="thread-favorite-mark"]');
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute('aria-label')).toBe('已收藏');
+  });
+
+  it('renders labels as one 16px compact tag button with overflow dots', () => {
+    renderThread({ threadLabels: ['product', 'architecture', 'bug', 'quality'] });
+
+    const labelButton = container.querySelector('[data-testid="thread-label-dots"]');
+    expect(labelButton).not.toBeNull();
+    expect(labelButton?.className).toContain('h-4');
+    expect(labelButton?.getAttribute('title')).toBe('产品体验, 架构规划, 缺陷排查, 评测质控');
+    expect(labelButton?.textContent).toContain('+1');
+  });
+
+  it('keeps the full code-compatible tooltip format on the thread item', () => {
+    renderThread({ participants: ['cat-a'], projectPath: '/projects/cat-cafe' });
+
+    const item = container.querySelector('[data-thread-id="thread-1"]');
+    expect(item?.getAttribute('title')).toContain('Thread 1');
+    expect(item?.getAttribute('title')).toContain('参与: 猫甲');
+    expect(item?.getAttribute('title')).toContain('路径: /projects/cat-cafe');
+    expect(item?.getAttribute('title')).toContain('1分');
   });
 });

--- a/packages/web/src/components/__tests__/thread-utils.test.ts
+++ b/packages/web/src/components/__tests__/thread-utils.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { Thread } from '@/stores/chat-types';
 import {
+  buildSidebarTabContent,
+  buildSidebarTabs,
   formatRelativeTime,
   getProjectPaths,
   mergeLiveActivityIntoThreads,
   projectDisplayName,
+  type SidebarTabId,
   sortAndGroupThreads,
   sortAndGroupThreadsWithWorkspace,
 } from '../ThreadSidebar/thread-utils';
@@ -505,5 +508,58 @@ describe('sortAndGroupThreadsWithWorkspace', () => {
     const system = groups.find((g) => g.type === 'system');
     expect(system).toBeDefined();
     expect(system?.threads).toHaveLength(2);
+  });
+});
+
+// ── sidebar tab selectors ─────────────────────────────
+
+describe('sidebar tab selectors', () => {
+  const tabThreads = [
+    makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+    makeThread({ id: 'regular-new', title: 'Zoo', projectPath: '/proj/beta', lastActiveAt: NOW - 1_000 }),
+    makeThread({ id: 'regular-old', title: 'Alpha', projectPath: '/proj/alpha', lastActiveAt: NOW - DAY }),
+    makeThread({ id: 'pinned', title: 'Pinned', pinned: true, projectPath: '/proj/beta', lastActiveAt: NOW - 2 * DAY }),
+    makeThread({
+      id: 'fav',
+      title: 'Favorite',
+      favorited: true,
+      projectPath: '/proj/alpha',
+      lastActiveAt: NOW - 3 * DAY,
+    }),
+    makeThread({ id: 'system', title: 'System', systemKind: 'eval_domain', lastActiveAt: NOW - 4 * DAY }),
+  ];
+
+  it('builds tabs in the v9 order with non-default counts', () => {
+    const tabs = buildSidebarTabs(tabThreads);
+    const tabIds: SidebarTabId[] = tabs.map((tab) => tab.id);
+    expect(tabIds).toEqual(['recent', 'project', 'system', 'favorites']);
+    expect(tabs.map((tab) => tab.label)).toEqual(['最近', '项目', '系统', '收藏']);
+    expect(tabs.map((tab) => tab.count)).toEqual([4, 4, 1, 1]);
+  });
+
+  it('recent tab excludes lobby and system threads, then sorts pinned first and activity desc', () => {
+    const content = buildSidebarTabContent('recent', tabThreads, new Set(['/proj/alpha']));
+
+    expect(content.kind).toBe('flat');
+    expect(content.threads.map((thread) => thread.id)).toEqual(['pinned', 'regular-new', 'regular-old', 'fav']);
+  });
+
+  it('system and favorites tabs are flat isolated views', () => {
+    const system = buildSidebarTabContent('system', tabThreads, new Set());
+    const favorites = buildSidebarTabContent('favorites', tabThreads, new Set());
+
+    expect(system.kind).toBe('flat');
+    expect(system.threads.map((thread) => thread.id)).toEqual(['system']);
+    expect(favorites.kind).toBe('flat');
+    expect(favorites.threads.map((thread) => thread.id)).toEqual(['fav']);
+  });
+
+  it('project tab groups non-system threads by path with pinned projects first and item titles alphabetical', () => {
+    const content = buildSidebarTabContent('project', tabThreads, new Set(['/proj/beta']));
+
+    expect(content.kind).toBe('project');
+    expect(content.projectGroups?.map((group) => group.projectPath)).toEqual(['/proj/beta', '/proj/alpha']);
+    expect(content.projectGroups?.[0].threads.map((thread) => thread.id)).toEqual(['pinned', 'regular-new']);
+    expect(content.projectGroups?.[1].threads.map((thread) => thread.id)).toEqual(['regular-old', 'fav']);
   });
 });


### PR DESCRIPTION
Redesign thread sidebar with tab-based navigation (Recent / Projects / System / Starred).

## Design source
demo v9 (`docs/design/sidebar-proposals.html`)

## Scope
- **ThreadSidebar**: tab row (sticky on scroll), tab content panels, project toolbar with expand/collapse
- **SectionGroup**: collapsible project sections; pushpin mark for pinned projects (accent color)
- **ThreadItem**: pushpin icon (demo style), tooltip
- **thread-utils**: `tabRecentThreads` includes pinned system threads (dual-pin per demo line 200/848)
- **use-collapse-state**: collapse/expand state per project section
- **use-overlay-scrollbar**: fluent-style scrollbar (transparent track, thumb on hover)

## Key behaviors
- Conversation pin = dual (Recent tab + owning tab) per demo design
- Project pin = pushpin mark in section header
- Project path: basename display, full path on hover title
- Tab row sticky on scroll
- Fluent scrollbar: no track background, thumb on hover

## Verification
- vitest: 16 files / 128 tests passed (sidebar + section-group + scroll-memory + a11y)
- `tsc --noEmit`: clean
- `pnpm build`: passed
- biome: errors are pre-existing on main (CRLF format + `use-scroll-anchor` exhaustive-deps), not a regression
- Code review: 2 rounds by 蓝白/乖乖 (reviewer), both findings fixed (PinSectionIcon dead code → driven by `isProjectPinned`; `allCollapsed` dead code removed)

## Commits included
- `8b82d172` docs: plan sidebar tab redesign
- `a5fbd906` feat: redesign thread sidebar tabs (squash of v1-v19 iteration)

Fork PR: labulalala/clowder-ai#2 (squash merged)