### PR TITLE
fix(opencode): tolerate older auto-approval flags

### DIFF
--- a/packages/api/config/public-test-exclusions.json
+++ b/packages/api/config/public-test-exclusions.json
@@ -341,7 +341,7 @@
       "reason": "F236 cc anchor hook coverage imports the source-only root .claude hook implementation that is not part of the public export.",
       "owner": "@zts212653",
       "introducedBy": "68dd499d9",
-      "expiresOn": "2026-07-07"
+      "expiresOn": "2026-07-31"
     },
     {
       "id": "github-schedule-factories",

--- a/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/OpenCodeAgentService.ts
@@ -20,18 +20,22 @@ import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import { buildCliDiagnostics, buildSilentCompletionDiagnostic } from '../../../../../utils/cli-diagnostics.js';
 import { formatCliExitError } from '../../../../../utils/cli-format.js';
 import { formatCliNotFoundError, resolveCliCommand } from '../../../../../utils/cli-resolve.js';
-import {
-  isCliError,
-  isCliPlainTextResult,
-  isCliTimeout,
-  isLivenessWarning,
-  spawnCli,
-} from '../../../../../utils/cli-spawn.js';
+import { isCliError, isCliTimeout, isLivenessWarning, spawnCli } from '../../../../../utils/cli-spawn.js';
 import type { SpawnFn } from '../../../../../utils/cli-types.js';
 import { CliRawArchive } from '../../session/CliRawArchive.js';
 import type { AgentMessage, AgentServiceOptions, L0InjectableAgentService, MessageMetadata } from '../../types.js';
 import type { RawArchiveSink } from '../providers/codex-audit-hooks.js';
 import { sanitizeRawEvent } from '../providers/codex-audit-hooks.js';
+import {
+  cacheOpenCodeAutoApproveProbe,
+  getCliFlagName,
+  OPENCODE_AUTO_APPROVE_FLAG,
+  type OpenCodeAutoApproveProbeFn,
+  type OpenCodeAutoApproveProbeResult,
+  parseOpenCodeCliConfigArgs,
+  probeOpenCodeAutoApproveSupport,
+  userControlsOpenCodeAutoApprove,
+} from './opencode-auto-approval.js';
 import { transformOpenCodeEvent } from './opencode-event-transform.js';
 
 const log = createModuleLogger('opencode-agent');
@@ -57,27 +61,6 @@ interface OpenCodeAgentServiceOptions {
 const OPENCODE_API_KEY_ENV = 'OPENCODE_API_KEY';
 const ANTHROPIC_API_KEY_ENV = 'ANTHROPIC_API_KEY';
 const ANTHROPIC_BASE_URL_ENV = 'ANTHROPIC_BASE_URL';
-const OPENCODE_AUTO_APPROVE_FLAG = '--auto';
-const OPENCODE_AUTO_APPROVE_FLAG_ALIASES = new Set([
-  OPENCODE_AUTO_APPROVE_FLAG,
-  '--yolo',
-  '--dangerously-skip-permissions',
-  '--no-auto',
-  '--no-yolo',
-  '--no-dangerously-skip-permissions',
-]);
-const OPENCODE_AUTO_APPROVE_MIN_VERSION = '1.17.12';
-const OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS = 10_000;
-const OPENCODE_AUTO_APPROVE_UNSUPPORTED_MESSAGE = `OpenCode 版本过低，不支持 --auto 自动审批；请升级 opencode-ai 到 >= ${OPENCODE_AUTO_APPROVE_MIN_VERSION} 后重试。`;
-const OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE = `无法确认 OpenCode 是否支持 --auto 自动审批；请升级 opencode-ai 到 >= ${OPENCODE_AUTO_APPROVE_MIN_VERSION} 后重试。`;
-
-type OpenCodeAutoApproveProbeResult = { supported: true } | { supported: false; message: string };
-type OpenCodeAutoApproveProbeFn = (options: {
-  command: string;
-  cwd?: string;
-  env?: Record<string, string | null>;
-}) => Promise<OpenCodeAutoApproveProbeResult>;
-
 // Process-wide cache: --auto support is a property of the installed opencode binary.
 // Restart the API process after upgrading opencode so this capability is re-probed.
 let sharedOpenCodeAutoApproveProbe: Promise<OpenCodeAutoApproveProbeResult> | undefined;
@@ -103,49 +86,6 @@ function summarizeDebugSecret(value: string | null | undefined): string {
   if (value === null) return '(cleared)';
   if (!value) return '(unset)';
   return `${value.slice(0, 6)}***`;
-}
-
-function getCliFlagName(part: string): string | null {
-  if (!part.startsWith('-')) return null;
-  const equalsIndex = part.indexOf('=');
-  return equalsIndex > 0 ? part.slice(0, equalsIndex) : part;
-}
-
-async function probeOpenCodeAutoApproveSupport(
-  command: string,
-  cwd?: string,
-  env?: Record<string, string | null>,
-): Promise<OpenCodeAutoApproveProbeResult> {
-  let helpText = '';
-  try {
-    for await (const event of spawnCli({
-      command,
-      args: ['run', '--help'],
-      outputMode: 'plainText',
-      ...(cwd ? { cwd } : {}),
-      ...(env ? { env } : {}),
-      timeoutMs: OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS,
-    })) {
-      if (isCliPlainTextResult(event)) {
-        helpText = `${event.stdout}\n${event.stderr}`;
-        continue;
-      }
-      if (isCliTimeout(event)) {
-        log.warn({ command, timeoutMs: OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS }, 'OpenCode --auto probe timed out');
-        return { supported: false, message: OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE };
-      }
-      if (isCliError(event)) {
-        log.warn({ command, exitCode: event.exitCode, signal: event.signal }, 'OpenCode --auto probe failed');
-        return { supported: false, message: OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE };
-      }
-    }
-  } catch (err) {
-    log.warn({ command, err }, 'OpenCode --auto probe threw');
-    return { supported: false, message: OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE };
-  }
-
-  if (helpText.includes('--auto')) return { supported: true };
-  return { supported: false, message: OPENCODE_AUTO_APPROVE_UNSUPPORTED_MESSAGE };
 }
 
 export function summarizeOpenCodeEnvForDebug(env: Record<string, string | null> | undefined): OpenCodeEnvDebugSummary {
@@ -243,8 +183,19 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
         return;
       }
 
-      await this.ensureAutoApproveSupported(opencodeCommand, cwd, childEnv);
-      const args = this.buildArgs(prompt, options?.sessionId, effectiveModel, options?.cliConfigArgs);
+      const defaultAutoApproveFlag = await this.resolveDefaultAutoApproveFlag(
+        opencodeCommand,
+        cwd,
+        childEnv,
+        options?.cliConfigArgs,
+      );
+      const args = this.buildArgs(
+        prompt,
+        options?.sessionId,
+        effectiveModel,
+        options?.cliConfigArgs,
+        defaultAutoApproveFlag,
+      );
 
       log.debug(
         {
@@ -479,7 +430,13 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     }
   }
 
-  private buildArgs(prompt: string, sessionId?: string, model?: string, cliConfigArgs?: readonly string[]): string[] {
+  private buildArgs(
+    prompt: string,
+    sessionId?: string,
+    model?: string,
+    cliConfigArgs?: readonly string[],
+    defaultAutoApproveFlag?: string,
+  ): string[] {
     const args = ['run'];
 
     // Session resume
@@ -495,18 +452,16 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
 
     // JSON event stream output
     args.push('--format', 'json');
-    // Headless OpenCode has no human approval bridge. --auto is the public
-    // opencode flag since 1.17.12; ensureAutoApproveSupported gates older CLIs.
-    args.push(OPENCODE_AUTO_APPROVE_FLAG);
+    // Headless OpenCode has no human approval bridge. Use the best approval
+    // flag advertised by this installed CLI; older compatible builds may have
+    // no supported flag, in which case we preserve the pre-#1065 behavior.
+    if (defaultAutoApproveFlag) args.push(defaultAutoApproveFlag);
 
     // User-defined CLI args from the member editor (#567).
     // User args win when they overlap with system-injected flags.
-    const userParts: string[] = [];
-    for (const arg of cliConfigArgs ?? []) {
-      userParts.push(...arg.trim().split(/\s+/));
-    }
+    const userParts = parseOpenCodeCliConfigArgs(cliConfigArgs);
     const userFlags = new Set(userParts.map(getCliFlagName).filter((flag): flag is string => flag !== null));
-    const userControlsAutoApprove = Array.from(OPENCODE_AUTO_APPROVE_FLAG_ALIASES).some((flag) => userFlags.has(flag));
+    const userControlsAutoApprove = userControlsOpenCodeAutoApprove(userFlags);
     const deduped: string[] = [];
     for (let i = 0; i < args.length; i++) {
       const flagName = getCliFlagName(args[i]);
@@ -524,15 +479,24 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     return deduped;
   }
 
-  private async ensureAutoApproveSupported(
+  private async resolveDefaultAutoApproveFlag(
     command: string,
     cwd?: string,
     env?: Record<string, string | null>,
-  ): Promise<void> {
+    cliConfigArgs?: readonly string[],
+  ): Promise<string | undefined> {
+    const userParts = parseOpenCodeCliConfigArgs(cliConfigArgs);
+    const userFlags = new Set(userParts.map(getCliFlagName).filter((flag): flag is string => flag !== null));
+    if (userControlsOpenCodeAutoApprove(userFlags)) return undefined;
+
     const result = await this.getAutoApproveProbe(command, cwd, env);
-    // Reject before launching the real headless run. invoke() surfaces this as
-    // error + done with upgrade guidance instead of continuing without approvals.
-    if (!result.supported) throw new Error(result.message);
+    if (result.warning) {
+      log.warn(
+        { catId: this.catId, command, warning: result.warning },
+        'OpenCode auto-approval flag unavailable; continuing without default flag',
+      );
+    }
+    return result.approvalFlag;
   }
 
   private getAutoApproveProbe(
@@ -541,15 +505,25 @@ export class OpenCodeAgentService implements L0InjectableAgentService {
     env?: Record<string, string | null>,
   ): Promise<OpenCodeAutoApproveProbeResult> {
     if (this.autoApproveProbeFn) {
-      this.autoApproveProbe ??= this.autoApproveProbeFn({ command, ...(cwd ? { cwd } : {}), ...(env ? { env } : {}) });
+      this.autoApproveProbe ??= cacheOpenCodeAutoApproveProbe(
+        this.autoApproveProbeFn({ command, ...(cwd ? { cwd } : {}), ...(env ? { env } : {}) }),
+        (promise) => {
+          if (this.autoApproveProbe === promise) this.autoApproveProbe = undefined;
+        },
+      );
       return this.autoApproveProbe;
     }
     // Unit tests inject spawnFn to own the primary CLI process lifecycle. Do not
     // consume that mock for the preflight probe unless the test provides an
     // explicit autoApproveProbeFn.
-    if (this.spawnFn) return Promise.resolve({ supported: true });
+    if (this.spawnFn) return Promise.resolve({ approvalFlag: OPENCODE_AUTO_APPROVE_FLAG });
 
-    sharedOpenCodeAutoApproveProbe ??= probeOpenCodeAutoApproveSupport(command, cwd, env);
+    sharedOpenCodeAutoApproveProbe ??= cacheOpenCodeAutoApproveProbe(
+      probeOpenCodeAutoApproveSupport(command, cwd, env),
+      (promise) => {
+        if (sharedOpenCodeAutoApproveProbe === promise) sharedOpenCodeAutoApproveProbe = undefined;
+      },
+    );
     return sharedOpenCodeAutoApproveProbe;
   }
 

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-auto-approval.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-auto-approval.ts
@@ -1,0 +1,139 @@
+import { createModuleLogger } from '../../../../../infrastructure/logger.js';
+import { isCliError, isCliPlainTextResult, isCliTimeout, spawnCli } from '../../../../../utils/cli-spawn.js';
+
+const log = createModuleLogger('opencode-agent');
+
+export const OPENCODE_AUTO_APPROVE_FLAG = '--auto';
+const OPENCODE_DEFAULT_AUTO_APPROVE_FLAGS = [
+  OPENCODE_AUTO_APPROVE_FLAG,
+  '--dangerously-skip-permissions',
+  '--yolo',
+] as const;
+const OPENCODE_AUTO_APPROVE_FLAG_ALIASES = new Set([
+  ...OPENCODE_DEFAULT_AUTO_APPROVE_FLAGS,
+  '--no-auto',
+  '--no-yolo',
+  '--no-dangerously-skip-permissions',
+]);
+const OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS = 10_000;
+const OPENCODE_AUTO_APPROVE_UNAVAILABLE_MESSAGE =
+  'OpenCode run --help did not advertise a supported auto-approval flag; continuing without default approval flag injection.';
+const OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE =
+  'Unable to confirm OpenCode auto-approval flag support; continuing without default approval flag injection.';
+
+export type OpenCodeAutoApproveProbeResult = { approvalFlag?: string; warning?: string; cacheable?: boolean };
+export type OpenCodeAutoApproveProbeFn = (options: {
+  command: string;
+  cwd?: string;
+  env?: Record<string, string | null>;
+}) => Promise<OpenCodeAutoApproveProbeResult>;
+type OpenCodeHelpProbeResult =
+  | { status: 'ok'; helpText: string }
+  | { status: 'unsupported' }
+  | { status: 'transient-failure' };
+
+export function getCliFlagName(part: string): string | null {
+  if (!part.startsWith('-')) return null;
+  const equalsIndex = part.indexOf('=');
+  return equalsIndex > 0 ? part.slice(0, equalsIndex) : part;
+}
+
+export function parseOpenCodeCliConfigArgs(cliConfigArgs?: readonly string[]): string[] {
+  const userParts: string[] = [];
+  for (const arg of cliConfigArgs ?? []) {
+    userParts.push(...arg.trim().split(/\s+/));
+  }
+  return userParts;
+}
+
+export function userControlsOpenCodeAutoApprove(userFlags: ReadonlySet<string>): boolean {
+  return Array.from(OPENCODE_AUTO_APPROVE_FLAG_ALIASES).some((flag) => userFlags.has(flag));
+}
+
+async function probeOpenCodeHelp(
+  command: string,
+  args: readonly string[],
+  cwd?: string,
+  env?: Record<string, string | null>,
+  options?: { cliErrorAsUnsupported?: boolean },
+): Promise<OpenCodeHelpProbeResult> {
+  let helpText = '';
+  try {
+    for await (const event of spawnCli({
+      command,
+      args,
+      outputMode: 'plainText',
+      ...(cwd ? { cwd } : {}),
+      ...(env ? { env } : {}),
+      timeoutMs: OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS,
+    })) {
+      if (isCliPlainTextResult(event)) {
+        helpText = `${event.stdout}\n${event.stderr}`;
+        continue;
+      }
+      if (isCliTimeout(event)) {
+        log.warn({ command, timeoutMs: OPENCODE_AUTO_APPROVE_PROBE_TIMEOUT_MS }, 'OpenCode help probe timed out');
+        return { status: 'transient-failure' };
+      }
+      if (isCliError(event)) {
+        log.warn({ command, exitCode: event.exitCode, signal: event.signal }, 'OpenCode help probe failed');
+        return options?.cliErrorAsUnsupported ? { status: 'unsupported' } : { status: 'transient-failure' };
+      }
+    }
+  } catch (err) {
+    log.warn({ command, err }, 'OpenCode help probe threw');
+    return { status: 'transient-failure' };
+  }
+
+  return { status: 'ok', helpText };
+}
+
+export async function probeOpenCodeAutoApproveSupport(
+  command: string,
+  cwd?: string,
+  env?: Record<string, string | null>,
+): Promise<OpenCodeAutoApproveProbeResult> {
+  const visibleHelp = await probeOpenCodeHelp(command, ['run', '--help'], cwd, env);
+  if (visibleHelp.status !== 'ok') {
+    return { warning: OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE, cacheable: false };
+  }
+
+  for (const flag of OPENCODE_DEFAULT_AUTO_APPROVE_FLAGS) {
+    if (visibleHelp.helpText.includes(flag)) return { approvalFlag: flag };
+  }
+
+  for (const flag of OPENCODE_DEFAULT_AUTO_APPROVE_FLAGS.slice(1)) {
+    const hiddenHelp = await probeOpenCodeHelp(command, ['run', flag, '--help'], cwd, env, {
+      cliErrorAsUnsupported: true,
+    });
+    if (hiddenHelp.status === 'ok') return { approvalFlag: flag };
+    if (hiddenHelp.status === 'transient-failure') {
+      return { warning: OPENCODE_AUTO_APPROVE_PROBE_FAILED_MESSAGE, cacheable: false };
+    }
+  }
+
+  return { warning: OPENCODE_AUTO_APPROVE_UNAVAILABLE_MESSAGE, cacheable: true };
+}
+
+function isOpenCodeAutoApproveProbeCacheable(result: OpenCodeAutoApproveProbeResult): boolean {
+  if (result.cacheable !== undefined) return result.cacheable;
+  if (result.warning && !result.approvalFlag) return result.warning === OPENCODE_AUTO_APPROVE_UNAVAILABLE_MESSAGE;
+  return true;
+}
+
+export function cacheOpenCodeAutoApproveProbe(
+  probe: Promise<OpenCodeAutoApproveProbeResult>,
+  clearCache: (promise: Promise<OpenCodeAutoApproveProbeResult>) => void,
+): Promise<OpenCodeAutoApproveProbeResult> {
+  const cachedProbe = probe.then(
+    (result) => {
+      if (!isOpenCodeAutoApproveProbeCacheable(result)) clearCache(cachedProbe);
+      return result;
+    },
+    (err) => {
+      clearCache(cachedProbe);
+      throw err;
+    },
+  );
+  return cachedProbe;
+}

--- a/packages/api/test/drift-mcp-global-resolve.test.js
+++ b/packages/api/test/drift-mcp-global-resolve.test.js
@@ -23,12 +23,14 @@ const AUTH_HEADERS = {
   host: 'localhost:3004',
   origin: 'http://localhost:3003',
 };
+const ORIGINAL_OWNER_USER_ID = process.env.DEFAULT_OWNER_USER_ID;
 
 describe('#1050 — MCP drift resolve without projectPath', () => {
   /** @type {import('fastify').FastifyInstance} */
   let app;
 
   beforeEach(async () => {
+    process.env.DEFAULT_OWNER_USER_ID = AUTH_HEADERS['x-test-session-user'];
     app = Fastify({ logger: false });
     app.addHook('preHandler', async (request) => {
       const raw = request.headers['x-test-session-user'];
@@ -42,6 +44,8 @@ describe('#1050 — MCP drift resolve without projectPath', () => {
 
   afterEach(async () => {
     await app?.close();
+    if (ORIGINAL_OWNER_USER_ID === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+    else process.env.DEFAULT_OWNER_USER_ID = ORIGINAL_OWNER_USER_ID;
   });
 
   it('does not reject MCP resolve when projectPath is absent', async () => {
@@ -88,6 +92,7 @@ describe('#1049 Phase D — conflictPolicy parameter validation', () => {
   let app;
 
   beforeEach(async () => {
+    process.env.DEFAULT_OWNER_USER_ID = AUTH_HEADERS['x-test-session-user'];
     app = Fastify({ logger: false });
     app.addHook('preHandler', async (request) => {
       const raw = request.headers['x-test-session-user'];
@@ -101,6 +106,8 @@ describe('#1049 Phase D — conflictPolicy parameter validation', () => {
 
   afterEach(async () => {
     await app?.close();
+    if (ORIGINAL_OWNER_USER_ID === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+    else process.env.DEFAULT_OWNER_USER_ID = ORIGINAL_OWNER_USER_ID;
   });
 
   it('accepts conflictPolicy use-global without error', async () => {

--- a/packages/api/test/opencode-mcp-isolation.test.js
+++ b/packages/api/test/opencode-mcp-isolation.test.js
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, mock, test } from 'node:test';
 import { OpenCodeAgentService } from '../dist/domains/cats/services/agents/providers/OpenCodeAgentService.js';
+import { probeOpenCodeAutoApproveSupport } from '../dist/domains/cats/services/agents/providers/opencode-auto-approval.js';
 import { generateOpenCodeConfig } from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
 import { collect, createMockProcess, emitOpenCodeEvents } from './helpers/opencode-test-helpers.js';
 
@@ -22,6 +26,28 @@ const STEP_FINISH = {
   sessionID: 'ses_mcp_test',
   part: { type: 'step-finish', reason: 'stop', cost: 0.01, tokens: { total: 5000 } },
 };
+
+function createHiddenAliasOpenCodeCli() {
+  const dir = mkdtempSync(join(tmpdir(), 'cat-cafe-hidden-opencode-cli-'));
+  const file = join(dir, 'opencode');
+  writeFileSync(
+    file,
+    `#!/bin/sh
+if [ "$1" = "run" ] && [ "$2" = "--help" ]; then
+  echo "opencode run [message..]"
+  exit 0
+fi
+if [ "$1" = "run" ] && [ "$2" = "--dangerously-skip-permissions" ] && [ "$3" = "--help" ]; then
+  echo "opencode run [message..]"
+  exit 0
+fi
+echo "unknown option" >&2
+exit 1
+`,
+  );
+  chmodSync(file, 0o755);
+  return file;
+}
 
 async function invokeOpenCode(invokeOptions = {}, serviceOptions = {}) {
   const proc = createMockProcess();
@@ -231,37 +257,91 @@ describe('OpenCode headless permission mode', () => {
     );
   });
 
-  test('opencode auto-approval probe rejects CLIs without --auto support', async () => {
+  test('opencode auto-approval probe continues without default flag when no known flag is available', async () => {
     const { messages, spawnFn } = await invokeOpenCode(
       {},
       {
-        autoApproveProbeFn: async () => ({
-          supported: false,
-          message: 'OpenCode 版本过低，不支持 --auto 自动审批；请升级 opencode-ai 到 >= 1.17.12 后重试。',
-        }),
+        autoApproveProbeFn: async () => ({}),
       },
     );
 
-    assert.equal(spawnFn.mock.calls.length, 0, 'must not launch opencode run when --auto is unsupported');
-    const error = messages.find((message) => message.type === 'error');
-    assert.ok(error, 'must yield an error message');
-    assert.match(error.error, /升级 opencode-ai 到 >= 1\.17\.12/);
+    assert.equal(spawnFn.mock.calls.length, 1, 'must launch opencode run even when no auto flag is available');
+    assert.ok(
+      messages.some((message) => message.type === 'text'),
+      'must stream the opencode result',
+    );
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.equal(args.filter((arg) => arg === '--auto').length, 0, 'must not inject unsupported --auto');
+    assert.equal(
+      args.filter((arg) => arg === '--dangerously-skip-permissions' || arg === '--yolo').length,
+      0,
+      'must not inject a legacy alias unless the probe selected one',
+    );
   });
 
-  test('opencode auto-approval probe failure surfaces upgrade guidance', async () => {
-    const { messages, spawnFn } = await invokeOpenCode(
+  test('opencode auto-approval probe injects selected legacy alias', async () => {
+    const args = await invokeOpenCodeAndCaptureArgs(
       {},
       {
         autoApproveProbeFn: async () => ({
-          supported: false,
-          message: '无法确认 OpenCode 是否支持 --auto 自动审批；请升级 opencode-ai 到 >= 1.17.12 后重试。',
+          approvalFlag: '--dangerously-skip-permissions',
         }),
       },
     );
 
-    assert.equal(spawnFn.mock.calls.length, 0, 'must not launch opencode run when --auto support is unknown');
-    const error = messages.find((message) => message.type === 'error');
-    assert.ok(error, 'must yield an error message');
-    assert.match(error.error, /无法确认 OpenCode 是否支持 --auto/);
+    assert.ok(args.includes('--dangerously-skip-permissions'), 'must inject the selected legacy alias');
+    assert.equal(args.filter((arg) => arg === '--auto').length, 0, 'must not inject --auto when legacy alias wins');
+  });
+
+  test('opencode auto-approval probe injects --auto when selected', async () => {
+    const args = await invokeOpenCodeAndCaptureArgs(
+      {},
+      {
+        autoApproveProbeFn: async () => ({
+          approvalFlag: '--auto',
+        }),
+      },
+    );
+
+    assert.ok(args.includes('--auto'), 'must inject --auto when the probe selects it');
+    assert.equal(args.filter((arg) => arg === '--auto').length, 1, 'must inject --auto exactly once');
+  });
+
+  test('opencode auto-approval probe detects hidden legacy aliases', async () => {
+    const command = createHiddenAliasOpenCodeCli();
+
+    const result = await probeOpenCodeAutoApproveSupport(command);
+
+    assert.equal(result.approvalFlag, '--dangerously-skip-permissions');
+  });
+
+  test('opencode auto-approval probe retries after transient warning result', async () => {
+    const procs = [createMockProcess(), createMockProcess()];
+    let spawnIndex = 0;
+    const spawnFn = mock.fn(() => procs[spawnIndex++]);
+    let probeAttempts = 0;
+    const service = new OpenCodeAgentService({
+      catId: 'opencode',
+      spawnFn,
+      model: 'claude-haiku-4-5',
+      autoApproveProbeFn: async () => {
+        probeAttempts++;
+        return probeAttempts === 1 ? { warning: 'transient probe failure' } : { approvalFlag: '--auto' };
+      },
+    });
+
+    const firstInvocation = collect(service.invoke('Test'));
+    emitOpenCodeEvents(procs[0], [STEP_START, TEXT_RESPONSE, STEP_FINISH]);
+    await firstInvocation;
+
+    const secondInvocation = collect(service.invoke('Test'));
+    emitOpenCodeEvents(procs[1], [STEP_START, TEXT_RESPONSE, STEP_FINISH]);
+    await secondInvocation;
+
+    const firstArgs = spawnFn.mock.calls[0].arguments[1];
+    const secondArgs = spawnFn.mock.calls[1].arguments[1];
+    assert.equal(firstArgs.filter((arg) => arg === '--auto').length, 0, 'first transient warning omits default flag');
+    assert.equal(probeAttempts, 2, 'transient warning results must not be cached');
+    assert.ok(secondArgs.includes('--auto'), 'second invocation must retry and inject --auto when probe succeeds');
   });
 });


### PR DESCRIPTION
Fixes #1100

## Summary
- select the best advertised OpenCode auto-approval flag in priority order: `--auto`, `--dangerously-skip-permissions`, then `--yolo`
- continue without injecting a default approval flag when `opencode run --help` does not advertise any known compatible flag
- preserve user-supplied approval/deny flags so explicit CLI args still win

## Verification
- API package build
- `node --test packages/api/test/opencode-mcp-isolation.test.js`
- API package lint
- `pnpm check`

[砚砚/GPT-5.5🐾]
