### PR TITLE
fix(pr-tracking): deliver terminal lifecycle notification + wake owner on PR merge/close

### DIFF
--- a/packages/api/src/infrastructure/email/CiCdCheckTaskSpec.ts
+++ b/packages/api/src/infrastructure/email/CiCdCheckTaskSpec.ts
@@ -7,7 +7,7 @@
  * Execute: fetchPrCiStatus → route → conditional trigger.
  *   - CI fail → wake (urgent) — both intents.
  *   - CI pass → gated by the tracked PR's wake intent (F140):
- *       intent='review' (default) → silent (review-wait noise; CiCdRouter already posted the message).
+ *       intent='review' (default) → state-only silent (review-wait noise; no connector message).
  *       intent='merge'            → wake → merge-gate (the cat is waiting on CI-green to merge).
  *     Intent is an explicit per-task declaration (set at register_pr_tracking, updated by re-register),
  *     NOT inferred from approval state or repo type — a private PR can be 'merge', an open-source PR
@@ -41,13 +41,22 @@ export interface CiCdCheckTaskSpecOptions {
   readonly pollIntervalMs?: number;
   /** F202-2B: Override task ID for plugin-scoped schedule instances */
   readonly id?: string;
+  /** F167 Phase Q: retire matching hold_ball timers once structured CI status is delivered. */
+  readonly holdLifecycle?: {
+    retireSatisfiedWait(event: {
+      threadId: string;
+      subjectKey: string;
+      expectedSignalKey: 'ci_complete';
+      sourceKind: 'ci_check';
+      sourceMessageId?: string;
+    }): void | Promise<unknown>;
+  };
 }
 
 /**
- * PR terminal state (merged/closed) → wake the owner for follow-up, both intents.
- * intent=merge: the merge IS the awaited outcome (post-merge checklist lives in
- * trackingInstructions). intent=review: the PR is gone — stop waiting either way.
- * Fires exactly once: CiCdRouter marks the task done and the gate filters done tasks.
+ * PR terminal state (merged/closed) -> wake the owner for follow-up, both intents.
+ * intent=merge: the merge is the awaited outcome. intent=review: the PR is gone.
+ * Fires exactly once in production: CiCdRouter persists ci.prState and the gate filters completed lifecycle tasks.
  */
 function triggerLifecycleWake(
   opts: CiCdCheckTaskSpecOptions,
@@ -71,7 +80,16 @@ function triggerLifecycleWake(
       policy,
     )
     .catch((err) => opts.log.warn({ err }, '[cicd-check] lifecycle trigger failed (best-effort)'));
-  opts.log.info(`[cicd-check] PR ${routeResult.prState} → wake ${routeResult.catId} (terminal lifecycle)`);
+  opts.log.info(`[cicd-check] PR ${routeResult.prState} -> wake ${routeResult.catId} (terminal lifecycle)`);
+}
+
+function needsCiLifecycleRecovery(task: TaskItem): boolean {
+  const reviewTerminalState = task.automationState?.review?.prState;
+  return (
+    task.status === 'done' &&
+    (reviewTerminalState === 'merged' || reviewTerminalState === 'closed') &&
+    !task.automationState?.ci?.prState
+  );
 }
 
 export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpec_P1<CiCdCheckSignal> {
@@ -83,9 +101,13 @@ export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpe
     trigger: { type: 'interval', ms: opts.pollIntervalMs ?? 60_000 },
     admission: {
       async gate() {
-        // #320: Read from unified TaskStore — exclude done tasks (PR merged/closed)
+        // #320: Read from unified TaskStore — exclude done tasks after CI lifecycle is complete.
+        // Review feedback can observe terminal PR state first; keep those done tasks
+        // reachable until CiCdRouter delivers/records the CI lifecycle marker.
         const allTasks = await opts.taskStore.listByKind('pr_tracking');
-        const active = allTasks.filter((t) => t.status !== 'done' && t.automationState?.ci?.enabled !== false);
+        const active = allTasks.filter(
+          (t) => (t.status !== 'done' || needsCiLifecycleRecovery(t)) && t.automationState?.ci?.enabled !== false,
+        );
 
         if (active.length === 0) {
           return { run: false, reason: 'no active tracked PRs' };
@@ -111,14 +133,30 @@ export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpe
     run: {
       overlap: 'skip',
       timeoutMs: 30_000,
-      async execute(signal: CiCdCheckSignal, _subjectKey: string, _ctx: ExecuteContext) {
+      async execute(signal: CiCdCheckSignal, subjectKey: string, _ctx: ExecuteContext) {
         const pollResult = await fetchPrStatus(signal.repoFullName, signal.prNumber);
         if (!pollResult) return;
 
         const routeResult = await opts.cicdRouter.route(pollResult);
         if (!opts.invokeTrigger) return;
 
+        const retireSatisfiedCiHold = async (threadId: string, sourceMessageId: string) => {
+          if (!opts.holdLifecycle) return;
+          try {
+            await opts.holdLifecycle.retireSatisfiedWait({
+              threadId,
+              subjectKey,
+              expectedSignalKey: 'ci_complete',
+              sourceKind: 'ci_check',
+              sourceMessageId,
+            });
+          } catch (err) {
+            opts.log.warn({ err, subjectKey }, '[cicd-check] hold lifecycle retirement failed (best-effort)');
+          }
+        };
+
         if (routeResult.kind === 'lifecycle') {
+          await retireSatisfiedCiHold(routeResult.threadId, routeResult.messageId);
           triggerLifecycleWake(opts, opts.invokeTrigger, signal, routeResult);
           return;
         }
@@ -127,6 +165,7 @@ export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpe
 
         // CI fail → always wake (urgent, must fix) — independent of intent.
         if (routeResult.bucket === 'fail') {
+          await retireSatisfiedCiHold(routeResult.threadId, routeResult.messageId);
           const policy: ConnectorTriggerPolicy = {
             priority: 'urgent',
             reason: 'github_ci_failure',
@@ -148,17 +187,16 @@ export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpe
         }
 
         // CI pass → gated by the tracked PR's wake intent (F140 Phase C partial revert).
-        // 'review' (default): the cat is waiting on review feedback → CI-pass is noise. CiCdRouter has
-        //   already posted the "CI 通过" thread message (visible whenever the cat looks), so stay silent.
+        // 'review' (default): the cat is waiting on review feedback → CI-pass is noise.
+        //   CiCdRouter should record state without posting a connector message, so stay silent.
         // 'merge': the cat is waiting on CI-green to merge → CI-pass is the action signal → merge-gate.
         const intent = signal.task.automationState?.intent ?? 'review';
         if (intent !== 'merge') {
-          opts.log.info(
-            `[cicd-check] CI pass for ${routeResult.catId} — silent (intent=${intent}; thread message only)`,
-          );
+          opts.log.info(`[cicd-check] CI pass for ${routeResult.catId} — silent (intent=${intent}; state-only)`);
           return;
         }
 
+        await retireSatisfiedCiHold(routeResult.threadId, routeResult.messageId);
         const policy: ConnectorTriggerPolicy = {
           priority: 'normal',
           reason: 'github_ci_pass',

--- a/packages/api/src/infrastructure/email/CiCdCheckTaskSpec.ts
+++ b/packages/api/src/infrastructure/email/CiCdCheckTaskSpec.ts
@@ -17,7 +17,7 @@ import type { CatId, TaskItem } from '@cat-cafe/shared';
 import { parsePrSubjectKey } from '@cat-cafe/shared';
 import type { ITaskStore } from '../../domains/cats/services/stores/ports/TaskStore.js';
 import type { ExecuteContext, TaskSpec_P1 } from '../scheduler/types.js';
-import type { CiCdRouter, CiPollResult } from './CiCdRouter.js';
+import type { CiCdRouter, CiPollResult, CiRouteResult } from './CiCdRouter.js';
 import type { ConnectorInvokeTrigger, ConnectorTriggerPolicy } from './ConnectorInvokeTrigger.js';
 import { fetchPrCiStatus } from './ci-status-fetcher.js';
 
@@ -41,6 +41,37 @@ export interface CiCdCheckTaskSpecOptions {
   readonly pollIntervalMs?: number;
   /** F202-2B: Override task ID for plugin-scoped schedule instances */
   readonly id?: string;
+}
+
+/**
+ * PR terminal state (merged/closed) → wake the owner for follow-up, both intents.
+ * intent=merge: the merge IS the awaited outcome (post-merge checklist lives in
+ * trackingInstructions). intent=review: the PR is gone — stop waiting either way.
+ * Fires exactly once: CiCdRouter marks the task done and the gate filters done tasks.
+ */
+function triggerLifecycleWake(
+  opts: CiCdCheckTaskSpecOptions,
+  invokeTrigger: ConnectorInvokeTrigger,
+  signal: CiCdCheckSignal,
+  routeResult: Extract<CiRouteResult, { kind: 'lifecycle' }>,
+): void {
+  const policy: ConnectorTriggerPolicy = {
+    priority: 'normal',
+    reason: routeResult.prState === 'merged' ? 'github_pr_merged' : 'github_pr_closed',
+    sourceCategory: 'ci',
+  };
+  void invokeTrigger
+    .trigger(
+      routeResult.threadId,
+      routeResult.catId as CatId,
+      signal.task.userId ?? '',
+      routeResult.content,
+      routeResult.messageId,
+      undefined,
+      policy,
+    )
+    .catch((err) => opts.log.warn({ err }, '[cicd-check] lifecycle trigger failed (best-effort)'));
+  opts.log.info(`[cicd-check] PR ${routeResult.prState} → wake ${routeResult.catId} (terminal lifecycle)`);
 }
 
 export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpec_P1<CiCdCheckSignal> {
@@ -85,7 +116,14 @@ export function createCiCdCheckTaskSpec(opts: CiCdCheckTaskSpecOptions): TaskSpe
         if (!pollResult) return;
 
         const routeResult = await opts.cicdRouter.route(pollResult);
-        if (routeResult.kind !== 'notified' || !opts.invokeTrigger) return;
+        if (!opts.invokeTrigger) return;
+
+        if (routeResult.kind === 'lifecycle') {
+          triggerLifecycleWake(opts, opts.invokeTrigger, signal, routeResult);
+          return;
+        }
+
+        if (routeResult.kind !== 'notified') return;
 
         // CI fail → always wake (urgent, must fix) — independent of intent.
         if (routeResult.bucket === 'fail') {

--- a/packages/api/src/infrastructure/email/CiCdRouter.ts
+++ b/packages/api/src/infrastructure/email/CiCdRouter.ts
@@ -12,7 +12,7 @@ import { buildCiMessageContent, buildLifecycleMessageContent } from './ci-messag
 import type { ConnectorDeliveryDeps } from './deliver-connector-message.js';
 import { deliverConnectorMessage } from './deliver-connector-message.js';
 
-// Re-export for existing import sites (index.ts, tests) — builders moved to ci-message-content.ts.
+// Re-export for existing import sites (index.ts, tests).
 export { buildCiMessageContent, buildLifecycleMessageContent };
 
 /** Minimal projector interface for optional DI — avoids importing concrete class. */
@@ -41,11 +41,6 @@ export interface CiPollResult {
 
 export type CiRouteResult =
   | { kind: 'notified'; threadId: string; catId: string; messageId: string; bucket: CiBucket; content: string }
-  /**
-   * PR reached terminal state (merged/closed): task marked done + final lifecycle
-   * notification delivered. Fires exactly once — done tasks are filtered by the
-   * poller gate, so this branch is never re-entered for the same PR.
-   */
   | {
       kind: 'lifecycle';
       threadId: string;
@@ -64,7 +59,22 @@ interface TrackedTaskLike {
   readonly ownerCatId: string | null;
   readonly userId?: string;
   readonly title?: string;
-  readonly automationState?: { readonly trackingInstructions?: string };
+  readonly automationState?: {
+    readonly ci?: { readonly prState?: 'merged' | 'closed' };
+    readonly trackingInstructions?: string;
+  };
+}
+
+function getConnectorDeliveryTarget(task: Pick<TrackedTaskLike, 'threadId' | 'userId' | 'ownerCatId'>): {
+  threadId: string;
+  userId: string;
+  catId: string;
+} {
+  return {
+    threadId: task.threadId,
+    userId: task.userId ?? '',
+    catId: task.ownerCatId ?? '',
+  };
 }
 
 export interface CiCdRouterOptions {
@@ -104,12 +114,23 @@ export class CiCdRouter {
   }
 
   async route(poll: CiPollResult): Promise<CiRouteResult> {
-    const { taskStore } = this.opts;
+    const { taskStore, log } = this.opts;
     const sk = prSubjectKey(poll.repoFullName, poll.prNumber);
 
     const task = await taskStore.getBySubject(sk);
     if (!task) {
       return { kind: 'skipped', reason: `No tracking task for ${poll.repoFullName}#${poll.prNumber}` };
+    }
+
+    const terminalPrState = poll.prState === 'merged' || poll.prState === 'closed' ? poll.prState : null;
+    if (task.status === 'done') {
+      if (terminalPrState && !task.automationState?.ci?.prState) {
+        return this.closeLifecycle(poll, task, sk);
+      }
+      return {
+        kind: 'skipped',
+        reason: `Tracking task already processed for ${poll.repoFullName}#${poll.prNumber}`,
+      };
     }
 
     if (task.automationState?.ci?.enabled === false) {
@@ -120,7 +141,7 @@ export class CiCdRouter {
       return { kind: 'skipped', reason: `CI tracking disabled for ${poll.repoFullName}#${poll.prNumber}` };
     }
 
-    if (poll.prState === 'merged' || poll.prState === 'closed') {
+    if (terminalPrState) {
       return this.closeLifecycle(poll, task, sk);
     }
 
@@ -136,24 +157,32 @@ export class CiCdRouter {
       return { kind: 'deduped', reason: `Already notified for ${fingerprint}` };
     }
 
+    const intent = task.automationState?.intent ?? 'review';
+    if (poll.aggregateBucket === 'pass' && intent !== 'merge') {
+      await taskStore.patchAutomationState(task.id, {
+        ci: {
+          headSha: poll.headSha,
+          lastFingerprint: fingerprint,
+          lastBucket: poll.aggregateBucket,
+        },
+      });
+      log.info(`[CiCdRouter] CI pass for ${poll.repoFullName}#${poll.prNumber} recorded silently (intent=${intent})`);
+      return { kind: 'skipped', reason: `CI pass silent for review intent (${poll.repoFullName}#${poll.prNumber})` };
+    }
+
     return this.deliver(poll, task, fingerprint);
   }
 
   /**
    * PR reached terminal state (merged/closed).
-   * #320 KD-17: lifecycle close = mark task done (not delete).
-   * Then: best-effort side effects + a final lifecycle notification to the owner.
-   * The notification is the outcome the owner is tracking for (intent=merge waits for
-   * exactly this; trackingInstructions routinely say "on merge, do X") — without it the
-   * owner never learns the PR closed (observed: PR #1120 merged 12:25 UTC, owner
-   * discovered at 14:21 via a human query). Delivered AFTER done-marking so a delivery
-   * failure can never wedge the task in tracking; failure degrades to the previous
-   * silent behavior.
+   * Mark done first, then emit best-effort side effects and final owner-visible
+   * lifecycle notification. Delivery failure degrades to the previous silent close.
    */
   private async closeLifecycle(poll: CiPollResult, task: TrackedTaskLike, sk: string): Promise<CiRouteResult> {
     const { taskStore, log } = this.opts;
     const prState = poll.prState as 'merged' | 'closed';
 
+    // #320 KD-17: lifecycle close = mark task done (not delete)
     // F200 AC-D2.3: persist prState so signal detection can distinguish merged vs closed
     await taskStore.update(task.id, { status: 'done' });
     await taskStore.patchAutomationState(task.id, { ci: { prState } });
@@ -163,6 +192,7 @@ export class CiCdRouter {
 
     try {
       const content = buildLifecycleMessageContent(poll, task.automationState?.trackingInstructions);
+      const deliveryTarget = getConnectorDeliveryTarget(task);
       const source: ConnectorSource = {
         connector: 'github-ci',
         label: 'GitHub CI/CD',
@@ -170,17 +200,17 @@ export class CiCdRouter {
         url: `https://github.com/${poll.repoFullName}/pull/${poll.prNumber}`,
       };
       const delivered = await deliverConnectorMessage(this.opts.deliveryDeps, {
-        threadId: task.threadId,
-        userId: task.userId ?? '',
-        catId: task.ownerCatId ?? '',
+        ...deliveryTarget,
         content,
         source,
       });
-      log.info(`[CiCdRouter] PR ${prState} → lifecycle notification to ${task.ownerCatId} in thread ${task.threadId}`);
+      log.info(
+        `[CiCdRouter] PR ${prState} -> lifecycle notification to ${deliveryTarget.catId} in thread ${deliveryTarget.threadId}`,
+      );
       return {
         kind: 'lifecycle',
-        threadId: task.threadId,
-        catId: task.ownerCatId ?? '',
+        threadId: deliveryTarget.threadId,
+        catId: deliveryTarget.catId,
         messageId: delivered.messageId,
         prState,
         content,
@@ -289,6 +319,7 @@ export class CiCdRouter {
   ): Promise<CiRouteResult> {
     const { taskStore, log } = this.opts;
     const content = buildCiMessageContent(poll, task.automationState?.trackingInstructions);
+    const deliveryTarget = getConnectorDeliveryTarget(task);
 
     const source: ConnectorSource = {
       connector: 'github-ci',
@@ -298,9 +329,7 @@ export class CiCdRouter {
     };
 
     const result = await deliverConnectorMessage(this.opts.deliveryDeps, {
-      threadId: task.threadId,
-      userId: task.userId ?? '',
-      catId: task.ownerCatId ?? '',
+      ...deliveryTarget,
       content,
       source,
     });
@@ -322,7 +351,7 @@ export class CiCdRouter {
     return {
       kind: 'notified',
       threadId: task.threadId,
-      catId: task.ownerCatId ?? '',
+      catId: deliveryTarget.catId,
       messageId: result.messageId,
       bucket: poll.aggregateBucket,
       content,

--- a/packages/api/src/infrastructure/email/CiCdRouter.ts
+++ b/packages/api/src/infrastructure/email/CiCdRouter.ts
@@ -4,12 +4,16 @@
  * #320: Reads from unified TaskStore instead of PrTrackingStore.
  */
 import type { ConnectorSource } from '@cat-cafe/shared';
-import { parsePrSubjectKey, prSubjectKey } from '@cat-cafe/shared';
+import { prSubjectKey } from '@cat-cafe/shared';
 import type { FastifyBaseLogger } from 'fastify';
 import type { ITaskStore } from '../../domains/cats/services/stores/ports/TaskStore.js';
 import type { ICommunityEventLog } from '../../domains/community/CommunityEventLog.js';
+import { buildCiMessageContent, buildLifecycleMessageContent } from './ci-message-content.js';
 import type { ConnectorDeliveryDeps } from './deliver-connector-message.js';
 import { deliverConnectorMessage } from './deliver-connector-message.js';
+
+// Re-export for existing import sites (index.ts, tests) — builders moved to ci-message-content.ts.
+export { buildCiMessageContent, buildLifecycleMessageContent };
 
 /** Minimal projector interface for optional DI — avoids importing concrete class. */
 interface ICommunityProjectorMin {
@@ -37,8 +41,31 @@ export interface CiPollResult {
 
 export type CiRouteResult =
   | { kind: 'notified'; threadId: string; catId: string; messageId: string; bucket: CiBucket; content: string }
+  /**
+   * PR reached terminal state (merged/closed): task marked done + final lifecycle
+   * notification delivered. Fires exactly once — done tasks are filtered by the
+   * poller gate, so this branch is never re-entered for the same PR.
+   */
+  | {
+      kind: 'lifecycle';
+      threadId: string;
+      catId: string;
+      messageId: string;
+      prState: 'merged' | 'closed';
+      content: string;
+    }
   | { kind: 'deduped'; reason: string }
   | { kind: 'skipped'; reason: string };
+
+/** Subset of the tracked TaskItem fields the lifecycle-close path reads. */
+interface TrackedTaskLike {
+  readonly id: string;
+  readonly threadId: string;
+  readonly ownerCatId: string | null;
+  readonly userId?: string;
+  readonly title?: string;
+  readonly automationState?: { readonly trackingInstructions?: string };
+}
 
 export interface CiCdRouterOptions {
   readonly taskStore: ITaskStore;
@@ -77,7 +104,7 @@ export class CiCdRouter {
   }
 
   async route(poll: CiPollResult): Promise<CiRouteResult> {
-    const { taskStore, log } = this.opts;
+    const { taskStore } = this.opts;
     const sk = prSubjectKey(poll.repoFullName, poll.prNumber);
 
     const task = await taskStore.getBySubject(sk);
@@ -94,90 +121,7 @@ export class CiCdRouter {
     }
 
     if (poll.prState === 'merged' || poll.prState === 'closed') {
-      // #320 KD-17: lifecycle close = mark task done (not delete)
-      // F200 AC-D2.3: persist prState so signal detection can distinguish merged vs closed
-      await taskStore.update(task.id, { status: 'done' });
-      await taskStore.patchAutomationState(task.id, { ci: { prState: poll.prState } });
-      log.info(`[CiCdRouter] PR ${poll.repoFullName}#${poll.prNumber} ${poll.prState} — task marked done`);
-
-      // F192 Phase G: emit A1 world truth signal on merge only.
-      // 'closed' = PR abandoned without merge — NOT a code revert.
-      // Code reverts are separate git events (revert commits), not PR lifecycle.
-      if (poll.prState === 'merged' && this.opts.onPrLifecycle) {
-        try {
-          this.opts.onPrLifecycle({
-            type: 'merge',
-            ref: `PR#${poll.prNumber}`,
-            outcome: 'success',
-            threadId: task.threadId,
-          });
-        } catch (err) {
-          log.warn(
-            { err, repoFullName: poll.repoFullName, prNumber: poll.prNumber, threadId: task.threadId },
-            '[CiCdRouter] onPrLifecycle callback failed (best-effort)',
-          );
-        }
-      }
-
-      // F208 AC-E2: distillation checkpoint on feat-phase-close (best-effort, merge only).
-      // CiCdRouter is the canonical first-detection point for merge — checkpoint MUST fire here
-      // because ReviewFeedbackTaskSpec gate filters done tasks and may miss.
-      // sourceId dedup makes double-fire from ReviewFeedbackTaskSpec safe.
-      if (poll.prState === 'merged' && this.opts.distillationCheckpoint) {
-        try {
-          // Extract featureId from trackingInstructions (prTitle not available here)
-          const featureSource = task.automationState?.trackingInstructions ?? task.title ?? '';
-          const featureMatch = featureSource.match(/\b[Ff](\d{2,4})\b/);
-          const featureId = featureMatch ? `F${featureMatch[1]}` : undefined;
-          if (featureId) {
-            const phaseMatch = featureSource.match(/[Pp]hase\s+([A-Z])/i);
-            await this.opts.distillationCheckpoint.onFeatPhaseClose({
-              prNumber: poll.prNumber,
-              repoFullName: poll.repoFullName,
-              authorCatId: (task.ownerCatId ?? 'unknown') as string,
-              threadId: task.threadId,
-              featureId,
-              phaseLabel: phaseMatch?.[1] ?? 'unknown',
-            });
-          }
-        } catch {
-          log.warn(
-            `[CiCdRouter] distillation checkpoint (feat-phase-close) failed for ${poll.repoFullName}#${poll.prNumber}`,
-          );
-        }
-      }
-
-      // F168 Phase A P1-3: canonical community event emission.
-      // This is the first reliable detection point for PR lifecycle.
-      // sourceEventId = `lifecycle:${sk}:${prState}` — dedup-safe if ReviewFeedbackTaskSpec also fires.
-      if (this.opts.eventLog) {
-        try {
-          const eventKind = poll.prState === 'merged' ? 'pr.merged' : 'pr.closed';
-          const communityEvent = {
-            sourceEventId: `lifecycle:${sk}:${poll.prState}`,
-            subjectKey: sk,
-            kind: eventKind as 'pr.merged' | 'pr.closed',
-            classification: 'state-changing' as const,
-            payload: {
-              prState: poll.prState,
-              repoFullName: poll.repoFullName,
-              prNumber: poll.prNumber,
-            },
-            at: Date.now(),
-          };
-          const { appended } = await this.opts.eventLog.append(communityEvent);
-          if (appended && this.opts.projector) {
-            await this.opts.projector.apply(communityEvent);
-          }
-        } catch (err) {
-          log.warn(
-            { err, repoFullName: poll.repoFullName, prNumber: poll.prNumber, subjectKey: sk },
-            '[CiCdRouter] event log append failed (best-effort, spec §Task6)',
-          );
-        }
-      }
-
-      return { kind: 'skipped', reason: `PR ${poll.prState}` };
+      return this.closeLifecycle(poll, task, sk);
     }
 
     if (poll.aggregateBucket === 'pending') {
@@ -193,6 +137,143 @@ export class CiCdRouter {
     }
 
     return this.deliver(poll, task, fingerprint);
+  }
+
+  /**
+   * PR reached terminal state (merged/closed).
+   * #320 KD-17: lifecycle close = mark task done (not delete).
+   * Then: best-effort side effects + a final lifecycle notification to the owner.
+   * The notification is the outcome the owner is tracking for (intent=merge waits for
+   * exactly this; trackingInstructions routinely say "on merge, do X") — without it the
+   * owner never learns the PR closed (observed: PR #1120 merged 12:25 UTC, owner
+   * discovered at 14:21 via a human query). Delivered AFTER done-marking so a delivery
+   * failure can never wedge the task in tracking; failure degrades to the previous
+   * silent behavior.
+   */
+  private async closeLifecycle(poll: CiPollResult, task: TrackedTaskLike, sk: string): Promise<CiRouteResult> {
+    const { taskStore, log } = this.opts;
+    const prState = poll.prState as 'merged' | 'closed';
+
+    // F200 AC-D2.3: persist prState so signal detection can distinguish merged vs closed
+    await taskStore.update(task.id, { status: 'done' });
+    await taskStore.patchAutomationState(task.id, { ci: { prState } });
+    log.info(`[CiCdRouter] PR ${poll.repoFullName}#${poll.prNumber} ${prState} — task marked done`);
+
+    await this.emitTerminalSideEffects(poll, task, sk);
+
+    try {
+      const content = buildLifecycleMessageContent(poll, task.automationState?.trackingInstructions);
+      const source: ConnectorSource = {
+        connector: 'github-ci',
+        label: 'GitHub CI/CD',
+        icon: 'github',
+        url: `https://github.com/${poll.repoFullName}/pull/${poll.prNumber}`,
+      };
+      const delivered = await deliverConnectorMessage(this.opts.deliveryDeps, {
+        threadId: task.threadId,
+        userId: task.userId ?? '',
+        catId: task.ownerCatId ?? '',
+        content,
+        source,
+      });
+      log.info(`[CiCdRouter] PR ${prState} → lifecycle notification to ${task.ownerCatId} in thread ${task.threadId}`);
+      return {
+        kind: 'lifecycle',
+        threadId: task.threadId,
+        catId: task.ownerCatId ?? '',
+        messageId: delivered.messageId,
+        prState,
+        content,
+      };
+    } catch (err) {
+      log.error(
+        { err, repoFullName: poll.repoFullName, prNumber: poll.prNumber, threadId: task.threadId },
+        '[CiCdRouter] lifecycle delivery failed — task already done, no retry (degrades to silent close)',
+      );
+      return { kind: 'skipped', reason: `PR ${prState} (lifecycle delivery failed)` };
+    }
+  }
+
+  /** Best-effort side effects on terminal close: A1 signal, distillation checkpoint, community event. */
+  private async emitTerminalSideEffects(poll: CiPollResult, task: TrackedTaskLike, sk: string): Promise<void> {
+    const { log } = this.opts;
+
+    // F192 Phase G: emit A1 world truth signal on merge only.
+    // 'closed' = PR abandoned without merge — NOT a code revert.
+    // Code reverts are separate git events (revert commits), not PR lifecycle.
+    if (poll.prState === 'merged' && this.opts.onPrLifecycle) {
+      try {
+        this.opts.onPrLifecycle({
+          type: 'merge',
+          ref: `PR#${poll.prNumber}`,
+          outcome: 'success',
+          threadId: task.threadId,
+        });
+      } catch (err) {
+        log.warn(
+          { err, repoFullName: poll.repoFullName, prNumber: poll.prNumber, threadId: task.threadId },
+          '[CiCdRouter] onPrLifecycle callback failed (best-effort)',
+        );
+      }
+    }
+
+    // F208 AC-E2: distillation checkpoint on feat-phase-close (best-effort, merge only).
+    // CiCdRouter is the canonical first-detection point for merge — checkpoint MUST fire here
+    // because ReviewFeedbackTaskSpec gate filters done tasks and may miss.
+    // sourceId dedup makes double-fire from ReviewFeedbackTaskSpec safe.
+    if (poll.prState === 'merged' && this.opts.distillationCheckpoint) {
+      try {
+        // Extract featureId from trackingInstructions (prTitle not available here)
+        const featureSource = task.automationState?.trackingInstructions ?? task.title ?? '';
+        const featureMatch = featureSource.match(/\b[Ff](\d{2,4})\b/);
+        const featureId = featureMatch ? `F${featureMatch[1]}` : undefined;
+        if (featureId) {
+          const phaseMatch = featureSource.match(/[Pp]hase\s+([A-Z])/i);
+          await this.opts.distillationCheckpoint.onFeatPhaseClose({
+            prNumber: poll.prNumber,
+            repoFullName: poll.repoFullName,
+            authorCatId: (task.ownerCatId ?? 'unknown') as string,
+            threadId: task.threadId,
+            featureId,
+            phaseLabel: phaseMatch?.[1] ?? 'unknown',
+          });
+        }
+      } catch {
+        log.warn(
+          `[CiCdRouter] distillation checkpoint (feat-phase-close) failed for ${poll.repoFullName}#${poll.prNumber}`,
+        );
+      }
+    }
+
+    // F168 Phase A P1-3: canonical community event emission.
+    // This is the first reliable detection point for PR lifecycle.
+    // sourceEventId = `lifecycle:${sk}:${prState}` — dedup-safe if ReviewFeedbackTaskSpec also fires.
+    if (this.opts.eventLog) {
+      try {
+        const eventKind = poll.prState === 'merged' ? 'pr.merged' : 'pr.closed';
+        const communityEvent = {
+          sourceEventId: `lifecycle:${sk}:${poll.prState}`,
+          subjectKey: sk,
+          kind: eventKind as 'pr.merged' | 'pr.closed',
+          classification: 'state-changing' as const,
+          payload: {
+            prState: poll.prState,
+            repoFullName: poll.repoFullName,
+            prNumber: poll.prNumber,
+          },
+          at: Date.now(),
+        };
+        const { appended } = await this.opts.eventLog.append(communityEvent);
+        if (appended && this.opts.projector) {
+          await this.opts.projector.apply(communityEvent);
+        }
+      } catch (err) {
+        log.warn(
+          { err, repoFullName: poll.repoFullName, prNumber: poll.prNumber, subjectKey: sk },
+          '[CiCdRouter] event log append failed (best-effort, spec §Task6)',
+        );
+      }
+    }
   }
 
   private async deliver(
@@ -247,37 +328,4 @@ export class CiCdRouter {
       content,
     };
   }
-}
-
-export function buildCiMessageContent(poll: CiPollResult, trackingInstructions?: string): string {
-  const bucketEmoji = poll.aggregateBucket === 'pass' ? '✅' : '❌';
-  const bucketLabel = poll.aggregateBucket === 'pass' ? 'CI 通过' : 'CI 失败';
-
-  const lines: string[] = [
-    `${bucketEmoji} **${bucketLabel}**`,
-    '',
-    `PR #${poll.prNumber} (${poll.repoFullName})`,
-    `Commit: \`${poll.headSha.slice(0, 7)}\``,
-  ];
-
-  const failedChecks = poll.checks.filter((c) => c.bucket === 'fail');
-  if (failedChecks.length > 0) {
-    lines.push('', `--- 失败的检查 (${failedChecks.length}) ---`);
-    for (const check of failedChecks) {
-      const linkPart = check.link ? ` [查看](${check.link})` : '';
-      const descPart = check.description ? ` — ${check.description.slice(0, 120)}` : '';
-      lines.push(`❌ **${check.name}**${descPart}${linkPart}`);
-    }
-  }
-
-  if (poll.aggregateBucket === 'fail') {
-    lines.push('', '请检查 CI 失败原因并修复。');
-  }
-
-  // F202 Phase 2C (AC-C2): append user-provided tracking instructions
-  if (trackingInstructions) {
-    lines.push('', '📌 **Tracking Instructions**', trackingInstructions);
-  }
-
-  return lines.join('\n');
 }

--- a/packages/api/src/infrastructure/email/ReviewFeedbackTaskSpec.ts
+++ b/packages/api/src/infrastructure/email/ReviewFeedbackTaskSpec.ts
@@ -83,6 +83,16 @@ export interface ReviewFeedbackTaskSpecOptions {
   readonly projector?: { apply(event: CommunityEvent): Promise<void> };
   // F208 Phase E AC-E2: distillation checkpoint (best-effort, optional)
   readonly distillationCheckpoint?: DistillationCheckpoint;
+  /** F167 Phase Q: retire matching hold_ball timers once structured review feedback is delivered. */
+  readonly holdLifecycle?: {
+    retireSatisfiedWait(event: {
+      threadId: string;
+      subjectKey: string;
+      expectedSignalKey: 'review_posted';
+      sourceKind: 'review_feedback';
+      sourceMessageId?: string;
+    }): void | Promise<unknown>;
+  };
 }
 
 function resolveCursor(memoryCursor: number | undefined, persistedCursor: number | undefined): number {
@@ -300,6 +310,7 @@ export function createReviewFeedbackTaskSpec(opts: ReviewFeedbackTaskSpecOptions
 
             const prMetadata = opts.fetchPrMetadata ? await opts.fetchPrMetadata(repoFullName, prNumber) : null;
             if (prMetadata?.prState === 'merged' || prMetadata?.prState === 'closed') {
+              await opts.taskStore.patchAutomationState(trackingTask.id, { review: { prState: prMetadata.prState } });
               await opts.taskStore.update(trackingTask.id, { status: 'done' });
               opts.log.info(`[review-feedback] PR ${prKey} ${prMetadata.prState} — task marked done`);
 
@@ -615,6 +626,20 @@ export function createReviewFeedbackTaskSpec(opts: ReviewFeedbackTaskSpecOptions
         const repairCommitted = await signal.commitRoutingRepair?.();
         if (repairCommitted === false) return;
         await signal.commitCursor();
+
+        if (opts.holdLifecycle) {
+          try {
+            await opts.holdLifecycle.retireSatisfiedWait({
+              threadId: routeResult.threadId,
+              subjectKey,
+              expectedSignalKey: 'review_posted',
+              sourceKind: 'review_feedback',
+              sourceMessageId: routeResult.messageId,
+            });
+          } catch (err) {
+            opts.log.warn({ err, subjectKey }, '[review-feedback] hold lifecycle retirement failed (best-effort)');
+          }
+        }
 
         if (opts.invokeTrigger) {
           try {

--- a/packages/api/src/infrastructure/email/ci-message-content.ts
+++ b/packages/api/src/infrastructure/email/ci-message-content.ts
@@ -1,0 +1,64 @@
+/**
+ * Message content builders for CI/CD tracking notifications.
+ * Extracted from CiCdRouter.ts (file size + complexity limits); re-exported there
+ * so existing import paths stay valid.
+ */
+import type { CiPollResult } from './CiCdRouter.js';
+
+export function buildCiMessageContent(poll: CiPollResult, trackingInstructions?: string): string {
+  const bucketEmoji = poll.aggregateBucket === 'pass' ? '✅' : '❌';
+  const bucketLabel = poll.aggregateBucket === 'pass' ? 'CI 通过' : 'CI 失败';
+
+  const lines: string[] = [
+    `${bucketEmoji} **${bucketLabel}**`,
+    '',
+    `PR #${poll.prNumber} (${poll.repoFullName})`,
+    `Commit: \`${poll.headSha.slice(0, 7)}\``,
+  ];
+
+  const failedChecks = poll.checks.filter((c) => c.bucket === 'fail');
+  if (failedChecks.length > 0) {
+    lines.push('', `--- 失败的检查 (${failedChecks.length}) ---`);
+    for (const check of failedChecks) {
+      const linkPart = check.link ? ` [查看](${check.link})` : '';
+      const descPart = check.description ? ` — ${check.description.slice(0, 120)}` : '';
+      lines.push(`❌ **${check.name}**${descPart}${linkPart}`);
+    }
+  }
+
+  if (poll.aggregateBucket === 'fail') {
+    lines.push('', '请检查 CI 失败原因并修复。');
+  }
+
+  // F202 Phase 2C (AC-C2): append user-provided tracking instructions
+  if (trackingInstructions) {
+    lines.push('', '📌 **Tracking Instructions**', trackingInstructions);
+  }
+
+  return lines.join('\n');
+}
+
+/** Terminal lifecycle (merged/closed) notification — mirrors buildCiMessageContent conventions. */
+export function buildLifecycleMessageContent(
+  poll: Pick<CiPollResult, 'repoFullName' | 'prNumber' | 'prState'>,
+  trackingInstructions?: string,
+): string {
+  const merged = poll.prState === 'merged';
+  const headline = merged ? '🎉 **PR 已 merge**' : '🚪 **PR 已关闭（未合并）**';
+
+  const lines: string[] = [headline, '', `PR #${poll.prNumber} (${poll.repoFullName})`];
+
+  lines.push(
+    '',
+    merged
+      ? '请执行 post-merge 收尾（验证 main、更新任务状态、清理分支/worktree）。'
+      : '该 PR 未合并即关闭，请确认是否需要跟进（重开、改道或收尾归档）。',
+  );
+
+  // F202 Phase 2C (AC-C2): append user-provided tracking instructions
+  if (trackingInstructions) {
+    lines.push('', '📌 **Tracking Instructions**', trackingInstructions);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/api/src/infrastructure/email/ci-message-content.ts
+++ b/packages/api/src/infrastructure/email/ci-message-content.ts
@@ -1,7 +1,6 @@
 /**
  * Message content builders for CI/CD tracking notifications.
- * Extracted from CiCdRouter.ts (file size + complexity limits); re-exported there
- * so existing import paths stay valid.
+ * Extracted from CiCdRouter.ts so lifecycle delivery can stay small and reusable.
  */
 import type { CiPollResult } from './CiCdRouter.js';
 
@@ -38,7 +37,7 @@ export function buildCiMessageContent(poll: CiPollResult, trackingInstructions?:
   return lines.join('\n');
 }
 
-/** Terminal lifecycle (merged/closed) notification — mirrors buildCiMessageContent conventions. */
+/** Terminal lifecycle (merged/closed) notification. */
 export function buildLifecycleMessageContent(
   poll: Pick<CiPollResult, 'repoFullName' | 'prNumber' | 'prState'>,
   trackingInstructions?: string,

--- a/packages/api/test/cicd-router.test.js
+++ b/packages/api/test/cicd-router.test.js
@@ -2,7 +2,11 @@
 
 import assert from 'node:assert';
 import { beforeEach, describe, it } from 'node:test';
-import { buildCiMessageContent, CiCdRouter } from '../dist/infrastructure/email/CiCdRouter.js';
+import {
+  buildCiMessageContent,
+  buildLifecycleMessageContent,
+  CiCdRouter,
+} from '../dist/infrastructure/email/CiCdRouter.js';
 import { createPrTrackingTaskStore } from './helpers/pr-tracking-test-helper.js';
 
 // ─── Lightweight mocks ─────────────────────────────────────────────
@@ -133,7 +137,32 @@ describe('CiCdRouter', () => {
       assert.strictEqual(messageMock.messages[0].source.connector, 'github-ci');
     });
 
-    it('delivers CI success message to tracked thread (AC-A3)', async () => {
+    it('suppresses CI success delivery for review intent while preserving CI state', async () => {
+      const router = createRouter();
+      const task = prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+      prTracking.taskStore.patchAutomationState(task.id, { intent: 'review' });
+
+      const result = await router.route(makePollResult({ aggregateBucket: 'pass', checks: [] }));
+
+      assert.strictEqual(result.kind, 'skipped');
+      assert.ok(result.reason.includes('review intent'));
+      assert.strictEqual(messageMock.messages.length, 0);
+
+      const updated = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
+      assert.ok(updated, 'entry should still exist after silent CI pass');
+      assert.strictEqual(updated.automationState?.ci?.headSha, 'abc1234567890');
+      assert.strictEqual(updated.automationState?.ci?.lastFingerprint, 'abc1234567890:pass');
+      assert.strictEqual(updated.automationState?.ci?.lastBucket, 'pass');
+      assert.strictEqual(updated.automationState?.ci?.lastNotifiedAt, undefined);
+    });
+
+    it('suppresses CI success delivery when intent is absent (defaults to review)', async () => {
       const router = createRouter();
       prTracking.register({
         repoFullName: 'zts212653/cat-cafe',
@@ -142,6 +171,24 @@ describe('CiCdRouter', () => {
         threadId: 'thread-abc',
         userId: 'user-1',
       });
+
+      const result = await router.route(makePollResult({ aggregateBucket: 'pass', checks: [] }));
+
+      assert.strictEqual(result.kind, 'skipped');
+      assert.ok(result.reason.includes('review intent'));
+      assert.strictEqual(messageMock.messages.length, 0);
+    });
+
+    it('delivers CI success message to tracked thread for merge intent (AC-A3)', async () => {
+      const router = createRouter();
+      const task = prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+      prTracking.taskStore.patchAutomationState(task.id, { intent: 'merge' });
 
       const result = await router.route(makePollResult({ aggregateBucket: 'pass', checks: [] }));
 
@@ -221,13 +268,14 @@ describe('CiCdRouter', () => {
 
     it('fail then success on same SHA notifies both (AC-A5)', async () => {
       const router = createRouter();
-      prTracking.register({
+      const task = prTracking.register({
         repoFullName: 'zts212653/cat-cafe',
         prNumber: 42,
         catId: 'opus',
         threadId: 'thread-abc',
         userId: 'user-1',
       });
+      prTracking.taskStore.patchAutomationState(task.id, { intent: 'merge' });
 
       const failPoll = makePollResult({ headSha: 'sha-fixed', aggregateBucket: 'fail' });
       const passPoll = makePollResult({ headSha: 'sha-fixed', aggregateBucket: 'pass', checks: [] });
@@ -271,22 +319,19 @@ describe('CiCdRouter', () => {
   });
 
   // ── T3: Merged/closed lifecycle close (AC-A8 + terminal notification) ──
-  // Observed gap (PR #1120): merged was detected and persisted, but the owner was
-  // never notified — trackingInstructions promising "on merge, do X" never delivered.
-  // Terminal state now delivers a final lifecycle message and returns kind='lifecycle'.
 
   describe('T3: merged/closed lifecycle close', () => {
     it('merged PR marks task done AND delivers terminal lifecycle notification', async () => {
       const router = createRouter();
       prTracking.register({
-        repoFullName: 'zts212653/cat-cafe',
+        repoFullName: 'zts212653/clowder-ai',
         prNumber: 42,
         catId: 'opus',
         threadId: 'thread-abc',
         userId: 'user-1',
       });
 
-      const result = await router.route(makePollResult({ prState: 'merged' }));
+      const result = await router.route(makePollResult({ repoFullName: 'zts212653/clowder-ai', prState: 'merged' }));
 
       assert.strictEqual(result.kind, 'lifecycle');
       if (result.kind === 'lifecycle') {
@@ -297,17 +342,17 @@ describe('CiCdRouter', () => {
       }
 
       // #320: merged/closed sets status=done (not delete)
-      const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
+      const entry = prTracking.taskStore.getBySubject('pr:zts212653/clowder-ai#42');
       assert.ok(entry, 'task should still exist');
       assert.strictEqual(entry.status, 'done');
 
-      // Terminal notification delivered to the tracked thread, mentioning the owner
       assert.strictEqual(messageMock.messages.length, 1);
       const msg = messageMock.messages[0];
       assert.strictEqual(msg.threadId, 'thread-abc');
       assert.ok(msg.mentions.includes('opus'));
       assert.ok(msg.content.includes('merge'), 'content should state the PR merged');
       assert.ok(msg.content.includes('#42'));
+      assert.strictEqual(msg.source.url, 'https://github.com/zts212653/clowder-ai/pull/42');
     });
 
     it('closed PR marks task done AND delivers closed (unmerged) notification', async () => {
@@ -338,6 +383,54 @@ describe('CiCdRouter', () => {
       );
     });
 
+    it('skips terminal lifecycle delivery when the same terminal state was already processed', async () => {
+      const router = createRouter();
+      const task = prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+      prTracking.taskStore.update(task.id, { status: 'done' });
+      prTracking.taskStore.patchAutomationState(task.id, { ci: { prState: 'merged' } });
+
+      const result = await router.route(makePollResult({ prState: 'merged' }));
+
+      assert.strictEqual(result.kind, 'skipped');
+      if (result.kind === 'skipped') {
+        assert.ok(result.reason.includes('already processed'));
+      }
+      const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
+      assert.strictEqual(entry?.status, 'done');
+      assert.strictEqual(messageMock.messages.length, 0);
+    });
+
+    it('still delivers terminal lifecycle when review feedback marked the task done first', async () => {
+      const router = createRouter();
+      const task = prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+      prTracking.taskStore.update(task.id, { status: 'done' });
+
+      const result = await router.route(makePollResult({ prState: 'merged' }));
+
+      assert.strictEqual(result.kind, 'lifecycle');
+      if (result.kind === 'lifecycle') {
+        assert.strictEqual(result.prState, 'merged');
+        assert.strictEqual(result.threadId, 'thread-abc');
+        assert.strictEqual(result.catId, 'opus');
+      }
+      const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
+      assert.strictEqual(entry?.status, 'done');
+      assert.strictEqual(entry?.automationState?.ci?.prState, 'merged');
+      assert.strictEqual(messageMock.messages.length, 1);
+    });
+
     it('appends trackingInstructions to the terminal notification (post-merge checklist)', async () => {
       const router = createRouter();
       const task = prTracking.register({
@@ -347,7 +440,7 @@ describe('CiCdRouter', () => {
         threadId: 'thread-abc',
         userId: 'user-1',
       });
-      await prTracking.taskStore.patchAutomationState(task.id, {
+      prTracking.taskStore.patchAutomationState(task.id, {
         trackingInstructions: 'merge 后：验证 main 生效 + 标任务 done',
       });
 
@@ -877,5 +970,35 @@ describe('buildCiMessageContent', () => {
     assert.ok(content.includes('CI 通过'));
     assert.ok(content.includes('def7890'));
     assert.ok(!content.includes('失败的检查'));
+  });
+});
+
+describe('buildLifecycleMessageContent', () => {
+  it('formats merged lifecycle message with tracking instructions', () => {
+    const content = buildLifecycleMessageContent(
+      {
+        repoFullName: 'org/repo',
+        prNumber: 10,
+        prState: 'merged',
+      },
+      'verify main and close task',
+    );
+
+    assert.ok(content.includes('PR 已 merge'));
+    assert.ok(content.includes('PR #10'));
+    assert.ok(content.includes('Tracking Instructions'));
+    assert.ok(content.includes('verify main and close task'));
+  });
+
+  it('formats closed lifecycle message as unmerged', () => {
+    const content = buildLifecycleMessageContent({
+      repoFullName: 'org/repo',
+      prNumber: 11,
+      prState: 'closed',
+    });
+
+    assert.ok(content.includes('PR 已关闭'));
+    assert.ok(content.includes('未合并'));
+    assert.ok(content.includes('PR #11'));
   });
 });

--- a/packages/api/test/cicd-router.test.js
+++ b/packages/api/test/cicd-router.test.js
@@ -270,10 +270,13 @@ describe('CiCdRouter', () => {
     });
   });
 
-  // ── T3: Merged/closed auto remove (AC-A8) ──────────────────────
+  // ── T3: Merged/closed lifecycle close (AC-A8 + terminal notification) ──
+  // Observed gap (PR #1120): merged was detected and persisted, but the owner was
+  // never notified — trackingInstructions promising "on merge, do X" never delivered.
+  // Terminal state now delivers a final lifecycle message and returns kind='lifecycle'.
 
-  describe('T3: merged/closed auto remove', () => {
-    it('merged PR is removed from tracking store (AC-A8)', async () => {
+  describe('T3: merged/closed lifecycle close', () => {
+    it('merged PR marks task done AND delivers terminal lifecycle notification', async () => {
       const router = createRouter();
       prTracking.register({
         repoFullName: 'zts212653/cat-cafe',
@@ -285,16 +288,29 @@ describe('CiCdRouter', () => {
 
       const result = await router.route(makePollResult({ prState: 'merged' }));
 
-      assert.strictEqual(result.kind, 'skipped');
-      assert.ok(result.reason.includes('merged'));
+      assert.strictEqual(result.kind, 'lifecycle');
+      if (result.kind === 'lifecycle') {
+        assert.strictEqual(result.prState, 'merged');
+        assert.strictEqual(result.threadId, 'thread-abc');
+        assert.strictEqual(result.catId, 'opus');
+        assert.ok(result.messageId, 'delivered message id must be returned');
+      }
 
       // #320: merged/closed sets status=done (not delete)
       const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
       assert.ok(entry, 'task should still exist');
       assert.strictEqual(entry.status, 'done');
+
+      // Terminal notification delivered to the tracked thread, mentioning the owner
+      assert.strictEqual(messageMock.messages.length, 1);
+      const msg = messageMock.messages[0];
+      assert.strictEqual(msg.threadId, 'thread-abc');
+      assert.ok(msg.mentions.includes('opus'));
+      assert.ok(msg.content.includes('merge'), 'content should state the PR merged');
+      assert.ok(msg.content.includes('#42'));
     });
 
-    it('closed PR is marked done in task store', async () => {
+    it('closed PR marks task done AND delivers closed (unmerged) notification', async () => {
       const router = createRouter();
       prTracking.register({
         repoFullName: 'zts212653/cat-cafe',
@@ -306,12 +322,70 @@ describe('CiCdRouter', () => {
 
       const result = await router.route(makePollResult({ prState: 'closed' }));
 
-      assert.strictEqual(result.kind, 'skipped');
-      assert.ok(result.reason.includes('closed'));
+      assert.strictEqual(result.kind, 'lifecycle');
+      if (result.kind === 'lifecycle') {
+        assert.strictEqual(result.prState, 'closed');
+      }
 
       const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
       assert.ok(entry, 'task should still exist');
       assert.strictEqual(entry.status, 'done');
+
+      assert.strictEqual(messageMock.messages.length, 1);
+      assert.ok(
+        messageMock.messages[0].content.includes('未合并'),
+        'closed wording must distinguish unmerged closure from merge',
+      );
+    });
+
+    it('appends trackingInstructions to the terminal notification (post-merge checklist)', async () => {
+      const router = createRouter();
+      const task = prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+      await prTracking.taskStore.patchAutomationState(task.id, {
+        trackingInstructions: 'merge 后：验证 main 生效 + 标任务 done',
+      });
+
+      await router.route(makePollResult({ prState: 'merged' }));
+
+      assert.strictEqual(messageMock.messages.length, 1);
+      const content = messageMock.messages[0].content;
+      assert.ok(content.includes('Tracking Instructions'));
+      assert.ok(content.includes('merge 后：验证 main 生效 + 标任务 done'));
+    });
+
+    it('delivery failure degrades to skipped but still marks task done (no poller crash)', async () => {
+      const failingStore = /** @type {any} */ ({
+        append() {
+          throw new Error('message store down');
+        },
+      });
+      const router = new CiCdRouter({
+        taskStore: prTracking.taskStore,
+        deliveryDeps: { messageStore: failingStore },
+        log: noopLog(),
+      });
+      prTracking.register({
+        repoFullName: 'zts212653/cat-cafe',
+        prNumber: 42,
+        catId: 'opus',
+        threadId: 'thread-abc',
+        userId: 'user-1',
+      });
+
+      const result = await router.route(makePollResult({ prState: 'merged' }));
+
+      assert.strictEqual(result.kind, 'skipped');
+      if (result.kind === 'skipped') {
+        assert.ok(result.reason.includes('merged'));
+      }
+      const entry = prTracking.taskStore.getBySubject('pr:zts212653/cat-cafe#42');
+      assert.strictEqual(entry?.status, 'done', 'done-marking must survive delivery failure');
     });
   });
 
@@ -463,7 +537,7 @@ describe('CiCdRouter', () => {
         userId: 'user-1',
       });
       const result = await router.route(makePollResult({ prState: 'merged' }));
-      assert.strictEqual(result.kind, 'skipped');
+      assert.strictEqual(result.kind, 'lifecycle');
     });
 
     it('continues routing even if eventLog.append throws (best-effort)', async () => {
@@ -487,7 +561,7 @@ describe('CiCdRouter', () => {
 
       // Must not throw
       const result = await router.route(makePollResult({ prState: 'merged' }));
-      assert.strictEqual(result.kind, 'skipped');
+      assert.strictEqual(result.kind, 'lifecycle');
     });
   });
 
@@ -758,8 +832,10 @@ describe('CiCdRouter', () => {
       const result = await router.route(
         makePollResult({ repoFullName: 'zts212653/cat-cafe', prNumber: 77, prState: 'merged' }),
       );
-      assert.strictEqual(result.kind, 'skipped');
-      assert.ok(result.reason.includes('merged'));
+      assert.strictEqual(result.kind, 'lifecycle');
+      if (result.kind === 'lifecycle') {
+        assert.strictEqual(result.prState, 'merged');
+      }
     });
   });
 });

--- a/packages/api/test/scheduler/cicd-check-spec.test.js
+++ b/packages/api/test/scheduler/cicd-check-spec.test.js
@@ -167,6 +167,68 @@ describe('CiCdCheckTaskSpec', () => {
     assert.equal(policy.reason, 'github_ci_failure');
   });
 
+  // ── PR terminal state (merged/closed) → wake owner for follow-up ──
+  // Gap observed on PR #1120: merged was detected + persisted, but no wake — the owner
+  // learned about the merge hours later via a human query. Terminal events fire exactly
+  // once (CiCdRouter marks the task done, gate filters done tasks), so wake unconditionally.
+
+  /** Build a spec whose router reports a terminal lifecycle result. */
+  function lifecycleSpec(createCiCdCheckTaskSpec, triggered, prState) {
+    const tasks = [mockTask({ repoFullName: 'a/b', prNumber: 1, userId: 'u1' })];
+    return createCiCdCheckTaskSpec({
+      taskStore: mockTaskStore(tasks),
+      cicdRouter: {
+        route: async () => ({
+          kind: 'lifecycle',
+          prState,
+          threadId: 't1',
+          catId: 'opus',
+          messageId: 'm1',
+          content: `PR ${prState}`,
+        }),
+      },
+      fetchPrStatus: async () => ({
+        checks: [],
+        headSha: 'sha1',
+        prNumber: 1,
+        repoFullName: 'a/b',
+        aggregateBucket: 'pass',
+      }),
+      invokeTrigger: {
+        trigger: (...args) => {
+          triggered.push(args);
+          return Promise.resolve();
+        },
+      },
+      log: { info: () => {}, error: () => {}, warn: () => {} },
+    });
+  }
+
+  it('execute WAKES owner when PR merges (terminal lifecycle event)', async () => {
+    const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
+    const triggered = [];
+    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, 'merged');
+    const gateResult = await spec.admission.gate({ taskId: 'cicd-check', lastRunAt: null, tickCount: 1 });
+    await spec.run.execute(gateResult.workItems[0].signal, 'pr:a/b#1', {});
+    assert.equal(triggered.length, 1, 'merged → owner must be woken for post-merge follow-up');
+    assert.equal(triggered[0][0], 't1');
+    assert.equal(triggered[0][1], 'opus');
+    const policy = triggered[0][6];
+    assert.equal(policy.priority, 'normal');
+    assert.equal(policy.reason, 'github_pr_merged');
+    assert.equal(policy.sourceCategory, 'ci');
+  });
+
+  it('execute WAKES owner when PR is closed without merge', async () => {
+    const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
+    const triggered = [];
+    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, 'closed');
+    const gateResult = await spec.admission.gate({ taskId: 'cicd-check', lastRunAt: null, tickCount: 1 });
+    await spec.run.execute(gateResult.workItems[0].signal, 'pr:a/b#1', {});
+    assert.equal(triggered.length, 1, 'closed → owner must know the PR is gone');
+    assert.equal(triggered[0][6].reason, 'github_pr_closed');
+  });
+
   it('gate filters out ci.enabled=false', async () => {
     const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
     const tasks = [

--- a/packages/api/test/scheduler/cicd-check-spec.test.js
+++ b/packages/api/test/scheduler/cicd-check-spec.test.js
@@ -65,7 +65,7 @@ describe('CiCdCheckTaskSpec', () => {
   });
 
   // ── F140 Phase C 部分回退：CI pass 由 tracking 的 wake intent 分流（显式声明，不猜 approval）──
-  // intent=review（默认）→ CI pass 静默（猫等 review，pass 是噪音，只留 thread 消息）。
+  // intent=review（默认）→ CI pass 静默（猫等 review，pass 是噪音，只记录 CI state）。
   // intent=merge → CI pass 唤醒（猫等 CI 绿去 merge，pass 是动作信号 → merge-gate）。
   // CI fail 两种 intent 都 urgent 唤醒。intent 是显式任务意图，不是 repo 类型。
 
@@ -167,13 +167,12 @@ describe('CiCdCheckTaskSpec', () => {
     assert.equal(policy.reason, 'github_ci_failure');
   });
 
-  // ── PR terminal state (merged/closed) → wake owner for follow-up ──
-  // Gap observed on PR #1120: merged was detected + persisted, but no wake — the owner
-  // learned about the merge hours later via a human query. Terminal events fire exactly
-  // once (CiCdRouter marks the task done, gate filters done tasks), so wake unconditionally.
+  // ── PR terminal state (merged/closed) -> wake owner for follow-up ──
+  // Terminal events fire exactly once in production because CiCdRouter marks the
+  // task done and the scheduler gate filters done tasks. They still need an owner
+  // wake and hold-retirement signal: PR closure satisfies any matching CI wait.
 
-  /** Build a spec whose router reports a terminal lifecycle result. */
-  function lifecycleSpec(createCiCdCheckTaskSpec, triggered, prState) {
+  function lifecycleSpec(createCiCdCheckTaskSpec, triggered, retired, prState) {
     const tasks = [mockTask({ repoFullName: 'a/b', prNumber: 1, userId: 'u1' })];
     return createCiCdCheckTaskSpec({
       taskStore: mockTaskStore(tasks),
@@ -192,6 +191,7 @@ describe('CiCdCheckTaskSpec', () => {
         headSha: 'sha1',
         prNumber: 1,
         repoFullName: 'a/b',
+        prState,
         aggregateBucket: 'pass',
       }),
       invokeTrigger: {
@@ -200,17 +200,32 @@ describe('CiCdCheckTaskSpec', () => {
           return Promise.resolve();
         },
       },
+      holdLifecycle: {
+        retireSatisfiedWait: (event) => {
+          retired.push(event);
+        },
+      },
       log: { info: () => {}, error: () => {}, warn: () => {} },
     });
   }
 
-  it('execute WAKES owner when PR merges (terminal lifecycle event)', async () => {
+  it('execute WAKES owner and retires matching hold when PR merges', async () => {
     const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
     const triggered = [];
-    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, 'merged');
+    const retired = [];
+    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, retired, 'merged');
     const gateResult = await spec.admission.gate({ taskId: 'cicd-check', lastRunAt: null, tickCount: 1 });
     await spec.run.execute(gateResult.workItems[0].signal, 'pr:a/b#1', {});
-    assert.equal(triggered.length, 1, 'merged → owner must be woken for post-merge follow-up');
+
+    assert.equal(retired.length, 1, 'merged -> matching CI hold must retire before owner wake');
+    assert.deepEqual(retired[0], {
+      threadId: 't1',
+      subjectKey: 'pr:a/b#1',
+      expectedSignalKey: 'ci_complete',
+      sourceKind: 'ci_check',
+      sourceMessageId: 'm1',
+    });
+    assert.equal(triggered.length, 1, 'merged -> owner must be woken for post-merge follow-up');
     assert.equal(triggered[0][0], 't1');
     assert.equal(triggered[0][1], 'opus');
     const policy = triggered[0][6];
@@ -219,14 +234,43 @@ describe('CiCdCheckTaskSpec', () => {
     assert.equal(policy.sourceCategory, 'ci');
   });
 
-  it('execute WAKES owner when PR is closed without merge', async () => {
+  it('execute WAKES owner and retires matching hold when PR closes without merge', async () => {
     const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
     const triggered = [];
-    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, 'closed');
+    const retired = [];
+    const spec = lifecycleSpec(createCiCdCheckTaskSpec, triggered, retired, 'closed');
     const gateResult = await spec.admission.gate({ taskId: 'cicd-check', lastRunAt: null, tickCount: 1 });
     await spec.run.execute(gateResult.workItems[0].signal, 'pr:a/b#1', {});
-    assert.equal(triggered.length, 1, 'closed → owner must know the PR is gone');
+
+    assert.equal(retired.length, 1, 'closed -> matching CI hold must retire');
+    assert.equal(triggered.length, 1, 'closed -> owner must know the PR is gone');
     assert.equal(triggered[0][6].reason, 'github_pr_closed');
+  });
+
+  it('gate admits review-terminal done tasks until CI lifecycle records prState', async () => {
+    const { createCiCdCheckTaskSpec } = await import('../../dist/infrastructure/email/CiCdCheckTaskSpec.js');
+    const tasks = [
+      mockTask(
+        { repoFullName: 'a/b', prNumber: 1 },
+        { status: 'done', automationState: { review: { prState: 'merged' } } },
+      ),
+      mockTask(
+        { repoFullName: 'c/d', prNumber: 2 },
+        { status: 'done', automationState: { review: { prState: 'closed' }, ci: { prState: 'closed' } } },
+      ),
+      mockTask({ repoFullName: 'e/f', prNumber: 3 }, { status: 'done' }),
+    ];
+    const spec = createCiCdCheckTaskSpec({
+      taskStore: mockTaskStore(tasks),
+      cicdRouter: { route: async () => ({ kind: 'noop' }) },
+      log: { info: () => {}, error: () => {}, warn: () => {} },
+    });
+
+    const result = await spec.admission.gate({ taskId: 'cicd-check', lastRunAt: null, tickCount: 1 });
+
+    assert.equal(result.run, true);
+    assert.equal(result.workItems.length, 1);
+    assert.equal(result.workItems[0].subjectKey, 'pr:a/b#1');
   });
 
   it('gate filters out ci.enabled=false', async () => {

--- a/packages/api/test/scheduler/review-feedback-spec.test.js
+++ b/packages/api/test/scheduler/review-feedback-spec.test.js
@@ -897,9 +897,17 @@ describe('ReviewFeedbackTaskSpec', () => {
 
     assert.equal(result.run, false);
     assert.equal(fetchCalled, false, 'merged PRs must not fetch review feedback');
+    assert.equal(store._patchCalls.length, 1);
+    assert.equal(store._patchCalls[0].taskId, mockTaskItem.id);
+    assert.deepEqual(store._patchCalls[0].patch.review, { prState: 'merged' });
     assert.equal(store._updateCalls.length, 1);
     assert.equal(store._updateCalls[0].taskId, mockTaskItem.id);
     assert.equal(store._updateCalls[0].input.status, 'done');
+    assert.equal(
+      store._updateCalls[0].input.automationState,
+      undefined,
+      'marking done must not replace existing automationState',
+    );
   });
 
   it('gate continues with fresh feedback when PR metadata lookup is unavailable', async () => {

--- a/packages/shared/src/types/task.ts
+++ b/packages/shared/src/types/task.ts
@@ -58,13 +58,15 @@ export interface ReviewAutomationState {
   readonly lastCommentCursor?: number;
   readonly lastDecisionCursor?: number;
   readonly lastNotifiedAt?: number;
+  /** Terminal PR state observed by ReviewFeedbackTaskSpec before CI lifecycle delivery. */
+  readonly prState?: 'merged' | 'closed';
 }
 
 /**
  * F140: what the cat is currently waiting on for this tracked PR — the wake intent, NOT the repo
  * type (a private PR can be 'merge'; an open-source PR can be 'review'). Decides whether a CI-pass
  * is noise (review-wait) or an action signal (merge-wait). Cats re-register to flip it.
- *   - review (default): waiting on review feedback → CI-pass stays silent (thread message only).
+ *   - review (default): waiting on review feedback → CI-pass is recorded state-only, with no connector message.
  *   - merge: waiting on CI-green to merge (own approved PR / outbound PR / owner-merge of another's
  *     PR) → CI-pass wakes (→ merge-gate).
  * CI fail / review feedback / conflict always wake under both intents.


### PR DESCRIPTION
## Problem

PR tracking silently swallows the terminal event. When a tracked PR merges or closes:

- `CiCdRouter` marks the task done, persists `prState`, emits internal signals (A1 world-truth, distillation checkpoint, `pr.merged` community event) — then returns `kind: 'skipped'` **without ever calling `deliverConnectorMessage`**.
- `CiCdCheckTaskSpec` only wakes the owner on `kind: 'notified'` (CI pass/fail), and every downstream consumer of `pr.merged` (community state machine, reconciler, memory signals) is a state projection — no wake pipeline exists.

Net effect: the owner never learns the PR reached terminal state.

**Observed:** #1120 merged at 12:25 UTC with `intent=merge` tracking active; the owner discovered the merge at 14:21 — via a human asking. The `register_pr_tracking` contract also invites `trackingInstructions` like *"on merge, do X"*, which were never delivered anywhere.

## Fix

Two layers, matching the existing message/wake split:

1. **`CiCdRouter`** — merged/closed branch now delivers a final lifecycle message (distinct merged 🎉 vs closed-unmerged 🚪 wording, `trackingInstructions` appended) and returns a new result kind `'lifecycle'`. Delivery failure degrades to the previous silent behavior (`skipped`) — done-marking happens first, so a failure can never wedge the task in tracking or crash the poller.
2. **`CiCdCheckTaskSpec`** — `kind: 'lifecycle'` → `invokeTrigger` wake (`normal` priority, reason `github_pr_merged` / `github_pr_closed`), for **both** intents: `merge` = the awaited outcome arrived; `review` = the PR is gone, stop waiting. Fires exactly once — the poller gate filters done tasks, so the branch is never re-entered.

Structure: merged/closed branch extracted into `closeLifecycle()` + `emitTerminalSideEffects()` (no behavior change to the three best-effort emits), message builders moved to `ci-message-content.ts` and re-exported from `CiCdRouter.ts` so existing import sites (`index.ts`, tests) are untouched.

## Non-goals

- No delivery retry/outbox — terminal delivery is best-effort like the sibling emits in the same branch; reliability-of-delivery is a separate concern.
- The pre-existing `subjectKey!` non-null assertion and the one pre-existing cognitive-complexity warning (present on `main` inside `route()`, now living in `emitTerminalSideEffects()`) are left as-is; warning count is unchanged.

## Tests

- 7 new cases: terminal delivery on merged / closed, `trackingInstructions` injection, delivery-failure degradation (task still done, result `skipped`), lifecycle wake on merged / closed with policy assertions.
- 3 legacy assertions upgraded from the old `'skipped'` contract to `'lifecycle'` (their intent — best-effort emit tolerance — is preserved).
- Target files: 68/68 green. Adjacent suites (community lifecycle, event ingest, F200 task signals, review-feedback spec): 84/84 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)