### PR TITLE
fix(windows): hide gh CLI child windows to prevent console flash

### DIFF
--- a/packages/api/src/domains/feat-trajectory/RealGhClient.ts
+++ b/packages/api/src/domains/feat-trajectory/RealGhClient.ts
@@ -20,6 +20,7 @@
  */
 
 import { spawn } from 'node:child_process';
+import { withHiddenGhCliWindow } from '../../infrastructure/github/gh-cli-env.js';
 import type { GhClient, PrInfo } from './GitRefSnapshotCollector.js';
 
 /** 注入式 gh 命令执行器 — 返回 stdout 字符串，非零退出抛错。 */
@@ -148,9 +149,13 @@ export class RealGhClient implements GhClient {
 /** Default real spawn-based gh command runner (production). */
 const defaultGhCmd: GhCmdRunner = (args) =>
   new Promise((resolve, reject) => {
-    const proc = spawn('gh', args as readonly string[], {
-      env: { ...process.env, GH_PROMPT_DISABLED: '1' },
-    });
+    const proc = spawn(
+      'gh',
+      args as readonly string[],
+      withHiddenGhCliWindow({
+        env: { ...process.env, GH_PROMPT_DISABLED: '1' },
+      }),
+    );
     let stdout = '';
     let stderr = '';
     proc.stdout.on('data', (d: Buffer) => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -157,7 +157,7 @@ import {
   ReviewFeedbackRouter,
 } from './infrastructure/email/index.js';
 import { fetchLatestIssueCommentCursor, maxGithubId } from './infrastructure/github/comment-cursors.js';
-import { buildGhCliEnv, resolveGhCliToken } from './infrastructure/github/gh-cli-env.js';
+import { buildGhCliEnv, resolveGhCliToken, withHiddenGhCliWindow } from './infrastructure/github/gh-cli-env.js';
 import type { EvalDomainId } from './infrastructure/harness-eval/domain/eval-domain-registry.js';
 import { runSchedulerReplyUserIdBackfill } from './infrastructure/scheduler/scheduler-reply-userid-backfill.js';
 import { securityHeadersPlugin } from './infrastructure/security-headers.js';
@@ -2248,11 +2248,11 @@ async function main(): Promise<void> {
   const getGitHubToken = (): string | undefined => {
     return resolveGhCliToken({ pluginEnv: getGitHubPluginEnv() });
   };
-  const getGitHubExecOptions = (timeout: number): { timeout: number; env?: NodeJS.ProcessEnv } => {
-    return {
+  const getGitHubExecOptions = (timeout: number): { timeout: number; env?: NodeJS.ProcessEnv; windowsHide: true } => {
+    return withHiddenGhCliWindow({
       timeout,
       env: buildGhCliEnv({ token: getGitHubToken() }),
-    };
+    });
   };
   const { createRepoActivityTemplate } = await import('./infrastructure/scheduler/templates/repo-activity.js');
   templateRegistry.register(createRepoActivityTemplate({ getGitHubToken }));
@@ -2889,7 +2889,7 @@ async function main(): Promise<void> {
         '-f',
         'per_page=100',
       ],
-      { timeout: 60_000 },
+      getGitHubExecOptions(60_000),
     );
     if (!stdout.trim()) return [];
     return stdout
@@ -2916,7 +2916,7 @@ async function main(): Promise<void> {
         '-f',
         'per_page=100',
       ],
-      { timeout: 60_000 },
+      getGitHubExecOptions(60_000),
     );
     if (!stdout.trim()) return [];
     return stdout
@@ -2939,7 +2939,7 @@ async function main(): Promise<void> {
         '--jq',
         '.[] | {user: .user.login, state, commit_id}',
       ],
-      { timeout: 30_000 },
+      getGitHubExecOptions(30_000),
     );
     if (!stdout.trim()) return [];
     return stdout

--- a/packages/api/src/infrastructure/email/ConflictAutoExecutor.ts
+++ b/packages/api/src/infrastructure/email/ConflictAutoExecutor.ts
@@ -9,6 +9,7 @@ import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import type { FastifyBaseLogger } from 'fastify';
 import { listWorktrees } from '../../domains/workspace/workspace-security.js';
+import { withHiddenGhCliWindow } from '../github/gh-cli-env.js';
 
 const execFileAsync = promisify(execFile);
 const GIT_TIMEOUT_MS = 30_000;
@@ -101,7 +102,7 @@ export class ConflictAutoExecutor {
       const { stdout } = await execFileAsync(
         'gh',
         ['api', `repos/${repoFullName}/pulls/${prNumber}`, '--jq', '.head.ref'],
-        { timeout: GH_TIMEOUT_MS },
+        withHiddenGhCliWindow({ timeout: GH_TIMEOUT_MS }),
       );
       return stdout.trim() || null;
     } catch {

--- a/packages/api/src/infrastructure/email/ci-status-fetcher.ts
+++ b/packages/api/src/infrastructure/email/ci-status-fetcher.ts
@@ -4,7 +4,7 @@
  */
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { buildGhCliEnv } from '../github/gh-cli-env.js';
+import { buildGhCliEnv, withHiddenGhCliWindow } from '../github/gh-cli-env.js';
 import type { CiBucket, CiCheckDetail, CiPollResult } from './CiCdRouter.js';
 
 const execFileAsync = promisify(execFile);
@@ -30,7 +30,7 @@ export async function fetchPrCiStatus(
     const { stdout } = await execFileAsync(
       'gh',
       ['pr', 'view', String(prNumber), '-R', repoFullName, '--json', 'headRefOid,state,mergedAt,statusCheckRollup'],
-      { timeout: GH_TIMEOUT_MS, env: buildGhCliEnv({ token: options.ghToken }) },
+      withHiddenGhCliWindow({ timeout: GH_TIMEOUT_MS, env: buildGhCliEnv({ token: options.ghToken }) }),
     );
     prViewJson = stdout;
   } catch (err) {
@@ -86,10 +86,14 @@ async function fetchCheckDetails(
       ];
       if (requiredFlag) args.push(requiredFlag);
 
-      const { stdout } = await execFileAsync('gh', args, {
-        timeout: GH_TIMEOUT_MS,
-        env: buildGhCliEnv({ token: options.ghToken }),
-      });
+      const { stdout } = await execFileAsync(
+        'gh',
+        args,
+        withHiddenGhCliWindow({
+          timeout: GH_TIMEOUT_MS,
+          env: buildGhCliEnv({ token: options.ghToken }),
+        }),
+      );
       const parsed: Array<{ name: string; bucket: string; link?: string; workflow?: string; description?: string }> =
         JSON.parse(stdout);
 

--- a/packages/api/src/infrastructure/github/fetch-paginated.ts
+++ b/packages/api/src/infrastructure/github/fetch-paginated.ts
@@ -14,7 +14,7 @@
  * support `since`/`direction` params, so we still scan all pages
  * client-side. A future optimization could use GraphQL `last:N`.
  */
-import { buildGhCliEnv } from './gh-cli-env.js';
+import { buildGhCliEnv, withHiddenGhCliWindow } from './gh-cli-env.js';
 
 export interface FetchPaginatedOptions {
   /** Items with id > sinceId are collected. 0 or omitted = collect all. */
@@ -25,7 +25,7 @@ export interface FetchPaginatedOptions {
   execFileAsync?: (
     file: string,
     args: string[],
-    opts: { timeout: number; maxBuffer: number; env?: NodeJS.ProcessEnv },
+    opts: { timeout: number; maxBuffer: number; env?: NodeJS.ProcessEnv; windowsHide: boolean },
   ) => Promise<{ stdout: string }>;
 }
 
@@ -42,7 +42,11 @@ export async function fetchPaginated(endpoint: string, options: FetchPaginatedOp
   const { sinceId, ghToken, execFileAsync: execOverride } = options;
   const execFn =
     execOverride ??
-    (async (file: string, args: string[], opts: { timeout: number; maxBuffer: number; env?: NodeJS.ProcessEnv }) => {
+    (async (
+      file: string,
+      args: string[],
+      opts: { timeout: number; maxBuffer: number; env?: NodeJS.ProcessEnv; windowsHide: boolean },
+    ) => {
       const { execFile } = await import('node:child_process');
       const { promisify } = await import('node:util');
       return promisify(execFile)(file, args, opts);
@@ -54,11 +58,15 @@ export async function fetchPaginated(endpoint: string, options: FetchPaginatedOp
   let page = 1;
 
   while (true) {
-    const { stdout } = await execFn('gh', ['api', `${endpoint}?per_page=100&page=${page}`, '--jq', '.[]'], {
-      timeout: 15_000,
-      maxBuffer: 2 * 1024 * 1024,
-      env: buildGhCliEnv({ token: ghToken }),
-    });
+    const { stdout } = await execFn(
+      'gh',
+      ['api', `${endpoint}?per_page=100&page=${page}`, '--jq', '.[]'],
+      withHiddenGhCliWindow({
+        timeout: 15_000,
+        maxBuffer: 2 * 1024 * 1024,
+        env: buildGhCliEnv({ token: ghToken }),
+      }),
+    );
     if (!stdout.trim()) break; // empty page = no more data
 
     const items = stdout

--- a/packages/api/src/infrastructure/github/gh-cli-env.ts
+++ b/packages/api/src/infrastructure/github/gh-cli-env.ts
@@ -43,3 +43,13 @@ export function buildGhCliEnv(options: GhCliEnvOptions = {}): NodeJS.ProcessEnv 
 
   return env;
 }
+
+/**
+ * Keep `gh` subprocesses from creating transient console windows on Windows.
+ *
+ * Apply this to every Node child-process invocation of `gh`. The final
+ * assignment intentionally overrides a caller-provided false value.
+ */
+export function withHiddenGhCliWindow<T extends object>(options: T): T & { readonly windowsHide: true } {
+  return { ...options, windowsHide: true };
+}

--- a/packages/api/src/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.ts
+++ b/packages/api/src/infrastructure/harness-eval/publish-verdict/git-worktree-publisher.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
+import { withHiddenGhCliWindow } from '../../github/gh-cli-env.js';
 import type { GitPublisher, PublishOnIsolatedWorktreeOpts } from './publish-verdict.js';
 
 const exec = promisify(execFile);
@@ -125,7 +126,7 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
             args.push('--color', meta.color, '--description', meta.description);
           }
           try {
-            await exec('gh', args, { cwd: worktreePath, timeout: 15_000 });
+            await exec('gh', args, withHiddenGhCliWindow({ cwd: worktreePath, timeout: 15_000 }));
           } catch (err) {
             // Best-effort: surface error on gh pr create below if it actually breaks PR.
             // (Swallowing here = avoid double-fail on label step; PR create will retry.)
@@ -148,7 +149,7 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
             prBody,
             ...labelFlags,
           ],
-          { cwd: worktreePath, timeout: 60_000 },
+          withHiddenGhCliWindow({ cwd: worktreePath, timeout: 60_000 }),
         );
         prUrl =
           prResult.stdout
@@ -172,7 +173,7 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
                 '--comment',
                 'Closing stale auto-verdict PR because post-publish writeback failed.',
               ],
-              { cwd: worktreePath, timeout: 60_000 },
+              withHiddenGhCliWindow({ cwd: worktreePath, timeout: 60_000 }),
             );
             prOpened = false;
           } catch (cleanupErr) {
@@ -226,7 +227,7 @@ export function createGitWorktreePublisher(deps: GitWorktreePublisherDeps): GitP
               const probe = await exec(
                 'gh',
                 ['pr', 'list', '--head', opts.branchName, '--state', 'open', '--json', 'state', '--limit', '1'],
-                { cwd: deps.repoRoot, timeout: 30_000 },
+                withHiddenGhCliWindow({ cwd: deps.repoRoot, timeout: 30_000 }),
               );
               const parsed = JSON.parse(probe.stdout) as Array<{ state?: string }>;
               if (Array.isArray(parsed) && parsed.length === 0) safeToDelete = true;

--- a/packages/api/test/fetch-paginated.test.js
+++ b/packages/api/test/fetch-paginated.test.js
@@ -123,6 +123,7 @@ describe('fetchPaginated', () => {
       const items = await fetchPaginated('/repos/o/r/issues/1/comments', { execFileAsync: fn });
 
       assert.equal(items.length, 1);
+      assert.equal(calls()[0].opts.windowsHide, true);
       assert.equal(calls()[0].opts.env.GITHUB_TOKEN, undefined);
       assert.equal(calls()[0].opts.env.GH_TOKEN, undefined);
       assert.equal(process.env.GITHUB_TOKEN, 'ambient-token-that-gh-must-not-see');

--- a/packages/api/test/gh-cli-env.test.js
+++ b/packages/api/test/gh-cli-env.test.js
@@ -1,7 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-const { buildGhCliEnv, resolveGhCliToken } = await import('../dist/infrastructure/github/gh-cli-env.js');
+const { buildGhCliEnv, resolveGhCliToken, withHiddenGhCliWindow } = await import(
+  '../dist/infrastructure/github/gh-cli-env.js'
+);
 
 describe('buildGhCliEnv', () => {
   it('strips ambient GitHub token env when no explicit token is provided', () => {
@@ -100,5 +102,17 @@ describe('buildGhCliEnv', () => {
 
     assert.equal(env.GITHUB_TOKEN, 'ambient-gh-token');
     assert.equal(env.GH_TOKEN, undefined);
+  });
+});
+
+describe('withHiddenGhCliWindow', () => {
+  it('forces gh child processes to stay hidden on Windows', () => {
+    const options = withHiddenGhCliWindow({
+      timeout: 15_000,
+      windowsHide: false,
+    });
+
+    assert.equal(options.timeout, 15_000);
+    assert.equal(options.windowsHide, true);
   });
 });

--- a/packages/api/test/gh-cli-window-policy.test.js
+++ b/packages/api/test/gh-cli-window-policy.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const API_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const SOURCE_ROOT = join(API_ROOT, 'src');
+
+function collectTypeScriptFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return collectTypeScriptFiles(path);
+    return entry.isFile() && entry.name.endsWith('.ts') ? [path] : [];
+  });
+}
+
+describe('gh CLI child-process policy', () => {
+  it('hides every direct Node gh invocation on Windows', () => {
+    const ghCalls = [];
+
+    for (const path of collectTypeScriptFiles(SOURCE_ROOT)) {
+      const sourceText = readFileSync(path, 'utf8');
+      const source = ts.createSourceFile(path, sourceText, ts.ScriptTarget.Latest, true);
+
+      function visit(node) {
+        if (ts.isCallExpression(node) && node.arguments.length >= 3) {
+          const command = node.arguments[0];
+          if (ts.isStringLiteral(command) && command.text === 'gh') {
+            const options = node.arguments[2].getText(source);
+            const line = source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1;
+            ghCalls.push({
+              location: `${relative(API_ROOT, path)}:${line}`,
+              hidden: options.includes('withHiddenGhCliWindow') || options.includes('getGitHubExecOptions'),
+            });
+          }
+        }
+        ts.forEachChild(node, visit);
+      }
+
+      visit(source);
+    }
+
+    assert.ok(ghCalls.length > 0, 'expected to find direct gh child-process calls');
+    assert.deepEqual(
+      ghCalls.filter((call) => !call.hidden).map((call) => call.location),
+      [],
+      'all direct gh child-process calls must use the shared hidden-window options',
+    );
+  });
+});


### PR DESCRIPTION
## What

Add `withHiddenGhCliWindow()` as a shared child-process option constructor for GitHub CLI calls, and apply it to all 22 direct Node `gh` invocations (execFile/spawn/exec) across the API.

## Why

The API background `gh pr view` polling launched `gh` without `windowsHide`. On Windows, `gh.exe send-telemetry → tzutil.exe` then created `conhost/OpenConsole`, causing a visible desktop flash.

**Captured process chain**: `node.exe → gh pr view → gh.exe send-telemetry → tzutil.exe → conhost/OpenConsole`

## Changes

| File | Change |
|------|--------|
| `gh-cli-env.ts` | New `withHiddenGhCliWindow()` helper — spread + force `windowsHide: true` |
| `ci-status-fetcher.ts` | Wrap both `gh pr view` and `gh pr checks` calls |
| `fetch-paginated.ts` | Wrap `gh api` paginated call |
| `RealGhClient.ts` | Wrap `spawn("gh", ...)` call |
| `ConflictAutoExecutor.ts` | Wrap `gh api` call |
| `git-worktree-publisher.ts` | Wrap 4 `gh` calls (pr edit/create/close/list) |
| `index.ts` | 3 sync `gh api` calls switched to `getGitHubExecOptions()` — also aligns token isolation |
| `gh-cli-env.test.js` | Test `withHiddenGhCliWindow` forces `windowsHide: true` |
| `gh-cli-window-policy.test.js` | Static AST scan — all 22 direct `gh` calls use the shared helper |
| `fetch-paginated.test.js` | Assert `windowsHide: true` in opts |

## Verification

```
pnpm lint                          → PASS
pnpm -r --if-present run build     → PASS
pnpm exec biome check <10 files>   → PASS (0 errors)
node --test <5 test files>         → 59/59 PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)