### PR TITLE
fix(desktop): batch fix #1107 + #1117

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
           GIT_AUTHOR_EMAIL: ci@clowder-ai.dev
           GIT_COMMITTER_NAME: CI Runner
           GIT_COMMITTER_EMAIL: ci@clowder-ai.dev
+      - name: Desktop tests
+        run: node --test desktop/*.test.js
 
   dir-size:
     name: Directory Size Guard

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -39,3 +39,5 @@ jobs:
           node --test packages/api/test/cli-spawn-win.test.js
           node --test packages/api/test/process-liveness-probe.test.js
           node --test packages/api/test/pick-directory.test.js
+      - name: Desktop config behavioral tests (PowerShell)
+        run: node --test desktop/generate-desktop-config-behavior.test.js

--- a/desktop/generate-desktop-config-behavior.test.js
+++ b/desktop/generate-desktop-config-behavior.test.js
@@ -9,10 +9,10 @@
  * Skipped on non-Windows platforms (PowerShell not available).
  */
 const assert = require('node:assert/strict');
-const { execSync } = require('node:child_process');
+const { execFileSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
-const { describe, it, before, beforeEach, afterEach } = require('node:test');
+const { describe, it, beforeEach, afterEach } = require('node:test');
 const os = require('node:os');
 
 const IS_WINDOWS = os.platform() === 'win32';
@@ -20,11 +20,18 @@ const SCRIPT = path.join(__dirname, 'scripts', 'generate-desktop-config.ps1');
 
 /**
  * Run generate-desktop-config.ps1 with given parameters.
- * Returns the parsed desktop-config.json content.
+ * Uses execFileSync to invoke powershell directly — bypasses cmd.exe
+ * shell layer entirely, eliminating double-quote mangling that causes
+ * PowerShell parsing errors on Windows CI (see #1112 review round 5).
+ * @param {string} appDir
+ * @param {{ version?: string, installType?: string }} opts
+ * @returns {object} parsed desktop-config.json
  */
-function runGenerator(appDir, extraArgs = '') {
-  const cmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${SCRIPT}" -AppDir "${appDir}" ${extraArgs}`;
-  execSync(cmd, { stdio: 'pipe', timeout: 15000 });
+function runGenerator(appDir, opts = {}) {
+  const args = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', SCRIPT, '-AppDir', appDir];
+  if (opts.version) args.push('-Version', opts.version);
+  if (opts.installType) args.push('-InstallType', opts.installType);
+  execFileSync('powershell', args, { stdio: 'pipe', timeout: 15000 });
   const configPath = path.join(appDir, '.cat-cafe', 'desktop-config.json');
   const raw = fs.readFileSync(configPath, 'utf8');
   return JSON.parse(raw);
@@ -45,7 +52,7 @@ describe(
     });
 
     it('installer path: explicit version + installType=installer', () => {
-      const config = runGenerator(tmpDir, "-Version '1.2.3' -InstallType 'installer'");
+      const config = runGenerator(tmpDir, { version: '1.2.3', installType: 'installer' });
       assert.equal(config.version, '1.2.3', 'version must match explicit -Version param');
       assert.equal(config.installType, 'installer', 'installType must be "installer"');
       assert.ok(config.installedAt, 'installedAt must be present');
@@ -57,7 +64,7 @@ describe(
       fs.mkdirSync(desktopDir, { recursive: true });
       fs.writeFileSync(path.join(desktopDir, 'package.json'), JSON.stringify({ name: 'test', version: '0.10.1' }));
 
-      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      const config = runGenerator(tmpDir, { installType: 'portable' });
       assert.equal(config.version, '0.10.1', 'version must be read from desktop/package.json');
       assert.equal(config.installType, 'portable', 'installType must be "portable"');
     });
@@ -66,12 +73,12 @@ describe(
       // Only root package.json, no desktop/package.json
       fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'root', version: '0.1.0' }));
 
-      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      const config = runGenerator(tmpDir, { installType: 'portable' });
       assert.equal(config.version, '0.1.0', 'version must fall back to root package.json');
     });
 
     it('fallback: version is "unknown" when no package.json exists', () => {
-      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      const config = runGenerator(tmpDir, { installType: 'portable' });
       assert.equal(config.version, 'unknown', 'version must fall back to "unknown"');
     });
 
@@ -82,7 +89,7 @@ describe(
       fs.mkdirSync(desktopDir, { recursive: true });
       fs.writeFileSync(path.join(desktopDir, 'package.json'), JSON.stringify({ name: 'desktop', version: '0.10.1' }));
 
-      const config = runGenerator(tmpDir, "-InstallType 'installer'");
+      const config = runGenerator(tmpDir, { installType: 'installer' });
       assert.equal(config.version, '0.10.1', 'desktop/package.json version must take priority');
       assert.notEqual(config.version, '0.1.0', 'root package.json version must not be used');
     });

--- a/desktop/generate-desktop-config-behavior.test.js
+++ b/desktop/generate-desktop-config-behavior.test.js
@@ -1,0 +1,90 @@
+/**
+ * Behavioral tests for generate-desktop-config.ps1 — Windows only.
+ *
+ * These tests actually execute the PowerShell script against temporary
+ * app directories and assert the generated desktop-config.json values.
+ * They validate the #1107 acceptance boundary: non-empty version and
+ * correct installType for both installer and portable paths.
+ *
+ * Skipped on non-Windows platforms (PowerShell not available).
+ */
+const assert = require('node:assert/strict');
+const { execSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { describe, it, before, beforeEach, afterEach } = require('node:test');
+const os = require('node:os');
+
+const IS_WINDOWS = os.platform() === 'win32';
+const SCRIPT = path.join(__dirname, 'scripts', 'generate-desktop-config.ps1');
+
+/**
+ * Run generate-desktop-config.ps1 with given parameters.
+ * Returns the parsed desktop-config.json content.
+ */
+function runGenerator(appDir, extraArgs = '') {
+  const cmd = `powershell -NoProfile -ExecutionPolicy Bypass -File "${SCRIPT}" -AppDir "${appDir}" ${extraArgs}`;
+  execSync(cmd, { stdio: 'pipe', timeout: 15000 });
+  const configPath = path.join(appDir, '.cat-cafe', 'desktop-config.json');
+  const raw = fs.readFileSync(configPath, 'utf8');
+  return JSON.parse(raw);
+}
+
+describe(
+  '#1107: generate-desktop-config.ps1 behavioral tests',
+  { skip: !IS_WINDOWS && 'PowerShell required (Windows only)' },
+  () => {
+    let tmpDir;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-desktop-test-'));
+    });
+
+    afterEach(() => {
+      if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('installer path: explicit version + installType=installer', () => {
+      const config = runGenerator(tmpDir, "-Version '1.2.3' -InstallType 'installer'");
+      assert.equal(config.version, '1.2.3', 'version must match explicit -Version param');
+      assert.equal(config.installType, 'installer', 'installType must be "installer"');
+      assert.ok(config.installedAt, 'installedAt must be present');
+    });
+
+    it('portable path: version from desktop/package.json + installType=portable', () => {
+      // Simulate portable app directory with desktop/package.json
+      const desktopDir = path.join(tmpDir, 'desktop');
+      fs.mkdirSync(desktopDir, { recursive: true });
+      fs.writeFileSync(path.join(desktopDir, 'package.json'), JSON.stringify({ name: 'test', version: '0.10.1' }));
+
+      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      assert.equal(config.version, '0.10.1', 'version must be read from desktop/package.json');
+      assert.equal(config.installType, 'portable', 'installType must be "portable"');
+    });
+
+    it('fallback: version from root package.json when desktop/package.json absent', () => {
+      // Only root package.json, no desktop/package.json
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'root', version: '0.1.0' }));
+
+      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      assert.equal(config.version, '0.1.0', 'version must fall back to root package.json');
+    });
+
+    it('fallback: version is "unknown" when no package.json exists', () => {
+      const config = runGenerator(tmpDir, "-InstallType 'portable'");
+      assert.equal(config.version, 'unknown', 'version must fall back to "unknown"');
+    });
+
+    it('desktop/package.json preferred over root package.json', () => {
+      // Both exist — desktop should win
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify({ name: 'root', version: '0.1.0' }));
+      const desktopDir = path.join(tmpDir, 'desktop');
+      fs.mkdirSync(desktopDir, { recursive: true });
+      fs.writeFileSync(path.join(desktopDir, 'package.json'), JSON.stringify({ name: 'desktop', version: '0.10.1' }));
+
+      const config = runGenerator(tmpDir, "-InstallType 'installer'");
+      assert.equal(config.version, '0.10.1', 'desktop/package.json version must take priority');
+      assert.notEqual(config.version, '0.1.0', 'root package.json version must not be used');
+    });
+  },
+);

--- a/desktop/generate-desktop-config.test.js
+++ b/desktop/generate-desktop-config.test.js
@@ -87,23 +87,40 @@ test('#1107: build script bakes resolved version into staged desktop/package.jso
     'build-desktop.ps1 must bake $zipVersion into staged desktop/package.json',
   );
 
-  // Must serialize the modified content back to the staging directory
+  // Must serialize the modified content back to the staging directory using
+  // BOM-less UTF-8 (WriteAllText + UTF8Encoding($false)), not Out-File.
   assert.match(
     buildScript,
-    /ConvertTo-Json.*Out-File.*package\.json/,
-    'build-desktop.ps1 must write modified package.json to staging',
+    /WriteAllText.*package\.json/,
+    'build-desktop.ps1 must write modified package.json to staging via WriteAllText',
   );
 
   // Execution order: version assignment MUST precede serialization.
-  // If Out-File runs before $pkgContent.version = $zipVersion, the
+  // If WriteAllText runs before $pkgContent.version = $zipVersion, the
   // written JSON still carries the old version — a silent data bug.
   const assignIdx = buildScript.search(/\$pkgContent\.version\s*=\s*\$zipVersion/);
-  const writeIdx = buildScript.search(/ConvertTo-Json.*Out-File/);
+  const writeIdx = buildScript.search(/WriteAllText.*package\.json/);
   assert.ok(assignIdx >= 0 && writeIdx >= 0, 'Both version-bake and serialization lines must exist');
   assert.ok(
     assignIdx < writeIdx,
     `Version assignment (pos ${assignIdx}) must appear before serialization (pos ${writeIdx})`,
   );
+});
+
+test('#1107: no JSON file is written with BOM-emitting Out-File -Encoding utf8', () => {
+  // Guard: Windows PowerShell 5.1's Out-File -Encoding utf8 emits a UTF-8 BOM
+  // (ef bb bf) that breaks JSON.parse. All JSON writes in desktop scripts must
+  // use [System.IO.File]::WriteAllText with UTF8Encoding($false) instead.
+  const scripts = ['generate-desktop-config.ps1', 'build-desktop.ps1'];
+  for (const name of scripts) {
+    const content = readFileSync(path.join(SCRIPTS_DIR, name), 'utf8');
+    // Match Out-File writing a .json path with -Encoding utf8
+    assert.doesNotMatch(
+      content,
+      /Out-File.*\.json.*-Encoding\s+utf8/,
+      `${name} must not use Out-File -Encoding utf8 for JSON files (emits BOM on PS 5.1)`,
+    );
+  }
 });
 
 test('#1107: desktop/package.json version differs from root', () => {

--- a/desktop/generate-desktop-config.test.js
+++ b/desktop/generate-desktop-config.test.js
@@ -1,0 +1,121 @@
+/**
+ * Regression tests for #1107 — desktop-config.json generation.
+ *
+ * Since the config generation scripts are PowerShell/Batch (not directly
+ * runnable in CI), these tests validate the script content structurally.
+ * Tests match actual PowerShell commands and logic constructs, not just
+ * comments or string occurrences, so that deleting functional lines
+ * causes test failures.
+ */
+const assert = require('node:assert/strict');
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const SCRIPTS_DIR = path.join(__dirname, 'scripts');
+const INSTALLER_DIR = path.join(__dirname, 'installer');
+
+test('#1107: Inno Setup installer passes -Version explicitly', () => {
+  const iss = readFileSync(path.join(INSTALLER_DIR, 'cat-cafe.iss'), 'utf8');
+  // Match the actual Parameters line that invokes the script with -Version.
+  // A comment mentioning -Version is not enough — the real invocation must exist.
+  assert.match(
+    iss,
+    /Parameters:.*generate-desktop-config\.ps1.*-Version/,
+    'cat-cafe.iss Parameters must invoke generate-desktop-config.ps1 with -Version',
+  );
+});
+
+test('#1107: Inno Setup installer passes -InstallType installer', () => {
+  const iss = readFileSync(path.join(INSTALLER_DIR, 'cat-cafe.iss'), 'utf8');
+  assert.match(
+    iss,
+    /Parameters:.*generate-desktop-config\.ps1.*-InstallType\s+'installer'/,
+    'cat-cafe.iss Parameters must pass -InstallType installer',
+  );
+});
+
+test('#1107: Portable launcher passes -InstallType portable', () => {
+  const bat = readFileSync(path.join(SCRIPTS_DIR, 'start-portable.bat'), 'utf8');
+  // Match the actual powershell invocation line, not a rem comment
+  assert.match(
+    bat,
+    /powershell.*generate-desktop-config\.ps1.*-InstallType\s+'portable'/i,
+    'start-portable.bat must invoke generate-desktop-config.ps1 with -InstallType portable',
+  );
+});
+
+test('#1107: PowerShell script resolves version from desktop/package.json first', () => {
+  const ps1 = readFileSync(path.join(SCRIPTS_DIR, 'generate-desktop-config.ps1'), 'utf8');
+
+  // Match the actual variable assignment that constructs the desktop path,
+  // not just any mention of the string in a comment.
+  assert.match(
+    ps1,
+    /\$desktopPkgPath\s*=\s*Join-Path.*desktop.*package\.json/,
+    'generate-desktop-config.ps1 must assign $desktopPkgPath from desktop/package.json',
+  );
+
+  // The conditional must prefer $desktopPkgPath over $rootPkgPath
+  assert.match(
+    ps1,
+    /if\s*\(Test-Path\s+\$desktopPkgPath\)\s*\{\s*\$desktopPkgPath\s*\}/,
+    'generate-desktop-config.ps1 must prefer $desktopPkgPath when it exists',
+  );
+});
+
+test('#1107: version fallback chain is complete', () => {
+  const ps1 = readFileSync(path.join(SCRIPTS_DIR, 'generate-desktop-config.ps1'), 'utf8');
+  // Must have a final fallback to "unknown" if all sources fail
+  assert.match(ps1, /\$Version\s*=\s*"unknown"/, 'Must fall back to "unknown" if no package.json is readable');
+});
+
+test('#1107: build script bakes resolved version into staged desktop/package.json', () => {
+  const buildScript = readFileSync(path.join(SCRIPTS_DIR, 'build-desktop.ps1'), 'utf8');
+
+  // Must read the source desktop/package.json
+  assert.match(
+    buildScript,
+    /\$desktopPkg\s*=\s*Join-Path.*desktop.*package\.json/,
+    'build-desktop.ps1 must locate source desktop/package.json',
+  );
+
+  // Must write $zipVersion into the staged copy (not just Copy-Item)
+  // so that CATCAFE_VERSION overrides propagate to portable config.
+  assert.match(
+    buildScript,
+    /\$pkgContent\.version\s*=\s*\$zipVersion/,
+    'build-desktop.ps1 must bake $zipVersion into staged desktop/package.json',
+  );
+
+  // Must serialize the modified content back to the staging directory
+  assert.match(
+    buildScript,
+    /ConvertTo-Json.*Out-File.*package\.json/,
+    'build-desktop.ps1 must write modified package.json to staging',
+  );
+
+  // Execution order: version assignment MUST precede serialization.
+  // If Out-File runs before $pkgContent.version = $zipVersion, the
+  // written JSON still carries the old version — a silent data bug.
+  const assignIdx = buildScript.search(/\$pkgContent\.version\s*=\s*\$zipVersion/);
+  const writeIdx = buildScript.search(/ConvertTo-Json.*Out-File/);
+  assert.ok(assignIdx >= 0 && writeIdx >= 0, 'Both version-bake and serialization lines must exist');
+  assert.ok(
+    assignIdx < writeIdx,
+    `Version assignment (pos ${assignIdx}) must appear before serialization (pos ${writeIdx})`,
+  );
+});
+
+test('#1107: desktop/package.json version differs from root', () => {
+  // Guard: if these versions ever converge, the fallback chain becomes
+  // irrelevant and this test should be updated. If they differ, the
+  // generate-desktop-config.ps1 MUST prefer desktop/package.json.
+  const rootPkg = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+  const desktopPkg = JSON.parse(readFileSync(path.join(__dirname, 'package.json'), 'utf8'));
+  assert.notEqual(
+    rootPkg.version,
+    desktopPkg.version,
+    'Root and desktop versions should differ — if they converge, update this test and the fallback logic',
+  );
+});

--- a/desktop/generate-desktop-config.test.js
+++ b/desktop/generate-desktop-config.test.js
@@ -1,11 +1,10 @@
 /**
- * Regression tests for #1107 — desktop-config.json generation.
+ * Structural regression tests for #1107 — desktop-config.json generation.
  *
- * Since the config generation scripts are PowerShell/Batch (not directly
- * runnable in CI), these tests validate the script content structurally.
- * Tests match actual PowerShell commands and logic constructs, not just
- * comments or string occurrences, so that deleting functional lines
- * causes test failures.
+ * These tests validate the PowerShell/Batch script content structurally
+ * (source patterns, execution order) and run on all platforms.
+ * Behavioral tests that execute the script on Windows are in
+ * generate-desktop-config-behavior.test.js (Windows Smoke CI).
  */
 const assert = require('node:assert/strict');
 const { readFileSync } = require('node:fs');

--- a/desktop/generate-desktop-config.test.js
+++ b/desktop/generate-desktop-config.test.js
@@ -71,6 +71,10 @@ test('#1107: version fallback chain is complete', () => {
 
 test('#1107: build script bakes resolved version into staged desktop/package.json', () => {
   const buildScript = readFileSync(path.join(SCRIPTS_DIR, 'build-desktop.ps1'), 'utf8');
+  // Exact regex for the staged package.json write — pins UTF8Encoding($false)
+  // so that a $true mutation (which silently re-enables the BOM) is caught.
+  const stagedPackageWrite =
+    /\[System\.IO\.File\]::WriteAllText\(\(Join-Path\s+\$desktopDir\s+"package\.json"\),\s*\$json,\s*\(New-Object\s+System\.Text\.UTF8Encoding\s+\$false\)\)/;
 
   // Must read the source desktop/package.json
   assert.match(
@@ -91,15 +95,15 @@ test('#1107: build script bakes resolved version into staged desktop/package.jso
   // BOM-less UTF-8 (WriteAllText + UTF8Encoding($false)), not Out-File.
   assert.match(
     buildScript,
-    /WriteAllText.*package\.json/,
-    'build-desktop.ps1 must write modified package.json to staging via WriteAllText',
+    stagedPackageWrite,
+    'build-desktop.ps1 must write staged package.json via WriteAllText with UTF8Encoding($false)',
   );
 
   // Execution order: version assignment MUST precede serialization.
   // If WriteAllText runs before $pkgContent.version = $zipVersion, the
   // written JSON still carries the old version — a silent data bug.
   const assignIdx = buildScript.search(/\$pkgContent\.version\s*=\s*\$zipVersion/);
-  const writeIdx = buildScript.search(/WriteAllText.*package\.json/);
+  const writeIdx = buildScript.search(stagedPackageWrite);
   assert.ok(assignIdx >= 0 && writeIdx >= 0, 'Both version-bake and serialization lines must exist');
   assert.ok(
     assignIdx < writeIdx,

--- a/desktop/installer/cat-cafe.iss
+++ b/desktop/installer/cat-cafe.iss
@@ -189,9 +189,9 @@ Filename: "powershell.exe"; \
   StatusMsg: "Configuring Agent CLI hooks..."; \
   Flags: runhidden waituntilterminated runasoriginaluser
 
-; Generate desktop-config.json
+; Generate desktop-config.json (pass version + install type for update detection, #1107)
 Filename: "powershell.exe"; \
-  Parameters: "-ExecutionPolicy Bypass -Command ""& '{app}\scripts\generate-desktop-config.ps1' -AppDir '{app}'"""; \
+  Parameters: "-ExecutionPolicy Bypass -Command ""& '{app}\scripts\generate-desktop-config.ps1' -AppDir '{app}' -Version '{#MyAppVersion}' -InstallType 'installer'"""; \
   StatusMsg: "Generating desktop configuration..."; \
   Flags: runhidden waituntilterminated
 

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -513,6 +513,20 @@ if (-not $SkipPortableZip) {
     # Desktop assets
     Copy-ToStaging (Join-Path (Join-Path $ProjectRoot "desktop") "assets") "desktop\assets"
 
+    # Desktop package.json — version source for generate-desktop-config.ps1.
+    # Bake the resolved $zipVersion (which honours CATCAFE_VERSION override)
+    # into the staged copy so portable first-run config always matches the
+    # archive name. Without this, a manual CATCAFE_VERSION override would
+    # produce a zip named X but a desktop-config.json recording Y. (#1107)
+    $desktopPkg = Join-Path (Join-Path $ProjectRoot "desktop") "package.json"
+    if (Test-Path $desktopPkg) {
+        $desktopDir = Join-Path $staging "desktop"
+        if (-not (Test-Path $desktopDir)) { New-Item -ItemType Directory -Path $desktopDir -Force | Out-Null }
+        $pkgContent = Get-Content $desktopPkg -Raw | ConvertFrom-Json
+        $pkgContent.version = $zipVersion
+        $pkgContent | ConvertTo-Json -Depth 10 | Out-File (Join-Path $desktopDir "package.json") -Encoding utf8
+    }
+
     # CLI tool tarballs
     Copy-ToStaging (Join-Path $ProjectRoot "bundled\cli-tools") "bundled\cli-tools"
 

--- a/desktop/scripts/build-desktop.ps1
+++ b/desktop/scripts/build-desktop.ps1
@@ -524,7 +524,10 @@ if (-not $SkipPortableZip) {
         if (-not (Test-Path $desktopDir)) { New-Item -ItemType Directory -Path $desktopDir -Force | Out-Null }
         $pkgContent = Get-Content $desktopPkg -Raw | ConvertFrom-Json
         $pkgContent.version = $zipVersion
-        $pkgContent | ConvertTo-Json -Depth 10 | Out-File (Join-Path $desktopDir "package.json") -Encoding utf8
+        # Write UTF-8 without BOM — same fix as generate-desktop-config.ps1.
+        # Windows PowerShell 5.1's -Encoding utf8 emits a BOM that breaks JSON.parse.
+        $json = $pkgContent | ConvertTo-Json -Depth 10
+        [System.IO.File]::WriteAllText((Join-Path $desktopDir "package.json"), $json, (New-Object System.Text.UTF8Encoding $false))
     }
 
     # CLI tool tarballs

--- a/desktop/scripts/generate-desktop-config.ps1
+++ b/desktop/scripts/generate-desktop-config.ps1
@@ -29,7 +29,7 @@ if (-not $Version) {
             $pkg = Get-Content $pkgPath -Raw | ConvertFrom-Json
             $Version = $pkg.version
         } catch {
-            Write-Warning "Could not read version from $pkgPath — using 'unknown'"
+            Write-Warning "Could not read version from $pkgPath -- using 'unknown'"
         }
     }
     if (-not $Version) { $Version = "unknown" }

--- a/desktop/scripts/generate-desktop-config.ps1
+++ b/desktop/scripts/generate-desktop-config.ps1
@@ -1,14 +1,43 @@
 <#
 .SYNOPSIS
   Generates desktop-config.json based on installer component selection.
+.PARAMETER AppDir
+  Root directory of the installed/portable application.
+.PARAMETER Version
+  Application version string. When omitted, the script reads it from
+  $AppDir\package.json (the monorepo root package.json shipped by the installer).
+.PARAMETER InstallType
+  How the app was installed: 'installer' (Inno Setup) or 'portable' (zip extract).
+  Defaults to 'unknown' if not provided.
 #>
 
 param(
-    [Parameter(Mandatory)] [string]$AppDir
+    [Parameter(Mandatory)] [string]$AppDir,
+    [string]$Version,
+    [string]$InstallType = "unknown"
 )
 
+# Resolve version from package.json when caller does not pass -Version.
+# Prefer desktop/package.json (the real desktop app version) over the monorepo
+# root package.json, which carries a different (workspace-root) version number.
+if (-not $Version) {
+    $desktopPkgPath = Join-Path $AppDir "desktop\package.json"
+    $rootPkgPath = Join-Path $AppDir "package.json"
+    $pkgPath = if (Test-Path $desktopPkgPath) { $desktopPkgPath } else { $rootPkgPath }
+    if (Test-Path $pkgPath) {
+        try {
+            $pkg = Get-Content $pkgPath -Raw | ConvertFrom-Json
+            $Version = $pkg.version
+        } catch {
+            Write-Warning "Could not read version from $pkgPath — using 'unknown'"
+        }
+    }
+    if (-not $Version) { $Version = "unknown" }
+}
+
 $config = @{
-    version = "0.10.1"
+    version     = $Version
+    installType = $InstallType
     installedAt = (Get-Date -Format "o")
 }
 

--- a/desktop/scripts/generate-desktop-config.ps1
+++ b/desktop/scripts/generate-desktop-config.ps1
@@ -47,5 +47,8 @@ if (-not (Test-Path $configDir)) {
     New-Item -ItemType Directory -Path $configDir -Force | Out-Null
 }
 
-$config | ConvertTo-Json -Depth 3 | Out-File -FilePath $configPath -Encoding utf8
+# Write UTF-8 without BOM. Windows PowerShell 5.1's -Encoding utf8
+# emits a BOM (ef bb bf) that breaks JSON.parse in Node.js consumers.
+$json = $config | ConvertTo-Json -Depth 3
+[System.IO.File]::WriteAllText($configPath, $json, (New-Object System.Text.UTF8Encoding $false))
 Write-Host "Desktop config written to $configPath"

--- a/desktop/scripts/start-portable.bat
+++ b/desktop/scripts/start-portable.bat
@@ -29,8 +29,8 @@ if not exist "%APPDIR%\.env" (
     echo.
 
     rem Step 3: Generate desktop-config.json (records installed components)
-    rem Portable mode: no CLI components pre-selected (omit switch = false)
-    powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%APPDIR%\scripts\generate-desktop-config.ps1' -AppDir '%APPDIR%'"
+    rem Portable mode: version is resolved from package.json by the script itself
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "& '%APPDIR%\scripts\generate-desktop-config.ps1' -AppDir '%APPDIR%' -InstallType 'portable'"
     echo.
 
     if errorlevel 1 (

--- a/packages/web/src/components/WorkspacePanel.tsx
+++ b/packages/web/src/components/WorkspacePanel.tsx
@@ -9,6 +9,7 @@ import type { TreeNode } from '@/hooks/useWorkspace';
 import { useWorkspace } from '@/hooks/useWorkspace';
 import { useChatStore } from '@/stores/chatStore';
 import { API_URL, apiFetch } from '@/utils/api-client';
+import { worktreeLabel } from '@/utils/worktree-label';
 import { ApprovalPanel } from './ApprovalPanel';
 import { ArtifactsPanel } from './ArtifactsPanel';
 import { CommunityPanel } from './CommunityPanel';
@@ -697,16 +698,11 @@ export function WorkspacePanel() {
                     onChange={(e) => setWorktreeId(e.target.value || null)}
                     className="flex-1 text-micro border border-cafe-subtle rounded-md px-2 py-1 bg-cafe-surface/80 text-cafe-black focus:outline-none focus:border-cafe-accent"
                   >
-                    {worktrees.map((w) => {
-                      const basename = w.root.split(/[\\/]/).pop();
-                      return (
-                        <option key={w.id} value={w.id} title={w.root}>
-                          {w.head === 'linked'
-                            ? `📂 ${basename} — ${w.branch}`
-                            : `${basename} — ${w.branch} (${w.head})`}
-                        </option>
-                      );
-                    })}
+                    {worktrees.map((w) => (
+                      <option key={w.id} value={w.id} title={w.root}>
+                        {worktreeLabel(w)}
+                      </option>
+                    ))}
                   </select>
                   {worktreeId && <LinkedRootRemoveButton id={worktreeId} onRemoved={fetchWorktrees} />}
                 </div>

--- a/packages/web/src/components/WorkspacePanel.tsx
+++ b/packages/web/src/components/WorkspacePanel.tsx
@@ -697,13 +697,16 @@ export function WorkspacePanel() {
                     onChange={(e) => setWorktreeId(e.target.value || null)}
                     className="flex-1 text-micro border border-cafe-subtle rounded-md px-2 py-1 bg-cafe-surface/80 text-cafe-black focus:outline-none focus:border-cafe-accent"
                   >
-                    {worktrees.map((w) => (
-                      <option key={w.id} value={w.id} title={w.root}>
-                        {w.head === 'linked'
-                          ? `📂 ${w.root.split(/[\\/]/).pop()}`
-                          : `${w.root.split(/[\\/]/).pop()} — ${w.branch} (${w.head})`}
-                      </option>
-                    ))}
+                    {worktrees.map((w) => {
+                      const basename = w.root.split(/[\\/]/).pop();
+                      return (
+                        <option key={w.id} value={w.id} title={w.root}>
+                          {w.head === 'linked'
+                            ? `📂 ${basename} — ${w.branch}`
+                            : `${basename} — ${w.branch} (${w.head})`}
+                        </option>
+                      );
+                    })}
                   </select>
                   {worktreeId && <LinkedRootRemoveButton id={worktreeId} onRemoved={fetchWorktrees} />}
                 </div>

--- a/packages/web/src/components/WorkspacePanel.tsx
+++ b/packages/web/src/components/WorkspacePanel.tsx
@@ -684,9 +684,12 @@ export function WorkspacePanel() {
             <div className="px-3 py-2 border-b border-cafe-subtle/60 bg-cafe-surface/30">
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-[var(--semantic-success)] flex-shrink-0" />
-                <span className="text-xs font-medium text-cafe-black truncate">{currentWorktree.branch}</span>
+                <span className="text-xs font-medium text-cafe-black truncate" title={currentWorktree.root}>
+                  {currentWorktree.root.split(/[\\/]/).pop()}
+                </span>
                 <span className="text-micro font-mono text-cafe-interactive/50">{currentWorktree.head}</span>
               </div>
+              <div className="ml-4 text-micro text-cafe-interactive/60 truncate">🌿 {currentWorktree.branch}</div>
               {worktrees.length > 1 && (
                 <div className="flex items-center gap-1 mt-1.5">
                   <select
@@ -695,8 +698,10 @@ export function WorkspacePanel() {
                     className="flex-1 text-micro border border-cafe-subtle rounded-md px-2 py-1 bg-cafe-surface/80 text-cafe-black focus:outline-none focus:border-cafe-accent"
                   >
                     {worktrees.map((w) => (
-                      <option key={w.id} value={w.id}>
-                        {w.head === 'linked' ? `📂 ${w.branch}` : `🌿 ${w.branch} (${w.head})`}
+                      <option key={w.id} value={w.id} title={w.root}>
+                        {w.head === 'linked'
+                          ? `📂 ${w.root.split(/[\\/]/).pop()}`
+                          : `${w.root.split(/[\\/]/).pop()} — ${w.branch} (${w.head})`}
                       </option>
                     ))}
                   </select>

--- a/packages/web/src/components/__tests__/workspace-panel-worktree-labels.test.ts
+++ b/packages/web/src/components/__tests__/workspace-panel-worktree-labels.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression test for #1117 — worktree selector labels.
+ *
+ * Verifies that linked roots with the same directory basename but
+ * different user-supplied aliases produce distinguishable labels.
+ */
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Mirror of the label logic in WorkspacePanel.tsx selector.
+ * Kept as a pure function here so we can test it without React rendering.
+ */
+function worktreeLabel(w: { head: string; root: string; branch: string }): string {
+  const basename = w.root.split(/[\\/]/).pop();
+  return w.head === 'linked' ? `📂 ${basename} — ${w.branch}` : `${basename} — ${w.branch} (${w.head})`;
+}
+
+describe('#1117: worktree selector labels', () => {
+  it('linked roots with same basename but different aliases produce different labels', () => {
+    const rootA = { head: 'linked', root: '/client-a/project', branch: 'client-a' };
+    const rootB = { head: 'linked', root: '/client-b/project', branch: 'client-b' };
+
+    const labelA = worktreeLabel(rootA);
+    const labelB = worktreeLabel(rootB);
+
+    expect(labelA).not.toBe(labelB);
+    expect(labelA).toContain('client-a');
+    expect(labelB).toContain('client-b');
+    // Both show the basename for directory orientation
+    expect(labelA).toContain('project');
+    expect(labelB).toContain('project');
+  });
+
+  it('linked root label includes both basename and alias', () => {
+    const root = { head: 'linked', root: '/path/to/my-app', branch: 'my-project' };
+    const label = worktreeLabel(root);
+
+    expect(label).toBe('📂 my-app — my-project');
+  });
+
+  it('worktree label shows basename, branch and head', () => {
+    const wt = { head: 'abc123', root: '/workspace/github/feature-x', branch: 'feat/cool-thing' };
+    const label = worktreeLabel(wt);
+
+    expect(label).toBe('feature-x — feat/cool-thing (abc123)');
+  });
+
+  it('handles Windows-style backslash paths', () => {
+    const root = { head: 'linked', root: 'C:\\Users\\dev\\project', branch: 'dev-project' };
+    const label = worktreeLabel(root);
+
+    expect(label).toBe('📂 project — dev-project');
+  });
+});

--- a/packages/web/src/components/__tests__/workspace-panel-worktree-labels.test.ts
+++ b/packages/web/src/components/__tests__/workspace-panel-worktree-labels.test.ts
@@ -1,19 +1,11 @@
 /**
  * Regression test for #1117 — worktree selector labels.
  *
- * Verifies that linked roots with the same directory basename but
- * different user-supplied aliases produce distinguishable labels.
+ * Imports the production worktreeLabel() from utils/worktree-label.ts
+ * so that mutations to the production code are caught by these tests.
  */
 import { describe, expect, it } from 'vitest';
-
-/**
- * Mirror of the label logic in WorkspacePanel.tsx selector.
- * Kept as a pure function here so we can test it without React rendering.
- */
-function worktreeLabel(w: { head: string; root: string; branch: string }): string {
-  const basename = w.root.split(/[\\/]/).pop();
-  return w.head === 'linked' ? `📂 ${basename} — ${w.branch}` : `${basename} — ${w.branch} (${w.head})`;
-}
+import { worktreeLabel } from '@/utils/worktree-label';
 
 describe('#1117: worktree selector labels', () => {
   it('linked roots with same basename but different aliases produce different labels', () => {

--- a/packages/web/src/utils/worktree-label.ts
+++ b/packages/web/src/utils/worktree-label.ts
@@ -1,0 +1,13 @@
+/**
+ * Format a worktree or linked-root entry for selector dropdowns.
+ *
+ * Linked roots show: 📂 basename — alias
+ * Worktrees show:    basename — branch (head)
+ *
+ * The alias (stored in `branch` for linked roots) is always included
+ * to disambiguate entries with the same directory basename (#1117).
+ */
+export function worktreeLabel(w: { head: string; root: string; branch: string }): string {
+  const basename = w.root.split(/[\\/]/).pop();
+  return w.head === 'linked' ? `📂 ${basename} — ${w.branch}` : `${basename} — ${w.branch} (${w.head})`;
+}


### PR DESCRIPTION
## Summary

Batch fix for 2 independent small issues that touch non-overlapping files:

- **#1107** — `generate-desktop-config.ps1` not receiving `-Version`/`-InstallType` from installer and portable launcher. Portable builds read the wrong `package.json` (root 0.1.0 instead of desktop 0.10.1), writing incorrect version into `desktop-config.json`.
- **#1117** — Workspace panel worktree selector showed only branch names. Now shows directory basenames (e.g. `cat-cafe-f150-guide/`) as primary identifier with branch as secondary info, matching user mental model. Handles both `/` and `\` path separators for Windows compatibility.

## Changes

### #1107 — Desktop config version resolution
- `generate-desktop-config.ps1`: add `-Version`/`-InstallType` params with `desktop/package.json` → root `package.json` → `"unknown"` fallback chain
- `cat-cafe.iss`: pass `-Version '{#MyAppVersion}' -InstallType 'installer'`
- `start-portable.bat`: pass `-InstallType 'portable'` (version resolved by script)
- `build-desktop.ps1`: include `desktop/package.json` in portable assembly
- `generate-desktop-config.test.js`: 7 regression tests (now wired into CI)
- `ci.yml`: add `node --test desktop/*.test.js` step to Test (Public) job

### #1117 — Worktree selector directory names
- `WorkspacePanel.tsx`: indicator and dropdown show `root.split(/[\\/]/).pop()` instead of branch name; branch shown as secondary line
- Cross-thread provenance: co-creator closed standalone PR #1118, directed merge into #1112 via cross-thread message `0001783500568565-000061-c5c6bc89` in `thread_mrbixglpd4leaap0` (2026-07-08T08:49Z)

## Test plan

- [x] `desktop/generate-desktop-config.test.js` — 7/7 green (new #1107 regression tests)
- [x] `desktop/project-root.test.js` — 3/3 green (pre-existing)
- [x] CI `Test (Public)` now runs `node --test desktop/*.test.js` — 12/12 green
- [x] `pnpm lint` / `pnpm check` — passes
- [x] CI — all 5 checks green

## Notes

- ~~#1054 (ReconciliationDedup TTL migration)~~ removed from scope per reviewer feedback — migration code retained for late-upgrader safety
- #1100 (opencode --auto) removed from scope — handled by PR #1101
- Commit history includes merge commits from syncing with main

Closes #1107, closes #1117

[宪宪/claude-opus-4-6🐾]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- maintainer-risk-assessment:1112:34fdd4517 -->
## Maintainer risk assessment

- **Behavior:** medium — desktop config metadata propagation and worktree-selector labels change intentionally; current-HEAD regression coverage is present.
- **Data:** low — writes a local JSON config/package staging artifact only; no database, migration, or user-data deletion.
- **Security:** low — no auth, callback, secret, or network trust-boundary change.
- **Contract:** medium — `desktop-config.json` now receives accurate `version`/`installType`; changes are additive/backward-compatible and tested on Windows.
- **Irreversible:** low — squash merge is revertible; no production data or external service mutation.

Independent maintainer code review: PASS on `34fdd4517e523c708d4c4849b5bdeb7182971e38`. Public CI: 5/5 green. Accepted issues: clowder-ai#1107 and clowder-ai#1117. Intake classification: shared web behavior + `desktop/**` manual-port; approved to proceed through the formal Cat Cafe intake lane after public merge.