### PR TITLE
fix(api): scope runtime cat identity edits

### DIFF
--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -85,7 +85,9 @@ const timeZoneSchema = z
 const catVariantSchema = z.object({
   id: z.string().min(1),
   catId: z.string().min(1).optional(), // F32-b: variant-level catId
+  name: z.string().min(1).optional(), // clowder-ai#1090: variant-level editable member name
   displayName: z.string().min(1).optional(), // F32-b: variant-level displayName
+  nickname: z.string().nullable().optional(), // clowder-ai#1090: null = explicit no nickname
   variantLabel: z.string().min(1).optional(), // F32-b P4: disambiguation label
   mentionPatterns: z.array(mentionPatternSchema).optional(), // F32-b: variant-level mentions
   source: z.string().optional(), // #441: legacy field, ignored — kept in schema for old catalog read compat
@@ -585,6 +587,7 @@ export function toAllCatConfigs(config: CatCafeConfig): Record<string, CatConfig
       // R1 fix: null = "explicitly no caution" (don't inherit breed).
       // undefined (omitted) = inherit from breed. ?? treats null as nullish, so use !== undefined.
       const caution = variant.caution !== undefined ? variant.caution : breed.caution;
+      const nickname = variant.nickname !== undefined ? variant.nickname : breed.nickname;
       // F167 Phase E (KD-20): variant restrictions override breed (no merge);
       // undefined (omitted) inherits breed-level restrictions.
       const restrictions = variant.restrictions ?? breed.restrictions;
@@ -596,9 +599,19 @@ export function toAllCatConfigs(config: CatCafeConfig): Record<string, CatConfig
 
       result[catId] = {
         id: createCatId(catId),
-        name: variant.displayName ?? breed.name,
+        // Identity fields normally follow a clean `variant.<field> ?? breed.<field>` chain.
+        // The `variant.displayName` middle step in `name` is a LEGACY-COMPAT exception:
+        // pre-clowder-ai#1090 catalogs shipped variants with `displayName` overrides but
+        // no `name` field (that field was introduced by this PR), so their resolved name
+        // came from `variant.displayName`. Keep this legacy branch here for read-time
+        // continuity ONLY — write-time coupling is broken in `updateRuntimeCat` (which
+        // snapshots the resolved name into `variant.name` before overwriting
+        // `variant.displayName`). Do NOT extend this cross-field fallback to other
+        // identity fields (nickname / avatar / color / role): they must stay
+        // variant→breed same-field chains to prevent similar leaks.
+        name: variant.name ?? variant.displayName ?? breed.name,
         displayName: variant.displayName ?? breed.displayName,
-        ...(breed.nickname != null ? { nickname: breed.nickname } : {}),
+        ...(nickname != null ? { nickname } : {}),
         avatar: variant.avatar ?? breed.avatar, // F32-b P4c: variant can override
         color: variant.color ?? breed.color, // F32-b P4c: variant can override
         mentionPatterns,

--- a/packages/api/src/config/runtime-cat-catalog.ts
+++ b/packages/api/src/config/runtime-cat-catalog.ts
@@ -344,13 +344,29 @@ export function updateRuntimeCat(projectRoot: string, catId: string, patch: Runt
 
   const breed = catalog.breeds[located.breedIndex] as Record<string, any>;
   const variant = breed.variants[located.variantIndex] as Record<string, any>;
+  const shouldWriteBreedIdentity = located.isDefaultVariant && breed.variants.length === 1;
 
-  if (patch.name !== undefined) breed.name = patch.name;
-  if (patch.nickname !== undefined) {
-    if (patch.nickname && patch.nickname.trim().length > 0) {
-      breed.nickname = patch.nickname.trim();
+  if (patch.name !== undefined) {
+    if (shouldWriteBreedIdentity) {
+      breed.name = patch.name;
+      delete variant.name;
     } else {
-      delete breed.nickname;
+      variant.name = patch.name;
+    }
+  }
+  if (patch.nickname !== undefined) {
+    const nickname = patch.nickname.trim();
+    if (shouldWriteBreedIdentity) {
+      if (nickname.length > 0) {
+        breed.nickname = nickname;
+      } else {
+        delete breed.nickname;
+      }
+      delete variant.nickname;
+    } else if (nickname.length > 0) {
+      variant.nickname = nickname;
+    } else {
+      variant.nickname = null;
     }
   }
   if (patch.roleDescription !== undefined) {
@@ -362,10 +378,21 @@ export function updateRuntimeCat(projectRoot: string, catId: string, patch: Runt
   }
 
   if (patch.displayName !== undefined) {
-    if (located.isDefaultVariant) {
+    if (shouldWriteBreedIdentity) {
       breed.displayName = patch.displayName;
       delete variant.displayName;
     } else {
+      // Multi-variant breed: keep name/displayName editing independent.
+      // toAllCatConfigs resolves `name` as `variant.name ?? variant.displayName ?? breed.name`;
+      // if we overwrite variant.displayName without a variant.name override,
+      // the resolved name silently follows the new displayName (P2 finding on
+      // clowder-ai#1090). Snapshot the currently-resolved name into variant.name
+      // so a displayName-only patch cannot alter this member's resolved name.
+      // Legacy variants that inherited name via variant.displayName fallback
+      // keep that name explicitly on their first displayName edit.
+      if (variant.name === undefined) {
+        variant.name = variant.displayName ?? breed.name;
+      }
       variant.displayName = patch.displayName;
     }
   }

--- a/packages/api/src/domains/story/content-sanitizer.ts
+++ b/packages/api/src/domains/story/content-sanitizer.ts
@@ -165,6 +165,10 @@ export function buildCatIdentityAliases(
     mentionPatterns?: string[];
     variants?: Array<{
       catId?: string;
+      // clowder-ai#1090: variant-scoped identity overrides — must feed redaction
+      // set so a renamed multi-variant member doesn't leak in public story exports.
+      name?: string;
+      nickname?: string | null;
       displayName?: string;
       variantLabel?: string;
       mentionPatterns?: string[];
@@ -187,24 +191,49 @@ export function buildCatIdentityAliases(
       const clean = p.replace(/^@/, '');
       if (clean !== breed.catId) set.add(clean);
     }
-    if (set.size > 0) aliases.set(breed.catId, [...set]);
+    // Breed aliases finalized AFTER variant loop so default-variant identity
+    // overrides (clowder-ai#1090) can be merged into the breed alias set —
+    // default variants inherit breed.catId at runtime, so their persisted
+    // name / nickname belong to the same alias entry.
 
-    // Variant aliases: skip displayName that matches breed name/displayName —
+    // Variant aliases: skip identity that matches breed name/displayName —
     // the breed catId owns the shared breed name (e.g. '布偶猫' belongs to
     // opus, not sonnet/opus-47/fable-5). Prevents first-wins collision where
     // the breed name gets bound to whichever variant appears first in events.
+    // Applies to variant.name (clowder-ai#1090) and variant.displayName alike.
     const breedNames = new Set([breed.name, breed.displayName].filter(Boolean));
     for (const v of breed.variants ?? []) {
-      if (!v.catId) continue;
-      const vset = new Set<string>();
-      if (v.displayName && !breedNames.has(v.displayName)) vset.add(v.displayName);
-      if (v.variantLabel) vset.add(v.variantLabel);
+      // clowder-ai#1090: default variants typically have no explicit v.catId
+      // (they inherit breed.catId, e.g. `opus-default` id). Resolve variant
+      // catId with the same `variant.catId ?? breed.catId` rule the runtime
+      // uses, so default-variant identity overrides written by
+      // `updateRuntimeCat` are still folded into the redaction map.
+      const variantCatId = v.catId ?? breed.catId;
+      const isDefaultVariant = variantCatId === breed.catId;
+      // Default variant overrides merge into the breed alias set (shared catId).
+      // Non-default variants get an independent alias entry.
+      const target = isDefaultVariant ? set : new Set<string>();
+
+      // clowder-ai#1090: include variant-scoped identity so renamed members
+      // don't leak into public story exports.
+      if (v.name && !breedNames.has(v.name)) target.add(v.name);
+      if (v.nickname) target.add(v.nickname);
+      if (v.displayName && !breedNames.has(v.displayName)) target.add(v.displayName);
+      if (v.variantLabel) target.add(v.variantLabel);
       for (const p of v.mentionPatterns ?? []) {
         const clean = p.replace(/^@/, '');
-        if (clean !== v.catId) vset.add(clean);
+        if (clean !== variantCatId) target.add(clean);
       }
-      if (vset.size > 0) aliases.set(v.catId, [...vset]);
+
+      if (!isDefaultVariant && target.size > 0) {
+        aliases.set(variantCatId, [...target]);
+      }
+      // Default variant path: mutations already flowed into `set` and are
+      // finalized in the breed-level `aliases.set` below.
     }
+
+    // Finalize breed aliases after default-variant merge.
+    if (set.size > 0) aliases.set(breed.catId, [...set]);
   }
 
   // coCreator identity (You / L.S. / Lysander etc.)

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3068,6 +3068,12 @@ async function main(): Promise<void> {
       mentionPatterns: [...b.mentionPatterns],
       variants: b.variants.map((v) => ({
         catId: v.catId,
+        // clowder-ai#1090: forward variant-scoped identity so the sanitizer
+        // redacts renamed members (multi-variant breeds now persist
+        // per-member name / nickname; without these fields the sanitizer
+        // would rebuild the redaction set from breed identity only).
+        name: v.name,
+        nickname: v.nickname,
         displayName: v.displayName,
         variantLabel: v.variantLabel,
         mentionPatterns: v.mentionPatterns ? [...v.mentionPatterns] : undefined,

--- a/packages/api/test/cat-catalog-store.test.js
+++ b/packages/api/test/cat-catalog-store.test.js
@@ -719,6 +719,235 @@ describe('cat-catalog-store', () => {
     assert.equal(catalog.coCreator?.mentionPatterns[0], '@co-worker');
   });
 
+  it('keeps identity updates scoped to the edited default variant', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    const template = validConfig();
+    template.breeds[0].nickname = '宪宪';
+    template.breeds[0].variants.push({
+      id: 'opus-sonnet',
+      catId: 'opus-sonnet',
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      mcpSupport: true,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+    });
+    writeFileSync(templatePath, JSON.stringify(template, null, 2));
+    writeCatCatalog(projectRoot, template);
+
+    const before = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(before.opus.name, '布偶猫');
+    assert.equal(before.opus.displayName, '布偶猫');
+    assert.equal(before.opus.nickname, '宪宪');
+    assert.equal(before['opus-sonnet'].name, '布偶猫');
+    assert.equal(before['opus-sonnet'].displayName, '布偶猫');
+    assert.equal(before['opus-sonnet'].nickname, '宪宪');
+
+    await updateRuntimeCat(projectRoot, 'opus', {
+      name: '默认布偶名',
+      displayName: '默认布偶显示名',
+      nickname: '默认布偶昵称',
+    });
+
+    const after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '默认布偶名');
+    assert.equal(after.opus.displayName, '默认布偶显示名');
+    assert.equal(after.opus.nickname, '默认布偶昵称');
+    assert.equal(after['opus-sonnet'].name, '布偶猫');
+    assert.equal(after['opus-sonnet'].displayName, '布偶猫');
+    assert.equal(after['opus-sonnet'].nickname, '宪宪');
+
+    const catalog = readRuntimeCatCatalog(projectRoot);
+    const breed = catalog.breeds.find((item) => item.id === 'ragdoll');
+    assert.ok(breed, 'ragdoll breed should still exist');
+    assert.equal(breed.name, '布偶猫');
+    assert.equal(breed.displayName, '布偶猫');
+    assert.equal(breed.nickname, '宪宪');
+    const defaultVariant = breed.variants.find((variant) => variant.id === 'opus-default');
+    assert.ok(defaultVariant, 'opus-default variant should still exist');
+    assert.equal(defaultVariant.name, '默认布偶名');
+    assert.equal(defaultVariant.displayName, '默认布偶显示名');
+    assert.equal(defaultVariant.nickname, '默认布偶昵称');
+  });
+
+  it('preserves displayName when only name changes on a member variant', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    const template = validConfig();
+    template.breeds[0].displayName = '布偶显示名';
+    template.breeds[0].variants.push({
+      id: 'opus-sonnet',
+      catId: 'opus-sonnet',
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      mcpSupport: true,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+    });
+    writeFileSync(templatePath, JSON.stringify(template, null, 2));
+    writeCatCatalog(projectRoot, template);
+
+    await updateRuntimeCat(projectRoot, 'opus', {
+      name: '默认布偶名',
+    });
+
+    let after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '默认布偶名');
+    assert.equal(after.opus.displayName, '布偶显示名');
+    assert.equal(after['opus-sonnet'].name, '布偶猫');
+    assert.equal(after['opus-sonnet'].displayName, '布偶显示名');
+
+    await updateRuntimeCat(projectRoot, 'opus-sonnet', {
+      name: 'Sonnet 布偶名',
+    });
+
+    after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '默认布偶名');
+    assert.equal(after.opus.displayName, '布偶显示名');
+    assert.equal(after['opus-sonnet'].name, 'Sonnet 布偶名');
+    assert.equal(after['opus-sonnet'].displayName, '布偶显示名');
+
+    const catalog = readRuntimeCatCatalog(projectRoot);
+    const breed = catalog.breeds.find((item) => item.id === 'ragdoll');
+    assert.ok(breed, 'ragdoll breed should still exist');
+    assert.equal(breed.name, '布偶猫');
+    assert.equal(breed.displayName, '布偶显示名');
+    const defaultVariant = breed.variants.find((variant) => variant.id === 'opus-default');
+    assert.ok(defaultVariant, 'opus-default variant should still exist');
+    assert.equal(defaultVariant.name, '默认布偶名');
+    assert.equal(defaultVariant.displayName, undefined);
+    const sonnetVariant = breed.variants.find((variant) => variant.id === 'opus-sonnet');
+    assert.ok(sonnetVariant, 'opus-sonnet variant should still exist');
+    assert.equal(sonnetVariant.name, 'Sonnet 布偶名');
+    assert.equal(sonnetVariant.displayName, undefined);
+  });
+
+  it('preserves name when only displayName changes on a member variant', async () => {
+    // Fresh-catalog symmetric of P1 (name-only vs displayName-only):
+    // patching displayName alone on a multi-variant breed member must NOT flip the
+    // resolved `name` to the new displayName via the `variant.name ?? variant.displayName`
+    // fallback chain in toAllCatConfigs.
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    const template = validConfig();
+    template.breeds[0].displayName = '布偶显示名';
+    template.breeds[0].variants.push({
+      id: 'opus-sonnet',
+      catId: 'opus-sonnet',
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      mcpSupport: true,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+    });
+    writeFileSync(templatePath, JSON.stringify(template, null, 2));
+    writeCatCatalog(projectRoot, template);
+
+    // (a) Default variant, no prior override: patch displayName only
+    await updateRuntimeCat(projectRoot, 'opus', {
+      displayName: '新布偶显示名',
+    });
+
+    let after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '布偶猫', 'opus resolved name must stay breed.name');
+    assert.equal(after.opus.displayName, '新布偶显示名');
+    assert.equal(after['opus-sonnet'].name, '布偶猫');
+    assert.equal(after['opus-sonnet'].displayName, '布偶显示名');
+
+    // (b) Non-default variant, no prior override: patch displayName only
+    await updateRuntimeCat(projectRoot, 'opus-sonnet', {
+      displayName: 'Sonnet 新显示名',
+    });
+
+    after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '布偶猫');
+    assert.equal(after.opus.displayName, '新布偶显示名');
+    assert.equal(after['opus-sonnet'].name, '布偶猫', 'opus-sonnet resolved name must stay breed.name');
+    assert.equal(after['opus-sonnet'].displayName, 'Sonnet 新显示名');
+  });
+
+  it('preserves legacy variant.displayName-derived name when patching displayName only', async () => {
+    // Legacy-catalog case: variant.displayName is set as an F32-b override but
+    // variant.name (the field added in this PR) is unset. Pre-fix resolved name
+    // comes from the `variant.name ?? variant.displayName ?? breed.name` fallback
+    // chain and equals variant.displayName. A displayName-only patch on such a
+    // legacy variant must snapshot the previously resolved name so partial edits
+    // don't silently rename the member.
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    const template = validConfig();
+    template.breeds[0].displayName = '布偶显示名';
+    template.breeds[0].variants.push({
+      id: 'opus-sonnet',
+      catId: 'opus-sonnet',
+      // Legacy override: displayName only, no name field.
+      displayName: 'Sonnet 独立显示名',
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      mcpSupport: true,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+    });
+    writeFileSync(templatePath, JSON.stringify(template, null, 2));
+    writeCatCatalog(projectRoot, template);
+
+    // Baseline: legacy fallback resolves name from variant.displayName.
+    const before = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(before['opus-sonnet'].name, 'Sonnet 独立显示名', 'legacy fallback baseline');
+
+    await updateRuntimeCat(projectRoot, 'opus-sonnet', {
+      displayName: 'Sonnet 新显示名',
+    });
+
+    const after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(
+      after['opus-sonnet'].name,
+      'Sonnet 独立显示名',
+      'legacy displayName-derived name must persist across displayName-only patch',
+    );
+    assert.equal(after['opus-sonnet'].displayName, 'Sonnet 新显示名');
+  });
+
+  it('keeps identity updates scoped to the edited non-default variant', async () => {
+    const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
+    const templatePath = join(projectRoot, 'cat-template.json');
+    const template = validConfig();
+    template.breeds[0].nickname = '宪宪';
+    template.breeds[0].variants.push({
+      id: 'opus-sonnet',
+      catId: 'opus-sonnet',
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-5-20250929',
+      mcpSupport: true,
+      cli: { command: 'claude', outputFormat: 'stream-json' },
+    });
+    writeFileSync(templatePath, JSON.stringify(template, null, 2));
+    writeCatCatalog(projectRoot, template);
+
+    await updateRuntimeCat(projectRoot, 'opus-sonnet', {
+      name: 'Sonnet 布偶名',
+      displayName: 'Sonnet 布偶显示名',
+      nickname: 'Sonnet 布偶昵称',
+    });
+
+    const after = toAllCatConfigs(readRuntimeCatCatalog(projectRoot));
+    assert.equal(after.opus.name, '布偶猫');
+    assert.equal(after.opus.displayName, '布偶猫');
+    assert.equal(after.opus.nickname, '宪宪');
+    assert.equal(after['opus-sonnet'].name, 'Sonnet 布偶名');
+    assert.equal(after['opus-sonnet'].displayName, 'Sonnet 布偶显示名');
+    assert.equal(after['opus-sonnet'].nickname, 'Sonnet 布偶昵称');
+
+    const catalog = readRuntimeCatCatalog(projectRoot);
+    const breed = catalog.breeds.find((item) => item.id === 'ragdoll');
+    assert.ok(breed, 'ragdoll breed should still exist');
+    assert.equal(breed.name, '布偶猫');
+    assert.equal(breed.displayName, '布偶猫');
+    assert.equal(breed.nickname, '宪宪');
+    const sonnetVariant = breed.variants.find((variant) => variant.id === 'opus-sonnet');
+    assert.ok(sonnetVariant, 'opus-sonnet variant should still exist');
+    assert.equal(sonnetVariant.name, 'Sonnet 布偶名');
+    assert.equal(sonnetVariant.displayName, 'Sonnet 布偶显示名');
+    assert.equal(sonnetVariant.nickname, 'Sonnet 布偶昵称');
+  });
+
   it('persists and clears voiceConfig when updating a runtime member', async () => {
     const projectRoot = mkdtempSync(join(tmpdir(), 'cat-catalog-store-'));
     const templatePath = join(projectRoot, 'cat-template.json');

--- a/packages/api/test/content-sanitizer.test.js
+++ b/packages/api/test/content-sanitizer.test.js
@@ -590,6 +590,140 @@ describe('sanitizeStoryExport', () => {
     assert.ok(sonnetAliases.includes('布偶猫 Sonnet'), 'sonnet aliases should include variant displayName');
   });
 
+  test('buildCatIdentityAliases includes variant.name and variant.nickname (clowder-ai#1090)', async () => {
+    // clowder-ai#1090 introduced variant-scoped name / nickname persistence
+    // for multi-variant breed members. Story export redaction must pick these
+    // up — otherwise a renamed member's identity leaks into public exports.
+    const { buildCatIdentityAliases } = await import('../dist/domains/story/content-sanitizer.js');
+    const breeds = [
+      {
+        catId: 'opus',
+        name: '布偶猫',
+        displayName: '布偶猫',
+        nickname: '宪宪',
+        mentionPatterns: ['@opus', '@布偶猫', '@宪宪'],
+        variants: [
+          {
+            catId: 'sonnet',
+            // Simulate clowder-ai#1090: multi-variant member rename
+            name: '斯奈特秘名',
+            nickname: '斯奈特昵称',
+            displayName: '布偶猫 Sonnet',
+            variantLabel: 'Sonnet',
+            mentionPatterns: ['@sonnet'],
+          },
+          {
+            catId: 'opus-47',
+            displayName: '布偶猫 Opus 4.7',
+            variantLabel: 'Opus 4.7',
+            mentionPatterns: ['@opus-47'],
+          },
+        ],
+      },
+    ];
+    const aliases = buildCatIdentityAliases(breeds);
+
+    const sonnetAliases = aliases.get('sonnet');
+    assert.ok(sonnetAliases, 'sonnet should have aliases');
+    assert.ok(
+      sonnetAliases.includes('斯奈特秘名'),
+      `sonnet aliases must include variant.name (redaction gap): ${JSON.stringify(sonnetAliases)}`,
+    );
+    assert.ok(
+      sonnetAliases.includes('斯奈特昵称'),
+      `sonnet aliases must include variant.nickname (redaction gap): ${JSON.stringify(sonnetAliases)}`,
+    );
+    // Existing variant aliases still populated
+    assert.ok(sonnetAliases.includes('布偶猫 Sonnet'), 'sonnet aliases should still include displayName');
+    assert.ok(sonnetAliases.includes('Sonnet'), 'sonnet aliases should still include variantLabel');
+  });
+
+  test('buildCatIdentityAliases merges default-variant identity overrides into breed entry (clowder-ai#1090)', async () => {
+    // Multi-variant breed default variants typically have no explicit
+    // variant.catId (they inherit breed.catId, e.g. `opus-default`).
+    // updateRuntimeCat now writes name / nickname onto that variant when the
+    // breed has multiple variants — so those overrides must still be
+    // discoverable by the sanitizer even though the variant has no v.catId.
+    // Since default variants share the breed's catId at runtime, their
+    // identity overrides get merged into the breed alias entry.
+    const { buildCatIdentityAliases } = await import('../dist/domains/story/content-sanitizer.js');
+    const breeds = [
+      {
+        catId: 'opus',
+        name: '布偶猫',
+        displayName: '布偶显示名',
+        nickname: '宪宪',
+        mentionPatterns: ['@opus'],
+        variants: [
+          {
+            // Default variant: no catId (inherits breed.catId = 'opus')
+            // Persisted identity overrides written by updateRuntimeCat:
+            name: '默认新名字',
+            nickname: '默认新昵称',
+          },
+          {
+            catId: 'opus-sonnet',
+            displayName: '布偶猫 Sonnet',
+            mentionPatterns: ['@opus-sonnet'],
+          },
+        ],
+      },
+    ];
+    const aliases = buildCatIdentityAliases(breeds);
+
+    const opusAliases = aliases.get('opus');
+    assert.ok(opusAliases, 'opus breed catId must have aliases');
+    assert.ok(opusAliases.includes('布偶猫'), 'opus aliases retain breed.name');
+    assert.ok(opusAliases.includes('布偶显示名'), 'opus aliases retain breed.displayName');
+    assert.ok(opusAliases.includes('宪宪'), 'opus aliases retain breed.nickname');
+    assert.ok(
+      opusAliases.includes('默认新名字'),
+      `opus aliases must include default variant name override: ${JSON.stringify(opusAliases)}`,
+    );
+    assert.ok(
+      opusAliases.includes('默认新昵称'),
+      `opus aliases must include default variant nickname override: ${JSON.stringify(opusAliases)}`,
+    );
+
+    // Non-default variant still gets independent alias entry
+    const sonnetAliases = aliases.get('opus-sonnet');
+    assert.ok(sonnetAliases, 'opus-sonnet aliases still populated');
+    assert.ok(sonnetAliases.includes('布偶猫 Sonnet'), 'opus-sonnet displayName preserved');
+  });
+
+  test('buildCatIdentityAliases skips variant.name that collides with breed identity (clowder-ai#1090)', async () => {
+    // Breed-level identity is shared: variant.name equal to breed.name/displayName
+    // must NOT be attached to a variant catId, else first-wins collision maps
+    // the breed's canonical name to a single variant.
+    const { buildCatIdentityAliases } = await import('../dist/domains/story/content-sanitizer.js');
+    const breeds = [
+      {
+        catId: 'opus',
+        name: '布偶猫',
+        displayName: '布偶显示名',
+        mentionPatterns: ['@opus'],
+        variants: [
+          // variant.name collides with breed.name — should not be added to variant aliases
+          { catId: 'sonnet', name: '布偶猫', displayName: '布偶显示名', mentionPatterns: ['@sonnet'] },
+        ],
+      },
+    ];
+    const aliases = buildCatIdentityAliases(breeds);
+
+    const sonnetAliases = aliases.get('sonnet');
+    // sonnet aliases may be empty or only contain non-colliding items, but
+    // must NOT rebind the shared breed name to the variant.
+    assert.ok(
+      !sonnetAliases || !sonnetAliases.includes('布偶猫'),
+      `variant.name collision with breed.name must not be added to variant aliases: ${JSON.stringify(sonnetAliases)}`,
+    );
+    // Existing displayName collision guard unchanged
+    assert.ok(
+      !sonnetAliases || !sonnetAliases.includes('布偶显示名'),
+      'variant.displayName collision with breed.displayName must not be added',
+    );
+  });
+
   test('non-participating roster catIds mentioned in content are also redacted', async () => {
     const { sanitizeStoryExport, buildCatIdentityAliases } = await import('../dist/domains/story/content-sanitizer.js');
     const breeds = [

--- a/packages/api/test/governance/sync-skills-cli.test.js
+++ b/packages/api/test/governance/sync-skills-cli.test.js
@@ -169,6 +169,15 @@ describe('sync-skills.sh --user opt-in (F239 Phase A, ADR-025)', () => {
    * runs and works under any worktree fs state.
    */
   describe('project-level coverage (F239 AC-A1)', () => {
+    it('does not pipe git worktree list into early-exit consumers under pipefail', async () => {
+      const content = await readFile(SCRIPT, 'utf-8');
+      assert.doesNotMatch(
+        content,
+        /git\s+worktree\s+list[^\n|]*\|\s*(head|grep)\b/,
+        'sync-skills.sh must not pipe git worktree list into head/grep under `set -o pipefail`; CI can surface SIGPIPE as exit 141',
+      );
+    });
+
     it('Part 1 worktree loop iterates over all 4 providers', async () => {
       const content = await readFile(SCRIPT, 'utf-8');
       // Extract Part 1 block between section delimiters.

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -57,8 +57,12 @@ export interface CatVariant {
   readonly id: string; // 'opus-4.6', 'codex-default'
   /** Override breed-level catId to register as an independent cat (F32-b) */
   readonly catId?: string;
+  /** Override breed-level name for this independent member */
+  readonly name?: string;
   /** Override breed-level displayName (F32-b) */
   readonly displayName?: string;
+  /** Override breed-level nickname. null means explicitly no nickname. */
+  readonly nickname?: string | null;
   /** F32-b P4: Human-readable label for disambiguation (e.g. "4.5", "Sonnet") */
   readonly variantLabel?: string;
   /** Independent mention patterns for this variant (F32-b).

--- a/scripts/sync-skills.sh
+++ b/scripts/sync-skills.sh
@@ -19,7 +19,20 @@
 
 set -euo pipefail
 
-MAIN_REPO="$(git worktree list --porcelain | head -1 | sed 's/^worktree //')"
+WORKTREE_LIST="$(git worktree list --porcelain)"
+MAIN_REPO=""
+while IFS= read -r line; do
+  case "$line" in
+    worktree\ *)
+      MAIN_REPO="${line#worktree }"
+      break
+      ;;
+  esac
+done <<< "$WORKTREE_LIST"
+if [ -z "$MAIN_REPO" ]; then
+  printf "ERROR: failed to resolve main worktree from git worktree list\n" >&2
+  exit 1
+fi
 SKILLS_SRC="$MAIN_REPO/cat-cafe-skills"
 
 # HOME-level uses absolute symlinks (check-skills-mount.sh expects this)
@@ -186,9 +199,13 @@ $DRY_RUN && printf "${YELLOW}[DRY RUN MODE]${NC}\n"
 # Collect worktree paths
 worktree_paths=()
 while IFS= read -r line; do
-  wt_path="${line#worktree }"
-  worktree_paths+=("$wt_path")
-done < <(git worktree list --porcelain | grep '^worktree ')
+  case "$line" in
+    worktree\ *)
+      wt_path="${line#worktree }"
+      worktree_paths+=("$wt_path")
+      ;;
+  esac
+done <<< "$WORKTREE_LIST"
 
 printf "\n${BOLD}[Worktrees]${NC} %d 个 × 4 providers (claude/codex/gemini/kimi)\n" "${#worktree_paths[@]}"
 for wt in "${worktree_paths[@]}"; do


### PR DESCRIPTION
## Summary
- Port upstream source fix zts212653/cat-cafe@c6895ec68 for #1090
- Scope multi-variant cat identity writes to the edited member/variant instead of shared breed identity
- Preserve independent partial update semantics for name/displayName/nickname
- Extend story export redaction aliases to include new variant name/nickname fields

Fixes #1090

## Verification
- `pnpm --filter @cat-cafe/api run build && CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash packages/api/scripts/with-test-home.sh node --import $(pwd)/packages/api/test/helpers/setup-cat-registry.js --test --test-timeout=60000 packages/api/test/cat-catalog-store.test.js packages/api/test/content-sanitizer.test.js`
- `env -u DEFAULT_OWNER_USER_ID -u NODE_ENV -u npm_config_production -u NPM_CONFIG_PRODUCTION pnpm gate`

Source: zts212653/cat-cafe@c6895ec68

[砚砚/GPT-5.5🐾]
