### PR TITLE
fix(desktop): propagate Clowder AI release branding

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,6 @@
-# Cat Cafe Desktop
+# Clowder AI Desktop
 
-基于 Electron 的桌面应用壳层，为 Cat Cafe 提供一键启动、系统托盘和独立窗口体验。
+基于 Electron 的桌面应用壳层，为 Clowder AI 提供一键启动、系统托盘和独立窗口体验。
 当前支持 **Windows 安装器** 和 **macOS DMG 安装器**。
 
 ## 设计哲学
@@ -141,16 +141,16 @@ pnpm desktop:pack
 | 3/6 | 下载 Node.js 便携版（匹配构建机 ABI 版本） | `bundled/node-darwin-{arm64,x64}/` |
 | 4/6 | 从源码编译 Redis（~30s/架构） | `bundled/redis-darwin-{arm64,x64}/` |
 | 5/6 | 跳过（macOS DMG 无 post-install 阶段，不捆绑 CLI 工具；用户自行安装） | — |
-| 6/6 | 生成 icon.icns + electron-builder 构建 DMG | `dist/CatCafe-{version}-{arch}.dmg` |
+| 6/6 | 生成 icon.icns + electron-builder 构建 DMG | `dist/ClowderAI-{version}-{arch}.dmg` |
 
 #### 已知注意事项
 
 - **node_modules 补拷**：electron-builder 从 v20.15.2 起不再将 `node_modules` 目录包含在 `extraResources` 中（[electron-builder#3104](https://github.com/electron-userland/electron-builder/issues/3104)）。项目通过 `desktop/afterPack.js` hook 在打包后手动拷贝 `node_modules` 解决此问题。
 - **未签名应用**：代码签名已禁用（`identity=null`）。首次启动需右键 → 打开，或执行：
   ```bash
-  xattr -cr "/Applications/Cat Cafe.app"
+  xattr -cr "/Applications/Clowder AI.app"
   ```
-- **支持的安装位置（macOS）**：packaged 版本仅支持从 `/Applications/Cat Cafe.app` 启动。
+- **支持的安装位置（macOS）**：packaged 版本仅支持从 `/Applications/Clowder AI.app` 启动。
   - 启动时 `desktop/main.js` 的 `ensureValidMacInstallLocation()` guard 会拒绝从 DMG 卷
     （`/Volumes/...`）直接运行，并弹出"必须先安装"对话框。
   - **范围外**：`~/Applications`（用户级 Applications）、外部卷（USB / 网络盘）、企业
@@ -163,8 +163,8 @@ pnpm desktop:pack
 #### 产物位置
 
 ```
-dist/CatCafe-{version}-arm64.dmg   # Apple Silicon
-dist/CatCafe-{version}-x64.dmg     # Intel Mac
+dist/ClowderAI-{version}-arm64.dmg   # Apple Silicon
+dist/ClowderAI-{version}-x64.dmg     # Intel Mac
 ```
 
 ---
@@ -187,7 +187,7 @@ pnpm desktop:installer
 3. 下载 Node.js 便携版（ABI 版本与构建机一致，确保 native 模块兼容）
 4. 下载/复制 Windows 便携版 Redis
 5. 构建 Electron 壳（`electron-builder --win --dir`）
-6. 编译 Inno Setup 安装包（`dist/CatCafe-Setup-x.x.x.exe`）
+6. 编译 Inno Setup 安装包（`dist/ClowderAI-Setup-x.x.x.exe`）
 
 安装包在目标机器上执行：
 - 复制运行时包 + 构建产物 + Electron 壳 + 便携 Node.js + 便携 Redis
@@ -213,9 +213,9 @@ pnpm desktop:installer
 
 ### 步骤
 
-1. **运行安装包** — 双击 `CatCafe-Setup-x.x.x.exe`，选择 `Full`（全部 CLI 工具）或 `Minimal`（仅核心）
+1. **运行安装包** — 双击 `ClowderAI-Setup-x.x.x.exe`，选择 `Full`（全部 CLI 工具）或 `Minimal`（仅核心）
 2. **等待安装完成** — 安装器自动完成：解包应用 + 便携 Node.js + 便携 Redis → 生成 `.env` → 挂载 skills → 安装所选 CLI 工具
-3. **启动 Cat Cafe** — 安装结束后勾选"Launch Cat Cafe"，或从桌面快捷方式启动
+3. **启动 Clowder AI** — 安装结束后勾选"Launch Clowder AI"，或从桌面快捷方式启动
 4. **配置 Provider** — 打开 Hub → 账号配置，为你要使用的 AI 服务完成认证：
    - **Claude** — 运行 `claude` 命令完成 Anthropic 登录
    - **Codex** — 运行 `codex` 命令完成 OpenAI 登录
@@ -236,8 +236,8 @@ pnpm desktop:installer
 
 桌面应用的运行日志集中在用户数据目录：
 
-- **Windows**：`%LOCALAPPDATA%\Cat Cafe\data\logs\` (`main.log` / `desktop.log` / `api\api.log`)
-- **macOS**：`~/Library/Application Support/Cat Cafe/data/logs/` (`main.log` / `desktop.log` / `api/api.log`)
+- **Windows**：`%LOCALAPPDATA%\Clowder AI\data\logs\` (`main.log` / `desktop.log` / `api\api.log`)
+- **macOS**：`~/Library/Application Support/Clowder AI/data/logs/` (`main.log` / `desktop.log` / `api/api.log`)
 
 ## 故障排查
 
@@ -253,8 +253,8 @@ pnpm desktop:installer
 
 | 平台 | 状态 | 说明 |
 |------|------|------|
-| Windows | ✅ 已验证 | Inno Setup 安装器（`dist/CatCafe-Setup-x.x.x.exe`） |
-| macOS | ✅ 已验证 | DMG 安装器（`dist/CatCafe-{version}-{arch}.dmg`），2026-04-23 已补齐 clean macOS build/首启证据 |
+| Windows | ✅ 已验证 | Inno Setup 安装器（`dist/ClowderAI-Setup-x.x.x.exe`） |
+| macOS | ✅ 已验证 | DMG 安装器（`dist/ClowderAI-{version}-{arch}.dmg`），2026-04-23 已补齐 clean macOS build/首启证据 |
 | Linux | ❌ 暂不支持 | 尚无 Linux 安装包 |
 
 ## 相关文档

--- a/desktop/installer/cat-cafe.iss
+++ b/desktop/installer/cat-cafe.iss
@@ -1,4 +1,4 @@
-; Cat Cafe — Inno Setup Installer Script
+; Clowder AI — Inno Setup Installer Script
 ; Builds an offline Windows .exe installer that bundles source + deps + Electron shell.
 ;
 ; Prerequisites: Inno Setup 6.x (https://jrsoftware.org/isinfo.php)
@@ -14,29 +14,29 @@
 ;   5. Runs user-level Agent CLI hook sync under the invoking user profile
 ;   6. Creates desktop shortcut to the Electron app
 
-#define MyAppName      "Cat Cafe"
+#define MyAppName      "Clowder AI"
 ; MyAppVersion can be overridden by iscc /DMyAppVersion=X.Y.Z (CI release pipeline).
 ; Default kept for local manual builds.
 #ifndef MyAppVersion
   #define MyAppVersion "0.10.1"
 #endif
-#define MyAppPublisher "Cat Cafe"
-#define MyAppURL       "https://github.com/zts212653/cat-cafe"
-#define MyAppExeName   "Cat Cafe.exe"
+#define MyAppPublisher "Clowder AI"
+#define MyAppURL       "https://github.com/zts212653/clowder-ai"
+#define MyAppExeName   "Clowder AI.exe"
 
 [Setup]
 AppId={{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 AppName={#MyAppName}
 AppVersion={#MyAppVersion}
-; Show just "Cat Cafe" in Add/Remove Programs, not "Cat Cafe 版本 X.Y.Z".
+; Show just "Clowder AI" in Add/Remove Programs, not "Clowder AI 版本 X.Y.Z".
 ; The version is still available in the detail pane via AppVersion.
 AppVerName={#MyAppName}
 AppPublisher={#MyAppPublisher}
 AppPublisherURL={#MyAppURL}
-DefaultDirName={autopf}\CatCafe
+DefaultDirName={autopf}\ClowderAI
 DefaultGroupName={#MyAppName}
 OutputDir=..\..\dist
-OutputBaseFilename=CatCafe-Setup-{#MyAppVersion}
+OutputBaseFilename=ClowderAI-Setup-{#MyAppVersion}
 Compression=lzma2/ultra64
 SolidCompression=yes
 WizardStyle=modern
@@ -179,7 +179,7 @@ Filename: "reg.exe"; \
 ; `npm install -g` fails on clean machines. Users install CLIs separately.
 Filename: "powershell.exe"; \
   Parameters: "-NoProfile -ExecutionPolicy Bypass -File ""{app}\scripts\post-install-offline.ps1"" -AppDir ""{app}"""; \
-  StatusMsg: "Configuring Cat Cafe..."; \
+  StatusMsg: "Configuring Clowder AI..."; \
   Flags: runhidden waituntilterminated
 ; User-level Agent CLI hook sync writes to ~/.claude and ~/.codex, so it must
 ; run as the invoking user rather than the elevated installer account.
@@ -201,7 +201,7 @@ Filename: "{app}\desktop-dist\{#MyAppExeName}"; \
 
 [UninstallRun]
 Filename: "powershell.exe"; \
-  Parameters: "-ExecutionPolicy Bypass -Command ""Stop-Process -Name 'Cat Cafe' -Force -ErrorAction SilentlyContinue"""; \
+  Parameters: "-ExecutionPolicy Bypass -Command ""Stop-Process -Name 'Clowder AI' -Force -ErrorAction SilentlyContinue"""; \
   Flags: runhidden
 
 [UninstallDelete]

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -16,9 +16,9 @@
     "electron-builder": "26.8.1"
   },
   "build": {
-    "appId": "ai.catcafe.desktop",
+    "appId": "ai.clowderai.desktop",
     "productName": "Clowder AI",
-    "artifactName": "CatCafe-${version}-${arch}.${ext}",
+    "artifactName": "ClowderAI-${version}-${arch}.${ext}",
     "win": {
       "target": "dir",
       "icon": "assets/icon.ico"

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Builds the Cat Cafe Windows installer package.
+  Builds the Clowder AI Windows installer package.
 
 .DESCRIPTION
   Full pipeline:
@@ -9,7 +9,7 @@
        with flat hoisted node_modules (real files, no junctions)
     3. Bundle Redis portable for offline install
     4. Build the Electron shell (via desktop/ npm install + electron-builder)
-    5. Compile Inno Setup installer -> dist/CatCafe-Setup-x.x.x.exe
+    5. Compile Inno Setup installer -> dist/ClowderAI-Setup-x.x.x.exe
 
   Why pnpm deploy (not tar of root node_modules): pnpm on Windows uses
   junctions, which require absolute paths. A tarball of node_modules bakes in
@@ -229,7 +229,7 @@ if (Test-Path (Join-Path $bundledRedis "redis-server.exe")) {
 } else {
     New-Item -ItemType Directory -Path $bundledRedis -Force | Out-Null
     Write-Host "  Downloading Redis for Windows..."
-    $headers = @{ "User-Agent" = "CatCafe-Build" }
+    $headers = @{ "User-Agent" = "ClowderAI-Build" }
     $releaseApi = "https://api.github.com/repos/redis-windows/redis-windows/releases/latest"
     try {
         $release = Invoke-RestMethod -Uri $releaseApi -Headers $headers -TimeoutSec 30
@@ -266,7 +266,7 @@ Install it with the official bootstrapper:
 
   powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-WebRequest -Uri https://antigravity.google/cli/install.cmd -OutFile `$env:TEMP\antigravity-cli-install.cmd; & `$env:TEMP\antigravity-cli-install.cmd"
 
-Offline Cat Cafe packages intentionally do not vendor agy until Google
+Offline Clowder AI packages intentionally do not vendor agy until Google
 publishes a redistributable native binary contract.
 "@ | Set-Content -Path $agyInstructionsPath -Encoding ascii
 Write-Ok "agy-install-instructions.txt written"
@@ -406,7 +406,7 @@ if (-not $SkipInstaller) {
     if ($LASTEXITCODE -ne 0) { Write-Err "Inno Setup compilation failed"; exit 1 }
     Write-Ok "Installer built"
 
-    $outputExe = Get-ChildItem -Path $distDir -Filter "CatCafe-Setup-*.exe" | Select-Object -First 1
+    $outputExe = Get-ChildItem -Path $distDir -Filter "ClowderAI-Setup-*.exe" | Select-Object -First 1
     Write-Host ""
     Write-Host "  ========================================" -ForegroundColor Green
     Write-Host "  Installer ready!" -ForegroundColor Green
@@ -428,7 +428,7 @@ if (-not $SkipPortableZip) {
     $desktopPkgJson = Get-Content $desktopPkgPath -Raw | ConvertFrom-Json
     $zipVersion = if ($env:CATCAFE_VERSION) { $env:CATCAFE_VERSION } else { $desktopPkgJson.version }
 
-    $stagingName = "CatCafe-$zipVersion"
+    $stagingName = "ClowderAI-$zipVersion"
     $staging = Join-Path $distDir $stagingName
     if (Test-Path $staging) { Remove-Item $staging -Recurse -Force }
     New-Item -ItemType Directory -Path $staging -Force | Out-Null

--- a/desktop/scripts/build-mac.sh
+++ b/desktop/scripts/build-mac.sh
@@ -3,8 +3,8 @@
 #
 # Mirrors desktop/scripts/build-desktop.ps1 for macOS. Outputs two DMGs
 # (arm64 + x64) under dist/:
-#   CatCafe-0.10.1-arm64.dmg
-#   CatCafe-0.10.1-x64.dmg
+#   ClowderAI-0.10.1-arm64.dmg
+#   ClowderAI-0.10.1-x64.dmg
 #
 # Prerequisites on the build machine:
 #   - macOS 13+ (Xcode Command Line Tools: xcode-select --install)
@@ -386,7 +386,7 @@ for arch in "${ARCHS[@]}"; do
     x64) app_dir="${DESKTOP_DIR}/dist/mac" ;;
     *) die "Unsupported macOS arch: ${arch}" ;;
   esac
-  dmg_name="CatCafe-${VERSION}-${arch}.dmg"
+  dmg_name="ClowderAI-${VERSION}-${arch}.dmg"
   dmg_out="${DIST_DIR}/${dmg_name}"
   if [[ ! -d "$app_dir" ]]; then
     die "Expected app bundle directory not found for ${arch}: ${app_dir}"
@@ -458,7 +458,7 @@ done
 echo ""
 echo "  ========================================"
 echo "  Installer(s) ready!"
-for dmg in "${DIST_DIR}"/CatCafe-*-*.dmg; do
+for dmg in "${DIST_DIR}"/ClowderAI-*-*.dmg; do
   [[ -f "$dmg" ]] || continue
   size_mb="$(stat -f "%z" "$dmg" 2>/dev/null | awk '{printf "%.2f", $1/1024/1024}')"
   echo "  $(basename "$dmg")  (${size_mb} MB)"

--- a/desktop/scripts/post-install-offline.ps1
+++ b/desktop/scripts/post-install-offline.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-  Post-install for the offline Cat Cafe installer.
+  Post-install for the offline Clowder AI installer.
 
 .DESCRIPTION
   Called by Inno Setup after file extraction.
@@ -190,11 +190,11 @@ if (Test-Path $redisExe) {
 Write-Host ""
 if ($allGood) {
     Write-Host "  ========================================" -ForegroundColor Green
-    Write-Host "  Cat Cafe configured!" -ForegroundColor Green
+    Write-Host "  Clowder AI configured!" -ForegroundColor Green
     Write-Host "  ========================================" -ForegroundColor Green
 } else {
     Write-Host "  ========================================" -ForegroundColor Yellow
-    Write-Host "  Cat Cafe installed with warnings" -ForegroundColor Yellow
+    Write-Host "  Clowder AI installed with warnings" -ForegroundColor Yellow
     Write-Host "  ========================================" -ForegroundColor Yellow
 }
 

--- a/desktop/scripts/start-portable.bat
+++ b/desktop/scripts/start-portable.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal EnableDelayedExpansion
 
-rem Cat Cafe Portable — launch script
+rem Clowder AI Portable — launch script
 rem Detects first run, auto-configures, then starts the Electron app.
 rem Equivalent to Inno Setup [Run] section but without admin requirement.
 
@@ -13,7 +13,7 @@ rem ── First-run configuration ───────────────
 if not exist "%APPDIR%\.env" (
     echo.
     echo  ============================================
-    echo   Cat Cafe — First Run Configuration
+    echo   Clowder AI — First Run Configuration
     echo  ============================================
     echo.
 
@@ -24,7 +24,7 @@ if not exist "%APPDIR%\.env" (
     echo.
 
     rem Step 2: Sync Agent CLI hooks to user profile (~/.claude, ~/.codex)
-    rem so any existing CLI installations can connect to this Cat Cafe instance.
+    rem so any existing CLI installations can connect to this Clowder AI instance.
     powershell -NoProfile -ExecutionPolicy Bypass -File "%APPDIR%\scripts\post-install-offline.ps1" -AppDir "%APPDIR%" -AgentHooksOnly
     echo.
 
@@ -35,7 +35,7 @@ if not exist "%APPDIR%\.env" (
 
     if errorlevel 1 (
         echo  [!!] Configuration encountered issues. See above for details.
-        echo       Cat Cafe will still attempt to start.
+        echo       Clowder AI will still attempt to start.
         echo.
     ) else (
         echo  [OK] Configuration complete.
@@ -54,6 +54,6 @@ if errorlevel 1 (
     )
 )
 
-rem ── Launch Cat Cafe ──────────────────────────────────────────────────
-echo  Starting Cat Cafe...
-start "" "%APPDIR%\desktop-dist\Cat Cafe.exe"
+rem ── Launch Clowder AI ──────────────────────────────────────────────────
+echo  Starting Clowder AI...
+start "" "%APPDIR%\desktop-dist\Clowder AI.exe"

--- a/desktop/splash.html
+++ b/desktop/splash.html
@@ -2,7 +2,7 @@
 <html lang="zh-CN">
 <head>
   <meta charset="UTF-8">
-  <title>Cat Cafe</title>
+  <title>Clowder AI</title>
   <style>
     * { margin: 0; padding: 0; box-sizing: border-box; }
     body {
@@ -31,7 +31,7 @@
 </head>
 <body>
   <div class="container">
-    <h1>Cat Cafe</h1>
+    <h1>Clowder AI</h1>
     <p class="subtitle">Multi-Agent Collaboration Platform</p>
     <div class="spinner"></div>
     <p class="status" id="status">Starting services...</p>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,7 +5,7 @@ doc_kind: note
 created: 2026-02-26
 ---
 
-# Cat Cafe Feature Roadmap
+# Clowder AI Feature Roadmap
 
 > 维护者：三猫 | 最后更新：2026-06-26（F252 Story Player done）
 >
@@ -22,7 +22,7 @@ created: 2026-02-26
 | F051 | 猫粮看板 v2 — Quota Board (glanceable + scheduling) | in-progress | Ragdoll | internal | [F051](features/F051-real-quota-dashboard.md) |
 | F054 | HCI 预热基础设施 — Social Media MCP + 内容管线 | spec | Ragdoll (Opus 4.6, Leader) | internal | [F054](features/F054-hci-preheat-infra.md) |
 | F055 | A2A MCP Structured Routing — targetCats 结构化路由 | spec | Ragdoll | internal | [F055](features/F055-a2a-mcp-structured-routing.md) |
-| F056 | Cat Café 设计语言 — 猫猫化不是猫化 | doing | 三猫 | internal | [F056](features/F056-cat-cafe-design-language.md) |
+| F056 | Clowder AI 设计语言 — 猫猫化不是猫化 | doing | 三猫 | internal | [F056](features/F056-cat-cafe-design-language.md) |
 | F067 | Cold-start Verifier — 无历史污染的交付物验证 | spec | Ragdoll | internal | [F067](features/F067-cold-start-verifier.md) |
 | F069 | Thread Read State — 未读 Badge 后端真相源 | spec | Ragdoll | internal | [F069](features/F069-thread-read-state.md) |
 | F077 | Multi-User Secure Collaboration — GitHub OAuth + Thread ACL + Session | spec | Ragdoll | internal | [F077](features/F077-multi-user-secure-collab.md) |
@@ -37,11 +37,11 @@ created: 2026-02-26
 | F109 | Message Actions 修复与增强 — 软删除/Branch/编辑/通知 | in-progress | Ragdoll | internal | [F109](features/F109-message-actions-overhaul.md) |
 | F110 | 训练营愿景引导增强 — operator 需求挖掘 + SOP 显式加载 | spec | Ragdoll | internal | [F110](features/F110-bootcamp-vision-elicitation.md) |
 | F119 | 谁是卧底 — 坏猫战术推理游戏 #2 | spec | Ragdoll | internal | [F119](features/F119-who-is-spy-game.md) |
-| F124 | Apple Ecosystem × Cat Café 语音交互系统 — iOS/watchOS/AirPods | spec | Ragdoll | internal | [F124](features/F124-apple-ecosystem-voice-interaction.md) |
-| F126 | 四肢控制面 — Cat Café Limb Control Plane | in-progress | Ragdoll | internal | [F126](features/F126-limb-control-plane.md) |
+| F124 | Apple Ecosystem × Clowder AI 语音交互系统 — iOS/watchOS/AirPods | spec | Ragdoll | internal | [F124](features/F124-apple-ecosystem-voice-interaction.md) |
+| F126 | 四肢控制面 — Clowder AI Limb Control Plane | in-progress | Ragdoll | internal | [F126](features/F126-limb-control-plane.md) |
 | F128 | Cat-Proposed Thread Creation — 猫猫提议创建 Thread | in-progress | 三猫 | community [#82](https://github.com/zts212653/clowder-ai/issues/82) [#85](https://github.com/zts212653/clowder-ai/pull/85) | [F128](features/F128-cat-create-thread.md) |
 | F129 | Pack System — Multi-Agent 共创世界的 Mod 生态 | in-progress | Ragdoll | internal | [F129](features/F129-pack-system-multi-agent-mod.md) |
-| F138 | Cat Café Video Studio — AI 视频制作管线 | spec | 金渐层 | internal | [F138](features/F138-video-studio.md) |
+| F138 | Clowder AI Video Studio — AI 视频制作管线 | spec | 金渐层 | internal | [F138](features/F138-video-studio.md) |
 | F143 | Hostable Agent Runtime — 统一宿主抽象 | spec | Ragdoll | internal | [F143](features/F143-hostable-agent-runtime.md) |
 | F147 | i18n — Hub 界面中英文切换 | idea | 待定 | internal | — |
 | F152 | Expedition Memory — 外部项目记忆冷启动 + 经验回流 | in-progress | Ragdoll | internal | [F152](features/F152-expedition-memory.md) |
@@ -78,7 +78,7 @@ created: 2026-02-26
 | F233 | Ball Custody Observability — 球权保管链可观测（值班简报：operator 收件箱+死球/睡美人/虚空告警，异常优先；feat 轨迹下钻；安乐死通道；A 简报 MVP / B 心跳+探针回执 / C 安乐死+轨迹）| in-progress（A✅ B✅ 2026-06-18 · C pending operator signoff）| Ragdoll Fable-5（spec）→ opus 家族（实现） | internal (operator 2026-06-12 "走起！喵"+"① 立项") | [F233](features/F233-ball-custody-observability.md) |
 | F241 | Agent Provider Plugin / Hostable Provider Runtime — 外部 agent runtime 以 plugin 声明式接入（新增 agentProvider 资源类型，provider 实现移出 core；不再改 ClientId union + index.ts switch）；Phase A host transport registry（F143/F161 lineage）/ B F202 agentProvider manifest / C clowder-code reference；安全边界全 host-owned（token/MCP/sandbox），F129 继承；core 安全 + merge-gate maintainer 守 | spec | community 彭潇(bouillipx) + Ragdoll家族 maintainer | community [#941](https://github.com/zts212653/clowder-ai/issues/941) | [F241](features/F241-agent-provider-plugin.md) |
 | F242 | Code Graph Layer Spike — 内生「约定层关联图」（Phase A/B spike 已落 main：convention-graph package + discovery skill + deer-flow skeleton；operator 2026-06-18 撤回 full close：仍缺猫猫认知路径 / 可用入口 / 更新或重建索引行为；进入 Phase C productization gate） | in-progress (spike done) | Maine Coon (gpt-5.5) + opus-48 design | internal | [F242](features/F242-code-graph-layer-spike.md) |
-| F243 | Docs Discovery Profile — OKF-inspired metadata + generated index（让 docs/features 从平铺文件堆变成可渐进探索的知识入口；4 Phase: stratified spike + profile draft + eval rubric → contract + lint + generator → rollout + checked-in index.md + sync gate → eval report + decisions/research 扩展 go/no-go；operator 2026-06-17 signoff；Maine Coon (gpt-5.5) co-design + R1 reviewer；F236 姊妹哲学 anchor-and-drill 调用侧 vs 文档侧；schema self-contained 供未来 consumer（F186 等是潜在候选但不绑定）；防"小猫代偿决策"反模式：抽查不可代 gate） | spec | Ragdoll (Ragdoll Opus-4.7) | internal (operator 2026-06-17) | [F243](features/F243-docs-discovery-profile.md) |
+| F243 | Docs Discovery Profile — OKF-inspired metadata + generated index（让 docs/features 从平铺文件堆变成可渐进探索的知识入口；4 Phase: stratified spike + profile draft + eval rubric → contract + lint + generator → rollout + checked-in index.md + sync gate → eval report + decisions/research 扩展 go/no-go；operator 2026-06-17 signoff；Maine Coon (gpt-5.5) co-design + R1 reviewer；F236 姊妹哲学 anchor-and-drill 调用侧 vs 文档侧；schema self-contained 供未来 consumer（F186 等是潜在候选但不绑定）；防"小猫代偿决策"反模式：抽查不可代 gate） | in-progress (B-0 merged 2026-06-30, PR #2693) | Ragdoll (Ragdoll Opus-4.7) | internal (operator 2026-06-17) | [F243](features/F243-docs-discovery-profile.md) |
 | F247 | Cloud Cat Family — 多 provider 云端猫接入平台（B1a interim done 2026-06-22：cloudflared named tunnel + spike server `?token=` 单防线 + MCP annotations 显式表 + cat-cafe API hot-add via POST /api/cats + Maine Coon云端 ChatGPT Pro 实证 read + write 工具通；B1b 升级 verified auth via CF Access OAuth 待排期；Phase C avatar/bubble UX 抛光；Phase D Console 多 provider UI；Phase E npm plugin spec） | in-progress (B1a done) | Ragdoll (Ragdoll Opus-4.7) | internal (operator 2026-06-21 立项) | [F247](features/F247-cloud-cat-family.md) |
 | F249 | Multi-Project MCP Sync Management — 多项目 MCP 配置同步管理（capabilities.json 单源 + invoke-time provider 注入 + 多项目漂移检测 + blockedCats 猫级控制 + 级联同步；含 #712 bug fix 前置；PR #713 原用 F240 撞号已纠正） | design | community @mindfn + maintainers | community [#713](https://github.com/zts212653/clowder-ai/pull/713) + [#712](https://github.com/zts212653/clowder-ai/issues/712) | [F249](features/F249-multi-project-mcp-sync-management.md) |
 | F251 | Public Target Delta Preservation Gate — 防 outbound rsync 抹掉 clowder-ai 已有 delta（V1 三方树 BLOCK + override > 3 触发 operator alarm + AC-A5 历史事故 dry-run replay anti-placebo）+ Community Contract Registry v0 兜底 home regression export | spec | Maine Coon (gpt-5.5) + Ragdoll (Opus 4.7) | internal (operator 2026-06-25 立项；operator痛点："不下十次了"反复改坏社区功能) | [F251](features/F251-public-delta-preservation-gate.md) |


### PR DESCRIPTION
## Summary
- update public desktop installer, portable launcher, splash, build scripts, and docs from Cat Cafe/CatCafe release branding to Clowder AI equivalents
- align Windows installer executable references with Electron `productName: Clowder AI` (`Clowder AI.exe`)
- keep internal package/path identifiers such as `cat-cafe-desktop`, `@cat-cafe/*`, and repo-local paths unchanged

## Source
- Source sanitizer PR: https://github.com/zts212653/cat-cafe/pull/2782

## Verification
- `node --test desktop/*.test.js`
- `pnpm check`
- `rg -n "Cat Cafe|CatCafe|ai\.catcafe\.desktop" desktop docs/ROADMAP.md --glob "!node_modules/**"` returned no scoped remnants

## Coordination
- PR #1105 touches nearby desktop update surfaces; if it merges first, this branch may need a rebase before merge.

Fixes #1104
Fixes #1106

[砚砚/GPT-5.5🐾]