### PR TITLE
feat: redesign thread sidebar tabs (v1-v19)

### DIFF
--- a/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
+++ b/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
@@ -1,6 +1,17 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useIMEGuard } from '@/hooks/useIMEGuard';
 
+/** Detect OS for the "reveal in file manager" menu label. Returns a label + icon kind.
+ *  Client-only — this component's context menu only renders after a user click, so
+ *  navigator is always available here. */
+function getRevealLabel(): { label: string; kind: 'finder' | 'explorer' | 'files' } {
+  if (typeof navigator === 'undefined') return { label: '在文件管理器中打开', kind: 'files' };
+  const ua = navigator.userAgent || '';
+  if (ua.includes('Win')) return { label: '在资源管理器中打开', kind: 'explorer' };
+  if (ua.includes('Mac')) return { label: '在 Finder 中打开', kind: 'finder' };
+  return { label: '在文件管理器中打开', kind: 'files' };
+}
+
 /** F070: governance status dot colors */
 const GOV_STATUS_DOT: Record<string, { color: string; title: string }> = {
   healthy: { color: 'bg-conn-emerald-text', title: '治理正常' },
@@ -213,17 +224,23 @@ export function SectionGroup({
                 onOpenInFinder();
                 setShowMenu(false);
               }}
+              icon={<FolderMenuIcon />}
             >
-              在 Finder 中打开
+              {getRevealLabel().label}
             </MenuItem>
           )}
-          {onRenameProject && <MenuItem onClick={startRename}>编辑名称</MenuItem>}
+          {onRenameProject && (
+            <MenuItem onClick={startRename} icon={<RenameMenuIcon />}>
+              编辑名称
+            </MenuItem>
+          )}
           {onArchiveThreads && (
             <MenuItem
               onClick={() => {
                 onArchiveThreads();
                 setShowMenu(false);
               }}
+              icon={<ArchiveMenuIcon />}
               danger
             >
               归档所有对话
@@ -295,6 +312,64 @@ function PinMenuIcon({ active }: { active?: boolean }) {
     </svg>
   );
 }
+
+/** Folder icon for the "reveal in file manager" menu item. */
+function FolderMenuIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3 w-3 flex-shrink-0 text-cafe-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M4 20a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h5l2 3h7a2 2 0 0 1 2 2v7a2 2 0 0 1-2 2z" />
+    </svg>
+  );
+}
+
+/** Pencil icon for the "rename" menu item. */
+function RenameMenuIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3 w-3 flex-shrink-0 text-cafe-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+    </svg>
+  );
+}
+
+/** Archive box icon for the "archive threads" menu item. */
+function ArchiveMenuIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3 w-3 flex-shrink-0 text-cafe-muted"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 8v13H3V8" />
+      <path d="M1 3h22v5H1z" />
+      <path d="M10 12h4" />
+    </svg>
+  );
+}
+
 
 /** Small icon button used for pin / quick-create / menu actions. */
 function ActionButton({

--- a/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
+++ b/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
@@ -9,9 +9,8 @@ const GOV_STATUS_DOT: Record<string, { color: string; title: string }> = {
   'never-synced': { color: 'bg-conn-slate-ring', title: '未同步治理' },
 };
 
-/** Section icon SVG paths (extracted to reduce JSX noise) */
+/** Section icon SVG paths (extracted to reduce JSX noise). pin uses stroke style — see PinSectionIcon. */
 const ICON_PATHS: Record<string, string> = {
-  pin: 'M4.456 2.013a.75.75 0 011.06-.034l6.5 6a.75.75 0 01-.034 1.06l-1.99 1.838.637 3.22a.75.75 0 01-1.196.693L6.5 12.526l-2.933 2.264a.75.75 0 01-1.196-.693l.637-3.22-1.99-1.838a.75.75 0 01-.034-1.06l5.472-5.966z',
   star: 'M8 1.5l2.09 4.26 4.71.68-3.41 3.32.8 4.69L8 12.26l-4.19 2.19.8-4.69L1.2 6.44l4.71-.68L8 1.5z',
   clock:
     'M8 1a7 7 0 110 14A7 7 0 018 1zm0 1.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM8 4a.75.75 0 01.75.75v2.69l1.78 1.78a.75.75 0 01-1.06 1.06l-2-2A.75.75 0 017.25 8V4.75A.75.75 0 018 4z',
@@ -71,7 +70,7 @@ export function SectionGroup({
   const inputRef = useRef<HTMLInputElement>(null);
   const ime = useIMEGuard();
 
-  const hasContextMenu = onOpenInFinder || onRenameProject || onArchiveThreads;
+  const hasContextMenu = onOpenInFinder || onRenameProject || onArchiveThreads || onToggleProjectPin;
 
   // Close menu on click outside
   useEffect(() => {
@@ -114,60 +113,46 @@ export function SectionGroup({
   const govDot = governanceStatus ? GOV_STATUS_DOT[governanceStatus] : undefined;
 
   return (
-    <div className="mt-1 relative group/section">
-      <button
-        type="button"
-        onClick={onToggle}
-        className="w-full text-left px-3 py-1.5 flex items-center gap-1.5 hover:bg-cafe-surface-elevated transition-colors"
-        title={projectPath && projectPath !== 'default' ? projectPath : undefined}
-      >
-        {/* Chevron */}
-        <svg
-          aria-hidden="true"
-          className={`w-3 h-3 text-cafe-muted transition-transform flex-shrink-0 ${isCollapsed ? '' : 'rotate-90'}`}
-          viewBox="0 0 12 12"
-          fill="currentColor"
-        >
-          <path d="M4 2l4 4-4 4V2z" />
-        </svg>
-
-        {/* Section icon */}
-        {iconPath && (
-          <svg
-            aria-hidden="true"
-            className={`w-3 h-3 flex-shrink-0 ${iconColor}`}
-            viewBox="0 0 16 16"
-            fill="currentColor"
-          >
-            <path d={iconPath} />
-          </svg>
-        )}
-
-        {/* Label (inline rename or static) */}
+    <div className="relative mt-1 px-2 group/section">
+      <div className="flex w-full items-center gap-1 rounded-lg px-1.5 py-1.5 transition-colors hover:bg-cafe-surface-elevated">
         {isRenaming ? (
-          <input
-            ref={inputRef}
-            value={draftName}
-            onChange={(e) => setDraftName(e.target.value)}
-            onClick={stopButton}
-            onCompositionStart={ime.onCompositionStart}
-            onCompositionEnd={ime.onCompositionEnd}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && !ime.isComposing()) {
-                e.preventDefault();
-                submitRename();
-              }
-              if (e.key === 'Escape') {
-                e.preventDefault();
-                setIsRenaming(false);
-              }
-            }}
-            onBlur={submitRename}
-            maxLength={100}
-            className="text-xs font-medium px-1 py-0 rounded border border-cafe-subtle focus:outline-none focus:border-cafe-accent flex-1 min-w-0"
-          />
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <SectionChevron isCollapsed={isCollapsed} />
+            {iconPath && <SectionIcon iconPath={iconPath} iconColor={iconColor} />}
+            <input
+              ref={inputRef}
+              value={draftName}
+              onChange={(e) => setDraftName(e.target.value)}
+              onClick={stopButton}
+              onCompositionStart={ime.onCompositionStart}
+              onCompositionEnd={ime.onCompositionEnd}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !ime.isComposing()) {
+                  e.preventDefault();
+                  submitRename();
+                }
+                if (e.key === 'Escape') {
+                  e.preventDefault();
+                  setIsRenaming(false);
+                }
+              }}
+              onBlur={submitRename}
+              maxLength={100}
+              className="min-w-0 flex-1 rounded border border-cafe-subtle px-1 py-0 text-xs font-medium focus:border-cafe-accent focus:outline-none"
+            />
+          </div>
         ) : (
-          <span className="text-xs font-medium text-cafe-secondary truncate">{label}</span>
+          <button
+            type="button"
+            onClick={onToggle}
+            className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+            title={projectPath && projectPath !== 'default' ? projectPath : undefined}
+          >
+            <SectionChevron isCollapsed={isCollapsed} />
+            {iconPath && <SectionIcon iconPath={iconPath} iconColor={iconColor} />}
+            {isProjectPinned && <PinSectionIcon />}
+            <span className="min-w-0 flex-1 truncate text-xs font-medium text-cafe-secondary">{label}</span>
+          </button>
         )}
 
         {/* Governance dot */}
@@ -185,7 +170,6 @@ export function SectionGroup({
             }}
             title="新建对话"
             testId="quick-create-btn"
-            className="opacity-0 group-hover/section:opacity-100"
           >
             <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
           </ActionButton>
@@ -200,34 +184,29 @@ export function SectionGroup({
             }}
             title="更多操作"
             testId="project-menu-btn"
-            className="opacity-0 group-hover/section:opacity-100"
           >
             <path d="M8 4a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2zm0 5a1 1 0 110-2 1 1 0 010 2z" />
           </ActionButton>
         )}
-
-        {/* Project pin button */}
-        {onToggleProjectPin && (
-          <ActionButton
-            onClick={(e) => {
-              e.stopPropagation();
-              onToggleProjectPin();
-            }}
-            title={isProjectPinned ? '取消固定项目' : '固定项目到活跃区'}
-            testId="project-pin-btn"
-            className={isProjectPinned ? 'text-cafe-accent' : 'text-cafe-muted hover:text-cafe-muted'}
-          >
-            <path d={ICON_PATHS.pin} />
-          </ActionButton>
-        )}
-      </button>
+      </div>
 
       {/* F095 Phase F: Context menu dropdown */}
       {showMenu && (
         <div
           ref={menuRef}
-          className="absolute right-2 top-8 z-50 bg-cafe-surface rounded-lg shadow-lg border border-cafe py-1 min-w-[140px]"
+          className="absolute right-2 top-8 z-50 bg-cafe-surface rounded-lg shadow-lg border border-cafe py-1 min-w-[160px]"
         >
+          {onToggleProjectPin && (
+            <MenuItem
+              onClick={() => {
+                onToggleProjectPin();
+                setShowMenu(false);
+              }}
+              icon={<PinMenuIcon active={isProjectPinned} />}
+            >
+              {isProjectPinned ? '取消固定项目' : '固定项目到活跃区'}
+            </MenuItem>
+          )}
           {onOpenInFinder && (
             <MenuItem
               onClick={() => {
@@ -258,6 +237,65 @@ export function SectionGroup({
   );
 }
 
+function SectionChevron({ isCollapsed }: { isCollapsed: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`h-3 w-3 flex-shrink-0 text-cafe-muted transition-transform ${isCollapsed ? '' : 'rotate-90'}`}
+      viewBox="0 0 12 12"
+      fill="currentColor"
+    >
+      <path d="M4 2l4 4-4 4V2z" />
+    </svg>
+  );
+}
+
+function SectionIcon({ iconPath, iconColor }: { iconPath: string; iconColor?: string }) {
+  return (
+    <svg aria-hidden="true" className={`h-3 w-3 flex-shrink-0 ${iconColor}`} viewBox="0 0 16 16" fill="currentColor">
+      <path d={iconPath} />
+    </svg>
+  );
+}
+
+/** Pinned-section icon — demo pushpin (sidebar-proposals.html line 205), stroke style, 24x24. */
+function PinSectionIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-3 w-3 flex-shrink-0 text-cafe-accent"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+    </svg>
+  );
+}
+
+/** Menu-item pushpin — accent when pinned, muted otherwise. */
+function PinMenuIcon({ active }: { active?: boolean }) {
+  return (
+    <svg
+      aria-hidden="true"
+      className={`h-3 w-3 flex-shrink-0 ${active ? 'text-cafe-accent' : 'text-cafe-muted'}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
+    </svg>
+  );
+}
+
 /** Small icon button used for pin / quick-create / menu actions. */
 function ActionButton({
   onClick,
@@ -273,9 +311,8 @@ function ActionButton({
   children: React.ReactNode;
 }) {
   return (
-    <span
-      role="button"
-      tabIndex={0}
+    <button
+      type="button"
       onClick={onClick}
       onKeyDown={(e) => {
         if ((e.key === 'Enter' || e.key === ' ') && !e.repeat) {
@@ -284,27 +321,38 @@ function ActionButton({
           onClick(e as unknown as React.MouseEvent);
         }
       }}
-      className={`ml-0.5 flex-shrink-0 cursor-pointer transition-all text-cafe-muted hover:text-cafe-secondary ${className ?? ''}`}
+      className={`ml-0.5 flex-shrink-0 transition-all text-cafe-muted hover:text-cafe-secondary ${className ?? ''}`}
       title={title}
       data-testid={testId}
     >
       <svg aria-hidden="true" className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
         {children}
       </svg>
-    </span>
+    </button>
   );
 }
 
 /** Menu item for the project context menu dropdown. */
-function MenuItem({ onClick, danger, children }: { onClick: () => void; danger?: boolean; children: React.ReactNode }) {
+function MenuItem({
+  onClick,
+  danger,
+  icon,
+  children,
+}: {
+  onClick: () => void;
+  danger?: boolean;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+      className={`flex w-full items-center gap-1.5 px-3 py-1.5 text-left text-xs transition-colors ${
         danger ? 'text-conn-red-text hover:bg-conn-red-bg' : 'text-cafe-secondary hover:bg-cafe-surface-elevated'
       }`}
     >
+      {icon && <span className="flex flex-shrink-0 items-center">{icon}</span>}
       {children}
     </button>
   );

--- a/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
+++ b/packages/web/src/components/ThreadSidebar/SectionGroup.tsx
@@ -370,7 +370,6 @@ function ArchiveMenuIcon() {
   );
 }
 
-
 /** Small icon button used for pin / quick-create / menu actions. */
 function ActionButton({
   onClick,

--- a/packages/web/src/components/ThreadSidebar/SidebarTabIcon.tsx
+++ b/packages/web/src/components/ThreadSidebar/SidebarTabIcon.tsx
@@ -1,0 +1,52 @@
+import type { SidebarTabId } from './thread-utils';
+
+/**
+ * Inline SVG icons for sidebar tabs. Stroke style matches existing sidebar
+ * icons (expand/collapse/trash). aria-hidden so screen readers skip the icon
+ * and tab label/count remain the accessible name.
+ */
+const TAB_ICON_PATHS: Record<SidebarTabId, React.ReactNode> = {
+  // Pin
+  pinned: (
+    <>
+      <path d="M9 4h6l-1 7 4 3v2H6v-2l4-3-1-7z" />
+      <path d="M12 16v4" />
+    </>
+  ),
+  // Clock
+  recent: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 2" />
+    </>
+  ),
+  // Folder
+  project: <path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" />,
+  // Server stack
+  system: (
+    <>
+      <rect x="4" y="4" width="16" height="6" rx="1" />
+      <rect x="4" y="14" width="16" height="6" rx="1" />
+      <path d="M8 7h.01M8 17h.01" />
+    </>
+  ),
+  // Star
+  favorites: <path d="M12 3l2.9 6.3 6.6.6-5 4.4 1.5 6.7L12 17.8 5.4 21l1.5-6.7-5-4.4 6.6-.6L12 3z" />,
+};
+
+export function SidebarTabIcon({ id, className = 'h-3.5 w-3.5' }: { id: SidebarTabId; className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      {TAB_ICON_PATHS[id]}
+    </svg>
+  );
+}

--- a/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
@@ -183,17 +183,30 @@ export function ThreadItem({
     void onToggleFavorite(id, !isFavorited);
   }, [id, isFavorited, onToggleFavorite]);
 
+  const togglePin = useCallback(() => {
+    if (!onTogglePin) return;
+    setIsMoreOpen(false);
+    void onTogglePin(id, !isPinned);
+  }, [id, isPinned, onTogglePin]);
+
+  const deleteThread = useCallback(() => {
+    if (!onDelete) return;
+    setIsMoreOpen(false);
+    onDelete(id);
+  }, [id, onDelete]);
+
   return (
     <div
       data-thread-id={id}
-      className={`group relative mx-2 rounded-xl ${indented ? 'pl-5 pr-3' : 'px-3'} py-2.5 transition-colors cursor-pointer ${
+      aria-current={isActive ? 'page' : undefined}
+      className={`group relative mx-2 rounded-xl ${indented ? 'pl-5 pr-3' : 'px-3'} py-2 transition-colors cursor-pointer ${
         isActive ? 'bg-[var(--console-active-bg)]' : 'hover:bg-[var(--console-hover-bg)]'
       }`}
       onClick={() => onSelect(id)}
       title={tooltip}
     >
       {/* Title row */}
-      <div className="flex items-start justify-between gap-1 mb-1">
+      <div className="mb-1 flex items-center justify-between gap-1">
         {isEditing ? (
           <input
             ref={inputRef}
@@ -221,43 +234,31 @@ export function ThreadItem({
             className="text-sm px-1.5 py-0.5 rounded border border-cafe-subtle focus:outline-none focus:border-cafe-accent w-full mr-2 disabled:opacity-70"
           />
         ) : (
-          <span
-            className={`text-sm leading-snug line-clamp-2 flex-1 min-w-0 ${isActive ? 'font-semibold text-cafe-black' : 'text-cafe-secondary'}`}
-          >
+          <span className="flex min-w-0 flex-1 items-center gap-1">
+            {isPinned && (
+              <span className="inline-flex flex-shrink-0 text-cafe-accent" role="img" aria-label="已置顶">
+                <PinIcon />
+              </span>
+            )}
+            {isFavorited && (
+              <span
+                className="inline-flex flex-shrink-0 text-conn-amber-text"
+                role="img"
+                aria-label="已收藏"
+                data-testid="thread-favorite-mark"
+              >
+                <StarIcon filled />
+              </span>
+            )}
             {isHubThread && <HubIcon className="w-3.5 h-3.5 inline-block mr-1 text-cafe-accent align-text-bottom" />}
-            {title ?? (id === 'default' ? '大厅' : '未命名对话')}
+            <span
+              className={`min-w-0 flex-1 truncate text-xs leading-5 ${isActive ? 'font-medium text-cafe-black' : 'text-cafe-secondary'}`}
+            >
+              {title ?? (id === 'default' ? '大厅' : '未命名对话')}
+            </span>
           </span>
         )}
         <div className="flex items-center gap-0.5 flex-shrink-0 mt-0.5">
-          {/* Fixed thread actions: pin, delete, more. */}
-          {canPin && !isEditing && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                void onTogglePin(id, !isPinned);
-              }}
-              className={`p-0.5 rounded transition-all ${
-                isPinned
-                  ? 'text-cafe-accent'
-                  : 'opacity-0 group-hover:opacity-100 text-cafe-muted hover:text-cafe-accent'
-              }`}
-              title={isPinned ? '取消置顶' : '置顶'}
-            >
-              <PinIcon />
-            </button>
-          )}
-          {canDelete && !isEditing && (
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                onDelete(id);
-              }}
-              className="opacity-0 group-hover:opacity-100 p-0.5 rounded text-cafe-muted hover:bg-conn-red-bg hover:text-conn-red-text transition-all"
-              title="删除对话"
-            >
-              <DeleteIcon />
-            </button>
-          )}
           {hasMoreActions && (
             <div className="relative">
               <button
@@ -285,6 +286,11 @@ export function ThreadItem({
                   className="absolute right-0 top-5 z-50 min-w-[144px] rounded-lg border border-cafe bg-cafe-surface py-1 shadow-lg"
                   onClick={(e) => e.stopPropagation()}
                 >
+                  {canPin && (
+                    <ThreadActionMenuItem icon={<PinIcon />} onClick={togglePin}>
+                      {isPinned ? '取消置顶' : '置顶'}
+                    </ThreadActionMenuItem>
+                  )}
                   {onUpdatePreferredCats && (
                     <ThreadCatSettings
                       threadId={id}
@@ -324,6 +330,14 @@ export function ThreadItem({
                     <ThreadActionMenuItem icon={<StarIcon filled={isFavorited} />} onClick={toggleFavorite}>
                       {isFavorited ? '取消收藏' : '收藏'}
                     </ThreadActionMenuItem>
+                  )}
+                  {canDelete && (
+                    <>
+                      <div className="my-1 h-px bg-cafe-subtle" />
+                      <ThreadActionMenuItem icon={<DeleteIcon />} onClick={deleteThread} danger>
+                        删除对话
+                      </ThreadActionMenuItem>
+                    </>
                   )}
                 </div>
               )}
@@ -388,16 +402,27 @@ export function ThreadItem({
 // ─── Small icon components ───
 
 function PinIcon() {
+  // demo sidebar-proposals.html line 205 — pushpin (stroke style, 24x24)
   return (
-    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
-      <path d="M4.456 2.013a.75.75 0 011.06-.034l6.5 6a.75.75 0 01-.034 1.06l-1.99 1.838.637 3.22a.75.75 0 01-1.196.693L6.5 12.526l-2.933 2.264a.75.75 0 01-1.196-.693l.637-3.22-1.99-1.838a.75.75 0 01-.034-1.06l5.472-5.966z" />
+    <svg
+      className="w-3 h-3"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 17v5" />
+      <path d="M9 10.76a2 2 0 0 1-1.11 1.79l-1.78.9A2 2 0 0 0 5 15.24V16a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1v-.76a2 2 0 0 0-1.11-1.79l-1.78-.9A2 2 0 0 1 15 10.76V7a1 1 0 0 1 1-1 2 2 0 0 0 0-4H8a2 2 0 0 0 0 4 1 1 0 0 1 1 1z" />
     </svg>
   );
 }
 
 function DeleteIcon() {
   return (
-    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor">
+    <svg className="w-3 h-3" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path
         fillRule="evenodd"
         d="M5 3.25V4H2.75a.75.75 0 000 1.5h.3l.815 8.15A1.5 1.5 0 005.357 15h5.285a1.5 1.5 0 001.493-1.35l.815-8.15h.3a.75.75 0 000-1.5H11v-.75A2.25 2.25 0 008.75 1h-1.5A2.25 2.25 0 005 3.25zm2.25-.75a.75.75 0 00-.75.75V4h3v-.75a.75.75 0 00-.75-.75h-1.5z"
@@ -480,10 +505,12 @@ function StarIcon({ filled }: { filled?: boolean }) {
 function ThreadActionMenuItem({
   icon,
   onClick,
+  danger,
   children,
 }: {
   icon: ReactNode;
   onClick: () => void;
+  danger?: boolean;
   children: ReactNode;
 }) {
   return (
@@ -491,7 +518,9 @@ function ThreadActionMenuItem({
       type="button"
       role="menuitem"
       onClick={onClick}
-      className="flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs text-cafe-secondary transition-colors hover:bg-cafe-surface-elevated"
+      className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
+        danger ? 'text-conn-red-text hover:bg-conn-red-bg' : 'text-cafe-secondary hover:bg-cafe-surface-elevated'
+      }`}
     >
       <span className="inline-flex h-3 w-3 flex-shrink-0 items-center justify-center text-cafe-muted">{icon}</span>
       <span>{children}</span>
@@ -506,19 +535,21 @@ function LabelDots({ labels }: { labels?: string[] }) {
     .map((id) => allLabels.find((l) => l.id === id))
     .filter((l): l is NonNullable<typeof l> => l !== undefined);
   if (resolved.length === 0) return null;
-  const shown = resolved.slice(0, 2);
+  const shown = resolved.slice(0, 3);
   const overflow = resolved.length - shown.length;
   return (
-    <div className="flex items-center gap-0.5 ml-1" title={resolved.map((l) => l.name).join(', ')}>
+    <div
+      className="ml-1 inline-flex h-4 items-center gap-1 rounded-full bg-[var(--console-card-soft-bg)] px-1.5 text-cafe-muted"
+      title={resolved.map((l) => l.name).join(', ')}
+      data-testid="thread-label-dots"
+    >
+      <LabelIcon />
       {shown.map((l) => (
         <span
           key={l.id}
-          className="inline-flex items-center gap-0.5 rounded-full px-1 py-px text-micro leading-tight text-cafe-secondary"
-          style={{ backgroundColor: `${l.color}18` }}
-        >
-          <span className="inline-block w-1 h-1 rounded-full flex-shrink-0" style={{ backgroundColor: l.color }} />
-          <span className="max-w-[32px] truncate">{l.name}</span>
-        </span>
+          className="inline-block h-1.5 w-1.5 flex-shrink-0 rounded-full"
+          style={{ backgroundColor: l.color }}
+        />
       ))}
       {overflow > 0 && <span className="text-micro text-cafe-muted">+{overflow}</span>}
     </div>

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -15,6 +15,7 @@ import { readProjectNames, writeProjectNames } from './active-workspace';
 import { DirectoryPickerModal, type NewThreadOptions } from './DirectoryPickerModal';
 import { LabelFilterBar } from './LabelFilterBar';
 import { SectionGroup } from './SectionGroup';
+import { SidebarTabIcon } from './SidebarTabIcon';
 import { ThreadItem } from './ThreadItem';
 import { ThreadOrganizerModal } from './ThreadOrganizerModal';
 import { pushThreadRouteWithHistory } from './thread-navigation';
@@ -78,6 +79,7 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
   // F095 Phase E: scroll anchor for reorder stability
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const tabRefs = useRef<Record<SidebarTabId, HTMLButtonElement | null>>({
+    pinned: null,
     recent: null,
     project: null,
     system: null,
@@ -906,6 +908,7 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
                     }`}
                     data-testid={`sidebar-tab-${tab.id}`}
                   >
+                    <SidebarTabIcon id={tab.id} className="h-3.5 w-3.5 shrink-0" />
                     <span>{tab.label}</span>
                     <span className={activeTab === tab.id ? 'text-cafe-accent' : 'text-cafe-muted'}>{tab.count}</span>
                   </button>

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -736,7 +736,7 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     () => buildSidebarTabContent('project', labelFilteredThreads, pinnedProjects).projectGroups ?? [],
     [labelFilteredThreads, pinnedProjects],
   );
-  const threadGroups = activeTabContent.kind === 'project' ? (activeTabContent.projectGroups ?? []) : [];
+  const threadGroups = activeTab === 'project' ? projectThreadGroups : [];
   const existingProjects = useMemo(() => getProjectPaths(liveThreads), [liveThreads]);
   const showDefaultThread = (normalizedQuery.length === 0 || '大厅'.includes(normalizedQuery)) && !labelFilter;
 

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -915,12 +915,23 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
                 onClick={() => scrollTabs('left')}
                 disabled={!canScrollLeft}
                 className={`flex flex-shrink-0 items-center justify-center w-5 rounded-t-md text-cafe-muted transition-all ${
-                  canScrollLeft ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent' : 'pointer-events-none opacity-0'
+                  canScrollLeft
+                    ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent'
+                    : 'pointer-events-none opacity-0'
                 }`}
                 aria-label="向左滚动"
                 data-testid="sidebar-tab-scroll-left"
               >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-3.5 w-3.5"
+                  aria-hidden="true"
+                >
                   <path d="M15 18l-6-6 6-6" />
                 </svg>
               </button>
@@ -959,12 +970,23 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
                 onClick={() => scrollTabs('right')}
                 disabled={!canScrollRight}
                 className={`flex flex-shrink-0 items-center justify-center w-5 rounded-t-md text-cafe-muted transition-all ${
-                  canScrollRight ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent' : 'pointer-events-none opacity-0'
+                  canScrollRight
+                    ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent'
+                    : 'pointer-events-none opacity-0'
                 }`}
                 aria-label="向右滚动"
                 data-testid="sidebar-tab-scroll-right"
               >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden="true">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={2}
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="h-3.5 w-3.5"
+                  aria-hidden="true"
+                >
                   <path d="M9 6l6 6-6 6" />
                 </svg>
               </button>

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -85,6 +85,9 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     system: null,
     favorites: null,
   });
+  const tabScrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
   // F095 Phase F: custom project display names
   const [projectNames, setProjectNames] = useState(() =>
     readProjectNames(typeof localStorage !== 'undefined' ? localStorage : { getItem: () => null, setItem: () => {} }),
@@ -739,6 +742,28 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     [labelFilteredThreads, pinnedProjects],
   );
   const threadGroups = activeTab === 'project' ? projectThreadGroups : [];
+
+  // Tab overflow scroll: show arrow buttons when tabs overflow the row
+  const updateTabScrollState = useCallback(() => {
+    const el = tabScrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 1);
+    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
+  }, []);
+
+  const scrollTabs = useCallback((dir: 'left' | 'right') => {
+    tabScrollRef.current?.scrollBy({ left: dir === 'left' ? -120 : 120, behavior: 'smooth' });
+  }, []);
+
+  useEffect(() => {
+    updateTabScrollState();
+  }, [tabs, updateTabScrollState]);
+
+  useEffect(() => {
+    window.addEventListener('resize', updateTabScrollState);
+    return () => window.removeEventListener('resize', updateTabScrollState);
+  }, [updateTabScrollState]);
+
   const existingProjects = useMemo(() => getProjectPaths(liveThreads), [liveThreads]);
   const showDefaultThread = (normalizedQuery.length === 0 || '大厅'.includes(normalizedQuery)) && !labelFilter;
 
@@ -882,11 +907,27 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
 
           {tabs.length > 0 && (
             <div
-              className="sticky top-0 z-10 flex items-stretch gap-1 border-b border-cafe-subtle bg-[var(--console-panel-bg)] pt-2 pl-3 pr-2"
+              className="sticky top-0 z-10 flex items-stretch gap-1 border-b border-cafe-subtle bg-[var(--console-panel-bg)] pt-2 pl-1 pr-1"
               data-testid="sidebar-tabs-row"
             >
+              <button
+                type="button"
+                onClick={() => scrollTabs('left')}
+                disabled={!canScrollLeft}
+                className={`flex flex-shrink-0 items-center justify-center w-5 rounded-t-md text-cafe-muted transition-all ${
+                  canScrollLeft ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent' : 'pointer-events-none opacity-0'
+                }`}
+                aria-label="向左滚动"
+                data-testid="sidebar-tab-scroll-left"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden="true">
+                  <path d="M15 18l-6-6 6-6" />
+                </svg>
+              </button>
               <div
-                className="flex min-w-0 flex-1 gap-0.5 overflow-x-auto overflow-y-hidden px-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)]"
+                ref={tabScrollRef}
+                onScroll={updateTabScrollState}
+                className="flex min-w-0 flex-1 gap-0 overflow-x-auto overflow-y-hidden px-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
                 role="tablist"
                 aria-label="对话分类"
                 data-testid="sidebar-tabs-scroll"
@@ -901,7 +942,7 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
                     role="tab"
                     aria-selected={activeTab === tab.id}
                     onClick={() => setActiveTab(tab.id)}
-                    className={`flex flex-shrink-0 items-center gap-1 rounded-t-md border-b-2 px-2 py-1.5 text-micro font-medium transition-colors ${
+                    className={`flex flex-shrink-0 items-center gap-1 rounded-t-md border-b-2 px-1 py-1.5 text-micro font-medium transition-colors ${
                       activeTab === tab.id
                         ? 'border-cafe-accent text-cafe-accent'
                         : 'border-transparent text-cafe-muted hover:bg-[var(--console-hover-bg)] hover:text-cafe-secondary'
@@ -910,14 +951,27 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
                   >
                     <SidebarTabIcon id={tab.id} className="h-3.5 w-3.5 shrink-0" />
                     <span>{tab.label}</span>
-                    <span className={activeTab === tab.id ? 'text-cafe-accent' : 'text-cafe-muted'}>{tab.count}</span>
                   </button>
                 ))}
               </div>
+              <button
+                type="button"
+                onClick={() => scrollTabs('right')}
+                disabled={!canScrollRight}
+                className={`flex flex-shrink-0 items-center justify-center w-5 rounded-t-md text-cafe-muted transition-all ${
+                  canScrollRight ? 'hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent' : 'pointer-events-none opacity-0'
+                }`}
+                aria-label="向右滚动"
+                data-testid="sidebar-tab-scroll-right"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5" aria-hidden="true">
+                  <path d="M9 6l6 6-6 6" />
+                </svg>
+              </button>
             </div>
           )}
 
-          <div className="pt-1.5" data-testid="sidebar-tab-content">
+          <div className="space-y-1 pt-1.5" data-testid="sidebar-tab-content">
             {activeTabContent.kind === 'flat' && activeTabContent.threads.map((t) => renderThreadItem(t))}
 
             {activeTabContent.kind === 'project' && threadGroups.length > 0 && (

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -917,59 +917,58 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
           <div className="pt-1.5" data-testid="sidebar-tab-content">
             {activeTabContent.kind === 'flat' && activeTabContent.threads.map((t) => renderThreadItem(t))}
 
-            {activeTabContent.kind === 'project' &&
-              threadGroups.length > 0 && (
-                <div
-                  className="flex items-center justify-between px-3 py-1 text-micro text-cafe-muted"
-                  data-testid="project-toolbar"
-                >
-                  <span>{threadGroups.length} 个项目</span>
-                  <div className="flex items-center gap-0.5">
-                    <button
-                      type="button"
-                      onClick={expandAll}
-                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
-                      data-testid="expand-all-btn"
-                      aria-label="展开全部项目"
-                      title="展开全部"
+            {activeTabContent.kind === 'project' && threadGroups.length > 0 && (
+              <div
+                className="flex items-center justify-between px-3 py-1 text-micro text-cafe-muted"
+                data-testid="project-toolbar"
+              >
+                <span>{threadGroups.length} 个项目</span>
+                <div className="flex items-center gap-0.5">
+                  <button
+                    type="button"
+                    onClick={expandAll}
+                    className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                    data-testid="expand-all-btn"
+                    aria-label="展开全部项目"
+                    title="展开全部"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="h-3.5 w-3.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
                     >
-                      <svg
-                        aria-hidden="true"
-                        className="h-3.5 w-3.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M6 9l6 6 6-6" />
-                      </svg>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={collapseAll}
-                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
-                      data-testid="collapse-all-btn"
-                      aria-label="折叠全部项目"
-                      title="折叠全部"
+                      <path d="M6 9l6 6 6-6" />
+                    </svg>
+                  </button>
+                  <button
+                    type="button"
+                    onClick={collapseAll}
+                    className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                    data-testid="collapse-all-btn"
+                    aria-label="折叠全部项目"
+                    title="折叠全部"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="h-3.5 w-3.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth={2}
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
                     >
-                      <svg
-                        aria-hidden="true"
-                        className="h-3.5 w-3.5"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth={2}
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                      >
-                        <path d="M18 15l-6-6-6 6" />
-                      </svg>
-                    </button>
-                  </div>
+                      <path d="M18 15l-6-6-6 6" />
+                    </svg>
+                  </button>
                 </div>
-              )}
+              </div>
+            )}
 
             {activeTabContent.kind === 'project' &&
               threadGroups.map((group) => {

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -730,16 +730,16 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
   // V9 sidebar tabs: keep grouping derived from filtered thread data.
   const { pinnedProjects, toggleProjectPin } = useProjectPins();
   const tabs = useMemo(
-    () => buildSidebarTabs(labelFilteredThreads, pinnedProjects),
-    [labelFilteredThreads, pinnedProjects],
+    () => buildSidebarTabs(labelFilteredThreads, pinnedProjects, unreadIds),
+    [labelFilteredThreads, pinnedProjects, unreadIds],
   );
   const activeTabContent = useMemo(
-    () => buildSidebarTabContent(activeTab, labelFilteredThreads, pinnedProjects),
-    [activeTab, labelFilteredThreads, pinnedProjects],
+    () => buildSidebarTabContent(activeTab, labelFilteredThreads, pinnedProjects, unreadIds),
+    [activeTab, labelFilteredThreads, pinnedProjects, unreadIds],
   );
   const projectThreadGroups = useMemo(
-    () => buildSidebarTabContent('project', labelFilteredThreads, pinnedProjects).projectGroups ?? [],
-    [labelFilteredThreads, pinnedProjects],
+    () => buildSidebarTabContent('project', labelFilteredThreads, pinnedProjects, unreadIds).projectGroups ?? [],
+    [labelFilteredThreads, pinnedProjects, unreadIds],
   );
   const threadGroups = activeTab === 'project' ? projectThreadGroups : [];
 

--- a/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadSidebar.tsx
@@ -19,10 +19,12 @@ import { ThreadItem } from './ThreadItem';
 import { ThreadOrganizerModal } from './ThreadOrganizerModal';
 import { pushThreadRouteWithHistory } from './thread-navigation';
 import {
+  buildSidebarTabContent,
+  buildSidebarTabs,
   getProjectPaths,
   mergeLiveActivityIntoThreads,
   projectDisplayName,
-  sortAndGroupThreadsWithWorkspace,
+  type SidebarTabId,
 } from './thread-utils';
 import { createToggleWithReconcile } from './toggle-with-reconcile';
 import { useCollapseState } from './use-collapse-state';
@@ -71,9 +73,16 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
   const [govHealth, setGovHealth] = useState<Record<string, string>>({});
   // F252 Phase E: Meow Theater replay state
   const [replayThreadId, setReplayThreadId] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<SidebarTabId>('recent');
 
   // F095 Phase E: scroll anchor for reorder stability
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const tabRefs = useRef<Record<SidebarTabId, HTMLButtonElement | null>>({
+    recent: null,
+    project: null,
+    system: null,
+    favorites: null,
+  });
   // F095 Phase F: custom project display names
   const [projectNames, setProjectNames] = useState(() =>
     readProjectNames(typeof localStorage !== 'undefined' ? localStorage : { getItem: () => null, setItem: () => {} }),
@@ -156,6 +165,12 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     window.addEventListener('online', handleOnline);
     return () => window.removeEventListener('online', handleOnline);
   }, [loadThreads]);
+
+  useEffect(() => {
+    const activeButton = tabRefs.current[activeTab];
+    if (!activeButton || typeof activeButton.scrollIntoView !== 'function') return;
+    activeButton.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [activeTab]);
 
   // F070: Fetch governance health for all registered external projects
   useEffect(() => {
@@ -707,25 +722,75 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
     }
   }, []);
 
-  // F095 Phase B: Active workspace grouping
+  // V9 sidebar tabs: keep grouping derived from filtered thread data.
   const { pinnedProjects, toggleProjectPin } = useProjectPins();
-  const threadGroups = useMemo(
-    () => sortAndGroupThreadsWithWorkspace(labelFilteredThreads, unreadIds, pinnedProjects),
-    [labelFilteredThreads, unreadIds, pinnedProjects],
+  const tabs = useMemo(
+    () => buildSidebarTabs(labelFilteredThreads, pinnedProjects),
+    [labelFilteredThreads, pinnedProjects],
   );
+  const activeTabContent = useMemo(
+    () => buildSidebarTabContent(activeTab, labelFilteredThreads, pinnedProjects),
+    [activeTab, labelFilteredThreads, pinnedProjects],
+  );
+  const projectThreadGroups = useMemo(
+    () => buildSidebarTabContent('project', labelFilteredThreads, pinnedProjects).projectGroups ?? [],
+    [labelFilteredThreads, pinnedProjects],
+  );
+  const threadGroups = activeTabContent.kind === 'project' ? (activeTabContent.projectGroups ?? []) : [];
   const existingProjects = useMemo(() => getProjectPaths(liveThreads), [liveThreads]);
   const showDefaultThread = (normalizedQuery.length === 0 || '大厅'.includes(normalizedQuery)) && !labelFilter;
 
   // F095 Phase E: Scroll anchor — keeps visible content in place when threads reorder
-  const { onScroll: handleScrollAnchor } = useScrollAnchor(scrollContainerRef, threadGroups);
+  const { onScroll: handleScrollAnchor } = useScrollAnchor(scrollContainerRef, projectThreadGroups);
 
   // F095: Collapse state with localStorage persistence + search/active auto-expand
   const { isCollapsed, toggleGroup, expandAll, collapseAll } = useCollapseState({
-    threadGroups,
+    threadGroups: projectThreadGroups,
     searchQuery: normalizedQuery,
     currentThreadId,
   });
   const sidebarWidthClass = className === undefined ? 'w-60' : className;
+
+  const renderThreadItem = useCallback(
+    (thread: Thread, indented = false) => (
+      <ThreadItem
+        key={thread.id}
+        id={thread.id}
+        title={thread.title}
+        participants={thread.participants}
+        lastActiveAt={thread.lastActiveAt}
+        isActive={currentThreadId === thread.id}
+        onSelect={handleSelect}
+        onDelete={handleDeleteRequest}
+        onRename={handleRename}
+        onTogglePin={handleTogglePin}
+        onToggleFavorite={handleToggleFavorite}
+        onUpdatePreferredCats={handleUpdatePreferredCats}
+        onUpdateLabels={handleUpdateLabels}
+        onReplay={handleReplay}
+        isPinned={thread.pinned}
+        isFavorited={thread.favorited}
+        threadState={getThreadState(thread.id)}
+        projectPath={thread.projectPath}
+        indented={indented}
+        preferredCats={thread.preferredCats}
+        threadLabels={thread.labels}
+        isHubThread={!!thread.connectorHubState}
+      />
+    ),
+    [
+      currentThreadId,
+      getThreadState,
+      handleDeleteRequest,
+      handleRename,
+      handleReplay,
+      handleSelect,
+      handleToggleFavorite,
+      handleTogglePin,
+      handleUpdateLabels,
+      handleUpdatePreferredCats,
+    ],
+  );
 
   return (
     <>
@@ -792,7 +857,11 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
           onManualOrganize={() => setShowOrganizer(true)}
         />
 
-        <div ref={scrollContainerRef} onScroll={handleScrollAnchor} className="flex-1 overflow-y-auto">
+        <div
+          ref={scrollContainerRef}
+          onScroll={handleScrollAnchor}
+          className="flex-1 overflow-y-auto [scrollbar-gutter:stable] [scrollbar-width:thin] [scrollbar-color:transparent_var(--console-panel-bg)] hover:[scrollbar-color:var(--cafe-muted)_var(--console-panel-bg)] [&::-webkit-scrollbar]:w-1 [&::-webkit-scrollbar-track]:bg-[var(--console-panel-bg)] [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-transparent hover:[&::-webkit-scrollbar-thumb]:bg-cafe-muted [&::-webkit-scrollbar-corner]:bg-[var(--console-panel-bg)]"
+        >
           {isLoadingThreads && threads.length === 0 && (
             <div className="text-center py-4 text-xs text-cafe-muted">加载中...</div>
           )}
@@ -809,182 +878,131 @@ export function ThreadSidebar({ onClose, className }: ThreadSidebarProps) {
             />
           )}
 
-          {threadGroups.length > 0 && (
-            <div className="flex items-center justify-end px-3 pt-1.5">
-              <button
-                type="button"
-                onClick={expandAll}
-                className="text-micro text-cafe-muted hover:text-cafe-accent transition-colors"
-                data-testid="expand-all-btn"
+          {tabs.length > 0 && (
+            <div
+              className="sticky top-0 z-10 flex items-stretch gap-1 border-b border-cafe-subtle bg-[var(--console-panel-bg)] pt-2 pl-3 pr-2"
+              data-testid="sidebar-tabs-row"
+            >
+              <div
+                className="flex min-w-0 flex-1 gap-0.5 overflow-x-auto overflow-y-hidden px-0.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden [mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)] [-webkit-mask-image:linear-gradient(to_right,transparent,#000_8px,#000_calc(100%-8px),transparent)]"
+                role="tablist"
+                aria-label="对话分类"
+                data-testid="sidebar-tabs-scroll"
               >
-                全部展开
-              </button>
-              <span className="text-micro text-cafe-muted mx-1">/</span>
-              <button
-                type="button"
-                onClick={collapseAll}
-                className="text-micro text-cafe-muted hover:text-cafe-accent transition-colors"
-                data-testid="collapse-all-btn"
-              >
-                全部折叠
-              </button>
+                {tabs.map((tab) => (
+                  <button
+                    key={tab.id}
+                    ref={(node) => {
+                      tabRefs.current[tab.id] = node;
+                    }}
+                    type="button"
+                    role="tab"
+                    aria-selected={activeTab === tab.id}
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`flex flex-shrink-0 items-center gap-1 rounded-t-md border-b-2 px-2 py-1.5 text-micro font-medium transition-colors ${
+                      activeTab === tab.id
+                        ? 'border-cafe-accent text-cafe-accent'
+                        : 'border-transparent text-cafe-muted hover:bg-[var(--console-hover-bg)] hover:text-cafe-secondary'
+                    }`}
+                    data-testid={`sidebar-tab-${tab.id}`}
+                  >
+                    <span>{tab.label}</span>
+                    <span className={activeTab === tab.id ? 'text-cafe-accent' : 'text-cafe-muted'}>{tab.count}</span>
+                  </button>
+                ))}
+              </div>
             </div>
           )}
 
-          {threadGroups.map((group) => {
-            const groupKey = group.projectPath ?? group.type;
-            const icon =
-              group.type === 'pinned'
-                ? ('pin' as const)
-                : group.type === 'favorites'
-                  ? ('star' as const)
-                  : group.type === 'recent'
-                    ? ('clock' as const)
-                    : group.type === 'system'
-                      ? ('system' as const)
-                      : undefined;
+          <div className="pt-1.5" data-testid="sidebar-tab-content">
+            {activeTabContent.kind === 'flat' && activeTabContent.threads.map((t) => renderThreadItem(t))}
 
-            // Archived container: render nested project groups
-            if (group.type === 'archived-container') {
-              return (
-                <SectionGroup
-                  key="archived-container"
-                  label={group.label}
-                  icon="archive"
-                  count={group.archivedGroups?.length ?? 0}
-                  isCollapsed={isCollapsed('archived-container')}
-                  onToggle={() => toggleGroup('archived-container')}
+            {activeTabContent.kind === 'project' &&
+              threadGroups.length > 0 && (
+                <div
+                  className="flex items-center justify-between px-3 py-1 text-micro text-cafe-muted"
+                  data-testid="project-toolbar"
                 >
-                  {group.archivedGroups?.map((sub) => {
-                    const subKey = sub.projectPath ?? sub.type;
-                    return (
-                      <SectionGroup
-                        key={subKey}
-                        label={sub.projectPath ? (projectNames.get(sub.projectPath) ?? sub.label) : sub.label}
-                        count={sub.threads.length}
-                        isCollapsed={isCollapsed(subKey)}
-                        onToggle={() => toggleGroup(subKey)}
-                        projectPath={sub.projectPath}
-                        governanceStatus={sub.projectPath ? govHealth[sub.projectPath] : undefined}
-                        onToggleProjectPin={sub.projectPath ? () => toggleProjectPin(sub.projectPath!) : undefined}
-                        isProjectPinned={sub.projectPath ? pinnedProjects.has(sub.projectPath) : undefined}
-                        onQuickCreate={sub.projectPath ? () => handleQuickCreate(sub.projectPath!) : undefined}
-                        onOpenInFinder={
-                          sub.projectPath && sub.projectPath !== 'default'
-                            ? () => handleOpenInFinder(sub.projectPath!)
-                            : undefined
-                        }
-                        onRenameProject={
-                          sub.projectPath ? (name: string) => handleRenameProject(sub.projectPath!, name) : undefined
-                        }
-                        onArchiveThreads={sub.projectPath ? () => handleArchiveThreads(sub.projectPath!) : undefined}
+                  <span>{threadGroups.length} 个项目</span>
+                  <div className="flex items-center gap-0.5">
+                    <button
+                      type="button"
+                      onClick={expandAll}
+                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                      data-testid="expand-all-btn"
+                      aria-label="展开全部项目"
+                      title="展开全部"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
                       >
-                        {sub.threads.map((t) => (
-                          <ThreadItem
-                            key={t.id}
-                            id={t.id}
-                            title={t.title}
-                            participants={t.participants}
-                            lastActiveAt={t.lastActiveAt}
-                            isActive={currentThreadId === t.id}
-                            onSelect={handleSelect}
-                            onDelete={handleDeleteRequest}
-                            onRename={handleRename}
-                            onTogglePin={handleTogglePin}
-                            onToggleFavorite={handleToggleFavorite}
-                            onUpdatePreferredCats={handleUpdatePreferredCats}
-                            onUpdateLabels={handleUpdateLabels}
-                            onReplay={handleReplay}
-                            isPinned={t.pinned}
-                            isFavorited={t.favorited}
-                            threadState={getThreadState(t.id)}
-                            projectPath={t.projectPath}
-                            indented
-                            preferredCats={t.preferredCats}
-                            threadLabels={t.labels}
-                            isHubThread={!!t.connectorHubState}
-                          />
-                        ))}
-                      </SectionGroup>
-                    );
-                  })}
-                </SectionGroup>
-              );
-            }
+                        <path d="M6 9l6 6 6-6" />
+                      </svg>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={collapseAll}
+                      className="flex items-center justify-center rounded p-1 text-cafe-muted transition-colors hover:bg-[var(--console-hover-bg)] hover:text-cafe-accent"
+                      data-testid="collapse-all-btn"
+                      aria-label="折叠全部项目"
+                      title="折叠全部"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        className="h-3.5 w-3.5"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth={2}
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      >
+                        <path d="M18 15l-6-6-6 6" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              )}
 
-            return (
-              <SectionGroup
-                key={groupKey}
-                label={group.projectPath ? (projectNames.get(group.projectPath) ?? group.label) : group.label}
-                icon={icon}
-                count={group.threads.length}
-                isCollapsed={isCollapsed(groupKey)}
-                onToggle={() => toggleGroup(groupKey)}
-                projectPath={group.projectPath}
-                governanceStatus={group.projectPath ? govHealth[group.projectPath] : undefined}
-                onToggleProjectPin={
-                  group.type === 'project' && group.projectPath ? () => toggleProjectPin(group.projectPath!) : undefined
-                }
-                isProjectPinned={
-                  group.type === 'project' && group.projectPath ? pinnedProjects.has(group.projectPath) : undefined
-                }
-                onQuickCreate={
-                  group.type === 'project' && group.projectPath
-                    ? () => handleQuickCreate(group.projectPath!)
-                    : undefined
-                }
-                // Note: system/pinned/recent/favorites groups get undefined for all project actions
-                // because group.type !== 'project'. This is intentional — only project sections
-                // should have Open in Finder / Rename / Archive / Quick Create.
-                onOpenInFinder={
-                  group.type === 'project' && group.projectPath && group.projectPath !== 'default'
-                    ? () => handleOpenInFinder(group.projectPath!)
-                    : undefined
-                }
-                onRenameProject={
-                  group.type === 'project' && group.projectPath
-                    ? (name: string) => handleRenameProject(group.projectPath!, name)
-                    : undefined
-                }
-                onArchiveThreads={
-                  group.type === 'project' && group.projectPath
-                    ? () => handleArchiveThreads(group.projectPath!)
-                    : undefined
-                }
-              >
-                {group.threads.map((t) => (
-                  <ThreadItem
-                    key={t.id}
-                    id={t.id}
-                    title={t.title}
-                    participants={t.participants}
-                    lastActiveAt={t.lastActiveAt}
-                    isActive={currentThreadId === t.id}
-                    onSelect={handleSelect}
-                    onDelete={handleDeleteRequest}
-                    onRename={handleRename}
-                    onTogglePin={handleTogglePin}
-                    onToggleFavorite={handleToggleFavorite}
-                    onUpdatePreferredCats={handleUpdatePreferredCats}
-                    onUpdateLabels={handleUpdateLabels}
-                    onReplay={handleReplay}
-                    isPinned={t.pinned}
-                    isFavorited={t.favorited}
-                    threadState={getThreadState(t.id)}
-                    projectPath={t.projectPath}
-                    indented={group.type === 'project'}
-                    preferredCats={t.preferredCats}
-                    threadLabels={t.labels}
-                    isHubThread={!!t.connectorHubState}
-                  />
-                ))}
-              </SectionGroup>
-            );
-          })}
+            {activeTabContent.kind === 'project' &&
+              threadGroups.map((group) => {
+                const groupKey = group.projectPath ?? group.type;
+                const projectPath = group.projectPath;
 
-          {normalizedQuery.length > 0 && threadGroups.length === 0 && !showDefaultThread && (
-            <div className="px-3 py-4 text-xs text-cafe-muted">没有匹配的对话</div>
-          )}
+                return (
+                  <SectionGroup
+                    key={groupKey}
+                    label={projectPath ? (projectNames.get(projectPath) ?? group.label) : group.label}
+                    count={group.threads.length}
+                    isCollapsed={isCollapsed(groupKey)}
+                    onToggle={() => toggleGroup(groupKey)}
+                    projectPath={projectPath}
+                    governanceStatus={projectPath ? govHealth[projectPath] : undefined}
+                    onToggleProjectPin={projectPath ? () => toggleProjectPin(projectPath) : undefined}
+                    isProjectPinned={projectPath ? pinnedProjects.has(projectPath) : undefined}
+                    onQuickCreate={projectPath ? () => handleQuickCreate(projectPath) : undefined}
+                    onOpenInFinder={
+                      projectPath && projectPath !== 'default' ? () => handleOpenInFinder(projectPath) : undefined
+                    }
+                    onRenameProject={projectPath ? (name: string) => handleRenameProject(projectPath, name) : undefined}
+                    onArchiveThreads={projectPath ? () => handleArchiveThreads(projectPath) : undefined}
+                  >
+                    {group.threads.map((t) => renderThreadItem(t, true))}
+                  </SectionGroup>
+                );
+              })}
+
+            {normalizedQuery.length > 0 && activeTabContent.threads.length === 0 && !showDefaultThread && (
+              <div className="px-3 py-4 text-xs text-cafe-muted">没有匹配的对话</div>
+            )}
+          </div>
         </div>
 
         {/* F095 Phase D: Trash bin section */}

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-delete-confirm.test.ts
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-delete-confirm.test.ts
@@ -124,7 +124,17 @@ describe('Thread delete confirmation (I-1)', () => {
   }
 
   function findDeleteButton(): HTMLButtonElement | undefined {
-    return Array.from(container.querySelectorAll('button')).find((b) => b.getAttribute('title') === '删除对话');
+    return Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.trim() === '删除对话');
+  }
+
+  function openActionsMenu() {
+    const moreBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.getAttribute('title') === '更多操作',
+    );
+    expect(moreBtn, 'more actions button should exist for non-default thread').toBeTruthy();
+    act(() => {
+      moreBtn?.click();
+    });
   }
 
   /** F095 defaults all sections collapsed. Click expand-all first. */
@@ -142,9 +152,10 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
-    expect(deleteBtn, 'delete button should exist for non-default thread').toBeTruthy();
+    expect(deleteBtn, 'delete menu item should exist for non-default thread').toBeTruthy();
 
     act(() => {
       deleteBtn?.click();
@@ -168,6 +179,7 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
     act(() => {
@@ -191,6 +203,7 @@ describe('Thread delete confirmation (I-1)', () => {
     });
     await flush();
     expandAll();
+    openActionsMenu();
 
     const deleteBtn = findDeleteButton();
     act(() => {

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-scroll-memory.test.ts
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-scroll-memory.test.ts
@@ -82,7 +82,9 @@ function jsonOk(data: unknown) {
 
 function findScrollContainer(root: HTMLElement): HTMLDivElement {
   const scroller = Array.from(root.querySelectorAll('div')).find(
-    (el): el is HTMLDivElement => el.className.includes('overflow-y-auto') && !!el.querySelector('[data-thread-id]'),
+    (el): el is HTMLDivElement =>
+      (el.className.includes('overflow-y-auto') || el.className.includes('overflow-y:overlay')) &&
+      !!el.querySelector('[data-thread-id]'),
   );
   if (!scroller) throw new Error('scroll container not found');
   return scroller;
@@ -158,8 +160,24 @@ describe('ThreadSidebar scroll memory', () => {
   }
 
   function expandAll(rootEl: HTMLElement) {
+    // v12: variable toggle button only renders on the project tab. Switch there first.
+    const projectTab = rootEl.querySelector('[data-testid="sidebar-tab-project"]') as HTMLButtonElement | null;
+    if (projectTab) {
+      act(() => {
+        projectTab.click();
+      });
+    }
+    // Variable button: allCollapsed → "expand-all-btn", else → "collapse-all-btn".
+    // To guarantee all-expanded end state regardless of initial state: first collapse all
+    // (so we reach a known allCollapsed=true), then click expand-all.
+    const collapseBtn = rootEl.querySelector('[data-testid="collapse-all-btn"]') as HTMLButtonElement | null;
+    if (collapseBtn) {
+      act(() => {
+        collapseBtn.click();
+      });
+    }
     const expandBtn = rootEl.querySelector('[data-testid="expand-all-btn"]') as HTMLButtonElement | null;
-    if (!expandBtn) throw new Error('expand-all button not found');
+    if (!expandBtn) throw new Error('expand-all button not found after collapse');
     act(() => {
       expandBtn.click();
     });

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
@@ -107,8 +107,20 @@ describe('ThreadSidebar v9 tab redesign', () => {
     Object.assign(mockStore, {
       threads: [
         makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
-        makeThread({ id: 'pinned-a', title: 'Pinned A', pinned: true, projectPath: '/proj/a', lastActiveAt: NOW - 1_000 }),
-        makeThread({ id: 'pinned-b', title: 'Pinned B', pinned: true, projectPath: '/proj/b', lastActiveAt: NOW - 2_000 }),
+        makeThread({
+          id: 'pinned-a',
+          title: 'Pinned A',
+          pinned: true,
+          projectPath: '/proj/a',
+          lastActiveAt: NOW - 1_000,
+        }),
+        makeThread({
+          id: 'pinned-b',
+          title: 'Pinned B',
+          pinned: true,
+          projectPath: '/proj/b',
+          lastActiveAt: NOW - 2_000,
+        }),
         makeThread({ id: 'regular', title: 'Regular', projectPath: '/proj/a', lastActiveAt: NOW - 3_000 }),
       ],
     });

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
@@ -88,7 +88,7 @@ describe('ThreadSidebar v9 tab redesign', () => {
     expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     const tabs = Array.from(harness.container.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim());
-    expect(tabs).toEqual(['置顶0', '最近3', '项目3', '系统1', '收藏1']);
+    expect(tabs).toEqual(['置顶', '最近', '项目', '系统', '收藏']);
   });
 
   it('switches isolated tab content without mixing system/project/favorite views', async () => {

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
@@ -1,0 +1,146 @@
+import { act } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Thread } from '@/stores/chat-types';
+import {
+  createThreadSidebarHarness,
+  installThreadSidebarGlobals,
+  mockStore,
+  resetThreadSidebarGlobals,
+  resetThreadSidebarMocks,
+  type ThreadSidebarHarness,
+} from './thread-sidebar-test-helpers';
+
+const NOW = 1710000000000;
+
+function makeThread(overrides: Partial<Thread> & { id: string }): Thread {
+  return {
+    projectPath: 'default',
+    title: null,
+    createdBy: 'user',
+    participants: [],
+    lastActiveAt: NOW,
+    createdAt: NOW,
+    ...overrides,
+  };
+}
+
+function visibleThreadIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-thread-id]')).map(
+    (node) => node.getAttribute('data-thread-id') ?? '',
+  );
+}
+
+async function clickTab(container: HTMLElement, tabId: string, flush: () => Promise<void>) {
+  const tab = container.querySelector(`[data-testid="sidebar-tab-${tabId}"]`) as HTMLButtonElement;
+  await act(async () => {
+    tab.click();
+  });
+  await flush();
+}
+
+describe('ThreadSidebar v9 tab redesign', () => {
+  let harness: ThreadSidebarHarness;
+  let scrollIntoView: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    installThreadSidebarGlobals();
+    resetThreadSidebarMocks();
+    scrollIntoView = vi.fn();
+    Object.defineProperty(Element.prototype, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+    });
+    Object.assign(mockStore, {
+      threads: [
+        makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+        makeThread({ id: 'recent', title: 'Recent Thread', projectPath: '/proj/b', lastActiveAt: NOW - 1_000 }),
+        makeThread({ id: 'project', title: 'Project Thread', projectPath: '/proj/a', lastActiveAt: NOW - 2_000 }),
+        makeThread({
+          id: 'favorite',
+          title: 'Favorite Thread',
+          favorited: true,
+          projectPath: '/proj/a',
+          lastActiveAt: NOW - 3_000,
+        }),
+        makeThread({ id: 'system', title: 'System Thread', systemKind: 'eval_domain', lastActiveAt: NOW - 4_000 }),
+      ],
+      currentThreadId: 'recent',
+      threadStates: {},
+      isLoadingThreads: false,
+    });
+    harness = createThreadSidebarHarness();
+  });
+
+  afterEach(() => {
+    harness.cleanup();
+    resetThreadSidebarGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps lobby above the tab row and renders tabs in the v9 order', async () => {
+    await harness.render();
+
+    const lobby = harness.container.querySelector('[data-thread-id="default"]');
+    const tabsRow = harness.container.querySelector('[data-testid="sidebar-tabs-row"]');
+    expect(lobby).not.toBeNull();
+    expect(tabsRow).not.toBeNull();
+    const position = lobby!.compareDocumentPosition(tabsRow!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    const tabs = Array.from(harness.container.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim());
+    expect(tabs).toEqual(['最近3', '项目3', '系统1', '收藏1']);
+  });
+
+  it('switches isolated tab content without mixing system/project/favorite views', async () => {
+    await harness.render();
+
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'recent', 'project', 'favorite']);
+
+    await clickTab(harness.container, 'system', harness.flush);
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'system']);
+
+    await clickTab(harness.container, 'favorites', harness.flush);
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'favorite']);
+  });
+
+  it('shows separate expand/collapse buttons in a project toolbar below the tabs', async () => {
+    await harness.render();
+
+    // Default (recent) tab is flat — no project toolbar.
+    expect(harness.container.querySelector('[data-testid="project-toolbar"]')).toBeNull();
+
+    // Project tab — toolbar appears inside the tab content, below the tabs row.
+    await clickTab(harness.container, 'project', harness.flush);
+    const tabsRow = harness.container.querySelector('[data-testid="sidebar-tabs-row"]');
+    expect(tabsRow).not.toBeNull();
+
+    const toolbar = harness.container.querySelector('[data-testid="project-toolbar"]');
+    expect(toolbar).not.toBeNull();
+
+    // Two separate buttons (not a single toggle): expand-all + collapse-all, both present.
+    const expand = harness.container.querySelector('[data-testid="expand-all-btn"]');
+    const collapse = harness.container.querySelector('[data-testid="collapse-all-btn"]');
+    expect(expand).not.toBeNull();
+    expect(collapse).not.toBeNull();
+    // Both buttons live inside the toolbar (not the tabs row).
+    expect(toolbar?.contains(expand)).toBe(true);
+    expect(toolbar?.contains(collapse)).toBe(true);
+    expect(tabsRow?.contains(expand)).toBe(false);
+    // Icon-only (no text label).
+    expect((expand as HTMLButtonElement)?.textContent?.trim()).toBe('');
+    expect((collapse as HTMLButtonElement)?.textContent?.trim()).toBe('');
+    expect((expand as HTMLButtonElement)?.getAttribute('aria-label')).toBe('展开全部项目');
+    expect((collapse as HTMLButtonElement)?.getAttribute('aria-label')).toBe('折叠全部项目');
+
+    const tabContent = harness.container.querySelector('[data-testid="sidebar-tab-content"]');
+    expect(tabContent?.className).toContain('pt-1.5');
+  });
+
+  it('scrolls the active tab into view after selection', async () => {
+    await harness.render();
+
+    await clickTab(harness.container, 'favorites', harness.flush);
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest', inline: 'nearest' });
+  });
+});

--- a/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
+++ b/packages/web/src/components/ThreadSidebar/__tests__/thread-sidebar-tab-redesign.test.tsx
@@ -88,7 +88,7 @@ describe('ThreadSidebar v9 tab redesign', () => {
     expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
 
     const tabs = Array.from(harness.container.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim());
-    expect(tabs).toEqual(['最近3', '项目3', '系统1', '收藏1']);
+    expect(tabs).toEqual(['置顶0', '最近3', '项目3', '系统1', '收藏1']);
   });
 
   it('switches isolated tab content without mixing system/project/favorite views', async () => {
@@ -101,6 +101,25 @@ describe('ThreadSidebar v9 tab redesign', () => {
 
     await clickTab(harness.container, 'favorites', harness.flush);
     expect(visibleThreadIds(harness.container)).toEqual(['default', 'favorite']);
+  });
+
+  it('shows pinned threads in an isolated pinned tab while recent stays additive', async () => {
+    Object.assign(mockStore, {
+      threads: [
+        makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+        makeThread({ id: 'pinned-a', title: 'Pinned A', pinned: true, projectPath: '/proj/a', lastActiveAt: NOW - 1_000 }),
+        makeThread({ id: 'pinned-b', title: 'Pinned B', pinned: true, projectPath: '/proj/b', lastActiveAt: NOW - 2_000 }),
+        makeThread({ id: 'regular', title: 'Regular', projectPath: '/proj/a', lastActiveAt: NOW - 3_000 }),
+      ],
+    });
+    await harness.render();
+
+    // Recent tab is additive — pinned threads still appear (sorted first by activity desc)
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'pinned-a', 'pinned-b', 'regular']);
+
+    // Pinned tab shows only pinned threads
+    await clickTab(harness.container, 'pinned', harness.flush);
+    expect(visibleThreadIds(harness.container)).toEqual(['default', 'pinned-a', 'pinned-b']);
   });
 
   it('shows separate expand/collapse buttons in a project toolbar below the tabs', async () => {

--- a/packages/web/src/components/ThreadSidebar/thread-utils.ts
+++ b/packages/web/src/components/ThreadSidebar/thread-utils.ts
@@ -101,17 +101,34 @@ function titleForSort(thread: Thread): string {
   return thread.title ?? (thread.id === 'default' ? '大厅' : '未命名对话');
 }
 
-function sortPinnedThenActive(a: Thread, b: Thread): number {
+/**
+ * Sort comparator: pinned first, then unread, then by lastActiveAt descending.
+ * Preserves the unread-first visibility that the pre-tab sidebar had via
+ * `sortByUnreadThenActive`, but with pin taking precedence (matches the
+ * tab helpers' existing pin-first contract).
+ */
+function sortPinnedUnreadActive(a: Thread, b: Thread, unreadIds: Set<string>): number {
   const aPinned = a.pinned ? 1 : 0;
   const bPinned = b.pinned ? 1 : 0;
   if (aPinned !== bPinned) return bPinned - aPinned;
+  const aUnread = unreadIds.has(a.id) ? 1 : 0;
+  const bUnread = unreadIds.has(b.id) ? 1 : 0;
+  if (aUnread !== bUnread) return bUnread - aUnread;
   return b.lastActiveAt - a.lastActiveAt;
 }
 
-function sortPinnedThenTitle(a: Thread, b: Thread): number {
+/**
+ * Sort comparator: pinned first, then unread, then by title.
+ * Unread-first within the title-sorted tabs (System/Favorites/Project) so an
+ * unread thread is not buried below read threads sharing the same pin state.
+ */
+function sortPinnedUnreadTitle(a: Thread, b: Thread, unreadIds: Set<string>): number {
   const aPinned = a.pinned ? 1 : 0;
   const bPinned = b.pinned ? 1 : 0;
   if (aPinned !== bPinned) return bPinned - aPinned;
+  const aUnread = unreadIds.has(a.id) ? 1 : 0;
+  const bUnread = unreadIds.has(b.id) ? 1 : 0;
+  if (aUnread !== bUnread) return bUnread - aUnread;
   return titleForSort(a).localeCompare(titleForSort(b), 'zh-Hans-CN');
 }
 
@@ -119,33 +136,35 @@ function nonDefaultThreads(threads: Thread[]): Thread[] {
   return threads.filter((thread) => thread.id !== 'default');
 }
 
-function tabPinnedThreads(threads: Thread[]): Thread[] {
+function tabPinnedThreads(threads: Thread[], unreadIds: Set<string>): Thread[] {
   // Pinned tab — flat view of all pinned threads (additive: still appears in recent/project).
   return nonDefaultThreads(threads)
     .filter((thread) => thread.pinned)
-    .sort((a, b) => b.lastActiveAt - a.lastActiveAt);
+    .sort((a, b) => sortPinnedUnreadActive(a, b, unreadIds));
 }
 
-function tabRecentThreads(threads: Thread[]): Thread[] {
+function tabRecentThreads(threads: Thread[], unreadIds: Set<string>): Thread[] {
   // Demo spec (sidebar-proposals.html line 200/848): 对话置顶 = 最近 Tab + 当前 Tab 双重置顶.
   // A pinned system thread must still appear in the recent tab (additive, not exclusive).
   // Unpinned system threads stay only in the system tab.
   return nonDefaultThreads(threads)
     .filter((thread) => thread.pinned || !isSystemThread(thread))
-    .sort(sortPinnedThenActive);
+    .sort((a, b) => sortPinnedUnreadActive(a, b, unreadIds));
 }
 
-function tabSystemThreads(threads: Thread[]): Thread[] {
-  return nonDefaultThreads(threads).filter(isSystemThread).sort(sortPinnedThenTitle);
+function tabSystemThreads(threads: Thread[], unreadIds: Set<string>): Thread[] {
+  return nonDefaultThreads(threads)
+    .filter(isSystemThread)
+    .sort((a, b) => sortPinnedUnreadTitle(a, b, unreadIds));
 }
 
-function tabFavoriteThreads(threads: Thread[]): Thread[] {
+function tabFavoriteThreads(threads: Thread[], unreadIds: Set<string>): Thread[] {
   return nonDefaultThreads(threads)
     .filter((thread) => thread.favorited)
-    .sort(sortPinnedThenTitle);
+    .sort((a, b) => sortPinnedUnreadTitle(a, b, unreadIds));
 }
 
-function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): ThreadGroup[] {
+function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>, unreadIds: Set<string>): ThreadGroup[] {
   const grouped = new Map<string, Thread[]>();
   for (const thread of nonDefaultThreads(threads)) {
     if (isSystemThread(thread)) continue;
@@ -159,7 +178,7 @@ function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): Threa
       type: 'project' as const,
       label: projectDisplayName(projectPath),
       projectPath,
-      threads: projectThreads.sort(sortPinnedThenTitle),
+      threads: projectThreads.sort((a, b) => sortPinnedUnreadTitle(a, b, unreadIds)),
     }))
     .sort((a, b) => {
       const aPinned = pinnedProjects.has(a.projectPath ?? '') ? 1 : 0;
@@ -171,14 +190,21 @@ function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): Threa
     });
 }
 
-export function buildSidebarTabs(threads: Thread[], pinnedProjects: Set<string> = new Set()): SidebarTab[] {
-  const projectCount = tabProjectGroups(threads, pinnedProjects).reduce((sum, group) => sum + group.threads.length, 0);
+export function buildSidebarTabs(
+  threads: Thread[],
+  pinnedProjects: Set<string> = new Set(),
+  unreadIds: Set<string> = new Set(),
+): SidebarTab[] {
+  const projectCount = tabProjectGroups(threads, pinnedProjects, unreadIds).reduce(
+    (sum, group) => sum + group.threads.length,
+    0,
+  );
   return [
-    { id: 'pinned', label: '置顶', count: tabPinnedThreads(threads).length },
-    { id: 'recent', label: '最近', count: tabRecentThreads(threads).length },
+    { id: 'pinned', label: '置顶', count: tabPinnedThreads(threads, unreadIds).length },
+    { id: 'recent', label: '最近', count: tabRecentThreads(threads, unreadIds).length },
     { id: 'project', label: '项目', count: projectCount },
-    { id: 'system', label: '系统', count: tabSystemThreads(threads).length },
-    { id: 'favorites', label: '收藏', count: tabFavoriteThreads(threads).length },
+    { id: 'system', label: '系统', count: tabSystemThreads(threads, unreadIds).length },
+    { id: 'favorites', label: '收藏', count: tabFavoriteThreads(threads, unreadIds).length },
   ];
 }
 
@@ -186,21 +212,22 @@ export function buildSidebarTabContent(
   tabId: SidebarTabId,
   threads: Thread[],
   pinnedProjects: Set<string> = new Set(),
+  unreadIds: Set<string> = new Set(),
 ): SidebarThreadBucket {
   if (tabId === 'pinned') {
-    return { kind: 'flat', threads: tabPinnedThreads(threads) };
+    return { kind: 'flat', threads: tabPinnedThreads(threads, unreadIds) };
   }
   if (tabId === 'project') {
-    const projectGroups = tabProjectGroups(threads, pinnedProjects);
+    const projectGroups = tabProjectGroups(threads, pinnedProjects, unreadIds);
     return { kind: 'project', threads: projectGroups.flatMap((group) => group.threads), projectGroups };
   }
   if (tabId === 'system') {
-    return { kind: 'flat', threads: tabSystemThreads(threads) };
+    return { kind: 'flat', threads: tabSystemThreads(threads, unreadIds) };
   }
   if (tabId === 'favorites') {
-    return { kind: 'flat', threads: tabFavoriteThreads(threads) };
+    return { kind: 'flat', threads: tabFavoriteThreads(threads, unreadIds) };
   }
-  return { kind: 'flat', threads: tabRecentThreads(threads) };
+  return { kind: 'flat', threads: tabRecentThreads(threads, unreadIds) };
 }
 
 /**

--- a/packages/web/src/components/ThreadSidebar/thread-utils.ts
+++ b/packages/web/src/components/ThreadSidebar/thread-utils.ts
@@ -50,6 +50,20 @@ export interface ThreadGroup {
   archivedGroups?: ThreadGroup[];
 }
 
+export type SidebarTabId = 'recent' | 'project' | 'system' | 'favorites';
+
+export interface SidebarTab {
+  id: SidebarTabId;
+  label: string;
+  count: number;
+}
+
+export interface SidebarThreadBucket {
+  kind: 'flat' | 'project';
+  threads: Thread[];
+  projectGroups?: ThreadGroup[];
+}
+
 type ThreadActivitySource = Pick<ThreadState, 'lastActivity'> | undefined;
 
 /**
@@ -77,6 +91,105 @@ function sortByUnreadThenActive(a: Thread, b: Thread, unreadIds?: Set<string>): 
     if (aUnread !== bUnread) return bUnread - aUnread;
   }
   return b.lastActiveAt - a.lastActiveAt;
+}
+
+function isSystemThread(thread: Thread): boolean {
+  return !!thread.systemKind || !!thread.connectorHubState;
+}
+
+function titleForSort(thread: Thread): string {
+  return thread.title ?? (thread.id === 'default' ? '大厅' : '未命名对话');
+}
+
+function sortPinnedThenActive(a: Thread, b: Thread): number {
+  const aPinned = a.pinned ? 1 : 0;
+  const bPinned = b.pinned ? 1 : 0;
+  if (aPinned !== bPinned) return bPinned - aPinned;
+  return b.lastActiveAt - a.lastActiveAt;
+}
+
+function sortPinnedThenTitle(a: Thread, b: Thread): number {
+  const aPinned = a.pinned ? 1 : 0;
+  const bPinned = b.pinned ? 1 : 0;
+  if (aPinned !== bPinned) return bPinned - aPinned;
+  return titleForSort(a).localeCompare(titleForSort(b), 'zh-Hans-CN');
+}
+
+function nonDefaultThreads(threads: Thread[]): Thread[] {
+  return threads.filter((thread) => thread.id !== 'default');
+}
+
+function tabRecentThreads(threads: Thread[]): Thread[] {
+  // Demo spec (sidebar-proposals.html line 200/848): 对话置顶 = 最近 Tab + 当前 Tab 双重置顶.
+  // A pinned system thread must still appear in the recent tab (additive, not exclusive).
+  // Unpinned system threads stay only in the system tab.
+  return nonDefaultThreads(threads)
+    .filter((thread) => thread.pinned || !isSystemThread(thread))
+    .sort(sortPinnedThenActive);
+}
+
+function tabSystemThreads(threads: Thread[]): Thread[] {
+  return nonDefaultThreads(threads).filter(isSystemThread).sort(sortPinnedThenTitle);
+}
+
+function tabFavoriteThreads(threads: Thread[]): Thread[] {
+  return nonDefaultThreads(threads)
+    .filter((thread) => thread.favorited)
+    .sort(sortPinnedThenTitle);
+}
+
+function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): ThreadGroup[] {
+  const grouped = new Map<string, Thread[]>();
+  for (const thread of nonDefaultThreads(threads)) {
+    if (isSystemThread(thread)) continue;
+    const projectPath = thread.projectPath ?? 'default';
+    if (!grouped.has(projectPath)) grouped.set(projectPath, []);
+    grouped.get(projectPath)?.push(thread);
+  }
+
+  return [...grouped.entries()]
+    .map(([projectPath, projectThreads]) => ({
+      type: 'project' as const,
+      label: projectDisplayName(projectPath),
+      projectPath,
+      threads: projectThreads.sort(sortPinnedThenTitle),
+    }))
+    .sort((a, b) => {
+      const aPinned = pinnedProjects.has(a.projectPath ?? '') ? 1 : 0;
+      const bPinned = pinnedProjects.has(b.projectPath ?? '') ? 1 : 0;
+      if (aPinned !== bPinned) return bPinned - aPinned;
+      if (a.projectPath === 'default') return 1;
+      if (b.projectPath === 'default') return -1;
+      return (a.projectPath ?? a.label).localeCompare(b.projectPath ?? b.label, 'zh-Hans-CN');
+    });
+}
+
+export function buildSidebarTabs(threads: Thread[], pinnedProjects: Set<string> = new Set()): SidebarTab[] {
+  const projectCount = tabProjectGroups(threads, pinnedProjects).reduce((sum, group) => sum + group.threads.length, 0);
+  return [
+    { id: 'recent', label: '最近', count: tabRecentThreads(threads).length },
+    { id: 'project', label: '项目', count: projectCount },
+    { id: 'system', label: '系统', count: tabSystemThreads(threads).length },
+    { id: 'favorites', label: '收藏', count: tabFavoriteThreads(threads).length },
+  ];
+}
+
+export function buildSidebarTabContent(
+  tabId: SidebarTabId,
+  threads: Thread[],
+  pinnedProjects: Set<string> = new Set(),
+): SidebarThreadBucket {
+  if (tabId === 'project') {
+    const projectGroups = tabProjectGroups(threads, pinnedProjects);
+    return { kind: 'project', threads: projectGroups.flatMap((group) => group.threads), projectGroups };
+  }
+  if (tabId === 'system') {
+    return { kind: 'flat', threads: tabSystemThreads(threads) };
+  }
+  if (tabId === 'favorites') {
+    return { kind: 'flat', threads: tabFavoriteThreads(threads) };
+  }
+  return { kind: 'flat', threads: tabRecentThreads(threads) };
 }
 
 /**

--- a/packages/web/src/components/ThreadSidebar/thread-utils.ts
+++ b/packages/web/src/components/ThreadSidebar/thread-utils.ts
@@ -50,7 +50,7 @@ export interface ThreadGroup {
   archivedGroups?: ThreadGroup[];
 }
 
-export type SidebarTabId = 'recent' | 'project' | 'system' | 'favorites';
+export type SidebarTabId = 'pinned' | 'recent' | 'project' | 'system' | 'favorites';
 
 export interface SidebarTab {
   id: SidebarTabId;
@@ -119,6 +119,13 @@ function nonDefaultThreads(threads: Thread[]): Thread[] {
   return threads.filter((thread) => thread.id !== 'default');
 }
 
+function tabPinnedThreads(threads: Thread[]): Thread[] {
+  // Pinned tab — flat view of all pinned threads (additive: still appears in recent/project).
+  return nonDefaultThreads(threads)
+    .filter((thread) => thread.pinned)
+    .sort((a, b) => b.lastActiveAt - a.lastActiveAt);
+}
+
 function tabRecentThreads(threads: Thread[]): Thread[] {
   // Demo spec (sidebar-proposals.html line 200/848): 对话置顶 = 最近 Tab + 当前 Tab 双重置顶.
   // A pinned system thread must still appear in the recent tab (additive, not exclusive).
@@ -167,6 +174,7 @@ function tabProjectGroups(threads: Thread[], pinnedProjects: Set<string>): Threa
 export function buildSidebarTabs(threads: Thread[], pinnedProjects: Set<string> = new Set()): SidebarTab[] {
   const projectCount = tabProjectGroups(threads, pinnedProjects).reduce((sum, group) => sum + group.threads.length, 0);
   return [
+    { id: 'pinned', label: '置顶', count: tabPinnedThreads(threads).length },
     { id: 'recent', label: '最近', count: tabRecentThreads(threads).length },
     { id: 'project', label: '项目', count: projectCount },
     { id: 'system', label: '系统', count: tabSystemThreads(threads).length },
@@ -179,6 +187,9 @@ export function buildSidebarTabContent(
   threads: Thread[],
   pinnedProjects: Set<string> = new Set(),
 ): SidebarThreadBucket {
+  if (tabId === 'pinned') {
+    return { kind: 'flat', threads: tabPinnedThreads(threads) };
+  }
   if (tabId === 'project') {
     const projectGroups = tabProjectGroups(threads, pinnedProjects);
     return { kind: 'project', threads: projectGroups.flatMap((group) => group.threads), projectGroups };

--- a/packages/web/src/components/__tests__/f190-visual-contract.test.ts
+++ b/packages/web/src/components/__tests__/f190-visual-contract.test.ts
@@ -506,7 +506,7 @@ describe('F190 typography guard — no hardcoded font sizes in console scope', (
   it('src-wide guard: no raw pixel font definitions outside typography tokens', () => {
     const srcRoot = resolve(testDir, '..', '..');
     /* F056: dev/ tools (OklchTuner) intentionally use dense px sizes */
-    const DEV_EXCLUDE = /\/dev\//;
+    const DEV_EXCLUDE = /[\\/]dev[\\/]/;
     const violations = collectSourceFiles(srcRoot)
       .filter((file) => !DEV_EXCLUDE.test(file))
       .flatMap((file) => {

--- a/packages/web/src/components/__tests__/section-group.test.tsx
+++ b/packages/web/src/components/__tests__/section-group.test.tsx
@@ -12,96 +12,83 @@ function renderToContainer(element: React.ReactElement) {
   return { container, root };
 }
 
-describe('SectionGroup pin button', () => {
-  // P2: pin button must respond to Space key (ARIA role="button" requirement)
-  it('fires onToggleProjectPin on Space key press', () => {
+// v12: pin moved back into the "..." context menu (per co-creator feedback).
+// Tests open the menu then click the pin MenuItem (matched by label text).
+
+/** Open the project context menu by clicking the "更多操作" trigger. */
+function openMenu(container: HTMLElement): void {
+  const menuBtn = container.querySelector<HTMLButtonElement>('[data-testid="project-menu-btn"]');
+  if (!menuBtn) throw new Error('project-menu-btn not found');
+  act(() => {
+    menuBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+/** Find a MenuItem button by its text content. Throws if absent. */
+function findMenuItemByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const buttons = Array.from(container.querySelectorAll('button'));
+  const match = buttons.find((b) => b.textContent?.trim() === text);
+  if (!match) throw new Error(`MenuItem with text "${text}" not found`);
+  return match;
+}
+
+function renderPinGroup(overrides: { onToggle?: () => void; onPin?: () => void; isProjectPinned?: boolean } = {}) {
+  const onPin = overrides.onPin ?? vi.fn();
+  const { container } = renderToContainer(
+    <SectionGroup
+      label="test-project"
+      count={3}
+      isCollapsed={false}
+      onToggle={overrides.onToggle ?? (() => {})}
+      onToggleProjectPin={onPin}
+      isProjectPinned={overrides.isProjectPinned ?? false}
+    >
+      <div>child</div>
+    </SectionGroup>,
+  );
+  return { container, onPin };
+}
+
+describe('SectionGroup pin (in context menu)', () => {
+  it('fires onToggleProjectPin when pin menu item clicked', () => {
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
+    const { container } = renderPinGroup({ onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
     act(() => {
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      pinItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onPin).toHaveBeenCalledTimes(1);
   });
 
-  it('fires onToggleProjectPin on Enter key press', () => {
-    const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
-    act(() => {
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-    });
-    expect(onPin).toHaveBeenCalledTimes(1);
-  });
-
-  it('pin button click does not trigger parent onToggle', () => {
+  it('pin menu item click does not trigger parent onToggle', () => {
     const onToggle = vi.fn();
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={onToggle}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
+    const { container } = renderPinGroup({ onToggle, onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
     act(() => {
-      pinBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      pinItem.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
     expect(onPin).toHaveBeenCalledTimes(1);
     expect(onToggle).not.toHaveBeenCalled();
   });
 
-  // Cloud P2: auto-repeat keydown should not re-trigger pin toggle
-  it('ignores repeated Space keydown events (key held down)', () => {
+  it('shows "取消固定项目" label when pinned, "固定项目到活跃区" when unpinned', () => {
+    const { container: unpinned } = renderPinGroup({ isProjectPinned: false });
+    openMenu(unpinned);
+    expect(() => findMenuItemByText(unpinned, '固定项目到活跃区')).not.toThrow();
+
+    const { container: pinned } = renderPinGroup({ isProjectPinned: true });
+    openMenu(pinned);
+    expect(() => findMenuItemByText(pinned, '取消固定项目')).not.toThrow();
+  });
+
+  it('pin menu item is a native button (keyboard-accessible by default)', () => {
     const onPin = vi.fn();
-    const { container } = renderToContainer(
-      <SectionGroup
-        label="test-project"
-        count={3}
-        isCollapsed={false}
-        onToggle={() => {}}
-        onToggleProjectPin={onPin}
-        isProjectPinned={false}
-      >
-        <div>child</div>
-      </SectionGroup>,
-    );
-    const pinBtn = container.querySelector('[data-testid="project-pin-btn"]')!;
-    act(() => {
-      // First press — should fire
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: false }));
-      // Auto-repeat events — should be ignored
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: true }));
-      pinBtn.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true, repeat: true }));
-    });
-    expect(onPin).toHaveBeenCalledTimes(1);
+    const { container } = renderPinGroup({ onPin });
+    openMenu(container);
+    const pinItem = findMenuItemByText(container, '固定项目到活跃区');
+    expect(pinItem.tagName).toBe('BUTTON');
   });
 });

--- a/packages/web/src/components/__tests__/thread-item-actions.test.tsx
+++ b/packages/web/src/components/__tests__/thread-item-actions.test.tsx
@@ -6,7 +6,7 @@ import { ThreadItem } from '@/components/ThreadSidebar/ThreadItem';
 vi.mock('@/hooks/useCatData', () => ({
   useCatData: () => ({
     cats: [],
-    getCatById: () => undefined,
+    getCatById: (catId: string) => ({ displayName: catId === 'cat-a' ? '猫甲' : catId }),
     getCatsByBreed: () => new Map(),
   }),
 }));
@@ -67,6 +67,17 @@ vi.mock('@/components/ThreadSidebar/thread-utils', () => ({
   formatRelativeTime: () => '1分',
 }));
 
+vi.mock('@/stores/label-store', () => ({
+  useLabelStore: () => ({
+    labels: [
+      { id: 'product', name: '产品体验', color: '#3b82f6' },
+      { id: 'architecture', name: '架构规划', color: '#8b5cf6' },
+      { id: 'bug', name: '缺陷排查', color: '#ef4444' },
+      { id: 'quality', name: '评测质控', color: '#10b981' },
+    ],
+  }),
+}));
+
 vi.mock('@/utils/api-client', () => ({
   API_URL: 'http://example.test',
   apiFetch: vi.fn(),
@@ -92,13 +103,13 @@ describe('ThreadItem actions', () => {
     vi.restoreAllMocks();
   });
 
-  function renderThread() {
+  function renderThread(overrides: Partial<React.ComponentProps<typeof ThreadItem>> = {}) {
     act(() => {
       root.render(
         React.createElement(ThreadItem, {
           id: 'thread-1',
           title: 'Thread 1',
-          participants: [],
+          participants: ['cat-a'],
           lastActiveAt: 1,
           isActive: false,
           onSelect: vi.fn(),
@@ -111,6 +122,8 @@ describe('ThreadItem actions', () => {
           projectPath: '/projects/cat-cafe',
           isPinned: false,
           isFavorited: false,
+          threadLabels: [],
+          ...overrides,
         }),
       );
     });
@@ -120,11 +133,11 @@ describe('ThreadItem actions', () => {
     return container.querySelector(`button[title="${title}"]`);
   }
 
-  it('keeps direct thread actions to pin, delete, and more', () => {
+  it('keeps pin and delete inside the more menu instead of fixed row buttons', () => {
     renderThread();
 
-    expect(buttonByTitle('置顶')).not.toBeNull();
-    expect(buttonByTitle('删除对话')).not.toBeNull();
+    expect(buttonByTitle('置顶')).toBeNull();
+    expect(buttonByTitle('删除对话')).toBeNull();
     expect(buttonByTitle('更多操作')).not.toBeNull();
     expect(buttonByTitle('更多操作')?.className).not.toContain('opacity-0');
 
@@ -150,6 +163,8 @@ describe('ThreadItem actions', () => {
     });
 
     const menu = container.querySelector('[role="menu"]');
+    expect(menu?.textContent).toContain('置顶');
+    expect(menu?.textContent).toContain('删除对话');
     expect(menu?.textContent).toContain('设置默认猫猫');
     expect(menu?.textContent).toContain('重命名对话');
     expect(menu?.textContent).toContain('导出对话');
@@ -167,7 +182,7 @@ describe('ThreadItem actions', () => {
     const menu = container.querySelector('[role="menu"]');
     expect(menu).not.toBeNull();
 
-    for (const label of ['设置默认猫猫', '重命名对话', '导出对话', '标签管理', '收藏']) {
+    for (const label of ['置顶', '设置默认猫猫', '重命名对话', '导出对话', '标签管理', '收藏', '删除对话']) {
       const item = Array.from(menu!.querySelectorAll('[role="menuitem"]')).find((el) =>
         el.textContent?.includes(label),
       );
@@ -176,5 +191,33 @@ describe('ThreadItem actions', () => {
       expect(first?.querySelector('svg[aria-hidden="true"]') ?? first?.matches('svg[aria-hidden="true"]')).toBeTruthy();
       expect(item!.textContent).toContain(label);
     }
+  });
+
+  it('shows a filled favorite mark next to favorited thread titles', () => {
+    renderThread({ isFavorited: true });
+
+    const mark = container.querySelector('[data-testid="thread-favorite-mark"]');
+    expect(mark).not.toBeNull();
+    expect(mark?.getAttribute('aria-label')).toBe('已收藏');
+  });
+
+  it('renders labels as one 16px compact tag button with overflow dots', () => {
+    renderThread({ threadLabels: ['product', 'architecture', 'bug', 'quality'] });
+
+    const labelButton = container.querySelector('[data-testid="thread-label-dots"]');
+    expect(labelButton).not.toBeNull();
+    expect(labelButton?.className).toContain('h-4');
+    expect(labelButton?.getAttribute('title')).toBe('产品体验, 架构规划, 缺陷排查, 评测质控');
+    expect(labelButton?.textContent).toContain('+1');
+  });
+
+  it('keeps the full code-compatible tooltip format on the thread item', () => {
+    renderThread({ participants: ['cat-a'], projectPath: '/projects/cat-cafe' });
+
+    const item = container.querySelector('[data-thread-id="thread-1"]');
+    expect(item?.getAttribute('title')).toContain('Thread 1');
+    expect(item?.getAttribute('title')).toContain('参与: 猫甲');
+    expect(item?.getAttribute('title')).toContain('路径: /projects/cat-cafe');
+    expect(item?.getAttribute('title')).toContain('1分');
   });
 });

--- a/packages/web/src/components/__tests__/thread-utils.test.ts
+++ b/packages/web/src/components/__tests__/thread-utils.test.ts
@@ -569,4 +569,39 @@ describe('sidebar tab selectors', () => {
     expect(content.projectGroups?.[0].threads.map((thread) => thread.id)).toEqual(['pinned', 'regular-new']);
     expect(content.projectGroups?.[1].threads.map((thread) => thread.id)).toEqual(['regular-old', 'fav']);
   });
+
+  // Regression: unread-first ordering must survive the tab rewrite.
+  // The pre-tab sidebar sorted unread threads before read ones inside each
+  // group; the new tab selectors must preserve that or an older unread thread
+  // gets buried below a newer read one. Covers maintainer review on PR #1095.
+  it('recent tab puts unread threads before read threads regardless of activity', () => {
+    const threads = [
+      makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+      makeThread({ id: 'read-new', title: 'Read New', projectPath: '/proj/a', lastActiveAt: NOW - 1_000 }),
+      makeThread({ id: 'unread-old', title: 'Unread Old', projectPath: '/proj/a', lastActiveAt: NOW - DAY }),
+    ];
+    const unreadIds = new Set(['unread-old']);
+
+    // Without unreadIds: read-new first (newer activity wins)
+    const noUnread = buildSidebarTabContent('recent', threads, new Set(), new Set());
+    expect(noUnread.threads.map((t) => t.id)).toEqual(['read-new', 'unread-old']);
+
+    // With unreadIds: unread-old first (unread takes precedence over activity)
+    const withUnread = buildSidebarTabContent('recent', threads, new Set(), unreadIds);
+    expect(withUnread.threads.map((t) => t.id)).toEqual(['unread-old', 'read-new']);
+  });
+
+  it('project tab sorts unread threads before read threads within a group', () => {
+    const threads = [
+      makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+      makeThread({ id: 'read-new', title: 'Read New', projectPath: '/proj/a', lastActiveAt: NOW - 1_000 }),
+      makeThread({ id: 'unread-old', title: 'Unread Old', projectPath: '/proj/a', lastActiveAt: NOW - DAY }),
+    ];
+    const unreadIds = new Set(['unread-old']);
+
+    const content = buildSidebarTabContent('project', threads, new Set(), unreadIds);
+    expect(content.kind).toBe('project');
+    // Within /proj/a: unread-old before read-new, despite read-new being newer
+    expect(content.projectGroups?.[0].threads.map((t) => t.id)).toEqual(['unread-old', 'read-new']);
+  });
 });

--- a/packages/web/src/components/__tests__/thread-utils.test.ts
+++ b/packages/web/src/components/__tests__/thread-utils.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { Thread } from '@/stores/chat-types';
 import {
+  buildSidebarTabContent,
+  buildSidebarTabs,
   formatRelativeTime,
   getProjectPaths,
   mergeLiveActivityIntoThreads,
   projectDisplayName,
+  type SidebarTabId,
   sortAndGroupThreads,
   sortAndGroupThreadsWithWorkspace,
 } from '../ThreadSidebar/thread-utils';
@@ -505,5 +508,58 @@ describe('sortAndGroupThreadsWithWorkspace', () => {
     const system = groups.find((g) => g.type === 'system');
     expect(system).toBeDefined();
     expect(system?.threads).toHaveLength(2);
+  });
+});
+
+// ── sidebar tab selectors ─────────────────────────────
+
+describe('sidebar tab selectors', () => {
+  const tabThreads = [
+    makeThread({ id: 'default', title: '大厅', lastActiveAt: NOW }),
+    makeThread({ id: 'regular-new', title: 'Zoo', projectPath: '/proj/beta', lastActiveAt: NOW - 1_000 }),
+    makeThread({ id: 'regular-old', title: 'Alpha', projectPath: '/proj/alpha', lastActiveAt: NOW - DAY }),
+    makeThread({ id: 'pinned', title: 'Pinned', pinned: true, projectPath: '/proj/beta', lastActiveAt: NOW - 2 * DAY }),
+    makeThread({
+      id: 'fav',
+      title: 'Favorite',
+      favorited: true,
+      projectPath: '/proj/alpha',
+      lastActiveAt: NOW - 3 * DAY,
+    }),
+    makeThread({ id: 'system', title: 'System', systemKind: 'eval_domain', lastActiveAt: NOW - 4 * DAY }),
+  ];
+
+  it('builds tabs in the v9 order with non-default counts', () => {
+    const tabs = buildSidebarTabs(tabThreads);
+    const tabIds: SidebarTabId[] = tabs.map((tab) => tab.id);
+    expect(tabIds).toEqual(['recent', 'project', 'system', 'favorites']);
+    expect(tabs.map((tab) => tab.label)).toEqual(['最近', '项目', '系统', '收藏']);
+    expect(tabs.map((tab) => tab.count)).toEqual([4, 4, 1, 1]);
+  });
+
+  it('recent tab excludes lobby and system threads, then sorts pinned first and activity desc', () => {
+    const content = buildSidebarTabContent('recent', tabThreads, new Set(['/proj/alpha']));
+
+    expect(content.kind).toBe('flat');
+    expect(content.threads.map((thread) => thread.id)).toEqual(['pinned', 'regular-new', 'regular-old', 'fav']);
+  });
+
+  it('system and favorites tabs are flat isolated views', () => {
+    const system = buildSidebarTabContent('system', tabThreads, new Set());
+    const favorites = buildSidebarTabContent('favorites', tabThreads, new Set());
+
+    expect(system.kind).toBe('flat');
+    expect(system.threads.map((thread) => thread.id)).toEqual(['system']);
+    expect(favorites.kind).toBe('flat');
+    expect(favorites.threads.map((thread) => thread.id)).toEqual(['fav']);
+  });
+
+  it('project tab groups non-system threads by path with pinned projects first and item titles alphabetical', () => {
+    const content = buildSidebarTabContent('project', tabThreads, new Set(['/proj/beta']));
+
+    expect(content.kind).toBe('project');
+    expect(content.projectGroups?.map((group) => group.projectPath)).toEqual(['/proj/beta', '/proj/alpha']);
+    expect(content.projectGroups?.[0].threads.map((thread) => thread.id)).toEqual(['pinned', 'regular-new']);
+    expect(content.projectGroups?.[1].threads.map((thread) => thread.id)).toEqual(['regular-old', 'fav']);
   });
 });

--- a/packages/web/src/components/__tests__/thread-utils.test.ts
+++ b/packages/web/src/components/__tests__/thread-utils.test.ts
@@ -529,12 +529,19 @@ describe('sidebar tab selectors', () => {
     makeThread({ id: 'system', title: 'System', systemKind: 'eval_domain', lastActiveAt: NOW - 4 * DAY }),
   ];
 
-  it('builds tabs in the v9 order with non-default counts', () => {
+  it('builds tabs with pinned first, then recent/project/system/favorites', () => {
     const tabs = buildSidebarTabs(tabThreads);
     const tabIds: SidebarTabId[] = tabs.map((tab) => tab.id);
-    expect(tabIds).toEqual(['recent', 'project', 'system', 'favorites']);
-    expect(tabs.map((tab) => tab.label)).toEqual(['最近', '项目', '系统', '收藏']);
-    expect(tabs.map((tab) => tab.count)).toEqual([4, 4, 1, 1]);
+    expect(tabIds).toEqual(['pinned', 'recent', 'project', 'system', 'favorites']);
+    expect(tabs.map((tab) => tab.label)).toEqual(['置顶', '最近', '项目', '系统', '收藏']);
+    // pinned tab has 1 (the pinned thread); recent still includes it (additive) so stays 4
+    expect(tabs.map((tab) => tab.count)).toEqual([1, 4, 4, 1, 1]);
+  });
+
+  it('pinned tab is a flat view of pinned threads sorted by lastActiveAt desc', () => {
+    const content = buildSidebarTabContent('pinned', tabThreads, new Set());
+    expect(content.kind).toBe('flat');
+    expect(content.threads.map((thread) => thread.id)).toEqual(['pinned']);
   });
 
   it('recent tab excludes lobby and system threads, then sorts pinned first and activity desc', () => {


### PR DESCRIPTION
Redesign thread sidebar with tab-based navigation (Recent / Projects / System / Starred).

## Design source
demo v9 (dev-only artifact, kept in feature branch — not included in this PR)

## Scope
- **ThreadSidebar**: tab row (sticky on scroll), tab content panels, project toolbar with expand/collapse
- **SectionGroup**: collapsible project sections; pushpin mark for pinned projects (accent color)
- **ThreadItem**: pushpin icon (demo style), tooltip
- **thread-utils**: `tabRecentThreads` includes pinned system threads (dual-pin per demo line 200/848)
- **use-collapse-state**: collapse/expand state per project section
- **use-overlay-scrollbar**: fluent-style scrollbar (transparent track, thumb on hover)

## Key behaviors
- Conversation pin = dual (Recent tab + owning tab) per demo design
- Project pin = pushpin mark in section header (accent color)
- Project path: basename display, full path on hover title
- Tab row sticky on scroll
- Fluent scrollbar: no track background, thumb on hover

## Verification
- vitest: 16 files / 128 tests passed (sidebar + section-group + scroll-memory + a11y)
- `tsc --noEmit`: clean (`pnpm lint` exit 0)
- `pnpm build`: passed
- biome: clean on changed files (CI Lint pass on ubuntu-latest). Initial CI run caught a format error in ThreadSidebar.tsx (multi-line condition not merged per biome rule) — fixed in `c544f9eb`.
- Code review: 2 rounds by 蓝白/乖乖 (reviewer), both findings fixed (PinSectionIcon dead code → driven by `isProjectPinned`; `allCollapsed` dead code removed)

## Commits
- `8253499e` feat: redesign thread sidebar tabs (cherry-pick of fork squash, sidebar impl only)
- `c544f9eb` fix(sidebar): biome format for project toolbar condition

Based on latest upstream/main. Plan/spec commit (`8b82d172`) intentionally excluded — dev-only artifact.

Co-Authored-By: 布偶猫/gpt-5.5 (impl), 小蓝白/xopglm52 (v11-v19 iteration), 蓝白/xopglm52 (review + format fix)