### PR TITLE
fix(opencode): recognize GLM v4 provider endpoints

### DIFF
--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5527,6 +5527,92 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     await assert.rejects(readFile(seenConfigPath, 'utf-8'));
   });
 
+  for (const { label, baseUrl } of [
+    { label: 'GLM v4', baseUrl: 'https://open.bigmodel.cn/api/paas/v4' },
+    { label: 'GLM Coding Plan v4', baseUrl: 'https://api.z.ai/api/coding/paas/v4' },
+  ]) {
+    it(`clowder-ai#1113: ${label} OpenCode binding preserves versioned baseUrl`, async () => {
+      const { createProviderProfile } = await import('./helpers/create-test-account.js');
+      const root = await mkdtemp(join(tmpdir(), 'clowder1113-opencode-glm-v4-'));
+      process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = root;
+      const apiDir = join(root, 'packages', 'api');
+      await mkdir(apiDir, { recursive: true });
+      await writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf-8');
+
+      const customProfile = await createProviderProfile(root, {
+        provider: 'openai',
+        name: 'zhipu-api',
+        mode: 'api_key',
+        authType: 'api_key',
+        protocol: 'openai',
+        baseUrl,
+        apiKey: 'sk-zhipu-key',
+        models: ['zhipu/glm-4.6v'],
+        setActive: false,
+      });
+
+      const registrySnapshot = catRegistry.getAllConfigs();
+      const originalConfig = catRegistry.tryGet('opencode')?.config;
+      assert.ok(originalConfig, 'opencode config should exist in registry');
+      const boundCatId = `opencode-zhipu-${label.toLowerCase().replace(/\W+/g, '-')}`;
+      catRegistry.register(boundCatId, {
+        ...originalConfig,
+        id: boundCatId,
+        mentionPatterns: [`@${boundCatId}`],
+        clientId: 'opencode',
+        accountRef: customProfile.id,
+        defaultModel: 'zhipu/glm-4.6v',
+        provider: 'zhipu',
+      });
+
+      const optionsSeen = [];
+      let seenConfigPath;
+      let seenRuntimeConfig;
+      const service = {
+        l0CompilerFn: dummyL0CompilerFn,
+        async *invoke(_prompt, options) {
+          optionsSeen.push(options ?? {});
+          seenConfigPath = options?.callbackEnv?.OPENCODE_CONFIG;
+          assert.ok(seenConfigPath, 'GLM OpenCode binding should receive OPENCODE_CONFIG');
+          seenRuntimeConfig = JSON.parse(await readFile(seenConfigPath, 'utf-8'));
+          yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+        },
+      };
+
+      const deps = makeDeps();
+      const previousCwd = process.cwd();
+      try {
+        process.chdir(apiDir);
+        const messages = await collect(
+          invokeSingleCat(deps, {
+            catId: boundCatId,
+            service,
+            prompt: 'test GLM v4 routing',
+            userId: 'user-clowder1113-opencode-glm-v4',
+            threadId: 'thread-clowder1113-opencode-glm-v4',
+            isLastCat: true,
+          }),
+        );
+        assert.ok(messages.some((m) => m.type === 'done'));
+      } finally {
+        process.chdir(previousCwd);
+        catRegistry.reset();
+        for (const [id, config] of Object.entries(registrySnapshot)) {
+          catRegistry.register(id, config);
+        }
+        await rmWithRetry(root);
+      }
+
+      const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
+      assert.equal(callbackEnv.CAT_CAFE_OC_API_KEY, 'sk-zhipu-key');
+      assert.equal(callbackEnv.CAT_CAFE_OC_BASE_URL, baseUrl);
+      assert.equal(seenRuntimeConfig?.model, 'zhipu/glm-4.6v');
+      assert.equal(seenRuntimeConfig?.provider?.zhipu?.npm, '@ai-sdk/openai-compatible');
+      assert.deepStrictEqual(seenRuntimeConfig?.provider?.zhipu?.models, { 'glm-4.6v': { name: 'glm-4.6v' } });
+      await assert.rejects(readFile(seenConfigPath, 'utf-8'));
+    });
+  }
+
   it('clowder-ai#223: bare model + provider assembles composite model for custom provider routing', async () => {
     const { createProviderProfile } = await import('./helpers/create-test-account.js');
     const root = await mkdtemp(join(tmpdir(), 'f189-oc-bare-model-'));

--- a/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
+++ b/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
@@ -26,7 +26,7 @@ describe('KNOWN_OC_PROVIDERS datalist suggestions', () => {
   });
 
   it('includes core provider names', () => {
-    for (const name of ['anthropic', 'openai', 'google', 'openrouter']) {
+    for (const name of ['anthropic', 'openai', 'google', 'openrouter', 'zhipu', 'glm']) {
       expect(KNOWN_OC_PROVIDERS).toContain(name);
     }
   });
@@ -36,6 +36,7 @@ describe('KNOWN_OC_PROVIDERS datalist suggestions', () => {
     expect(resolveOpenCodeEndpoint('anthropic')).toBe('/v1/messages');
     expect(resolveOpenCodeEndpoint('google')).toBe('/models/{model}:generateContent');
     expect(resolveOpenCodeEndpoint('maas')).toBe('/v1/chat/completions');
+    expect(resolveOpenCodeEndpoint('zhipu')).toBe('/v1/chat/completions');
   });
 });
 
@@ -48,6 +49,16 @@ describe('buildCallHint — API version URL display (#886)', () => {
   it('base ending /v2 produces /v2/chat/completions, not /v2/v1/chat/completions', () => {
     const hint = buildCallHint('opencode', mkProfile('https://maas-api.cn-huabei-1.xf-yun.com/v2'), 'spark', 'maas');
     expect(hint?.url).toBe('https://maas-api.cn-huabei-1.xf-yun.com/v2/chat/completions');
+  });
+
+  it('clowder-ai#1113: GLM v4 endpoint produces /v4/chat/completions, not /v4/v1/chat/completions', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://open.bigmodel.cn/api/paas/v4'), 'glm-4.6v', 'zhipu');
+    expect(hint?.url).toBe('https://open.bigmodel.cn/api/paas/v4/chat/completions');
+  });
+
+  it('clowder-ai#1113: GLM Coding Plan v4 endpoint preserves the coding prefix', () => {
+    const hint = buildCallHint('opencode', mkProfile('https://api.z.ai/api/coding/paas/v4'), 'glm-4.6v', 'zhipu');
+    expect(hint?.url).toBe('https://api.z.ai/api/coding/paas/v4/chat/completions');
   });
 
   it('base without version appends full /v1 suffix', () => {

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -250,6 +250,8 @@ export const KNOWN_OC_PROVIDERS = [
   'google',
   'azure',
   'deepseek',
+  'zhipu',
+  'glm',
 ];
 
 /** Merge well-known providers with any prefixes extracted from model strings like "openai/gpt-5.4". */


### PR DESCRIPTION
## Summary
- add `zhipu` and `glm` as OpenCode provider suggestions
- keep GLM v4 base URLs version-aware in the call hint, including general and Coding Plan endpoints
- add regressions for UI hints and runtime OpenCode baseUrl passthrough

## Root Cause
GLM/Zhipu OpenAI-compatible endpoints already include the API version in the base URL. The UI/provider flow did not treat GLM as a first-class OpenCode provider suggestion, so users could see a misleading `v4/v1/chat/completions` style call hint. Runtime OpenCode binding should continue to pass the configured base URL through unchanged.

## Source Truth
Source cat-cafe fix landed as commit `d1692107d0fc294d328af0c05ac1565839f1c5b7`.

`sync-hotfix.sh --dry-run` found drift in two public files, so this downstream hotfix was ported manually while preserving the public checkout's current file shapes.

Fixes #1113

## Validation
- `pnpm --dir packages/web exec vitest run src/components/__tests__/hub-cat-editor-oc-providers.test.ts`
- `pnpm --dir packages/api build && node --test packages/api/test/invoke-single-cat.test.js --test-name-pattern "clowder-ai#1113"`
- `pnpm gate` (passed on `fbdb01bc`, rebased onto `origin/main`)