### PR TITLE
fix(f24): raise stale CLI context-window reports to known-model floors

### DIFF
--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -13,6 +13,11 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
   'claude-opus-4-6': 200_000,
   'claude-sonnet-4-5': 200_000,
   'claude-haiku-4-5': 200_000,
+  // Fable 5: native 1M context — the maximum is also the default (no [1m]
+  // suffix needed). Also listed in KNOWN_MIN_CONTEXT_WINDOWS below because
+  // stale CLIs (≤2.1.177) mis-REPORT it as 200K, which this table alone
+  // cannot fix (CLI report outranks the fallback table).
+  'claude-fable-5': 1_000_000,
   // Codex/GPT
   'gpt-5.3': 128_000,
   'gpt-5.2': 128_000,
@@ -49,25 +54,78 @@ export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
  */
 export const OPENCODE_DEFAULT_CONTEXT_WINDOW = 128_000;
 
-export function getContextWindowFallback(model: string): number | undefined {
-  // Normalize provider-prefixed model IDs before lookup. The account routing
-  // path in invoke-single-cat sets `callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE`
-  // to a `safeProvider/model` form (see L1459 `safeProvider/safeModel`), and
-  // OpenCodeAgentService propagates that prefixed string as `metadata.model`.
-  // Without normalization, lookups like `anthropic/claude-opus-4-6` or
-  // `openai-compat/gpt-5.3` would miss the table entirely → no windowSize →
-  // F24 context_health silently skipped → opencode handoff (clowder#915)
-  // bypassed in production. (clowder#915 R2 cloud P1)
-  //
-  // Use lastIndexOf to handle multi-segment prefixes like `openai-compat/x/y`
-  // (defensive — current code emits at most one slash, but the cost is the
-  // same and we don't want to be the next migration's footgun).
+// Normalize provider-prefixed model IDs before lookup. The account routing
+// path in invoke-single-cat sets `callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE`
+// to a `safeProvider/model` form (see L1459 `safeProvider/safeModel`), and
+// OpenCodeAgentService propagates that prefixed string as `metadata.model`.
+// Without normalization, lookups like `anthropic/claude-opus-4-6` or
+// `openai-compat/gpt-5.3` would miss the table entirely → no windowSize →
+// F24 context_health silently skipped → opencode handoff (clowder#915)
+// bypassed in production. (clowder#915 R2 cloud P1)
+//
+// Use lastIndexOf to handle multi-segment prefixes like `openai-compat/x/y`
+// (defensive — current code emits at most one slash, but the cost is the
+// same and we don't want to be the next migration's footgun).
+function stripProviderPrefix(model: string): string {
   const slashAt = model.lastIndexOf('/');
-  const bare = slashAt >= 0 ? model.slice(slashAt + 1) : model;
-  if (CONTEXT_WINDOW_SIZES[bare]) return CONTEXT_WINDOW_SIZES[bare];
-  // Try prefix match (e.g. 'claude-opus-4-6-20260101' matches 'claude-opus-4-6')
-  for (const [key, value] of Object.entries(CONTEXT_WINDOW_SIZES)) {
+  return slashAt >= 0 ? model.slice(slashAt + 1) : model;
+}
+
+function lookupWithPrefixMatch(table: Record<string, number>, bare: string): number | undefined {
+  if (table[bare]) return table[bare];
+  // Prefix match (e.g. 'claude-opus-4-6-20260101' matches 'claude-opus-4-6')
+  for (const [key, value] of Object.entries(table)) {
     if (bare.startsWith(key)) return value;
   }
   return undefined;
+}
+
+export function getContextWindowFallback(model: string): number | undefined {
+  return lookupWithPrefixMatch(CONTEXT_WINDOW_SIZES, stripProviderPrefix(model));
+}
+
+/**
+ * Known-minimum context windows — authoritative floors used to correct
+ * STALE CLI-reported window sizes, applied as `max(reported, floor)`.
+ *
+ * Why this exists (F24 follow-up): the Claude CLI reports
+ * `modelUsage[*].contextWindow` and invoke-single-cat trusts that report
+ * FIRST — so a stale CLI ships a stale window and the fallback table
+ * above can never correct it. Proven in production: CLI 2.1.177 reported
+ * 200_000 for `claude-fable-5` (native 1M) while the very same turn
+ * consumed 303K input tokens without error; auto-seal fired at
+ * "fillRatio 1.0" with 80% of the real window unused (sessions
+ * 59a48070 / 6b8d4b5f, thread_mraghcf19yl6ukzu, 2026-07-08).
+ *
+ * Rules:
+ * - `[1m]` suffix: Claude Code's own "run at 1M context" directive — if
+ *   the CLI accepted the model string, 1M IS the session window.
+ * - Table entries: ONLY models whose window we know from official specs
+ *   with certainty. An over-estimate defeats auto-seal (the session
+ *   would drift into CLI auto-compact instead of sealing with a clean
+ *   handoff), so keep this list conservative.
+ * - `max()` semantics: never shrinks a CLI report. Once the CLI catches
+ *   up (2.1.204+ presumably reports 1M), the floor becomes a no-op.
+ */
+const KNOWN_MIN_CONTEXT_WINDOWS: Record<string, number> = {
+  'claude-fable-5': 1_000_000,
+};
+
+export function getKnownMinContextWindow(model: string): number | undefined {
+  const bare = stripProviderPrefix(model);
+  if (bare.endsWith('[1m]')) return 1_000_000;
+  return lookupWithPrefixMatch(KNOWN_MIN_CONTEXT_WINDOWS, bare);
+}
+
+/**
+ * Single resolution point for "how big is this session's context window":
+ * CLI-reported value → fallback table, then raised to any known
+ * authoritative floor. Callers needing a provider-specific last resort
+ * (e.g. opencode's 128K default) apply it AFTER this returns undefined.
+ */
+export function resolveContextWindow(reported: number | undefined, model: string): number | undefined {
+  const base = reported ?? getContextWindowFallback(model);
+  const floor = getKnownMinContextWindow(model);
+  if (base != null && floor != null) return Math.max(base, floor);
+  return base ?? floor;
 }

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -32,10 +32,7 @@ import { resolveBoundAccountRefForCat } from '../../../../../config/cat-account-
 import { isSessionChainEnabled } from '../../../../../config/cat-config-loader.js';
 import { buildCatGitIdentityEnv } from '../../../../../config/cat-git-identity.js';
 import { getCatModel } from '../../../../../config/cat-models.js';
-import {
-  getContextWindowFallback,
-  OPENCODE_DEFAULT_CONTEXT_WINDOW,
-} from '../../../../../config/context-window-sizes.js';
+import { OPENCODE_DEFAULT_CONTEXT_WINDOW, resolveContextWindow } from '../../../../../config/context-window-sizes.js';
 import { getSessionStrategy, shouldTakeAction } from '../../../../../config/session-strategy.js';
 import { assertSafeTestConfigRoot } from '../../../../../config/test-config-write-guard.js';
 import { capturePromptIfEnabled } from '../../../../../infrastructure/debug/prompt-capture-bridge.js';
@@ -2141,9 +2138,13 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           //    actually targets). Crucially this is LAST so known opencode
           //    models like the default claude-opus-4-6 get their precise 200k
           //    from the table, NOT the 128k conservative default.
+          // F24 known-min floor: tiers 1-2 are additionally raised to
+          // max(value, known floor) inside resolveContextWindow — a stale
+          // CLI (≤2.1.177) reports 200K for claude-fable-5 (native 1M),
+          // and tier 1 outranking tier 2 meant the wrong value always won:
+          // sessions sealed budget_exhausted with 80% of the window unused.
           const windowSize =
-            msg.metadata.usage.contextWindowSize ??
-            getContextWindowFallback(msg.metadata.model ?? '') ??
+            resolveContextWindow(msg.metadata.usage.contextWindowSize, msg.metadata.model ?? '') ??
             (msg.metadata.provider === 'opencode' ? OPENCODE_DEFAULT_CONTEXT_WINDOW : undefined);
           const usedFrom =
             msg.metadata.usage.lastTurnInputTokens != null

--- a/packages/api/test/context-window-sizes.test.js
+++ b/packages/api/test/context-window-sizes.test.js
@@ -85,3 +85,68 @@ describe('getContextWindowFallback', () => {
     assert.equal(getContextWindowFallback('o3'), 200_000);
   });
 });
+
+// F24 known-min floor: stale CLI window reports (e.g. CLI 2.1.177 reporting
+// 200K for claude-fable-5, natively 1M) outrank the fallback table, so the
+// table alone can't correct them. Floors are applied as max(reported, floor).
+// Production evidence: sessions 59a48070/6b8d4b5f consumed 303K/307K input
+// tokens in a single turn while windowTokens claimed 200000 → premature
+// budget_exhausted seal with 80% of the real window unused.
+describe('getKnownMinContextWindow / resolveContextWindow', () => {
+  let getContextWindowFallback;
+  let getKnownMinContextWindow;
+  let resolveContextWindow;
+
+  test('setup', async () => {
+    const mod = await import('../dist/config/context-window-sizes.js');
+    getContextWindowFallback = mod.getContextWindowFallback;
+    getKnownMinContextWindow = mod.getKnownMinContextWindow;
+    resolveContextWindow = mod.resolveContextWindow;
+  });
+
+  test('knows claude-fable-5 native 1M window (exact, versioned, provider-prefixed)', async () => {
+    assert.equal(getKnownMinContextWindow('claude-fable-5'), 1_000_000);
+    assert.equal(getKnownMinContextWindow('claude-fable-5-20260601'), 1_000_000);
+    assert.equal(getKnownMinContextWindow('anthropic/claude-fable-5'), 1_000_000);
+  });
+
+  test('treats the CLI [1m] directive as a 1M floor', async () => {
+    assert.equal(getKnownMinContextWindow('claude-opus-4-6[1m]'), 1_000_000);
+    assert.equal(getKnownMinContextWindow('claude-opus-4-8[1m]'), 1_000_000);
+    assert.equal(getKnownMinContextWindow('claude-sonnet-4-6[1m]'), 1_000_000);
+  });
+
+  test('returns undefined when no authoritative floor is known', async () => {
+    assert.equal(getKnownMinContextWindow('claude-opus-4-6'), undefined);
+    assert.equal(getKnownMinContextWindow('claude-sonnet-4-5'), undefined);
+    assert.equal(getKnownMinContextWindow('gpt-5.3'), undefined);
+    assert.equal(getKnownMinContextWindow(''), undefined);
+  });
+
+  test('fallback table gained claude-fable-5 (non-Claude-CLI provider paths)', async () => {
+    assert.equal(getContextWindowFallback('claude-fable-5'), 1_000_000);
+  });
+
+  test('resolveContextWindow corrects a stale CLI report upward (the fable-5 seal bug)', async () => {
+    assert.equal(resolveContextWindow(200_000, 'claude-fable-5'), 1_000_000);
+    assert.equal(resolveContextWindow(200_000, 'claude-opus-4-8[1m]'), 1_000_000);
+  });
+
+  test('resolveContextWindow never shrinks a CLI report', async () => {
+    // CLI catches up → floor is a no-op
+    assert.equal(resolveContextWindow(1_000_000, 'claude-fable-5'), 1_000_000);
+    // window grows beyond our floor → trust the CLI
+    assert.equal(resolveContextWindow(2_000_000, 'claude-fable-5'), 2_000_000);
+    // no floor known → passthrough
+    assert.equal(resolveContextWindow(200_000, 'claude-opus-4-6'), 200_000);
+  });
+
+  test('resolveContextWindow falls back to the table; floor still applies', async () => {
+    assert.equal(resolveContextWindow(undefined, 'claude-opus-4-6'), 200_000);
+    // Without the floor, the [1m] form would prefix-match to the bare
+    // model's 200K table entry — the floor corrects it to 1M.
+    assert.equal(resolveContextWindow(undefined, 'claude-opus-4-6[1m]'), 1_000_000);
+    assert.equal(resolveContextWindow(undefined, 'claude-fable-5'), 1_000_000);
+    assert.equal(resolveContextWindow(undefined, 'unknown-model'), undefined);
+  });
+});


### PR DESCRIPTION
## 问题

Claude CLI ≤2.1.177 对 `claude-fable-5`（原生 1M window）上报 `modelUsage[*].contextWindow = 200000`，而 F24 记账链路里 **CLI 上报值优先级最高**（invoke-single-cat 三级解析的第一级），fallback 表无法纠正它。

后果：四只 fable5 variant 的 session 全部按 200K 记账 → ~190K 就 `budget_exhausted` 强制 seal → **1M 窗口浪费 80%**。

### 生产铁证（thread_mraghcf19yl6ukzu）

| session | windowTokens（记账） | usedTokens（实际单 turn） | 结果 |
|---|---|---|---|
| `59a48070` seq0 | 200000（source=exact） | **303,416** | budget_exhausted，回答截断 |
| `6b8d4b5f` seq1 | 200000（source=exact） | **307,529** | budget_exhausted，同一回答再次截断 |

单 turn 实际吃下 300K+ input token 还正常工作 = 模型真实窗口远大于记账值。同一个回答连续两次被这个 bug 腰斩（第三个 session 提交了本 PR——修 bug 的猫正是被咬的猫）。

## 修复

`context-window-sizes.ts` 新增 **known-min floor** 机制，`resolveContextWindow()` 以 `max(CLI上报 ?? fallback表, floor)` 应用：

- `claude-fable-5` → floor 1M（官方规格：native 1M，maximum is also the default）
- 任何 `[1m]` 后缀模型 → floor 1M（后缀本身就是 CLI「以 1M 运行」的指令语义；顺带修掉 fallback 表里 `claude-opus-4-6[1m]` prefix-match 到裸模型 200K 条目的暗坑）
- **max() 语义 = 只向上纠正，永不低于 CLI 上报**：CLI 升级修好后（2.1.204+）floor 自动退化为 no-op；未来窗口再涨也直接信 CLI
- fallback 表补 `claude-fable-5: 1M`（覆盖 opencode 等非 Claude-CLI provider 路径）
- opencode 128K last-resort 兜底保持原位不变；`getContextWindowFallback` 行为不变（仅内部提取共用 helper）

## 风险评估（给 reviewer）

- floor 表只收录**官方规格确定**的模型——高估会让 auto-seal 失效（session 漂进 CLI auto-compact 而不是干净 seal handoff），注释里写明了收录守则
- `[1m]` floor 对 opus 猫的影响：若 CLI 本来就正确上报 1M → no-op；若也在低报 → 同样被纠正（与 fable-5 同因同治）。residual risk（CLI 接受 `[1m]` 却静默按 200K 跑）由紧邻的 F-BLOAT 压缩检测兜底
- 治本是升级 CLI 2.1.177 → 2.1.204（另行 ops 动作，已在 thread 里向 co-creator 建议），本 PR 是防御层：**过时 CLI 不该再有能力烧掉 80% 的窗口**

## 测试

- `test/context-window-sizes.test.js` 新增 8 用例（floor 精确/前缀/provider 前缀剥离、`[1m]` 指令、stale 纠正、max 不缩、fallback+floor 组合）——该文件 17/17 全绿
- `pnpm run build`（tsc 全量编译）通过；`biome check --diagnostic-level=error` 通过
- RED 状态由生产快照证实（上表两个 sealed session 即失败断言的实录）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #1124