### PR TITLE
fix(memory): restore local embedding recall

### DIFF
--- a/packages/api/src/domains/memory/CollectionIndexBuilder.ts
+++ b/packages/api/src/domains/memory/CollectionIndexBuilder.ts
@@ -29,7 +29,7 @@ function createLiveEmbeddingCapability(getEmbeddingService: () => IEmbeddingServ
 
   return {
     load: () => requireService().load(),
-    embed: (texts) => requireService().embed(texts),
+    embed: (texts, options) => requireService().embed(texts, options),
     isReady: () => getEmbeddingService()?.isReady() === true,
     reprobeIfNeeded: async () => {
       const service = getEmbeddingService();

--- a/packages/api/src/domains/memory/EmbeddingService.ts
+++ b/packages/api/src/domains/memory/EmbeddingService.ts
@@ -7,7 +7,7 @@
 import { normalizeLoopbackUrl } from '../services/loopback-url.js';
 import { getServiceConfig } from '../services/service-config.js';
 import { getServiceManifest, resolveServiceEndpoint } from '../services/service-manifest.js';
-import type { EmbedModelInfo, IEmbeddingService } from './interfaces.js';
+import type { EmbedModelInfo, EmbedRequestOptions, IEmbeddingService } from './interfaces.js';
 
 interface EmbeddingServiceConfig {
   embedModel: string;
@@ -111,15 +111,15 @@ export class EmbeddingService implements IEmbeddingService {
     };
   }
 
-  async embed(texts: string[], signal?: AbortSignal): Promise<Float32Array[]> {
+  async embed(texts: string[], options?: EmbedRequestOptions): Promise<Float32Array[]> {
     if (!this.ready) throw new Error('EmbeddingService not ready — embed-api server not available');
     if (texts.length === 0) return [];
 
     const results: Float32Array[] = new Array(texts.length);
     for (let offset = 0; offset < texts.length; offset += EMBED_BATCH_SIZE) {
-      signal?.throwIfAborted();
+      options?.signal?.throwIfAborted();
       const batch = texts.slice(offset, offset + EMBED_BATCH_SIZE);
-      const vectors = await this.embedBatch(batch, signal);
+      const vectors = await this.embedBatch(batch, options);
       for (let i = 0; i < vectors.length; i++) {
         const vector = vectors[i];
         if (!vector) throw new Error(`Embed API omitted vector ${i} from batch`);
@@ -129,10 +129,10 @@ export class EmbeddingService implements IEmbeddingService {
     return results;
   }
 
-  private async embedBatch(texts: string[], parentSignal?: AbortSignal): Promise<Float32Array[]> {
-    const timeoutMs = this.config.embedTimeoutMs;
+  private async embedBatch(texts: string[], options?: EmbedRequestOptions): Promise<Float32Array[]> {
+    const timeoutMs = options?.timeoutMs ?? this.config.embedTimeoutMs;
     const timeoutSignal = AbortSignal.timeout(timeoutMs);
-    const signal = parentSignal ? AbortSignal.any([parentSignal, timeoutSignal]) : timeoutSignal;
+    const signal = options?.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
     const deadlineMs = Date.now() + timeoutMs;
     const res = await fetch(`${this.resolveBaseUrl()}/v1/embeddings`, {
       method: 'POST',

--- a/packages/api/src/domains/memory/SqliteEvidenceStore.ts
+++ b/packages/api/src/domains/memory/SqliteEvidenceStore.ts
@@ -985,7 +985,7 @@ export class SqliteEvidenceStore implements IEvidenceStore {
     options?: SearchOptions,
   ): Promise<PassageResult[]> {
     await coverageSearchCheckpoint(options);
-    const queryVec = await this.embedDeps!.embedding.embed([query], options?.signal);
+    const queryVec = await this.embedDeps!.embedding.embed([query], { signal: options?.signal });
     await coverageSearchCheckpoint(options);
     const nnResults = this.embedDeps!.passageVectorStore!.search(queryVec[0], limit);
     await coverageSearchCheckpoint(options);
@@ -1376,7 +1376,7 @@ export class SqliteEvidenceStore implements IEvidenceStore {
   ): Promise<EvidenceItem[]> {
     const pool = Math.min(Math.max(limit * 4, 20), 100); // 砚砚: generous pool, cap 100
     await coverageSearchCheckpoint(options);
-    const queryVec = await this.embedDeps!.embedding.embed([query], options?.signal);
+    const queryVec = await this.embedDeps!.embedding.embed([query], { signal: options?.signal });
     await coverageSearchCheckpoint(options);
     const nnResults = this.embedDeps!.vectorStore.search(queryVec[0], pool);
     await coverageSearchCheckpoint(options);
@@ -1414,7 +1414,7 @@ export class SqliteEvidenceStore implements IEvidenceStore {
   ): Promise<EvidenceItem[]> {
     const pool = Math.min(Math.max(limit * 4, 20), 100);
     await coverageSearchCheckpoint(options);
-    const queryVec = await this.embedDeps!.embedding.embed([query], options?.signal);
+    const queryVec = await this.embedDeps!.embedding.embed([query], { signal: options?.signal });
     await coverageSearchCheckpoint(options);
     const nnResults = this.embedDeps!.vectorStore.search(queryVec[0], pool);
     await coverageSearchCheckpoint(options);

--- a/packages/api/src/domains/memory/embed-utils.ts
+++ b/packages/api/src/domains/memory/embed-utils.ts
@@ -3,7 +3,9 @@ import { type PassageVectorStore, passageVectorKey } from './PassageVectorStore.
 import type { VectorStore } from './VectorStore.js';
 
 const EMBED_BATCH_SIZE = 64;
-// Passage contents are much longer than doc summaries; keep warmup calls below the 3s client timeout.
+const BACKGROUND_EMBED_TIMEOUT_MS = 120_000;
+// Passage contents are much longer than doc summaries; keep warmup calls small
+// enough to avoid one slow passage stalling a large batch.
 const PASSAGE_EMBED_BATCH_SIZE = 8;
 
 export interface EmbedPipelineContext {
@@ -33,7 +35,7 @@ export async function embedIndexedItems(ctx: EmbedPipelineContext): Promise<void
   for (let offset = 0; offset < toEmbed.length; offset += EMBED_BATCH_SIZE) {
     const batch = toEmbed.slice(offset, offset + EMBED_BATCH_SIZE);
     const texts = batch.map((i) => `${i.title} ${i.summary ?? ''}`);
-    const vectors = await ctx.embedding.embed(texts);
+    const vectors = await ctx.embedding.embed(texts, { timeoutMs: BACKGROUND_EMBED_TIMEOUT_MS });
     for (let i = 0; i < batch.length; i++) {
       ctx.vectorStore.upsert(batch[i].anchor, vectors[i]);
     }
@@ -61,7 +63,9 @@ export async function embedPassages(ctx: PassageEmbedPipelineContext): Promise<v
 
   for (let offset = 0; offset < ctx.passages.length; offset += PASSAGE_EMBED_BATCH_SIZE) {
     const batch = ctx.passages.slice(offset, offset + PASSAGE_EMBED_BATCH_SIZE);
-    const vectors = await ctx.embedding.embed(batch.map((p) => p.content));
+    const vectors = await ctx.embedding.embed(batch.map((p) => p.content), {
+      timeoutMs: BACKGROUND_EMBED_TIMEOUT_MS,
+    });
     for (let i = 0; i < batch.length; i++) {
       const passage = batch[i];
       ctx.passageVectorStore.upsert(passageVectorKey(passage.docAnchor, passage.passageId), vectors[i]);

--- a/packages/api/src/domains/memory/embed-utils.ts
+++ b/packages/api/src/domains/memory/embed-utils.ts
@@ -63,9 +63,12 @@ export async function embedPassages(ctx: PassageEmbedPipelineContext): Promise<v
 
   for (let offset = 0; offset < ctx.passages.length; offset += PASSAGE_EMBED_BATCH_SIZE) {
     const batch = ctx.passages.slice(offset, offset + PASSAGE_EMBED_BATCH_SIZE);
-    const vectors = await ctx.embedding.embed(batch.map((p) => p.content), {
-      timeoutMs: BACKGROUND_EMBED_TIMEOUT_MS,
-    });
+    const vectors = await ctx.embedding.embed(
+      batch.map((p) => p.content),
+      {
+        timeoutMs: BACKGROUND_EMBED_TIMEOUT_MS,
+      },
+    );
     for (let i = 0; i < batch.length; i++) {
       const passage = batch[i];
       ctx.passageVectorStore.upsert(passageVectorKey(passage.docAnchor, passage.passageId), vectors[i]);

--- a/packages/api/src/domains/memory/interfaces.ts
+++ b/packages/api/src/domains/memory/interfaces.ts
@@ -459,9 +459,16 @@ export interface EmbedModelInfo {
   dim: number;
 }
 
+export interface EmbedRequestOptions {
+  /** Cancel an in-flight online embedding request when its parent search is aborted. */
+  signal?: AbortSignal;
+  /** Per-call timeout override. Background indexing may be slower than online recall. */
+  timeoutMs?: number;
+}
+
 export interface IEmbeddingService {
   load(signal?: AbortSignal): Promise<void>;
-  embed(texts: string[], signal?: AbortSignal): Promise<Float32Array[]>;
+  embed(texts: string[], options?: EmbedRequestOptions): Promise<Float32Array[]>;
   isReady(): boolean;
   reprobeIfNeeded(signal?: AbortSignal): Promise<void>;
   getModelInfo(): EmbedModelInfo;
@@ -482,6 +489,8 @@ export function resolveEmbedConfig(partial?: Partial<EmbedConfig>): EmbedConfig 
     embedModel: model,
     embedDim: partial?.embedDim ?? 768, // LL-034: 768 is sweet spot for CJK bilingual; 256 too low
     maxModelMemMb: partial?.maxModelMemMb ?? 800,
+    // Online semantic/hybrid recall must fail open quickly. Background indexing
+    // supplies a longer per-call override through EmbedRequestOptions.
     embedTimeoutMs: partial?.embedTimeoutMs ?? 3000,
   };
 }

--- a/packages/api/test/memory/embed-utils.test.js
+++ b/packages/api/test/memory/embed-utils.test.js
@@ -6,11 +6,13 @@ describe('embedIndexedItems (shared utility with batch splitting + consistency c
     const { embedIndexedItems } = await import('../../dist/domains/memory/embed-utils.js');
 
     const batchSizes = [];
+    const timeoutOverrides = [];
     const mockEmbedding = {
       isReady: () => true,
       reprobeIfNeeded: async () => {},
-      embed: async (texts) => {
+      embed: async (texts, options) => {
         batchSizes.push(texts.length);
+        timeoutOverrides.push(options?.timeoutMs);
         return texts.map(() => new Float32Array([0.1, 0.2]));
       },
       getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
@@ -38,6 +40,7 @@ describe('embedIndexedItems (shared utility with batch splitting + consistency c
       `no batch should exceed 64, got: ${batchSizes}`,
     );
     assert.equal(batchSizes.length, 3, 'should split 150 into 3 batches (64+64+22)');
+    assert.deepEqual(timeoutOverrides, [120_000, 120_000, 120_000]);
   });
 
   it('handles exactly 64 items in single batch', async () => {
@@ -228,11 +231,13 @@ describe('embedPassages', () => {
     const { embedPassages } = await import('../../dist/domains/memory/embed-utils.js');
 
     const batchSizes = [];
+    const timeoutOverrides = [];
     const mockEmbedding = {
       isReady: () => true,
       reprobeIfNeeded: async () => {},
-      embed: async (texts) => {
+      embed: async (texts, options) => {
         batchSizes.push(texts.length);
+        timeoutOverrides.push(options?.timeoutMs);
         return texts.map(() => new Float32Array([0.1, 0.2]));
       },
       getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
@@ -255,7 +260,8 @@ describe('embedPassages', () => {
       passageVectorStore: mockPassageVectorStore,
     });
 
-    assert.deepEqual(batchSizes, [8, 8, 8, 8, 8], 'passage warmup should avoid bulk requests that hit 3s timeout');
+    assert.deepEqual(batchSizes, [8, 8, 8, 8, 8], 'passage warmup should use bounded batches');
+    assert.deepEqual(timeoutOverrides, [120_000, 120_000, 120_000, 120_000, 120_000]);
     assert.equal(upserted.length, 40, 'all passage vectors should still be written');
   });
 });

--- a/packages/api/test/memory/embedding-service.test.js
+++ b/packages/api/test/memory/embedding-service.test.js
@@ -111,12 +111,45 @@ describe('EmbeddingService (HTTP client to embed-api.py)', () => {
     const controller = new AbortController();
     const startedAt = Date.now();
     try {
-      const embedding = svc.embed(['abort me'], controller.signal);
+      const embedding = svc.embed(['abort me'], { signal: controller.signal });
       setTimeout(() => controller.abort(new DOMException('coverage deadline', 'AbortError')), 5);
       await assert.rejects(embedding, /coverage deadline|aborted/i);
       assert.ok(Date.now() - startedAt < 100, 'parent deadline should win over the embedding client timeout');
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('keeps online timeout short while allowing a per-call background override', async () => {
+    const { EmbeddingService } = await import('../../dist/domains/memory/EmbeddingService.js');
+    const svc = new EmbeddingService({
+      embedModel: 'qwen3-embedding-0.6b',
+      embedDim: 2,
+      embedTimeoutMs: 3000,
+      maxModelMemMb: 800,
+    });
+    svc.markReady();
+
+    const originalFetch = globalThis.fetch;
+    const originalTimeout = AbortSignal.timeout;
+    const timeoutCalls = [];
+    AbortSignal.timeout = (timeoutMs) => {
+      timeoutCalls.push(timeoutMs);
+      return new AbortController().signal;
+    };
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: [{ index: 0, embedding: [0.1, 0.2] }], model: 'mock' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+
+    try {
+      await svc.embed(['online query']);
+      await svc.embed(['background passage'], { timeoutMs: 120_000 });
+      assert.deepEqual(timeoutCalls, [3000, 120_000]);
+    } finally {
+      globalThis.fetch = originalFetch;
+      AbortSignal.timeout = originalTimeout;
     }
   });
 

--- a/packages/api/test/memory/library-register-rebuild.test.js
+++ b/packages/api/test/memory/library-register-rebuild.test.js
@@ -109,6 +109,7 @@ describe('library register + rebuild endpoints', () => {
     const lateDataDir = mkdtempSync(join(tmpdir(), 'lib-api-late-embed-'));
     const lateApp = Fastify();
     let embeddingService;
+    const embedOptions = [];
     await lateApp.register(libraryRoutes, {
       catalog: lateCatalog,
       stores: lateStores,
@@ -139,7 +140,10 @@ describe('library register + rebuild endpoints', () => {
       embeddingService = {
         isReady: () => true,
         reprobeIfNeeded: async () => {},
-        embed: async (texts) => texts.map(() => new Float32Array([1, 0, 0, 0])),
+        embed: async (texts, options) => {
+          embedOptions.push(options);
+          return texts.map(() => new Float32Array([1, 0, 0, 0]));
+        },
         getModelInfo: () => ({ modelId: 'test-model', modelRev: 'test', dim: 4 }),
       };
       const rebuild = await lateApp.inject({
@@ -149,6 +153,7 @@ describe('library register + rebuild endpoints', () => {
       assert.equal(rebuild.statusCode, 200, rebuild.payload);
       const db = lateStores.get('domain:late-embed').getDb();
       assert.equal(db.prepare('SELECT count(*) AS c FROM evidence_vectors').get().c, 1);
+      assert.deepEqual(embedOptions, [{ timeoutMs: 120_000 }]);
     } finally {
       for (const store of lateStores.values()) store.close?.();
       await lateApp.close();

--- a/scripts/services/python-resolve.sh
+++ b/scripts/services/python-resolve.sh
@@ -298,9 +298,13 @@ _install_project_python_locked() {
   fi
   local curl_log
   curl_log=$(mktemp) || curl_log=""
-  local curl_proxy_args=()
-  [ -n "$pbs_proxy" ] && [ -z "${HTTP_PROXY:-}${HTTPS_PROXY:-}" ] && curl_proxy_args=(-x "$pbs_proxy")
-  if ! curl -fL --silent --show-error "${curl_proxy_args[@]}" -o "${tmpdir}/python.tar.gz" -w "  HTTP status: %{http_code}  time: %{time_total}s  size: %{size_download} bytes\n" "$tar_url" 2>"${curl_log:-/dev/null}"; then
+  local curl_status=0
+  if [ -n "$pbs_proxy" ] && [ -z "${HTTP_PROXY:-}${HTTPS_PROXY:-}" ]; then
+    curl -fL --silent --show-error -x "$pbs_proxy" -o "${tmpdir}/python.tar.gz" -w "  HTTP status: %{http_code}  time: %{time_total}s  size: %{size_download} bytes\n" "$tar_url" 2>"${curl_log:-/dev/null}" || curl_status=$?
+  else
+    curl -fL --silent --show-error -o "${tmpdir}/python.tar.gz" -w "  HTTP status: %{http_code}  time: %{time_total}s  size: %{size_download} bytes\n" "$tar_url" 2>"${curl_log:-/dev/null}" || curl_status=$?
+  fi
+  if [ "$curl_status" -ne 0 ]; then
     echo "  Failed to download $tar_url" >&2
     if [ -n "$curl_log" ] && [ -s "$curl_log" ]; then
       echo "  curl error detail:" >&2

--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -936,6 +936,17 @@ describe('Whisper sidecar startup guards', () => {
   });
 });
 
+describe('POSIX Python resolver guards', () => {
+  it('does not expand empty curl proxy arrays under nounset', () => {
+    const resolver = readFileSync(resolve(ROOT, 'scripts/services/python-resolve.sh'), 'utf8');
+
+    assert.doesNotMatch(resolver, /curl_proxy_args/);
+    assert.match(resolver, /local curl_status=0/);
+    assert.match(resolver, /\|\| curl_status=\$\?/);
+    assert.match(resolver, /\[ "\$curl_status" -ne 0 \]/);
+  });
+});
+
 describe('Windows Python resolver guards', () => {
   it('does not block behind a Python install lock after another installer has finished', () => {
     const resolver = readFileSync(resolve(ROOT, 'scripts/services/python-resolve.ps1'), 'utf8');


### PR DESCRIPTION
## Summary

- fix macOS Bash 3.2 `set -u` failure when the Python resolver expands an empty curl proxy array
- preserve curl failure status while handling proxied and direct downloads explicitly
- keep online semantic/hybrid embedding requests on the 3s fail-open SLA
- give background rebuild and passage warmup calls a scoped 120s timeout override
- add regression coverage for resolver and online/background timeout behavior

## Root causes

1. `python-resolve.sh` used `${curl_proxy_args[@]}` with an empty Bash array. macOS Bash 3.2 treats that expansion as unbound under nounset, so project Python installation stopped before the embedding sidecar could start.
2. Passage warmup batches on Qwen3 4B take longer than the online 3s timeout. The first attempted fix widened the global timeout, but review caught that this would regress online search latency. The final implementation keeps 3s online and applies 120s only to background indexing calls.

## Verification

- `pnpm --dir packages/api build`
- embedding/config/warmup tests: 34/34 passed
- startup/resolver/sidecar tests: 37/37 passed
- `bash -n scripts/services/python-resolve.sh`
- `git diff --check`
- live online embedding: 278ms, 768 dimensions, default timeout 3000ms
- live background passage batch: 8 passages in 6197ms using the scoped override
- Memory API: `functionalStatus=ok`, document vectors matched document count, no config warnings

Reviewed and approved by a separate reviewer.

[宪宪/gpt-5.6-sol🐾]