### PR TITLE
fix(eval): route eval domains to current opus

### DIFF
--- a/docs/harness-feedback/eval-domains/eval-a2a.yaml
+++ b/docs/harness-feedback/eval-domains/eval-a2a.yaml
@@ -3,9 +3,9 @@ domainId: eval:a2a
 displayName: A2A Harness Eval
 systemThreadId: thread_eval_a2a
 evalCat:
-  catId: codex
-  handle: "@codex"
-  model: gpt-5.5
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: daily
 sourceAdapter: f167-runtime-eval
 sourceRefsKind: a2a-snapshot-attribution
@@ -19,7 +19,7 @@ threadPolicy:
 legacyScheduledTaskIds: [] # Cleaned 2026-06-01 — see migrations/2026-06-01-eval-a2a-legacy-task-cleanup.md
 handoffTargetResolver:
   featureId: F167
-  ownerCatId: opus-47
+  ownerCatId: opus
   threadLookup: feature-thread
 sla:
   acknowledgeHours: 24

--- a/docs/harness-feedback/eval-domains/eval-anchor-first.yaml
+++ b/docs/harness-feedback/eval-domains/eval-anchor-first.yaml
@@ -2,12 +2,12 @@
 domainId: eval:anchor-first
 displayName: Anchor-First Context Entry Eval
 systemThreadId: thread_eval_anchor_first
-# evalCat: gpt52 (Maine Coon GPT-5.4) — cross-family separation (Ragdoll authored
-# F236 anchor-first → Maine Coon evaluates). Same cost rationale as eval:friction.
+# evalCat: current opus runtime member. The local catalog no longer exposes
+# legacy eval runner ids, so scheduled invocations must use opus.
 evalCat:
-  catId: gpt52
-  handle: "@gpt52"
-  model: gpt-5.4
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 # frequency: weekly means the eval cat fires weekly. Each fire reads
 # the latest 24h in-memory snapshot (EVICTION_TTL_MS in anchor-telemetry.ts).
 # The eval window covers the most recent 24h, not the full week (Maine Coon R1 P2).
@@ -22,10 +22,10 @@ threadPolicy:
     - verdict-discussion
     - handoff-drafts
 legacyScheduledTaskIds: []
-# Findings route to F236 owner (opus-47 as the registered harness-eval cell owner).
+# Findings route to the current opus runtime member.
 handoffTargetResolver:
   featureId: F236
-  ownerCatId: opus-47
+  ownerCatId: opus
   threadLookup: feature-thread
 sla:
   acknowledgeHours: 48

--- a/docs/harness-feedback/eval-domains/eval-capability-tips.yaml
+++ b/docs/harness-feedback/eval-domains/eval-capability-tips.yaml
@@ -5,7 +5,7 @@
 #   1. Web client records CapabilityTipUsageEvent in localStorage (PR-D1)
 #   2. Future: web→API telemetry rollup sends daily usage batch
 #   3. Source adapter reads rollup, produces eval traces
-#   4. Eval cat (opus-47 in capability-wakeup domain) extends verdict
+#   4. Eval cat (current opus runtime member) extends verdict
 #      to include tips effectiveness signals
 #
 # Current state (Phase D):
@@ -19,14 +19,14 @@
 #   - Different signal source: tips usage events vs session trace analysis
 #   - Different cadence: tips effectiveness needs multi-week window
 #   - Different handoff target: tips → F244 owner, wakeup → F203 owner
-#   - Can share evalCat (opus-47) — domain runner, not signal source
+#   - Can share evalCat (opus) — domain runner, not signal source
 domainId: eval:capability-tips
 displayName: Capability Tips Effectiveness
 systemThreadId: thread_eval_capability_tips
 evalCat:
-  catId: opus-47
-  handle: "@opus47"
-  model: claude-opus-4-7
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: weekly
 sourceAdapter: capability-tips-usage
 sourceRefsKind: capability-tips-usage-window

--- a/docs/harness-feedback/eval-domains/eval-capability-wakeup.yaml
+++ b/docs/harness-feedback/eval-domains/eval-capability-wakeup.yaml
@@ -3,9 +3,9 @@ domainId: eval:capability-wakeup
 displayName: Capability Wakeup Eval
 systemThreadId: thread_eval_capability_wakeup
 evalCat:
-  catId: opus-47
-  handle: "@opus47"
-  model: claude-opus-4-7
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: weekly
 sourceAdapter: capability-wakeup-eval
 sourceRefsKind: capability-wakeup-trial-window
@@ -19,7 +19,7 @@ threadPolicy:
 legacyScheduledTaskIds: []
 handoffTargetResolver:
   featureId: F203
-  ownerCatId: opus-47
+  ownerCatId: opus
   threadLookup: feature-thread
 sla:
   acknowledgeHours: 48

--- a/docs/harness-feedback/eval-domains/eval-friction.yaml
+++ b/docs/harness-feedback/eval-domains/eval-friction.yaml
@@ -2,13 +2,12 @@
 domainId: eval:friction
 displayName: Friction Signal Eval
 systemThreadId: thread_eval_friction
-# evalCat: F245 owner default — gpt52 (Maine Coon GPT-5.4) for cost (codex is ~2x) +
-# cross-family separation (Ragdoll authors/owns F245 → Maine Coon evaluates the friction
-# its own family reports). Adjustable config — flagged for review/operator.
+# evalCat: current opus runtime member. The local catalog no longer exposes
+# legacy eval runner ids, so scheduled invocations must use opus.
 evalCat:
-  catId: gpt52
-  handle: "@gpt52"
-  model: gpt-5.4
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 # F245 PR2: 本家 3-day cadence — N-day infra landed.
 # Community default remains `weekly` in community eval-domains/ copies.
 frequency: every-3d
@@ -24,13 +23,10 @@ threadPolicy:
 legacyScheduledTaskIds: []
 # Actionable friction findings route to the harness-eval owner (Phase D wires
 # per-finding propose_thread; until then the owner triages from here).
-# ownerCatId must be a REGISTERED catId in cat-config.json (cloud R2 P2): opus-48
-# (F245 author) is an invocation identity but NOT in the routing catalog, so it
-# would be an unwakeable handoff. Use opus-47 — registered + the harness-eval cell
-# owner (same target eval:a2a / eval:memory / eval:capability-wakeup hand off to).
+# ownerCatId must be a REGISTERED catId in the runtime catalog.
 handoffTargetResolver:
   featureId: F245
-  ownerCatId: opus-47
+  ownerCatId: opus
   threadLookup: feature-thread
 sla:
   acknowledgeHours: 48

--- a/docs/harness-feedback/eval-domains/eval-memory.yaml
+++ b/docs/harness-feedback/eval-domains/eval-memory.yaml
@@ -3,9 +3,9 @@ domainId: eval:memory
 displayName: Memory Recall & Library Health Eval
 systemThreadId: thread_eval_memory
 evalCat:
-  catId: opus-47
-  handle: "@opus47"
-  model: claude-opus-4-7
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: daily
 sourceAdapter: f200-f188-memory-eval
 sourceRefsKind: memory-recall-snapshot
@@ -20,7 +20,7 @@ legacyScheduledTaskIds:
   - memory-recall-digest
 handoffTargetResolver:
   featureId: F200
-  ownerCatId: opus-47
+  ownerCatId: opus
   threadLookup: feature-thread
 sla:
   acknowledgeHours: 48

--- a/docs/harness-feedback/eval-domains/eval-qc.yaml
+++ b/docs/harness-feedback/eval-domains/eval-qc.yaml
@@ -5,7 +5,7 @@ systemThreadId: thread_eval_qc
 evalCat:
   catId: opus
   handle: "@opus"
-  model: claude-opus-4-6
+  model: claude-sonnet-5
 frequency: weekly
 sourceAdapter: qc-metrics-eval
 sourceRefsKind: qc-metrics-rollup

--- a/docs/harness-feedback/eval-domains/eval-sop.yaml
+++ b/docs/harness-feedback/eval-domains/eval-sop.yaml
@@ -17,9 +17,9 @@ domainId: eval:sop
 displayName: SOP Compliance Eval
 systemThreadId: thread_eval_sop
 evalCat:
-  catId: opus-47
-  handle: "@opus47"
-  model: claude-opus-4-7
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: weekly
 sourceAdapter: sop-trace-eval
 sourceRefsKind: sop-trace-eval

--- a/docs/harness-feedback/eval-domains/eval-task-outcome.yaml
+++ b/docs/harness-feedback/eval-domains/eval-task-outcome.yaml
@@ -3,9 +3,9 @@ domainId: eval:task-outcome
 displayName: Task Outcome Eval
 systemThreadId: thread_eval_task_outcome
 evalCat:
-  catId: opus-47
-  handle: "@opus47"
-  model: claude-opus-4-7
+  catId: opus
+  handle: "@opus"
+  model: claude-sonnet-5
 frequency: daily
 sourceAdapter: task-outcome-eval
 sourceRefsKind: task-outcome-snapshot

--- a/packages/api/test/harness-eval/eval-domain-runtime-opus.test.js
+++ b/packages/api/test/harness-eval/eval-domain-runtime-opus.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { parse } from 'yaml';
+import { parseEvalDomainRegistryFile } from '../../dist/infrastructure/harness-eval/domain/eval-domain-registry.js';
+
+const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+const evalDomainsDir = join(repoRoot, 'docs', 'harness-feedback', 'eval-domains');
+const currentOpus = {
+  catId: 'opus',
+  handle: '@opus',
+  model: 'claude-sonnet-5',
+};
+
+function readEvalDomains() {
+  return readdirSync(evalDomainsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.yaml'))
+    .map((entry) => {
+      const path = join(evalDomainsDir, entry.name);
+      return {
+        file: entry.name,
+        domain: parseEvalDomainRegistryFile(parse(readFileSync(path, 'utf8'))),
+      };
+    });
+}
+
+describe('docs-backed eval domain runtime routing', () => {
+  it('routes every eval domain invocation and handoff to the current opus identity', () => {
+    const mismatches = [];
+    for (const { file, domain } of readEvalDomains()) {
+      if (domain.evalCat.catId !== currentOpus.catId) {
+        mismatches.push(`${file}: evalCat.catId expected ${currentOpus.catId}, got ${domain.evalCat.catId}`);
+      }
+      if (domain.evalCat.handle !== currentOpus.handle) {
+        mismatches.push(`${file}: evalCat.handle expected ${currentOpus.handle}, got ${domain.evalCat.handle}`);
+      }
+      if (domain.evalCat.model !== currentOpus.model) {
+        mismatches.push(`${file}: evalCat.model expected ${currentOpus.model}, got ${domain.evalCat.model}`);
+      }
+      if (domain.handoffTargetResolver.ownerCatId !== currentOpus.catId) {
+        mismatches.push(
+          `${file}: handoffTargetResolver.ownerCatId expected ${currentOpus.catId}, got ${domain.handoffTargetResolver.ownerCatId}`,
+        );
+      }
+    }
+
+    assert.deepEqual(mismatches, []);
+  });
+});

--- a/packages/api/test/harness-eval/eval-hub-route.test.js
+++ b/packages/api/test/harness-eval/eval-hub-route.test.js
@@ -93,7 +93,7 @@ describe('Eval Hub API route', () => {
             ok: true,
             record: {
               agentKeyId: 'ak-test-001',
-              catId: 'codex',
+              catId: 'opus',
               userId: 'you',
               secretHash: 'unused',
               salt: 'unused',
@@ -179,7 +179,7 @@ describe('Eval Hub API route', () => {
       });
 
       // Generator not invoked (stage skipped in mock), so we just verify route
-      // got past auth + cat allowlist (registry codex == derivedPrincipal.catId).
+      // got past auth + cat allowlist (registry opus == derivedPrincipal.catId).
       // Mock publisher returns success → 200.
       assert.equal(response.statusCode, 200, `expected 200, got ${response.statusCode}: ${response.body}`);
       const body = response.json();
@@ -243,7 +243,7 @@ describe('Eval Hub API route', () => {
     // 砚砚 R18/R19 P2 newline-injection lock extracted to eval-hub-route-newline.test.js
     // per AGENTS.md 350-line limit (砚砚 R20 P1)
 
-    it('rejects wrong cat under agent-key (registry codex vs principal opus-47 → 403)', async () => {
+    it('rejects wrong cat under agent-key (registry opus vs principal opus-47 -> 403)', async () => {
       // Override mock to return a different catId
       const app = Fastify({ logger: false });
       const agentKeyRegistry = {


### PR DESCRIPTION
## Summary
- Route every docs-backed eval domain runner to the current `opus` identity: `catId=opus`, `handle=@opus`, `model=claude-sonnet-5`.
- Route every eval domain handoff owner to `opus` so scheduled eval triggers no longer target stale IDs such as `codex`, `gpt52`, or `opus-47`.
- Add a docs-backed regression test that fails if any eval domain drifts away from the current `opus` routing contract.

## Verification
- `pnpm run build` in `packages/api`
- `node --test test/harness-eval/eval-domain-runtime-opus.test.js test/harness-eval/eval-domain-registry.test.js test/harness-eval/eval-domain-daily.test.js` -> 47 pass, 0 fail
- Static scan over `docs/harness-feedback/eval-domains/*.yaml` for stale IDs/handles/models -> no matches

[砚砚/gpt-5.5🐾]