### PR TITLE
fix(runtime): keep UI writes out of disposable checkout

### DIFF
--- a/packages/api/src/config/governance/list-all-projects.ts
+++ b/packages/api/src/config/governance/list-all-projects.ts
@@ -16,7 +16,8 @@
 
 import { readdir, realpath, stat } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
-
+import { resolvePersistentProjectPathDetailed } from '../../utils/persistent-project-path.js';
+import { pathsEqual } from '../../utils/project-path.js';
 import { GovernanceRegistry } from './governance-registry.js';
 
 /**
@@ -84,7 +85,19 @@ export async function listAllProjectPaths(catCafeRoot: string, opts?: { maxScanD
   const visitedDirs = new Set<string>();
   await scanNestedProjects(catCafeRoot, maxDepth, seen, result, visitedDirs);
 
-  return result;
+  const rootResolution = await resolvePersistentProjectPathDetailed(catCafeRoot);
+  const persistentRoot = rootResolution.ok ? rootResolution.path : resolvedRoot;
+  const canonicalResult: string[] = [];
+  for (const projectPath of result) {
+    const resolution = await resolvePersistentProjectPathDetailed(projectPath);
+    if (!resolution.ok) continue;
+    const persistentPath = resolution.remappedFrom ? resolution.path : projectPath;
+    if (pathsEqual(resolution.path, persistentRoot)) continue;
+    if (!canonicalResult.some((existing) => pathsEqual(existing, persistentPath))) {
+      canonicalResult.push(persistentPath);
+    }
+  }
+  return canonicalResult;
 }
 
 async function scanNestedProjects(

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -69,7 +69,8 @@ import { resolveActiveProjectRoot } from '../../../../../utils/active-project-ro
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
 import { findMonorepoRoot, isSameProject } from '../../../../../utils/monorepo-root.js';
-import { pathsEqual, validateProjectPathDetailed } from '../../../../../utils/project-path.js';
+import { resolvePersistentProjectPathDetailed } from '../../../../../utils/persistent-project-path.js';
+import { pathsEqual } from '../../../../../utils/project-path.js';
 import { tcpProbe } from '../../../../../utils/tcp-probe.js';
 import type { AgentPaneRegistry } from '../../../../terminal/agent-pane-registry.js';
 import type { TmuxGateway } from '../../../../terminal/tmux-gateway.js';
@@ -1216,9 +1217,11 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
           if (thread.projectPath.startsWith('games/')) {
             workspaceResolutionFailureMessage = `OpenCode requires a filesystem thread projectPath for ${threadId}; virtual game projectPath ${thread.projectPath} cannot be used as a working directory.`;
           } else {
-            const validatedProjectPath = await validateProjectPathDetailed(thread.projectPath);
+            const validatedProjectPath = await resolvePersistentProjectPathDetailed(thread.projectPath);
             if (!validatedProjectPath.ok) {
-              const isTransient = validatedProjectPath.reason === 'io_error';
+              const isTransient = ['io_error', 'runtime_root_invalid', 'runtime_workspace_missing'].includes(
+                validatedProjectPath.reason,
+              );
               workspaceResolutionFailureMessage = isTransient
                 ? `Unable to validate thread projectPath for ${threadId}: ${thread.projectPath}. ${validatedProjectPath.message ?? 'Transient filesystem error.'} Retry; if it persists, re-bind the thread's project workspace.`
                 : `Invalid thread projectPath for ${threadId}: ${thread.projectPath}. Expected an existing directory under allowed roots.`;
@@ -1234,6 +1237,29 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
               );
             } else {
               workingDirectory = validatedProjectPath.path;
+              if (validatedProjectPath.remappedFrom && threadStore.updateProjectPath) {
+                try {
+                  await preflightRace(
+                    Promise.resolve(threadStore.updateProjectPath(threadId, validatedProjectPath.path)),
+                    'updateProjectPath',
+                    signal,
+                  );
+                  log.info(
+                    {
+                      catId,
+                      threadId,
+                      previousProjectPath: validatedProjectPath.remappedFrom,
+                      projectPath: validatedProjectPath.path,
+                    },
+                    'migrated thread projectPath out of the runtime worktree',
+                  );
+                } catch (migrationErr) {
+                  log.warn(
+                    { catId, threadId, err: migrationErr, projectPath: validatedProjectPath.path },
+                    'failed to persist runtime projectPath migration; continuing with persistent workspace',
+                  );
+                }
+              }
             }
           }
         } else if (thread?.bootcampState) {

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -18,7 +18,7 @@ import { deleteCredential, hasCredential, writeCredential } from '../config/cred
 
 import { resolveActiveProjectRoot } from '../utils/active-project-root.js';
 import { findMonorepoRoot } from '../utils/monorepo-root.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPathDetailed } from '../utils/persistent-project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 
 // clowder-ai#340: Derive client identity from well-known account IDs, not stored protocol.
@@ -199,9 +199,12 @@ const deleteBodySchema = z.object({
 });
 
 async function resolveProjectRoot(projectPath?: string): Promise<string | null> {
-  if (!projectPath) return resolveActiveProjectRoot();
-  const validated = await validateProjectPath(projectPath);
-  if (validated) return validated;
+  if (!projectPath) return redirectRuntimeProjectPath(resolveActiveProjectRoot());
+  const persistent = await resolvePersistentProjectPathDetailed(projectPath);
+  if (persistent.ok) return persistent.path;
+  if (['runtime_root_invalid', 'runtime_workspace_missing', 'runtime_target_unmappable'].includes(persistent.reason)) {
+    return null;
+  }
 
   // Workspace project switcher can provide sibling repo paths (outside homedir/tmp allowlist).
   // Allow paths under current workspace root while keeping realpath boundary checks.

--- a/packages/api/src/routes/agent-hooks.ts
+++ b/packages/api/src/routes/agent-hooks.ts
@@ -5,7 +5,7 @@ import type { FastifyPluginAsync, FastifyRequest } from 'fastify';
 import { getAgentHookStatus, syncAgentHooks } from '../agent-hooks/index.js';
 import { findMonorepoRoot } from '../utils/monorepo-root.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 
 export interface AgentHooksRouteOptions {
   projectRoot?: string;
@@ -88,7 +88,7 @@ async function validateExplicitProjectPath(
 ): Promise<{ ok: true; path: string | null } | { ok: false; error: string }> {
   if (!rawPath) return { ok: true, path: null };
 
-  const validated = await validateProjectPath(rawPath);
+  const validated = await resolvePersistentProjectPath(rawPath);
   if (!validated) {
     return { ok: false, error: `Invalid project path: not found, denied, or not a directory: ${rawPath}` };
   }

--- a/packages/api/src/routes/callback-propose-thread-routes.ts
+++ b/packages/api/src/routes/callback-propose-thread-routes.ts
@@ -19,7 +19,7 @@ import type { IProposalStore } from '../domains/cats/services/stores/ports/Propo
 import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
 import type { SocketManager } from '../infrastructure/websocket/index.js';
 import { normalizeCatIdMentionsInText } from '../utils/cat-mention-handle.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { migrateStoredProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { requireCallbackAuth } from './callback-auth-prehandler.js';
 import { buildProposalCardBlock } from './proposal-card-block.js';
 
@@ -31,7 +31,7 @@ const proposeThreadCallbackSchema = z.object({
   // F128 Phase AA (AC-AA1): reporting contract. Omitted → default final-only (supersedes Phase Y AC-Y6 none).
   reportingMode: z.enum(['none', 'final-only', 'state-transitions', 'blocking-ack']).optional(),
   // F128: explicit project ownership for the child thread. Validated against allowed roots
-  // (validateProjectPath) — NOT hardcoded. Omitted → inherit source thread's projectPath;
+  // (resolvePersistentProjectPath) — NOT hardcoded. Omitted → inherit source thread's projectPath;
   // supplied-but-invalid → 400 (fail loud, never silently fall back to default).
   projectPath: z.string().min(1).max(500).optional(),
   parentThreadId: z.string().min(1).optional(),
@@ -148,12 +148,19 @@ export function registerCallbackProposeThreadRoutes(app: FastifyInstance, deps: 
     // thinks it pinned `clowder-ai` would land in `default` (砚砚 review push-back #1).
     let resolvedProjectPath = parentThread.projectPath; // omitted → inherit effective parent thread
     if (explicitProjectPath !== undefined) {
-      const validatedProjectPath = await validateProjectPath(explicitProjectPath);
+      const validatedProjectPath = await resolvePersistentProjectPath(explicitProjectPath);
       if (!validatedProjectPath) {
         reply.status(400);
         return { error: 'Invalid projectPath: must be an existing directory under allowed roots' };
       }
       resolvedProjectPath = validatedProjectPath; // supplied & valid → canonical real path
+    } else if (resolvedProjectPath && resolvedProjectPath !== 'default') {
+      const inheritedProjectPath = await migrateStoredProjectPath(resolvedProjectPath);
+      if (!inheritedProjectPath) {
+        reply.status(400);
+        return { error: 'Inherited projectPath no longer resolves to a persistent workspace' };
+      }
+      resolvedProjectPath = inheritedProjectPath;
     }
 
     // P2: Reserve dedup BEFORE create. Pre-generate a candidate proposalId, then atomically

--- a/packages/api/src/routes/capabilities-mcp-write.ts
+++ b/packages/api/src/routes/capabilities-mcp-write.ts
@@ -34,7 +34,7 @@ import {
   resolveCapabilityWriteSessionUserId,
 } from '../config/capabilities/capability-write-guards.js';
 import { syncMcpAll } from '../mcp/mcp-sync-all.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 import { resolveMainRepoPath } from '../utils/skill-mount.js';
 import { type McpProbeResult, probeMcpCapability } from './mcp-probe.js';
@@ -178,7 +178,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
 
     let projectRoot = getProjectRoot();
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -228,7 +228,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
 
     let projectRoot = getProjectRoot();
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -378,7 +378,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
 
     let projectRoot = getProjectRoot();
     if (query.projectPath) {
-      const validated = await validateProjectPath(query.projectPath);
+      const validated = await resolvePersistentProjectPath(query.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -515,7 +515,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
 
     let projectRoot = getProjectRoot();
     if (body?.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -588,7 +588,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
     let projectRoot = getProjectRoot();
     const body = request.body as { projectPath?: string } | undefined;
     if (body?.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -662,7 +662,7 @@ export const capabilitiesMcpWriteRoutes: FastifyPluginAsync<{
     let projectRoot = getProjectRoot();
     const query = request.query as { projectPath?: string; limit?: string };
     if (query.projectPath) {
-      const validated = await validateProjectPath(query.projectPath);
+      const validated = await resolvePersistentProjectPath(query.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path' };

--- a/packages/api/src/routes/capabilities.ts
+++ b/packages/api/src/routes/capabilities.ts
@@ -68,7 +68,12 @@ import {
 } from '../skills/skill-meta.js';
 import { syncAll } from '../skills/skill-sync-all.js';
 import { type MountConflict, syncProject } from '../skills/skill-sync-engine.js';
-import { pathsEqual, validateProjectPath } from '../utils/project-path.js';
+import {
+  redirectRuntimeProjectPath,
+  resolvePersistentProjectPath,
+  validateExternalProjectPathDetailed,
+} from '../utils/persistent-project-path.js';
+import { pathsEqual } from '../utils/project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 import {
   buildMountPointDirCandidates,
@@ -280,10 +285,6 @@ function findMonorepoRoot(): string {
 
 const PROJECT_ROOT = findMonorepoRoot();
 
-function getProjectRoot(): string {
-  return PROJECT_ROOT;
-}
-
 export async function buildKnownProjectPaths(
   catCafeRoot: string,
   projectRoot: string,
@@ -376,7 +377,7 @@ function resolveCatCafeSkillsSourceDir(): string {
     if (existsSync(candidate)) return join(dir, 'cat-cafe-skills');
     dir = dirname(dir);
   }
-  return join(getProjectRoot(), 'cat-cafe-skills');
+  return join(PROJECT_ROOT, 'cat-cafe-skills');
 }
 
 const CAT_CAFE_SKILLS_SRC = resolveCatCafeSkillsSourceDir();
@@ -531,6 +532,10 @@ function buildCatFamilies(): CatFamily[] {
 // ────────── Route Plugin ──────────
 
 export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
+  const persistentProjectRoot = await redirectRuntimeProjectPath(PROJECT_ROOT);
+  if (!persistentProjectRoot) throw new Error('Unable to resolve persistent global capabilities root');
+  const getProjectRoot = (): string => persistentProjectRoot;
+
   // ── GET /api/capabilities ──
   app.get('/api/capabilities', async (request, reply) => {
     const userId = resolveUserId(request);
@@ -545,7 +550,7 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
     const includeMcpLaunchFields = canReadSensitiveMcpConfig(request);
     let projectRoot = getProjectRoot();
     if (query.projectPath) {
-      const validated = await validateProjectPath(query.projectPath);
+      const validated = await resolvePersistentProjectPath(query.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path: must be an existing directory under allowed roots' };
@@ -1155,7 +1160,7 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
     const mainProjectRoot = getProjectRoot();
     let selectedProjectRoot = mainProjectRoot;
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path: must be an existing directory under allowed roots' };
@@ -1511,17 +1516,18 @@ export const capabilitiesRoutes: FastifyPluginAsync = async (app) => {
       return { error: 'Required: projectPath' };
     }
 
-    const validated = await validateProjectPath(body.projectPath);
-    if (!validated) {
-      reply.status(400);
-      return { error: 'Invalid project path' };
-    }
-
     const catCafeRoot = getProjectRoot();
-    if (validated === catCafeRoot) {
+    const validatedResult = await validateExternalProjectPathDetailed(body.projectPath, catCafeRoot);
+    if (!validatedResult.ok) {
       reply.status(400);
-      return { error: 'Cannot confirm governance for Clowder AI itself' };
+      return {
+        error:
+          validatedResult.reason === 'cat_cafe_owned_path'
+            ? 'Cannot confirm governance inside Clowder AI; choose an external project'
+            : 'Invalid project path',
+      };
     }
+    const validated = validatedResult.path;
 
     const { GovernanceBootstrapService } = await import('../config/governance/governance-bootstrap.js');
     const service = new GovernanceBootstrapService(catCafeRoot);

--- a/packages/api/src/routes/drift.ts
+++ b/packages/api/src/routes/drift.ts
@@ -18,12 +18,18 @@ import type { McpDriftResolution } from '../mcp/mcp-drift-resolver.js';
 import { syncMcpDrift, VALID_MCP_DRIFT_DECISIONS } from '../mcp/mcp-drift-resolver.js';
 import { syncDrift } from '../skills/drift-resolver.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveSessionUserId, resolveUserId } from '../utils/request-identity.js';
 import { resolveStartupProjectRoot } from '../utils/startup-root.js';
 import { computeSkillDrift } from './skills-drift.js';
 
 const STARTUP_REPO_ROOT = resolveStartupProjectRoot();
+
+async function resolveGlobalProjectRoot(): Promise<string> {
+  const root = await redirectRuntimeProjectPath(STARTUP_REPO_ROOT);
+  if (!root) throw new Error('Unable to resolve persistent global drift root');
+  return root;
+}
 const VALID_TYPES = ['skill', 'mcp'] as const;
 type DriftType = (typeof VALID_TYPES)[number];
 
@@ -97,13 +103,14 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // type === 'mcp'
-    const projectRoot = projectPath ? await validateProjectPath(projectPath) : null;
+    const projectRoot = projectPath ? await resolvePersistentProjectPath(projectPath) : null;
     if (projectPath && !projectRoot) {
       reply.status(400);
       return { error: 'Invalid project path' };
     }
-    const effectiveRoot = projectRoot ?? STARTUP_REPO_ROOT;
-    const drift = await checkMcpProject(effectiveRoot, STARTUP_REPO_ROOT);
+    const globalRoot = await resolveGlobalProjectRoot();
+    const effectiveRoot = projectRoot ?? globalRoot;
+    const drift = await checkMcpProject(effectiveRoot, globalRoot);
     const issues: DriftIssue[] = drift.issues.map((i) => ({
       id: i.mcpId,
       issueType: i.type,
@@ -152,7 +159,9 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     if (type === 'skill') {
-      const targetRoot = projectPath ? await validateProjectPath(projectPath) : STARTUP_REPO_ROOT;
+      const targetRoot = projectPath
+        ? await resolvePersistentProjectPath(projectPath)
+        : await resolveGlobalProjectRoot();
       if (!targetRoot) {
         reply.status(400);
         return { error: 'Invalid project path' };
@@ -207,20 +216,21 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
       resolutions = body.resolutions as McpDriftResolution[];
     }
 
-    const projectRoot = projectPath ? await validateProjectPath(projectPath) : null;
+    const projectRoot = projectPath ? await resolvePersistentProjectPath(projectPath) : null;
     if (projectPath && !projectRoot) {
       reply.status(400);
       return { error: 'Invalid project path' };
     }
-    const effectiveRoot = projectRoot ?? STARTUP_REPO_ROOT;
-    const drift = await checkMcpProject(effectiveRoot, STARTUP_REPO_ROOT);
+    const globalRoot = await resolveGlobalProjectRoot();
+    const effectiveRoot = projectRoot ?? globalRoot;
+    const drift = await checkMcpProject(effectiveRoot, globalRoot);
     if (drift.issues.length === 0) {
       return {
         action: 'sync',
         report: { added: [], removed: [], updated: [], skipped: [], syncedHash: drift.driftHash },
       };
     }
-    const report = await syncMcpDrift(effectiveRoot, STARTUP_REPO_ROOT, drift, resolutions, conflictPolicy);
+    const report = await syncMcpDrift(effectiveRoot, globalRoot, drift, resolutions, conflictPolicy);
     return { action: 'sync', report, projectRoot: effectiveRoot };
   });
 };

--- a/packages/api/src/routes/governance-status.ts
+++ b/packages/api/src/routes/governance-status.ts
@@ -11,7 +11,7 @@ import { promisify } from 'node:util';
 import type { FastifyPluginAsync } from 'fastify';
 import { checkGovernancePreflight } from '../config/governance/governance-preflight.js';
 import { findMonorepoRoot } from '../utils/monorepo-root.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 const execFileAsync = promisify(execFile);
@@ -67,7 +67,7 @@ export const governanceStatusRoute: FastifyPluginAsync<GovernanceStatusRouteOpti
       return { error: 'projectPath parameter is required' };
     }
 
-    const validated = await validateProjectPath(query.projectPath);
+    const validated = await resolvePersistentProjectPath(query.projectPath);
     if (!validated) {
       reply.status(403);
       return { error: 'Project path not allowed' };

--- a/packages/api/src/routes/mcp-drift.ts
+++ b/packages/api/src/routes/mcp-drift.ts
@@ -19,7 +19,7 @@ import type { McpDriftResolution } from '../mcp/mcp-drift-resolver.js';
 import { syncMcpDrift, VALID_MCP_DRIFT_DECISIONS } from '../mcp/mcp-drift-resolver.js';
 import { syncMcpAll } from '../mcp/mcp-sync-all.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
-import { pathsEqual, validateProjectPath } from '../utils/project-path.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveSessionUserId, resolveUserId } from '../utils/request-identity.js';
 import { resolveStartupProjectRoot } from '../utils/startup-root.js';
 import { probeMcpCapability } from './mcp-probe.js';
@@ -72,6 +72,12 @@ async function resolveProbeTarget(
 
 const STARTUP_REPO_ROOT = resolveStartupProjectRoot();
 
+async function resolveGlobalProjectRoot(): Promise<string> {
+  const root = await redirectRuntimeProjectPath(STARTUP_REPO_ROOT);
+  if (!root) throw new Error('Unable to resolve persistent global MCP root');
+  return root;
+}
+
 function requireMcpWriteAccess(request: FastifyRequest, reply: FastifyReply): { userId?: string; error?: string } {
   const userId = resolveSessionUserId(request);
   if (!userId) {
@@ -101,10 +107,12 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const body = (request.body ?? {}) as { projectPath?: string };
+    const globalRoot = await resolveGlobalProjectRoot();
 
-    // No projectPath or same as main → global drift check (aggregate all projects)
-    if (!body.projectPath || pathsEqual(body.projectPath, STARTUP_REPO_ROOT)) {
-      const globalDrift = await checkMcpGlobal(STARTUP_REPO_ROOT);
+    // An omitted projectPath means global aggregate. An explicit runtime path
+    // is resolved below so it cannot silently mutate the runtime checkout.
+    if (!body.projectPath) {
+      const globalDrift = await checkMcpGlobal(globalRoot);
       return {
         result: {
           perProject: globalDrift.perProject.map((p) => ({
@@ -119,13 +127,13 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // Specific project → single-project drift check
-    const projectRoot = await validateProjectPath(body.projectPath);
+    const projectRoot = await resolvePersistentProjectPath(body.projectPath);
     if (!projectRoot) {
       reply.status(400);
       return { error: 'Invalid project path' };
     }
 
-    const drift = await checkMcpProject(projectRoot, STARTUP_REPO_ROOT);
+    const drift = await checkMcpProject(projectRoot, globalRoot);
     return {
       result: {
         issues: drift.issues,
@@ -156,6 +164,7 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
       reply.status(400);
       return { error: 'Required: projectPath' };
     }
+    const globalRoot = await resolveGlobalProjectRoot();
 
     // #712 review: validate resolutions array against resolver contract (use-global | keep-project)
     const MAX_RESOLUTIONS = 200;
@@ -182,14 +191,14 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
       }
     }
 
-    const projectRoot = await validateProjectPath(body.projectPath);
+    const projectRoot = await resolvePersistentProjectPath(body.projectPath);
     if (!projectRoot) {
       reply.status(400);
       return { error: 'Invalid project path' };
     }
 
     // Re-compute drift (state may have changed since last check)
-    const drift = await checkMcpProject(projectRoot, STARTUP_REPO_ROOT);
+    const drift = await checkMcpProject(projectRoot, globalRoot);
     if (drift.issues.length === 0) {
       return {
         action: 'sync',
@@ -197,7 +206,7 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
       };
     }
 
-    const report = await syncMcpDrift(projectRoot, STARTUP_REPO_ROOT, drift, body.resolutions);
+    const report = await syncMcpDrift(projectRoot, globalRoot, drift, body.resolutions);
     return { action: 'sync', report, projectRoot };
   });
 
@@ -206,7 +215,7 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
     const access = requireMcpWriteAccess(request, reply);
     if (!access.userId) return { error: access.error };
 
-    const result = await syncMcpAll(STARTUP_REPO_ROOT);
+    const result = await syncMcpAll(await resolveGlobalProjectRoot());
     return result;
   });
 
@@ -262,9 +271,9 @@ export const mcpDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     // #712 P2-1: use project-scoped root when probing from a project tab
-    let probeRoot = STARTUP_REPO_ROOT;
+    let probeRoot = await resolveGlobalProjectRoot();
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: `Invalid project path: ${body.projectPath}` };

--- a/packages/api/src/routes/mount-rules.ts
+++ b/packages/api/src/routes/mount-rules.ts
@@ -30,8 +30,8 @@ import {
 import { syncAll } from '../skills/skill-sync-all.js';
 import { classifyMountPath, syncProject } from '../skills/skill-sync-engine.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolvePluginSkillSourcesForProject } from '../utils/plugin-skill-source.js';
-import { validateProjectPath } from '../utils/project-path.js';
 import { resolveSessionUserId, resolveUserId } from '../utils/request-identity.js';
 import { buildSkillMountTargets, createSkillSymlink, type MountTarget } from '../utils/skill-mount.js';
 import { resolveStartupProjectRoot } from '../utils/startup-root.js';
@@ -66,11 +66,12 @@ interface MountRulesRouteOptions {
 }
 
 export const mountRulesRoutes: FastifyPluginAsync<MountRulesRouteOptions> = async (app, opts) => {
-  const globalRoot = opts.mainProjectRoot ?? STARTUP_PROJECT_ROOT;
+  const globalRoot = await redirectRuntimeProjectPath(opts.mainProjectRoot ?? STARTUP_PROJECT_ROOT);
+  if (!globalRoot) throw new Error('Unable to resolve persistent global project root for mount rules');
 
   async function resolveTargetProjectRoot(projectPath?: string): Promise<string | null> {
     if (!projectPath) return globalRoot;
-    return validateProjectPath(projectPath);
+    return resolvePersistentProjectPath(projectPath);
   }
   app.get('/api/mount-rules', async (request, reply) => {
     const userId = resolveUserId(request);

--- a/packages/api/src/routes/projects-bootstrap.ts
+++ b/packages/api/src/routes/projects-bootstrap.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import type { BootstrapProgress, ExpeditionBootstrapService } from '../domains/memory/ExpeditionBootstrapService.js';
 import type { IndexStateManager } from '../domains/memory/IndexStateManager.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 interface SocketManagerLike {
@@ -33,7 +33,7 @@ export const projectsBootstrapRoutes: FastifyPluginAsync<BootstrapRoutesOptions>
         return { error: 'projectPath query parameter is required' };
       }
 
-      const validated = await validateProjectPath(projectPath);
+      const validated = await resolvePersistentProjectPath(projectPath);
       if (!validated) {
         reply.status(403);
         return { error: 'Project path not allowed' };
@@ -57,7 +57,7 @@ export const projectsBootstrapRoutes: FastifyPluginAsync<BootstrapRoutesOptions>
       return { error: 'projectPath is required' };
     }
 
-    const validated = await validateProjectPath(projectPath);
+    const validated = await resolvePersistentProjectPath(projectPath);
     if (!validated) {
       reply.status(403);
       return { error: 'Project path not allowed' };
@@ -105,7 +105,7 @@ export const projectsBootstrapRoutes: FastifyPluginAsync<BootstrapRoutesOptions>
       return { error: 'projectPath is required' };
     }
 
-    const validated = await validateProjectPath(projectPath);
+    const validated = await resolvePersistentProjectPath(projectPath);
     if (!validated) {
       reply.status(403);
       return { error: 'Project path not allowed' };

--- a/packages/api/src/routes/projects-mkdir.ts
+++ b/packages/api/src/routes/projects-mkdir.ts
@@ -7,7 +7,8 @@
 import { mkdir, stat } from 'node:fs/promises';
 import { basename, join, resolve } from 'node:path';
 import type { FastifyPluginAsync } from 'fastify';
-import { isUnderAllowedRoot, validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
+import { isUnderAllowedRoot } from '../utils/project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 /** Characters not allowed in directory names (cross-platform safe) */
@@ -37,7 +38,7 @@ export const mkdirRoute: FastifyPluginAsync = async (app) => {
     }
 
     // Validate parentPath exists and is under allowed roots
-    const validatedParent = await validateProjectPath(parentPath);
+    const validatedParent = await resolvePersistentProjectPath(parentPath);
     if (!validatedParent) {
       reply.status(403);
       return { error: 'Parent path not allowed' };

--- a/packages/api/src/routes/projects-setup.ts
+++ b/packages/api/src/routes/projects-setup.ts
@@ -9,7 +9,7 @@ import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FastifyPluginAsync } from 'fastify';
 import { findMonorepoRoot } from '../utils/monorepo-root.js';
-import { validateExternalProjectPathDetailed } from '../utils/persistent-project-path.js';
+import { redirectRuntimeProjectPath, validateExternalProjectPathDetailed } from '../utils/persistent-project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 const VALID_MODES = ['clone', 'init', 'skip'] as const;
@@ -133,6 +133,9 @@ async function isEmptyDir(dirPath: string): Promise<boolean> {
 }
 
 export const projectSetupRoute: FastifyPluginAsync<ProjectSetupRouteOptions> = async (app, opts) => {
+  const catCafeRoot = await redirectRuntimeProjectPath(opts.catCafeRoot ?? findMonorepoRoot(process.cwd()));
+  if (!catCafeRoot) throw new Error('Unable to resolve persistent Clowder AI root for project setup');
+
   app.post('/api/projects/setup', async (request, reply) => {
     const userId = resolveHeaderUserId(request);
     if (!userId) {
@@ -160,7 +163,6 @@ export const projectSetupRoute: FastifyPluginAsync<ProjectSetupRouteOptions> = a
       return { error: `mode must be one of: ${VALID_MODES.join(', ')}` };
     }
 
-    const catCafeRoot = opts?.catCafeRoot ?? findMonorepoRoot(process.cwd());
     const validatedResult = await validateExternalProjectPathDetailed(projectPath, catCafeRoot);
     if (!validatedResult.ok) {
       const isOwnedPath = validatedResult.reason === 'cat_cafe_owned_path';

--- a/packages/api/src/routes/projects-setup.ts
+++ b/packages/api/src/routes/projects-setup.ts
@@ -9,7 +9,7 @@ import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FastifyPluginAsync } from 'fastify';
 import { findMonorepoRoot } from '../utils/monorepo-root.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { validateExternalProjectPathDetailed } from '../utils/persistent-project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 const VALID_MODES = ['clone', 'init', 'skip'] as const;
@@ -160,18 +160,18 @@ export const projectSetupRoute: FastifyPluginAsync<ProjectSetupRouteOptions> = a
       return { error: `mode must be one of: ${VALID_MODES.join(', ')}` };
     }
 
-    const validated = await validateProjectPath(projectPath);
-    if (!validated) {
-      reply.status(403);
-      return { error: 'Project path not allowed' };
-    }
-
-    // Guard: never bootstrap Clowder AI's own directory (same as governance/confirm)
     const catCafeRoot = opts?.catCafeRoot ?? findMonorepoRoot(process.cwd());
-    if (validated === catCafeRoot) {
-      reply.status(400);
-      return { error: 'Cannot setup governance for Clowder AI itself' };
+    const validatedResult = await validateExternalProjectPathDetailed(projectPath, catCafeRoot);
+    if (!validatedResult.ok) {
+      const isOwnedPath = validatedResult.reason === 'cat_cafe_owned_path';
+      reply.status(isOwnedPath ? 400 : 403);
+      return {
+        error: isOwnedPath
+          ? 'Cannot setup governance inside Clowder AI; choose an external project'
+          : 'Project path not allowed',
+      };
     }
+    const validated = validatedResult.path;
 
     // ── Mode: clone ──
     if (mode === 'clone') {

--- a/packages/api/src/routes/projects.ts
+++ b/packages/api/src/routes/projects.ts
@@ -11,7 +11,8 @@ import { homedir } from 'node:os';
 import { basename, posix, resolve, win32 } from 'node:path';
 import { promisify } from 'node:util';
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
-import { getAllowedRoots, isDenylistMode, isUnderAllowedRoot, validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
+import { getAllowedRoots, isDenylistMode, isUnderAllowedRoot } from '../utils/project-path.js';
 import { resolveHeaderUserId } from '../utils/request-identity.js';
 
 const execFileAsync = promisify(execFile);
@@ -156,7 +157,7 @@ export const projectsRoutes: FastifyPluginAsync = async (app) => {
       reply.status(500);
       return { error: result.message };
     }
-    const validated = await validateProjectPath(result.path);
+    const validated = await resolvePersistentProjectPath(result.path);
     if (!validated) {
       reply.status(403);
       return {
@@ -188,7 +189,7 @@ export const projectsRoutes: FastifyPluginAsync = async (app) => {
     const { parentDir, fragment } = splitProjectCompletePrefix(prefix, cwd);
 
     // Validate parent directory
-    const validatedParent = await validateProjectPath(parentDir);
+    const validatedParent = await resolvePersistentProjectPath(parentDir);
     if (!validatedParent) {
       reply.status(403);
       return {
@@ -241,7 +242,7 @@ export const projectsRoutes: FastifyPluginAsync = async (app) => {
     const targetPath = query.path || homedir();
 
     // Validate path: realpath() resolves symlinks, then boundary check
-    const validatedPath = await validateProjectPath(targetPath);
+    const validatedPath = await resolvePersistentProjectPath(targetPath);
     if (!validatedPath) {
       reply.status(403);
       return {

--- a/packages/api/src/routes/proposal-approve-overrides.ts
+++ b/packages/api/src/routes/proposal-approve-overrides.ts
@@ -11,7 +11,7 @@
 
 import type { CatId, ProposalApproveOverrides, ReportingMode, ThreadProposal } from '@cat-cafe/shared';
 import type { IThreadStore } from '../domains/cats/services/stores/ports/ThreadStore.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { migrateStoredProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 
 /** Parsed approve-body overrides (preferredCats arrives as plain strings from zod). */
 export interface ApproveOverridesInput {
@@ -75,7 +75,7 @@ export async function resolveApproveOverrides(
   // `approving`, and a cat/user who thinks they pinned a repo never silently lands in `default`.
   let finalProjectPath = proposal.projectPath;
   if (overrides.projectPath !== undefined) {
-    const validatedProjectPath = await validateProjectPath(overrides.projectPath);
+    const validatedProjectPath = await resolvePersistentProjectPath(overrides.projectPath);
     if (!validatedProjectPath) {
       return {
         ok: false,
@@ -86,6 +86,17 @@ export async function resolveApproveOverrides(
     finalProjectPath = validatedProjectPath;
   } else if (reparentedThread) {
     finalProjectPath = reparentedThread.projectPath;
+  }
+  if (finalProjectPath && finalProjectPath !== 'default') {
+    const persistentProjectPath = await migrateStoredProjectPath(finalProjectPath);
+    if (!persistentProjectPath) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'Resolved projectPath no longer maps to a persistent workspace',
+      };
+    }
+    finalProjectPath = persistentProjectPath;
   }
 
   return {

--- a/packages/api/src/routes/proposal-routes.ts
+++ b/packages/api/src/routes/proposal-routes.ts
@@ -40,7 +40,7 @@ const approveBodySchema = z
     preferredCats: z.array(catIdSchema()).max(10).optional(),
     initialMessage: z.string().max(4000).nullable().optional(),
     // F128: let the user re-home the child thread at approve time. Validated against allowed
-    // roots (validateProjectPath) — supplied-but-invalid → 400 (fail loud, never silent default).
+    // roots (resolvePersistentProjectPath) — supplied-but-invalid → 400 (fail loud, never silent default).
     projectPath: z.string().min(1).max(500).optional(),
     reportingMode: z.enum(['none', 'final-only', 'state-transitions', 'blocking-ack']).optional(),
   })

--- a/packages/api/src/routes/rules.ts
+++ b/packages/api/src/routes/rules.ts
@@ -14,7 +14,8 @@ import type { CatCafeConfig } from '@cat-cafe/shared';
 import type { FastifyPluginAsync } from 'fastify';
 import { readCapabilitiesConfig } from '../config/capabilities/capability-orchestrator.js';
 import { getRoster, loadCatConfig, toAllCatConfigs } from '../config/cat-config-loader.js';
-import { getDefaultRootsForPlatform, isPathUnderRoots, validateProjectPath } from '../utils/project-path.js';
+import { resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
+import { getDefaultRootsForPlatform, isPathUnderRoots } from '../utils/project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 
 function findProjectRoot(): string {
@@ -251,7 +252,7 @@ export function isLegacySkillProjectPath(absPath: string, roots: string[] = getD
 
 async function findSkillPath(root: string, name: string, projectPath?: string): Promise<string | null> {
   const home = homedir();
-  const validatedProject = projectPath ? await validateProjectPath(projectPath) : null;
+  const validatedProject = projectPath ? await resolvePersistentProjectPath(projectPath) : null;
   const projectRoot = validatedProject && isLegacySkillProjectPath(validatedProject) ? validatedProject : root;
   const candidateDirs = [
     join(root, 'cat-cafe-skills'),

--- a/packages/api/src/routes/skills-drift.ts
+++ b/packages/api/src/routes/skills-drift.ts
@@ -20,7 +20,8 @@ import { readMountRules } from '../config/mount/mount-rules-store.js';
 import { checkGlobal, checkProject } from '../skills/drift-detector.js';
 import { syncDrift } from '../skills/drift-resolver.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
-import { pathsEqual, validateProjectPath } from '../utils/project-path.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
+import { pathsEqual } from '../utils/project-path.js';
 import { resolveSessionUserId, resolveUserId } from '../utils/request-identity.js';
 import { resolveCatCafeSkillsSource } from '../utils/skill-source.js';
 import { resolveStartupProjectRoot } from '../utils/startup-root.js';
@@ -62,9 +63,9 @@ export function fillDefaultMountPaths(policy: ProjectSkillMountPolicy, mountRule
   }
 }
 
-async function resolveTargetProjectRoot(projectPath?: string): Promise<string | null> {
-  if (!projectPath) return STARTUP_REPO_ROOT;
-  return validateProjectPath(projectPath);
+async function resolveTargetProjectRoot(projectPath?: string, defaultRoot = STARTUP_REPO_ROOT): Promise<string | null> {
+  if (!projectPath) return redirectRuntimeProjectPath(defaultRoot);
+  return resolvePersistentProjectPath(projectPath);
 }
 
 interface ProjectSkillMountPolicy {
@@ -226,10 +227,12 @@ async function loadDriftPolicies(projectRoot: string, globalProjectRoot: string)
  * and the unified /api/drift/check route can reuse it.
  */
 export async function computeSkillDrift(projectPath?: string, mainProjectRoot?: string) {
-  const projectRoot = await resolveTargetProjectRoot(projectPath);
-  if (!projectRoot) return null;
   const skillsSource = await resolveCatCafeSkillsSource();
-  const globalProjectRoot = mainProjectRoot ?? dirname(skillsSource);
+  const configuredGlobalRoot = mainProjectRoot ?? dirname(skillsSource);
+  const globalProjectRoot = await redirectRuntimeProjectPath(configuredGlobalRoot);
+  if (!globalProjectRoot) return null;
+  const projectRoot = await resolveTargetProjectRoot(projectPath, globalProjectRoot);
+  if (!projectRoot) return null;
   const isGlobalScope = !projectPath || pathsEqual(projectRoot, globalProjectRoot);
 
   if (isGlobalScope) {
@@ -342,7 +345,7 @@ export const skillsDriftRoutes: FastifyPluginAsync<SkillsDriftRouteOptions> = as
       return { error: 'Required: action ("sync")' };
     }
 
-    const targetRoot = await resolveTargetProjectRoot(body.projectPath);
+    const targetRoot = await resolveTargetProjectRoot(body.projectPath, opts.mainProjectRoot ?? STARTUP_REPO_ROOT);
     if (!targetRoot) {
       reply.status(400);
       return { error: 'Invalid project path: must be an existing directory under allowed roots' };

--- a/packages/api/src/routes/skills-write.ts
+++ b/packages/api/src/routes/skills-write.ts
@@ -18,8 +18,8 @@ import { validateSkillName } from '../config/governance/skill-sync.js';
 import { readMountRules } from '../config/mount/mount-rules-store.js';
 import { classifyMountPath, syncProject } from '../skills/skill-sync-engine.js';
 import { resolveOwnerGate } from '../utils/owner-gate.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolvePluginSkillSourcesForProject } from '../utils/plugin-skill-source.js';
-import { validateProjectPath } from '../utils/project-path.js';
 import { resolveSessionUserId } from '../utils/request-identity.js';
 import { buildSkillMountTargets, createSkillSymlink, resolveMainRepoPath } from '../utils/skill-mount.js';
 import { listSourceSkillNames } from '../utils/skill-source.js';
@@ -51,17 +51,18 @@ interface SkillsWriteRouteOptions {
 
 export const skillsWriteRoutes: FastifyPluginAsync<SkillsWriteRouteOptions> = async (app, opts) => {
   const CAT_CAFE_SKILLS_SRC = opts.skillsSourceDir ?? resolveSkillsSourceDir();
+  const skillsRepoRoot = dirname(CAT_CAFE_SKILLS_SRC);
+  const globalProjectRoot = await redirectRuntimeProjectPath(opts.mainProjectRoot ?? skillsRepoRoot);
+  if (!globalProjectRoot) throw new Error('Unable to resolve persistent global project root for skill writes');
 
   app.post('/api/skills/sync', async (request, reply) => {
     const access = requireSkillsWriteAccess(request, reply);
     if (access.error) return { error: access.error };
     const body = (request.body ?? {}) as { projectPath?: string };
     const skillsSrc = CAT_CAFE_SKILLS_SRC;
-    const skillsRepoRoot = dirname(skillsSrc);
-    const globalProjectRoot = opts.mainProjectRoot ?? skillsRepoRoot;
     let projectRoot = globalProjectRoot;
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path: must be an existing directory under allowed roots' };
@@ -183,10 +184,9 @@ export const skillsWriteRoutes: FastifyPluginAsync<SkillsWriteRouteOptions> = as
     }
 
     const skillsSrc = CAT_CAFE_SKILLS_SRC;
-    const globalProjectRoot = opts.mainProjectRoot ?? dirname(skillsSrc);
     let projectRoot = globalProjectRoot;
     if (body.projectPath) {
-      const validated = await validateProjectPath(body.projectPath);
+      const validated = await resolvePersistentProjectPath(body.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path: must be an existing directory under allowed roots' };

--- a/packages/api/src/routes/skills-write.ts
+++ b/packages/api/src/routes/skills-write.ts
@@ -21,7 +21,7 @@ import { resolveOwnerGate } from '../utils/owner-gate.js';
 import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolvePluginSkillSourcesForProject } from '../utils/plugin-skill-source.js';
 import { resolveSessionUserId } from '../utils/request-identity.js';
-import { buildSkillMountTargets, createSkillSymlink, resolveMainRepoPath } from '../utils/skill-mount.js';
+import { buildSkillMountTargets, createSkillSymlink } from '../utils/skill-mount.js';
 import { listSourceSkillNames } from '../utils/skill-source.js';
 import { resolveSkillsSourceDir } from './skills.js';
 
@@ -71,9 +71,8 @@ export const skillsWriteRoutes: FastifyPluginAsync<SkillsWriteRouteOptions> = as
     }
 
     return withCapabilityLock(projectRoot, async () => {
-      const mainRoot = opts.mainProjectRoot ?? (await resolveMainRepoPath());
       const [mountRules, globalConfig] = await Promise.all([
-        readMountRules(projectRoot, mainRoot),
+        readMountRules(projectRoot, globalProjectRoot),
         readCapabilitiesConfig(globalProjectRoot),
       ]);
 
@@ -200,8 +199,7 @@ export const skillsWriteRoutes: FastifyPluginAsync<SkillsWriteRouteOptions> = as
     }
 
     return withCapabilityLock(projectRoot, async () => {
-      const mainRoot = opts.mainProjectRoot ?? (await resolveMainRepoPath());
-      const mountRules = await readMountRules(projectRoot, mainRoot);
+      const mountRules = await readMountRules(projectRoot, globalProjectRoot);
       const globalConfig = await readCapabilitiesConfig(globalProjectRoot);
       const globalDisabledSkills = new Set<string>();
       const globalMountPaths = new Map<string, readonly string[]>();

--- a/packages/api/src/routes/skills.ts
+++ b/packages/api/src/routes/skills.ts
@@ -15,7 +15,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { readCapabilitiesConfig } from '../config/capabilities/capability-orchestrator.js';
 import { readMountRules } from '../config/mount/mount-rules-store.js';
 import { parseManifestSkillMeta, resolveSkillMcpStatuses, type SkillMcpDependency } from '../skills/skill-meta.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { redirectRuntimeProjectPath, resolvePersistentProjectPath } from '../utils/persistent-project-path.js';
 import { resolveUserId } from '../utils/request-identity.js';
 import {
   buildMountPointDirCandidates,
@@ -128,11 +128,16 @@ export const skillsRoutes: FastifyPluginAsync<SkillsRouteOptions> = async (app, 
       return { error: 'Identity required (session cookie or X-Cat-Cafe-User header)' };
     }
     const skillsSrc = CAT_CAFE_SKILLS_SRC;
-    const repoRoot = dirname(skillsSrc);
+    const sourceRepoRoot = dirname(skillsSrc);
+    const repoRoot = await redirectRuntimeProjectPath(sourceRepoRoot);
+    if (!repoRoot) {
+      reply.status(500);
+      return { error: 'Unable to resolve persistent global project root' };
+    }
     const query = request.query as { projectPath?: string };
     let projectRoot = repoRoot;
     if (query.projectPath) {
-      const validated = await validateProjectPath(query.projectPath);
+      const validated = await resolvePersistentProjectPath(query.projectPath);
       if (!validated) {
         reply.status(400);
         return { error: 'Invalid project path: must be an existing directory under allowed roots' };

--- a/packages/api/src/routes/skills.ts
+++ b/packages/api/src/routes/skills.ts
@@ -120,6 +120,14 @@ function collectCatCafeSkillPolicy(
 // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: GET /api/skills builds full skill inventory
 export const skillsRoutes: FastifyPluginAsync<SkillsRouteOptions> = async (app, opts) => {
   const CAT_CAFE_SKILLS_SRC = opts.skillsSourceDir ?? resolveSkillsSourceDir();
+  const sourceRepoRoot = dirname(CAT_CAFE_SKILLS_SRC);
+  const [defaultProjectRoot, mainProjectRoot] = await Promise.all([
+    redirectRuntimeProjectPath(sourceRepoRoot),
+    redirectRuntimeProjectPath(opts.mainProjectRoot ?? (await resolveMainRepoPath())),
+  ]);
+  if (!defaultProjectRoot || !mainProjectRoot) {
+    throw new Error('Unable to resolve persistent project roots for skills');
+  }
 
   app.get('/api/skills', async (request, reply) => {
     const userId = resolveUserId(request);
@@ -128,12 +136,7 @@ export const skillsRoutes: FastifyPluginAsync<SkillsRouteOptions> = async (app, 
       return { error: 'Identity required (session cookie or X-Cat-Cafe-User header)' };
     }
     const skillsSrc = CAT_CAFE_SKILLS_SRC;
-    const sourceRepoRoot = dirname(skillsSrc);
-    const repoRoot = await redirectRuntimeProjectPath(sourceRepoRoot);
-    if (!repoRoot) {
-      reply.status(500);
-      return { error: 'Unable to resolve persistent global project root' };
-    }
+    const repoRoot = defaultProjectRoot;
     const query = request.query as { projectPath?: string };
     let projectRoot = repoRoot;
     if (query.projectPath) {
@@ -145,7 +148,7 @@ export const skillsRoutes: FastifyPluginAsync<SkillsRouteOptions> = async (app, 
       projectRoot = validated;
     }
     const home = homedir();
-    const mainRepo = opts.mainProjectRoot ?? (await resolveMainRepoPath());
+    const mainRepo = mainProjectRoot;
     const mountRules = await readMountRules(projectRoot, mainRepo);
     const enabledMountPoints = STANDARD_MOUNT_POINT_IDS.filter((id) => mountRules.mountPoints[id].enabled);
     const mountPointDirCandidates = buildMountPointDirCandidates(projectRoot, home, mountRules);

--- a/packages/api/src/routes/threads.ts
+++ b/packages/api/src/routes/threads.ts
@@ -38,7 +38,7 @@ import type {
 import { SYSTEM_USER_IDS } from '../domains/cats/services/stores/visibility.js';
 import { createModuleLogger } from '../infrastructure/logger.js';
 import { CHATGPT_CHAT_URL_REGEX } from '../utils/chatgpt-chat-url.js';
-import { validateProjectPath } from '../utils/project-path.js';
+import { migrateStoredProjectPath, resolvePersistentProjectPathDetailed } from '../utils/persistent-project-path.js';
 import { resolveStrictUserId, resolveUserId } from '../utils/request-identity.js';
 import { getMultiMentionOrchestrator } from './callback-multi-mention-routes.js';
 
@@ -205,15 +205,18 @@ async function resolveCreateThreadProjectPath(
   }
 
   if (projectPath && projectPath !== 'default') {
-    const validated = await validateProjectPath(projectPath);
-    if (!validated) {
+    const resolved = await resolvePersistentProjectPathDetailed(projectPath);
+    if (!resolved.ok) {
+      const runtimeConfigError = ['runtime_root_invalid', 'runtime_workspace_missing'].includes(resolved.reason);
       return {
         ok: false,
-        statusCode: 400,
-        error: 'Invalid projectPath: must be an existing directory under allowed roots',
+        statusCode: runtimeConfigError ? 500 : 400,
+        error: runtimeConfigError
+          ? `Unable to resolve persistent workspace: ${resolved.message ?? resolved.reason}`
+          : 'Invalid projectPath: must be an existing directory under allowed roots',
       };
     }
-    return { ok: true, projectPath: validated };
+    return { ok: true, projectPath: resolved.path };
   }
 
   return { ok: true, projectPath };
@@ -243,6 +246,26 @@ export function sanitizeThreadForResponse(thread: Thread, _userId: string): Thre
   if (!hasPendingContinuation && !hasCloudCatBindings && !hasThreadMetadata) return thread;
   const { pendingContinuation: _pc, cloudCatBindings: _ccb, threadMetadata: _tm, ...sanitized } = thread;
   return sanitized as Thread;
+}
+
+async function migrateRuntimeProjectPath(thread: Thread, threadStore: IThreadStore): Promise<Thread> {
+  if (!thread.projectPath || thread.projectPath === 'default' || thread.projectPath.startsWith('games/')) {
+    return thread;
+  }
+  const previousProjectPath = thread.projectPath;
+  const migratedProjectPath = await migrateStoredProjectPath(previousProjectPath);
+  if (migratedProjectPath === previousProjectPath) return thread;
+  const projectPath = migratedProjectPath ?? 'default';
+
+  try {
+    await threadStore.updateProjectPath(thread.id, projectPath);
+  } catch (err) {
+    log.warn(
+      { err, threadId: thread.id, previousProjectPath, projectPath },
+      'failed to persist runtime projectPath migration during thread read',
+    );
+  }
+  return { ...thread, projectPath };
 }
 
 function isConciergeThread(thread: Thread): boolean {
@@ -391,7 +414,7 @@ export const threadsRoutes: FastifyPluginAsync<ThreadsRoutesOptions> = async (ap
     }
 
     reply.status(201);
-    return sanitizeThreadForResponse(thread, userId);
+    return sanitizeThreadForResponse(await migrateRuntimeProjectPath(thread, threadStore), userId);
   });
 
   // GET /api/threads - 列出用户的对话
@@ -418,8 +441,10 @@ export const threadsRoutes: FastifyPluginAsync<ThreadsRoutesOptions> = async (ap
 
     // F095 Phase D: Return soft-deleted threads when deleted=true
     if (showDeleted) {
-      let deletedThreads = (await threadStore.listDeleted(userId)).map((thread) =>
-        sanitizeThreadForResponse(thread, userId),
+      let deletedThreads = await Promise.all(
+        (await threadStore.listDeleted(userId)).map(async (thread) =>
+          sanitizeThreadForResponse(await migrateRuntimeProjectPath(thread, threadStore), userId),
+        ),
       );
       // F229: Apply the same concierge exclusion to the trash view.
       // Without this, a soft-deleted concierge thread appears in the default trash list;
@@ -431,8 +456,16 @@ export const threadsRoutes: FastifyPluginAsync<ThreadsRoutesOptions> = async (ap
       return { threads: deletedThreads };
     }
 
-    let threads = projectPath ? await threadStore.listByProject(userId, projectPath) : await threadStore.list(userId);
-    threads = threads.map((thread) => sanitizeThreadForResponse(thread, userId));
+    const migratedProjectPath = projectPath ? await migrateStoredProjectPath(projectPath) : undefined;
+    if (projectPath && migratedProjectPath === null) return { threads: [] };
+    let threads = migratedProjectPath
+      ? await threadStore.listByProject(userId, migratedProjectPath)
+      : await threadStore.list(userId);
+    threads = await Promise.all(
+      threads.map(async (thread) =>
+        sanitizeThreadForResponse(await migrateRuntimeProjectPath(thread, threadStore), userId),
+      ),
+    );
 
     // F229: Exclude concierge threads from default sidebar listing.
     // createdBy=userId (P1 fix) means threadStore.list(userId) includes concierge threads;
@@ -548,7 +581,7 @@ export const threadsRoutes: FastifyPluginAsync<ThreadsRoutesOptions> = async (ap
       return { error: 'Thread not found' };
     }
     const userId = resolveUserId(request, { defaultUserId: 'default-user' }) ?? 'default-user';
-    return sanitizeThreadForResponse(thread, userId);
+    return sanitizeThreadForResponse(await migrateRuntimeProjectPath(thread, threadStore), userId);
   });
 
   // PATCH /api/threads/:id - 更新标题/置顶/收藏

--- a/packages/api/src/routes/threads.ts
+++ b/packages/api/src/routes/threads.ts
@@ -458,8 +458,14 @@ export const threadsRoutes: FastifyPluginAsync<ThreadsRoutesOptions> = async (ap
 
     const migratedProjectPath = projectPath ? await migrateStoredProjectPath(projectPath) : undefined;
     if (projectPath && migratedProjectPath === null) return { threads: [] };
-    let threads = migratedProjectPath
-      ? await threadStore.listByProject(userId, migratedProjectPath)
+    const projectPathMatches =
+      projectPath && migratedProjectPath
+        ? await Promise.all(
+            [...new Set([projectPath, migratedProjectPath])].map((path) => threadStore.listByProject(userId, path)),
+          )
+        : null;
+    let threads = projectPathMatches
+      ? [...new Map(projectPathMatches.flat().map((thread) => [thread.id, thread] as const)).values()]
       : await threadStore.list(userId);
     threads = await Promise.all(
       threads.map(async (thread) =>

--- a/packages/api/src/utils/index.ts
+++ b/packages/api/src/utils/index.ts
@@ -14,5 +14,18 @@ export type {
 } from './cli-types.js';
 export { isParseError, parseNDJSON } from './ndjson-parser.js';
 export { normalizeErrorMessage } from './normalize-error.js';
+export type {
+  ExternalProjectPathResult,
+  PersistentProjectPathFailureReason,
+  PersistentProjectPathOptions,
+  PersistentProjectPathResult,
+} from './persistent-project-path.js';
+export {
+  migrateStoredProjectPath,
+  redirectRuntimeProjectPath,
+  resolvePersistentProjectPath,
+  resolvePersistentProjectPathDetailed,
+  validateExternalProjectPathDetailed,
+} from './persistent-project-path.js';
 export type { ProjectPathValidationFailureReason, ProjectPathValidationResult } from './project-path.js';
 export { isUnderAllowedRoot, validateProjectPath, validateProjectPathDetailed } from './project-path.js';

--- a/packages/api/src/utils/persistent-project-path.ts
+++ b/packages/api/src/utils/persistent-project-path.ts
@@ -1,0 +1,185 @@
+/**
+ * Persistent project-path boundary.
+ *
+ * The runtime checkout is a disposable binary worktree. User-owned project
+ * writes must target the persistent workspace, while portable governance must
+ * reject Cat Cafe itself (including descendants) because it is external-only.
+ */
+
+import { realpath, stat } from 'node:fs/promises';
+import { relative, resolve } from 'node:path';
+import {
+  isPathUnderRoots,
+  type ProjectPathValidationFailureReason,
+  pathsEqual,
+  validateProjectPathDetailed,
+} from './project-path.js';
+
+export type PersistentProjectPathFailureReason =
+  | ProjectPathValidationFailureReason
+  | 'runtime_root_invalid'
+  | 'runtime_workspace_missing'
+  | 'runtime_target_unmappable';
+
+export type PersistentProjectPathResult =
+  | { ok: true; path: string; remappedFrom?: string }
+  | { ok: false; reason: PersistentProjectPathFailureReason; message?: string };
+
+export type ExternalProjectPathResult =
+  | { ok: true; path: string }
+  | {
+      ok: false;
+      reason: ProjectPathValidationFailureReason | 'cat_cafe_root_invalid' | 'cat_cafe_owned_path';
+      message?: string;
+    };
+
+export interface PersistentProjectPathOptions {
+  runtimeRoot?: string;
+  workspaceRoot?: string;
+  realpath?: typeof realpath;
+  stat?: typeof stat;
+}
+
+/** Map a runtime-root path to the same relative path in the workspace. */
+export async function resolvePersistentProjectPathDetailed(
+  rawPath: string,
+  options: PersistentProjectPathOptions = {},
+): Promise<PersistentProjectPathResult> {
+  const target = await validateProjectPathDetailed(rawPath, options);
+  if (!target.ok) return target;
+
+  const runtimeRootRaw = options.runtimeRoot ?? process.env.CAT_CAFE_RUNTIME_ROOT;
+  if (!runtimeRootRaw) return target;
+
+  const runtimeRoot = await validateProjectPathDetailed(runtimeRootRaw, options);
+  if (!runtimeRoot.ok) {
+    return {
+      ok: false,
+      reason: 'runtime_root_invalid',
+      message: `CAT_CAFE_RUNTIME_ROOT is invalid: ${runtimeRoot.message ?? runtimeRoot.reason}`,
+    };
+  }
+  if (!isPathUnderRoots(target.path, [runtimeRoot.path])) return target;
+
+  const workspaceRootRaw = options.workspaceRoot ?? process.env.CAT_CAFE_WORKSPACE_ROOT;
+  if (!workspaceRootRaw) {
+    return {
+      ok: false,
+      reason: 'runtime_workspace_missing',
+      message: 'CAT_CAFE_WORKSPACE_ROOT is required for a project path inside CAT_CAFE_RUNTIME_ROOT',
+    };
+  }
+
+  const workspaceRoot = await validateProjectPathDetailed(workspaceRootRaw, options);
+  if (!workspaceRoot.ok) {
+    return {
+      ok: false,
+      reason: 'runtime_workspace_missing',
+      message: `CAT_CAFE_WORKSPACE_ROOT is invalid: ${workspaceRoot.message ?? workspaceRoot.reason}`,
+    };
+  }
+  if (pathsEqual(runtimeRoot.path, workspaceRoot.path)) return target;
+
+  return mapRuntimeTarget(target.path, runtimeRoot.path, workspaceRoot.path, options);
+}
+
+async function mapRuntimeTarget(
+  targetPath: string,
+  runtimeRoot: string,
+  workspaceRoot: string,
+  options: PersistentProjectPathOptions,
+): Promise<PersistentProjectPathResult> {
+  const mappedCandidate = resolve(workspaceRoot, relative(runtimeRoot, targetPath));
+  const mapped = await validateProjectPathDetailed(mappedCandidate, options);
+  if (!mapped.ok || !isPathUnderRoots(mapped.path, [workspaceRoot]) || isPathUnderRoots(mapped.path, [runtimeRoot])) {
+    return {
+      ok: false,
+      reason: 'runtime_target_unmappable',
+      message: mapped.ok
+        ? 'Mapped workspace target escapes the persistent workspace or remains inside the runtime root'
+        : `Matching workspace target is invalid: ${mapped.message ?? mapped.reason}`,
+    };
+  }
+
+  return { ok: true, path: mapped.path, remappedFrom: targetPath };
+}
+
+export async function resolvePersistentProjectPath(rawPath: string): Promise<string | null> {
+  const result = await resolvePersistentProjectPathDetailed(rawPath);
+  return result.ok ? result.path : null;
+}
+
+/** Redirect runtime-owned roots while preserving the caller's path spelling otherwise. */
+export async function redirectRuntimeProjectPath(
+  rawPath: string,
+  options: PersistentProjectPathOptions = {},
+): Promise<string | null> {
+  const result = await resolvePersistentProjectPathDetailed(rawPath, options);
+  if (!result.ok) return null;
+  return result.remappedFrom ? result.path : rawPath;
+}
+
+/**
+ * Migrate an already-stored project path without re-validating unrelated legacy values.
+ * Historical thread/proposal records may refer to an external directory that no longer
+ * exists, so only a value demonstrably inside the runtime checkout is fail-closed here.
+ */
+export async function migrateStoredProjectPath(
+  rawPath: string,
+  options: PersistentProjectPathOptions = {},
+): Promise<string | null> {
+  const result = await resolvePersistentProjectPathDetailed(rawPath, options);
+  if (result.ok) return result.remappedFrom ? result.path : rawPath;
+
+  const runtimeRootRaw = options.runtimeRoot ?? process.env.CAT_CAFE_RUNTIME_ROOT;
+  if (!runtimeRootRaw) return rawPath;
+
+  const lexicalRuntimeRoot = resolve(runtimeRootRaw);
+  const comparableRuntimeRoots = [lexicalRuntimeRoot];
+  try {
+    const canonicalRuntimeRoot = await (options.realpath ?? realpath)(lexicalRuntimeRoot);
+    if (!comparableRuntimeRoots.includes(canonicalRuntimeRoot)) comparableRuntimeRoots.push(canonicalRuntimeRoot);
+  } catch {
+    // The runtime checkout may already be gone. Lexical comparison still
+    // fail-closes ordinary descendants while preserving unrelated legacy paths.
+  }
+
+  return isPathUnderRoots(resolve(rawPath), comparableRuntimeRoots) ? null : rawPath;
+}
+
+/** Validate the external-only boundary used by portable governance. */
+export async function validateExternalProjectPathDetailed(
+  rawPath: string,
+  catCafeRoot: string,
+  options: PersistentProjectPathOptions = {},
+): Promise<ExternalProjectPathResult> {
+  const target = await validateProjectPathDetailed(rawPath, options);
+  if (!target.ok) return target;
+
+  const rootInputs = [
+    catCafeRoot,
+    options.runtimeRoot ?? process.env.CAT_CAFE_RUNTIME_ROOT,
+    options.workspaceRoot ?? process.env.CAT_CAFE_WORKSPACE_ROOT,
+  ].filter((root): root is string => Boolean(root));
+  const ownedRoots: string[] = [];
+  for (const rootInput of rootInputs) {
+    const root = await validateProjectPathDetailed(rootInput, options);
+    if (!root.ok) {
+      return {
+        ok: false,
+        reason: 'cat_cafe_root_invalid',
+        message: `Cat Cafe root is invalid: ${root.message ?? root.reason}`,
+      };
+    }
+    if (!ownedRoots.some((existing) => pathsEqual(existing, root.path))) ownedRoots.push(root.path);
+  }
+
+  if (isPathUnderRoots(target.path, ownedRoots)) {
+    return {
+      ok: false,
+      reason: 'cat_cafe_owned_path',
+      message: 'Portable governance can only bootstrap an external project, not Cat Cafe or its descendants',
+    };
+  }
+  return target;
+}

--- a/packages/api/src/utils/persistent-project-path.ts
+++ b/packages/api/src/utils/persistent-project-path.ts
@@ -40,6 +40,31 @@ export interface PersistentProjectPathOptions {
   stat?: typeof stat;
 }
 
+type DirectoryPathResult =
+  | { ok: true; path: string }
+  | { ok: false; reason: Exclude<ProjectPathValidationFailureReason, 'denied_root'>; message?: string };
+
+function isStoredProjectPathSentinel(rawPath: string): boolean {
+  return rawPath === 'default' || rawPath.startsWith('games/');
+}
+
+async function resolveInternalDirectoryPath(
+  rawPath: string,
+  options: PersistentProjectPathOptions,
+): Promise<DirectoryPathResult> {
+  try {
+    const path = await (options.realpath ?? realpath)(resolve(rawPath));
+    const info = await (options.stat ?? stat)(path);
+    if (!info.isDirectory()) return { ok: false, reason: 'not_directory' };
+    return { ok: true, path };
+  } catch (err) {
+    const code =
+      typeof err === 'object' && err !== null && 'code' in err ? String((err as { code?: unknown }).code) : undefined;
+    const message = err instanceof Error ? err.message : undefined;
+    return { ok: false, reason: ['ENOENT', 'ENOTDIR'].includes(code ?? '') ? 'not_found' : 'io_error', message };
+  }
+}
+
 /** Map a runtime-root path to the same relative path in the workspace. */
 export async function resolvePersistentProjectPathDetailed(
   rawPath: string,
@@ -51,7 +76,10 @@ export async function resolvePersistentProjectPathDetailed(
   const runtimeRootRaw = options.runtimeRoot ?? process.env.CAT_CAFE_RUNTIME_ROOT;
   if (!runtimeRootRaw) return target;
 
-  const runtimeRoot = await validateProjectPathDetailed(runtimeRootRaw, options);
+  // Runtime is an internal disposable checkout, not a user-selectable project.
+  // Canonicalize it without applying PROJECT_ALLOWED_ROOTS, then apply project
+  // policy only to the requested target and persistent workspace destination.
+  const runtimeRoot = await resolveInternalDirectoryPath(runtimeRootRaw, options);
   if (!runtimeRoot.ok) {
     return {
       ok: false,
@@ -128,6 +156,8 @@ export async function migrateStoredProjectPath(
   rawPath: string,
   options: PersistentProjectPathOptions = {},
 ): Promise<string | null> {
+  if (isStoredProjectPathSentinel(rawPath)) return rawPath;
+
   const result = await resolvePersistentProjectPathDetailed(rawPath, options);
   if (result.ok) return result.remappedFrom ? result.path : rawPath;
 

--- a/packages/api/src/utils/persistent-project-path.ts
+++ b/packages/api/src/utils/persistent-project-path.ts
@@ -70,15 +70,14 @@ export async function resolvePersistentProjectPathDetailed(
   rawPath: string,
   options: PersistentProjectPathOptions = {},
 ): Promise<PersistentProjectPathResult> {
-  const target = await validateProjectPathDetailed(rawPath, options);
-  if (!target.ok) return target;
-
   const runtimeRootRaw = options.runtimeRoot ?? process.env.CAT_CAFE_RUNTIME_ROOT;
-  if (!runtimeRootRaw) return target;
+  if (!runtimeRootRaw) return validateProjectPathDetailed(rawPath, options);
 
   // Runtime is an internal disposable checkout, not a user-selectable project.
-  // Canonicalize it without applying PROJECT_ALLOWED_ROOTS, then apply project
-  // policy only to the requested target and persistent workspace destination.
+  // Canonicalize both sides without applying PROJECT_ALLOWED_ROOTS so a runtime
+  // input can be identified before project policy is applied to its destination.
+  const target = await resolveInternalDirectoryPath(rawPath, options);
+  if (!target.ok) return target;
   const runtimeRoot = await resolveInternalDirectoryPath(runtimeRootRaw, options);
   if (!runtimeRoot.ok) {
     return {
@@ -87,7 +86,9 @@ export async function resolvePersistentProjectPathDetailed(
       message: `CAT_CAFE_RUNTIME_ROOT is invalid: ${runtimeRoot.message ?? runtimeRoot.reason}`,
     };
   }
-  if (!isPathUnderRoots(target.path, [runtimeRoot.path])) return target;
+  if (!isPathUnderRoots(target.path, [runtimeRoot.path])) {
+    return validateProjectPathDetailed(target.path, options);
+  }
 
   const workspaceRootRaw = options.workspaceRoot ?? process.env.CAT_CAFE_WORKSPACE_ROOT;
   if (!workspaceRootRaw) {
@@ -106,7 +107,9 @@ export async function resolvePersistentProjectPathDetailed(
       message: `CAT_CAFE_WORKSPACE_ROOT is invalid: ${workspaceRoot.message ?? workspaceRoot.reason}`,
     };
   }
-  if (pathsEqual(runtimeRoot.path, workspaceRoot.path)) return target;
+  if (pathsEqual(runtimeRoot.path, workspaceRoot.path)) {
+    return validateProjectPathDetailed(target.path, options);
+  }
 
   return mapRuntimeTarget(target.path, runtimeRoot.path, workspaceRoot.path, options);
 }
@@ -193,7 +196,7 @@ export async function validateExternalProjectPathDetailed(
   ].filter((root): root is string => Boolean(root));
   const ownedRoots: string[] = [];
   for (const rootInput of rootInputs) {
-    const root = await validateProjectPathDetailed(rootInput, options);
+    const root = await resolveInternalDirectoryPath(rootInput, options);
     if (!root.ok) {
       return {
         ok: false,

--- a/packages/api/test/capabilities-route.test.js
+++ b/packages/api/test/capabilities-route.test.js
@@ -1539,6 +1539,47 @@ describe('GET /api/capabilities (Fastify)', () => {
     await app.close();
   });
 
+  it('keeps global capability writes persistent and rejects governance under Cat Cafe descendants', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { capabilitiesRoutes } = await import('../dist/routes/capabilities.js');
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    const runtimeRoot = findRepoRoot();
+    const workspaceRoot = await makeTmpDir('persistent-global-root');
+    const internalPackage = join(workspaceRoot, 'packages', 'api');
+    await mkdir(internalPackage, { recursive: true });
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const app = Fastify();
+
+    try {
+      await app.register(capabilitiesRoutes);
+      await app.ready();
+
+      const getRes = await app.inject({ method: 'GET', url: '/api/capabilities', headers: AUTH_HEADERS });
+      assert.equal(getRes.statusCode, 200, getRes.body);
+      assert.equal(getRes.json().projectPath, await realpath(workspaceRoot));
+      assert.ok(await readCapabilitiesConfig(workspaceRoot), 'global config must be written to the workspace');
+
+      const confirmRes = await app.inject({
+        method: 'POST',
+        url: '/api/governance/confirm',
+        headers: AUTH_HEADERS,
+        payload: { projectPath: internalPackage },
+      });
+      assert.equal(confirmRes.statusCode, 400, confirmRes.body);
+      assert.match(confirmRes.json().error, /external project/i);
+      assert.deepEqual(await readdir(internalPackage), []);
+    } finally {
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
+      await app.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('returns only catCafeRoot and projectRoot (not governance registry)', async () => {
     const { buildKnownProjectPaths } = await import('../dist/routes/capabilities.js');
 

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -7047,6 +7047,57 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(optionsSeen[0]?.workingDirectory, projectRoot);
   });
 
+  it('migrates a legacy runtime-root thread before invoking the agent', async () => {
+    const workspaceRoot = await realpath(join(__dirname, '..', '..', '..'));
+    const runtimeRoot = await realpath(await mkdtemp(join(tmpdir(), 'legacy-thread-runtime-root-')));
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+
+    const optionsSeen = [];
+    const migrations = [];
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        optionsSeen.push(options ?? {});
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+    const threadId = 'thread-legacy-runtime-root';
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: runtimeRoot, createdBy: 'user1' }),
+        updateProjectPath: async (...args) => migrations.push(args),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    try {
+      const msgs = await collect(
+        invokeSingleCat(deps, {
+          catId: 'opencode',
+          service,
+          prompt: 'test legacy runtime cwd migration',
+          userId: 'user1',
+          threadId,
+          isLastCat: true,
+        }),
+      );
+
+      assert.ok(msgs.some((m) => m.type === 'done'));
+      assert.equal(optionsSeen[0]?.workingDirectory, workspaceRoot);
+      assert.deepEqual(migrations, [[threadId, workspaceRoot]]);
+    } finally {
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
+      await rmWithRetry(runtimeRoot);
+    }
+  });
+
   it('drops OpenCode resume when the stored session workspace differs from the current thread workspace', async () => {
     const repoA = await makeSameProjectWorkspace('opencode-repo-a-');
     const repoB = await makeSameProjectWorkspace('opencode-repo-b-');

--- a/packages/api/test/mount-rules-route.test.js
+++ b/packages/api/test/mount-rules-route.test.js
@@ -67,6 +67,50 @@ function expectedSymlinkTarget(linkPath, sourcePath) {
 }
 
 describe('Mount Rules Route (F228)', () => {
+  it('PUT /api/mount-rules persists provider rules outside the runtime worktree', async () => {
+    const prevOwner = process.env.DEFAULT_OWNER_USER_ID;
+    const prevRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const prevWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    process.env.DEFAULT_OWNER_USER_ID = OWNER_ID;
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'mount-rules-runtime-root-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'mount-rules-workspace-root-'));
+    const canonicalWorkspaceRoot = await realpath(workspaceRoot);
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const rules = {
+      ...DEFAULT_MOUNT_RULES,
+      mountPoints: Object.fromEntries(
+        Object.entries(DEFAULT_MOUNT_RULES.mountPoints).map(([id, provider]) => [id, { ...provider, enabled: false }]),
+      ),
+      customPaths: [],
+    };
+    const app = await buildMountRulesApp({ mainProjectRoot: canonicalWorkspaceRoot });
+
+    try {
+      const res = await app.inject({
+        method: 'PUT',
+        url: '/api/mount-rules',
+        headers: LOCAL_WRITE_HEADERS,
+        payload: { projectPath: runtimeRoot, rules },
+      });
+
+      assert.equal(res.statusCode, 200, res.body);
+      assert.equal(JSON.parse(res.body).projectRoot, canonicalWorkspaceRoot);
+      assert.equal(await exists(join(workspaceRoot, '.cat-cafe/capabilities.json')), true);
+      assert.equal(await exists(join(runtimeRoot, '.cat-cafe/capabilities.json')), false);
+    } finally {
+      if (prevOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = prevOwner;
+      if (prevRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = prevRuntimeRoot;
+      if (prevWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = prevWorkspaceRoot;
+      await app.close();
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('PUT /api/mount-rules waits for capability lock before writing project rules', async () => {
     const prevOwner = process.env.DEFAULT_OWNER_USER_ID;
     process.env.DEFAULT_OWNER_USER_ID = OWNER_ID;

--- a/packages/api/test/project-path.test.js
+++ b/packages/api/test/project-path.test.js
@@ -271,6 +271,32 @@ describe('resolvePersistentProjectPathDetailed', () => {
     assert.equal(await migrateStoredProjectPath(raw, { runtimeRoot, workspaceRoot }), raw);
   });
 
+  it('preserves virtual game project paths during stored ownership migration', async () => {
+    const virtualProjectPath = 'games/werewolf';
+
+    assert.equal(
+      await migrateStoredProjectPath(virtualProjectPath, {
+        runtimeRoot: process.cwd(),
+        workspaceRoot,
+      }),
+      virtualProjectPath,
+    );
+  });
+
+  it('does not require the internal runtime root to be project-allowlisted for an external target', async () => {
+    const previousAllowedRoots = process.env.PROJECT_ALLOWED_ROOTS;
+    process.env.PROJECT_ALLOWED_ROOTS = realpathSync(externalProject);
+
+    try {
+      const result = await resolvePersistentProjectPathDetailed(externalProject, { runtimeRoot, workspaceRoot });
+
+      assert.deepStrictEqual(result, { ok: true, path: realpathSync(externalProject) });
+    } finally {
+      if (previousAllowedRoots === undefined) delete process.env.PROJECT_ALLOWED_ROOTS;
+      else process.env.PROJECT_ALLOWED_ROOTS = previousAllowedRoots;
+    }
+  });
+
   it('fails closed for a missing stored path lexically inside runtime', async () => {
     assert.equal(await migrateStoredProjectPath(join(runtimeRoot, 'missing'), { runtimeRoot, workspaceRoot }), null);
   });

--- a/packages/api/test/project-path.test.js
+++ b/packages/api/test/project-path.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync } from 'node:fs';
 import { realpath } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { after, before, describe, it } from 'node:test';
 
 const {
@@ -14,6 +14,12 @@ const {
   isPathUnderRoots,
   isDenylistMode,
 } = await import('../dist/utils/project-path.js');
+const {
+  migrateStoredProjectPath,
+  redirectRuntimeProjectPath,
+  resolvePersistentProjectPathDetailed,
+  validateExternalProjectPathDetailed,
+} = await import('../dist/utils/persistent-project-path.js');
 
 describe('denylist mode (default)', () => {
   let savedAllowedRoots;
@@ -178,6 +184,131 @@ describe('validateProjectPath', () => {
     } catch {
       // symlink creation may fail in sandboxed environments
     }
+  });
+});
+
+describe('resolvePersistentProjectPathDetailed', () => {
+  let testDir;
+  let runtimeRoot;
+  let workspaceRoot;
+  let runtimePackage;
+  let workspacePackage;
+  let externalProject;
+
+  before(() => {
+    testDir = mkdtempSync('/tmp/cat-cafe-persistent-project-path-');
+    runtimeRoot = join(testDir, 'cat-cafe-runtime');
+    workspaceRoot = join(testDir, 'cat-cafe');
+    runtimePackage = join(runtimeRoot, 'packages', 'api');
+    workspacePackage = join(workspaceRoot, 'packages', 'api');
+    externalProject = join(testDir, 'external-project');
+    mkdirSync(runtimePackage, { recursive: true });
+    mkdirSync(workspacePackage, { recursive: true });
+    mkdirSync(externalProject, { recursive: true });
+  });
+
+  after(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('remaps the runtime root to the persistent workspace root', async () => {
+    const result = await resolvePersistentProjectPathDetailed(runtimeRoot, { runtimeRoot, workspaceRoot });
+
+    assert.deepStrictEqual(result, {
+      ok: true,
+      path: realpathSync(workspaceRoot),
+      remappedFrom: realpathSync(runtimeRoot),
+    });
+    assert.equal(
+      await redirectRuntimeProjectPath(runtimeRoot, { runtimeRoot, workspaceRoot }),
+      realpathSync(workspaceRoot),
+    );
+  });
+
+  it('preserves a runtime descendant relative path when remapping to the workspace', async () => {
+    const result = await resolvePersistentProjectPathDetailed(runtimePackage, { runtimeRoot, workspaceRoot });
+
+    assert.deepStrictEqual(result, {
+      ok: true,
+      path: realpathSync(workspacePackage),
+      remappedFrom: realpathSync(runtimePackage),
+    });
+  });
+
+  it('leaves an external project unchanged', async () => {
+    const result = await resolvePersistentProjectPathDetailed(externalProject, { runtimeRoot, workspaceRoot });
+
+    assert.deepStrictEqual(result, { ok: true, path: realpathSync(externalProject) });
+    assert.equal(
+      await redirectRuntimeProjectPath(externalProject, { runtimeRoot, workspaceRoot }),
+      externalProject,
+      'configured roots outside runtime retain the caller path spelling',
+    );
+  });
+
+  it('leaves an in-place deployment root unchanged', async () => {
+    const result = await resolvePersistentProjectPathDetailed(workspacePackage, {
+      runtimeRoot: workspaceRoot,
+      workspaceRoot,
+    });
+
+    assert.deepStrictEqual(result, { ok: true, path: realpathSync(workspacePackage) });
+  });
+
+  it('fails closed when the matching workspace descendant does not exist', async () => {
+    const runtimeOnly = join(runtimeRoot, 'runtime-only');
+    mkdirSync(runtimeOnly);
+
+    const result = await resolvePersistentProjectPathDetailed(runtimeOnly, { runtimeRoot, workspaceRoot });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'runtime_target_unmappable');
+  });
+
+  it('preserves a missing external legacy path when migrating stored ownership', async () => {
+    const raw = join(testDir, 'missing-external');
+
+    assert.equal(await migrateStoredProjectPath(raw, { runtimeRoot, workspaceRoot }), raw);
+  });
+
+  it('fails closed for a missing stored path lexically inside runtime', async () => {
+    assert.equal(await migrateStoredProjectPath(join(runtimeRoot, 'missing'), { runtimeRoot, workspaceRoot }), null);
+  });
+
+  it('fails closed for a missing stored runtime path across a canonical root alias', async () => {
+    const runtimeAlias = join(testDir, 'runtime-alias');
+    const canonicalRuntimeRoot = realpathSync(runtimeRoot);
+    const canonicalMissingPath = join(canonicalRuntimeRoot, 'missing-through-alias');
+    const realpathWithAlias = async (path) => {
+      if (resolve(path) === resolve(runtimeAlias)) return canonicalRuntimeRoot;
+      return realpath(path);
+    };
+
+    assert.equal(
+      await migrateStoredProjectPath(canonicalMissingPath, {
+        runtimeRoot: runtimeAlias,
+        workspaceRoot,
+        realpath: realpathWithAlias,
+      }),
+      null,
+    );
+  });
+
+  it('rejects Cat Cafe runtime and workspace descendants as external governance targets', async () => {
+    for (const target of [runtimeRoot, runtimePackage, workspaceRoot, workspacePackage]) {
+      const result = await validateExternalProjectPathDetailed(target, runtimeRoot, { runtimeRoot, workspaceRoot });
+      assert.equal(result.ok, false, `${target} must not be treated as an external project`);
+      assert.equal(result.reason, 'cat_cafe_owned_path');
+    }
+  });
+
+  it('accepts a project outside both Cat Cafe checkouts as an external governance target', async () => {
+    const result = await validateExternalProjectPathDetailed(externalProject, runtimeRoot, {
+      runtimeRoot,
+      workspaceRoot,
+    });
+
+    assert.deepStrictEqual(result, { ok: true, path: realpathSync(externalProject) });
   });
 });
 

--- a/packages/api/test/project-path.test.js
+++ b/packages/api/test/project-path.test.js
@@ -297,6 +297,24 @@ describe('resolvePersistentProjectPathDetailed', () => {
     }
   });
 
+  it('remaps a runtime target before applying the project allowlist to the workspace', async () => {
+    const previousAllowedRoots = process.env.PROJECT_ALLOWED_ROOTS;
+    process.env.PROJECT_ALLOWED_ROOTS = realpathSync(workspaceRoot);
+
+    try {
+      const result = await resolvePersistentProjectPathDetailed(runtimePackage, { runtimeRoot, workspaceRoot });
+
+      assert.deepStrictEqual(result, {
+        ok: true,
+        path: realpathSync(workspacePackage),
+        remappedFrom: realpathSync(runtimePackage),
+      });
+    } finally {
+      if (previousAllowedRoots === undefined) delete process.env.PROJECT_ALLOWED_ROOTS;
+      else process.env.PROJECT_ALLOWED_ROOTS = previousAllowedRoots;
+    }
+  });
+
   it('fails closed for a missing stored path lexically inside runtime', async () => {
     assert.equal(await migrateStoredProjectPath(join(runtimeRoot, 'missing'), { runtimeRoot, workspaceRoot }), null);
   });
@@ -335,6 +353,23 @@ describe('resolvePersistentProjectPathDetailed', () => {
     });
 
     assert.deepStrictEqual(result, { ok: true, path: realpathSync(externalProject) });
+  });
+
+  it('does not apply the project allowlist to internal governance exclusion roots', async () => {
+    const previousAllowedRoots = process.env.PROJECT_ALLOWED_ROOTS;
+    process.env.PROJECT_ALLOWED_ROOTS = realpathSync(externalProject);
+
+    try {
+      const result = await validateExternalProjectPathDetailed(externalProject, runtimeRoot, {
+        runtimeRoot,
+        workspaceRoot,
+      });
+
+      assert.deepStrictEqual(result, { ok: true, path: realpathSync(externalProject) });
+    } finally {
+      if (previousAllowedRoots === undefined) delete process.env.PROJECT_ALLOWED_ROOTS;
+      else process.env.PROJECT_ALLOWED_ROOTS = previousAllowedRoots;
+    }
   });
 });
 

--- a/packages/api/test/routes/projects-setup.test.js
+++ b/packages/api/test/routes/projects-setup.test.js
@@ -142,6 +142,42 @@ describe('POST /api/projects/setup', () => {
     assert.equal(res.statusCode, 400);
   });
 
+  it('default registration writes the governance registry to the persistent workspace', async () => {
+    const previousCwd = process.cwd();
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    const runtimeRoot = join(tmpdir(), `catcafe-runtime-${randomUUID()}`);
+    const workspaceRoot = join(tmpdir(), `catcafe-workspace-${randomUUID()}`);
+    await Promise.all([mkdir(runtimeRoot, { recursive: true }), mkdir(workspaceRoot, { recursive: true })]);
+    await writeFile(join(runtimeRoot, 'pnpm-workspace.yaml'), 'packages: []\n');
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    process.chdir(runtimeRoot);
+    const defaultApp = buildApp(undefined);
+
+    try {
+      const res = await defaultApp.inject({
+        method: 'POST',
+        url: '/api/projects/setup',
+        headers: HEADERS,
+        payload: { projectPath: testRoot, mode: 'skip' },
+      });
+
+      assert.equal(res.statusCode, 200, res.payload);
+      await assert.rejects(() => stat(join(runtimeRoot, '.cat-cafe', 'governance-registry.json')), /ENOENT/);
+      assert.equal((await stat(join(workspaceRoot, '.cat-cafe', 'governance-registry.json'))).isFile(), true);
+    } finally {
+      await defaultApp.close();
+      process.chdir(previousCwd);
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects Cat Cafe descendants as external governance targets', async () => {
     const internalPackage = join(fakeCatCafeRoot, 'packages', 'api');
     await mkdir(internalPackage, { recursive: true });

--- a/packages/api/test/routes/projects-setup.test.js
+++ b/packages/api/test/routes/projects-setup.test.js
@@ -142,6 +142,22 @@ describe('POST /api/projects/setup', () => {
     assert.equal(res.statusCode, 400);
   });
 
+  it('rejects Cat Cafe descendants as external governance targets', async () => {
+    const internalPackage = join(fakeCatCafeRoot, 'packages', 'api');
+    await mkdir(internalPackage, { recursive: true });
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/projects/setup',
+      headers: HEADERS,
+      payload: { projectPath: internalPackage, mode: 'skip' },
+    });
+
+    assert.equal(res.statusCode, 400);
+    assert.match(JSON.parse(res.payload).error, /external project/i);
+    assert.deepEqual(await readdir(internalPackage), [], 'rejected self-bootstrap must leave the directory untouched');
+  });
+
   it('rejects requests without identity header', async () => {
     const res = await app.inject({
       method: 'POST',

--- a/packages/api/test/skills-drift-route.test.js
+++ b/packages/api/test/skills-drift-route.test.js
@@ -47,6 +47,37 @@ function expectedSymlinkTarget(linkPath, sourcePath) {
 }
 
 describe('Skills Drift Route (F228)', () => {
+  it('POST /api/skills/drift-check reads runtime selections from the persistent workspace', async () => {
+    const prevRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const prevWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'skills-drift-runtime-root-'));
+    const workspaceRoot = await realpath(await mkdtemp(join(tmpdir(), 'skills-drift-workspace-root-')));
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    await writeCapabilitiesConfig(workspaceRoot, { version: 2, capabilities: [] });
+    const app = await buildSkillsDriftApp({ mainProjectRoot: workspaceRoot });
+
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/skills/drift-check',
+        headers: { 'x-cat-cafe-user': 'default-user' },
+        payload: { projectPath: runtimeRoot },
+      });
+
+      assert.equal(res.statusCode, 200, res.body);
+      assert.equal(JSON.parse(res.body).projectRoot, workspaceRoot);
+    } finally {
+      if (prevRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = prevRuntimeRoot;
+      if (prevWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = prevWorkspaceRoot;
+      await app.close();
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('POST /api/skills/drift-check respects per-skill mountPaths provider exclusions', async () => {
     const mainRoot = await mkdtemp(join(tmpdir(), 'skills-drift-route-mount-paths-main-'));
     const projectDir = await mkdtemp(join(tmpdir(), 'skills-drift-route-mount-paths-'));

--- a/packages/api/test/skills-owner-gate.test.js
+++ b/packages/api/test/skills-owner-gate.test.js
@@ -236,6 +236,45 @@ describe('Skills write-route owner gate (AC-E4)', () => {
     }
   });
 
+  it('POST /api/skills/sync redirects runtime-root writes to the persistent workspace', async () => {
+    const prevOwner = process.env.DEFAULT_OWNER_USER_ID;
+    const prevRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const prevWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    process.env.DEFAULT_OWNER_USER_ID = OWNER_ID;
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'skills-sync-runtime-root-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'skills-sync-workspace-root-'));
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+
+    const app = await buildSkillsApp({ mainProjectRoot: workspaceRoot });
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/skills/sync',
+        headers: LOCAL_WRITE_HEADERS,
+        payload: { projectPath: runtimeRoot },
+      });
+
+      assert.equal(res.statusCode, 200, res.body);
+      assert.equal(await pathExists(join(workspaceRoot, '.claude/skills')), true);
+      assert.equal(
+        await pathExists(join(runtimeRoot, '.claude/skills')),
+        false,
+        'runtime checkout must remain untouched',
+      );
+    } finally {
+      if (prevOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = prevOwner;
+      if (prevRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = prevRuntimeRoot;
+      if (prevWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = prevWorkspaceRoot;
+      await app.close();
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
   it('POST /api/skills/sync mounts configured custom paths', async () => {
     const prev = process.env.DEFAULT_OWNER_USER_ID;
     process.env.DEFAULT_OWNER_USER_ID = OWNER_ID;

--- a/packages/api/test/skills-route.test.js
+++ b/packages/api/test/skills-route.test.js
@@ -1056,6 +1056,19 @@ describe('Skills Route', () => {
     const app = await buildSessionSkillsApp({ mainProjectRoot: runtimeRoot });
     const projectRoots = [];
     try {
+      const getRes = await app.inject({
+        method: 'GET',
+        url: `/api/skills?projectPath=${encodeURIComponent(workspaceRoot)}`,
+        headers: AUTH_HEADERS,
+      });
+      assert.equal(getRes.statusCode, 200, getRes.payload);
+      const listedSkill = JSON.parse(getRes.body).skills.find((skill) => skill.name === skillName);
+      assert.deepEqual(
+        listedSkill.mountHealth.enabledMountPoints,
+        ['claude'],
+        'GET /api/skills must read defaultMountRules from the persistent workspace',
+      );
+
       for (const route of ['/api/skills/sync', '/api/skills/sync-skill']) {
         const projectRoot = await mkdtemp(join(tmpdir(), 'skills-route-persistent-default-project-'));
         projectRoots.push(projectRoot);

--- a/packages/api/test/skills-route.test.js
+++ b/packages/api/test/skills-route.test.js
@@ -14,7 +14,7 @@ import {
   readCapabilitiesConfig,
   writeCapabilitiesConfig,
 } from '../dist/config/capabilities/capability-orchestrator.js';
-import { writeMountRules } from '../dist/config/mount/mount-rules-store.js';
+import { writeDefaultMountRules, writeMountRules } from '../dist/config/mount/mount-rules-store.js';
 import { skillsRoutes } from '../dist/routes/skills.js';
 import { skillsWriteRoutes } from '../dist/routes/skills-write.js';
 import { resolveStartupProjectRoot } from '../dist/utils/startup-root.js';
@@ -1027,6 +1027,67 @@ describe('Skills Route', () => {
       await rm(projectDir, { recursive: true, force: true });
       if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
       else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    }
+  });
+
+  it('skill sync routes inherit default mount rules from the remapped persistent root', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'skills-route-runtime-defaults-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'skills-route-workspace-defaults-'));
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    await writeCapabilitiesConfig(workspaceRoot, { version: 2, capabilities: [] });
+    await writeDefaultMountRules(workspaceRoot, {
+      ...DEFAULT_MOUNT_RULES,
+      mountPoints: {
+        claude: { enabled: true, path: '.persistent-claude/skills' },
+        codex: { enabled: false, path: '.codex/skills' },
+        gemini: { enabled: false, path: '.gemini/skills' },
+        kimi: { enabled: false, path: '.kimi/skills' },
+      },
+    });
+    const sourceSkillsDir = resolveRepoSkillsDir();
+    const skillName = (await listSourceSkillNames(sourceSkillsDir))[0];
+    assert.ok(skillName, 'expected at least one source skill');
+
+    const app = await buildSessionSkillsApp({ mainProjectRoot: runtimeRoot });
+    const projectRoots = [];
+    try {
+      for (const route of ['/api/skills/sync', '/api/skills/sync-skill']) {
+        const projectRoot = await mkdtemp(join(tmpdir(), 'skills-route-persistent-default-project-'));
+        projectRoots.push(projectRoot);
+        const payload = route.endsWith('sync-skill')
+          ? { projectPath: projectRoot, skillName }
+          : { projectPath: projectRoot };
+        const res = await app.inject({
+          method: 'POST',
+          url: route,
+          headers: OWNER_SESSION_HEADERS,
+          payload,
+        });
+
+        assert.equal(res.statusCode, 200, res.payload);
+        assert.equal(
+          (await lstat(join(projectRoot, '.persistent-claude/skills', skillName))).isSymbolicLink(),
+          true,
+          `${route} must read defaultMountRules from the persistent workspace`,
+        );
+        await assert.rejects(() => lstat(join(projectRoot, '.claude/skills', skillName)), /ENOENT/);
+      }
+    } finally {
+      await app.close();
+      await Promise.all(projectRoots.map((root) => rm(root, { recursive: true, force: true })));
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+      if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+      else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
     }
   });
 

--- a/packages/api/test/threads-endpoint.test.js
+++ b/packages/api/test/threads-endpoint.test.js
@@ -5,6 +5,8 @@
  */
 
 import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { mkdtemp, realpath, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -108,6 +110,41 @@ describe('Thread API', () => {
     assert.equal(res.statusCode, 500);
     const body = JSON.parse(res.body);
     assert.match(body.error, /Bootcamp workspace root/);
+  });
+
+  it('POST /api/threads migrates an explicit runtime path to the persistent workspace', async () => {
+    const runtimeRoot = await createTempWorkspace();
+    const workspaceRoot = await createTempWorkspace();
+    for (const root of [runtimeRoot, workspaceRoot]) {
+      mkdirSync(join(root, 'cat-cafe-skills'), { recursive: true });
+      writeFileSync(join(root, 'cat-cafe-skills', 'manifest.yaml'), 'skills: []\n');
+      execFileSync('git', ['init', '-b', 'main'], { cwd: root, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root, stdio: 'ignore' });
+      execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root, stdio: 'ignore' });
+      execFileSync('git', ['add', '.'], { cwd: root, stdio: 'ignore' });
+      execFileSync('git', ['commit', '-m', 'baseline'], { cwd: root, stdio: 'ignore' });
+    }
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/threads',
+      payload: { userId: 'alice', title: 'Persistent workspace', projectPath: runtimeRoot },
+    });
+
+    assert.equal(res.statusCode, 201, res.body);
+    const targetRoot = JSON.parse(res.body).projectPath;
+    assert.equal(targetRoot, workspaceRoot);
+
+    // Simulate a page-triggered agent/governance write to a tracked file. The exact
+    // runtime restart predicate (`git status --short -uno`) must remain clean.
+    writeFileSync(join(targetRoot, 'cat-cafe-skills', 'manifest.yaml'), 'skills:\n  - generated\n');
+    assert.equal(execFileSync('git', ['status', '--short', '-uno'], { cwd: runtimeRoot, encoding: 'utf8' }).trim(), '');
+    assert.match(
+      execFileSync('git', ['status', '--short', '-uno'], { cwd: workspaceRoot, encoding: 'utf8' }),
+      /cat-cafe-skills\/manifest\.yaml/,
+    );
   });
 
   it('POST /api/threads with pinned=true creates a pinned thread', async () => {
@@ -252,6 +289,71 @@ describe('Thread API', () => {
     assert.ok(titles.includes('Thread A'));
     assert.ok(titles.includes('Thread B'));
     assert.ok(!titles.includes('Thread C'));
+  });
+
+  it('GET /api/threads migrates legacy runtime paths before exposing project selectors', async () => {
+    const runtimeRoot = await createTempWorkspace();
+    const workspaceRoot = await createTempWorkspace();
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const legacyThread = threadStore.create('alice', 'Legacy runtime thread', runtimeRoot);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/threads',
+      headers: { 'x-cat-cafe-user': 'alice' },
+    });
+
+    assert.equal(res.statusCode, 200);
+    const listed = JSON.parse(res.body).threads.find((thread) => thread.id === legacyThread.id);
+    assert.equal(listed.projectPath, workspaceRoot);
+    assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
+  });
+
+  it('GET /api/threads remaps a legacy runtime projectPath filter after migration', async () => {
+    const runtimeRoot = await createTempWorkspace();
+    const workspaceRoot = await createTempWorkspace();
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const legacyThread = threadStore.create('alice', 'Filtered legacy runtime thread', runtimeRoot);
+
+    const migrateRes = await app.inject({
+      method: 'GET',
+      url: '/api/threads',
+      headers: { 'x-cat-cafe-user': 'alice' },
+    });
+    assert.equal(migrateRes.statusCode, 200);
+    assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
+
+    const filteredRes = await app.inject({
+      method: 'GET',
+      url: `/api/threads?projectPath=${encodeURIComponent(runtimeRoot)}`,
+      headers: { 'x-cat-cafe-user': 'alice' },
+    });
+
+    assert.equal(filteredRes.statusCode, 200);
+    const filteredIds = JSON.parse(filteredRes.body).threads.map((thread) => thread.id);
+    assert.ok(filteredIds.includes(legacyThread.id));
+  });
+
+  it('GET /api/threads resets a stale runtime descendant to the safe default project', async () => {
+    const runtimeRoot = await createTempWorkspace();
+    const workspaceRoot = await createTempWorkspace();
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const staleRuntimePath = join(runtimeRoot, 'deleted-project');
+    const legacyThread = threadStore.create('alice', 'Stale runtime thread', staleRuntimePath);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/threads',
+      headers: { 'x-cat-cafe-user': 'alice' },
+    });
+
+    assert.equal(res.statusCode, 200);
+    const listed = JSON.parse(res.body).threads.find((thread) => thread.id === legacyThread.id);
+    assert.equal(listed.projectPath, 'default');
+    assert.equal((await threadStore.get(legacyThread.id)).projectPath, 'default');
   });
 
   it('GET /api/threads trusts localhost origin fallback and lists default-user threads', async () => {
@@ -465,6 +567,20 @@ describe('Thread API', () => {
     const body = JSON.parse(res.body);
     assert.equal(body.id, thread.id);
     assert.equal(body.title, 'Details Test');
+  });
+
+  it('GET /api/threads/:id migrates and persists a legacy runtime projectPath', async () => {
+    const runtimeRoot = await createTempWorkspace();
+    const workspaceRoot = await createTempWorkspace();
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    const legacyThread = threadStore.create('alice', 'Legacy runtime details', runtimeRoot);
+
+    const res = await app.inject({ method: 'GET', url: `/api/threads/${legacyThread.id}` });
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(JSON.parse(res.body).projectPath, workspaceRoot);
+    assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
   });
 
   // [F155 Phase B] guideState removed from Thread — redaction test no longer applicable
@@ -1200,6 +1316,39 @@ describe('F095 Phase D: Soft delete + trash bin', () => {
     const titles = body.threads.map((t) => t.title);
     assert.ok(titles.includes('Trashed 1'));
     assert.ok(titles.includes('Trashed 2'));
+  });
+
+  it('GET /api/threads?deleted=true migrates and persists legacy runtime projectPaths', async () => {
+    const runtimeDir = await mkdtemp(join(process.cwd(), '.tmp-deleted-runtime-'));
+    const workspaceDir = await mkdtemp(join(process.cwd(), '.tmp-deleted-workspace-'));
+    const runtimeRoot = await realpath(runtimeDir);
+    const workspaceRoot = await realpath(workspaceDir);
+    const savedRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const savedWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    try {
+      const legacyThread = threadStore.create('alice', 'Legacy runtime trash', runtimeRoot);
+      threadStore.softDelete(legacyThread.id);
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/threads?deleted=true',
+        headers: { 'x-cat-cafe-user': 'alice' },
+      });
+
+      assert.equal(res.statusCode, 200);
+      const listed = JSON.parse(res.body).threads.find((thread) => thread.id === legacyThread.id);
+      assert.equal(listed.projectPath, workspaceRoot);
+      assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
+    } finally {
+      if (savedRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = savedRuntimeRoot;
+      if (savedWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = savedWorkspaceRoot;
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it('GET /api/threads?deleted=true excludes soft-deleted concierge thread by default (R17 P2)', async () => {

--- a/packages/api/test/threads-endpoint.test.js
+++ b/packages/api/test/threads-endpoint.test.js
@@ -310,20 +310,12 @@ describe('Thread API', () => {
     assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
   });
 
-  it('GET /api/threads remaps a legacy runtime projectPath filter after migration', async () => {
+  it('GET /api/threads migrates a legacy runtime thread on the first filtered request', async () => {
     const runtimeRoot = await createTempWorkspace();
     const workspaceRoot = await createTempWorkspace();
     process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
     process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
     const legacyThread = threadStore.create('alice', 'Filtered legacy runtime thread', runtimeRoot);
-
-    const migrateRes = await app.inject({
-      method: 'GET',
-      url: '/api/threads',
-      headers: { 'x-cat-cafe-user': 'alice' },
-    });
-    assert.equal(migrateRes.statusCode, 200);
-    assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
 
     const filteredRes = await app.inject({
       method: 'GET',
@@ -334,6 +326,7 @@ describe('Thread API', () => {
     assert.equal(filteredRes.statusCode, 200);
     const filteredIds = JSON.parse(filteredRes.body).threads.map((thread) => thread.id);
     assert.ok(filteredIds.includes(legacyThread.id));
+    assert.equal((await threadStore.get(legacyThread.id)).projectPath, workspaceRoot);
   });
 
   it('GET /api/threads resets a stale runtime descendant to the safe default project', async () => {


### PR DESCRIPTION
## What

Establish one persistent project-path boundary for settings, governance, Skill, MCP/mount, thread, proposal, and invocation flows:

- redirect runtime-root paths and descendants to the durable workspace root;
- reject Clowder AI/runtime/workspace roots and descendants for portable governance bootstrap;
- lazily migrate legacy thread/proposal paths while stale runtime descendants fail closed;
- preserve public-main route behavior while porting the invariant;
- add regression coverage across mutation and read-back paths.

## Why

Page-driven mutations could treat the disposable runtime checkout, including `packages/api`, as a persistent project. Governance bootstrap then created tracked files there, and a legacy thread path let later agent work add more tracked changes. The next normal daemon start correctly failed closed on the dirty runtime worktree.

## Issue Closure

- Closes #1141

## Original Requirements

- Source: issue #1141
- Original report:
  > 纯代码方式运行项目后（没有在后台执行命令，均在页面操作），停止服务再启动失败。
  > 第一次 `pnpm start --daemon` 能正常启动；停止服务后再次启动提示目录中存在未提交的本地更改。
- Core pain: UI-only operations must not write tracked files into the disposable runtime checkout and break the next restart.
- Reviewer should verify that the delivered invariant closes this failure chain.

## Plan / ADR

- Plan: investigation and TDD checkpoints in the linked Cat Cafe thread
- ADR: none; this is a route-level safety invariant, not a new ownership topology
- Architecture cell: none
- Map delta: none
- Why: one shared resolver replaces duplicated route assumptions; no Store, Queue, Router, Adapter, Dispatcher, or Binding is introduced

## Tips Contribution

- [ ] Added or updated a capability tip
- [ ] Existing tip still covers this change
- [x] `tips_exempt:` runtime safety bugfix; no new user action or discoverable capability

## Tradeoff

The patch does not move, delete, stash, or overwrite existing dirty files because their keep/discard intent is unknown. It prevents new runtime writes and migrates stored path references. Missing external paths unrelated to runtime retain their legacy behavior.

## Test Evidence

- `packages/api public test suite` — 16,586 tests; 16,558 pass; 0 fail; 28 skip
- `pnpm check` — exit 0
- `pnpm lint` — exit 0; baseline warnings only
- `pnpm -r run build` — exit 0
- `git diff --check` — exit 0
- Targeted path and migration suites green
- Root Artifact Guard: empty
- Exact reviewed HEAD: `a1617d792f251794dc453601315ea4a92ddc7441`

## Open Questions

- Does every persistent write and read-back path preserve the runtime-to-workspace invariant?
- Are symlink aliases and deleted runtime descendants fail-closed without breaking unrelated external paths?
- Does the manual public port preserve public-main behavior without importing an old sync snapshot?

---

**本地 Review**: [x] sonnet independently reviewed and approved exact HEAD
**云端 Review**: [ ] trigger after PR creation

<!-- 猫猫签名: 小太阳·砚砚, GPT-5.6 Sol -->

