### PR TITLE
fix: preserve provider-native CLI effort values

### DIFF
--- a/docs/features/F127-cat-instance-management.md
+++ b/docs/features/F127-cat-instance-management.md
@@ -197,7 +197,7 @@ community_issue: "#109"
 | R-8 | **切换认证方式（订阅↔API key）没有一键切换** — 要一只猫一只猫改 provider profile binding | 高（UX 痛点） | operator想批量切换认证方式时 | 加"一键切换所有猫的 provider profile"功能 |
 | R-9 | **nuoda.vip 代理 model name 格式混淆** — API 代理用 `claude-opus-4-6`（Anthropic 原生），但 opencode CLI 需要 `anthropic/claude-opus-4-6`（provider/model 格式），Hub 不知道该用哪个 | 中（配置困惑） | 用第三方 API 代理时 | Hub 编辑器应按 client 类型自动处理 model name 格式 |
 | R-10 | **本地反代 `anthropic-proxy.mjs` 的 upstream 配置未初始化** — `start-dev.sh` 启动的反代（端口 9877）依赖 `.cat-cafe/proxy-upstreams.json` 配置上游，但 F127 intake 后 runtime 里该文件不存在。API key profile 创建应自动注册 upstream 到反代 | 中（反代功能不可用） | 配置 API key profile 用本地反代时 | profile 创建/更新时自动写 `proxy-upstreams.json` |
-| R-11 | ~~**Hub 缺少结构化、provider-aware 的 `cli.effort` 编辑**~~ — ✅ 已修复（PR #882）。Hub 已提供结构化 effort 字段；Claude=`low/medium/high/max`，Codex=`low/medium/high/xhigh`；保存写 `variant.cli.effort`；只对新 invocation 生效，不强切旧 session；开源跟踪 issue: [clowder-ai#315](https://github.com/zts212653/clowder-ai/issues/315) | ~~高（易错 + UX 差）~~ done | — | — |
+| R-11 | ~~**Hub 缺少结构化、provider-aware 的 `cli.effort` 编辑**~~ — ✅ PR #882 提供维护 preset；#315 进一步支持直接输入并原样持久化 provider 原生值（如 Codex `max` / `ultra`）。保存写 `variant.cli.effort`；只对新 invocation 生效，不强切旧 session。 | ~~高（易错 + UX 差）~~ done | — | — |
 | R-12 | ~~**跨项目 homedir legacy 账号污染 runtime 账号配置**~~ — ✅ 已修复（PR #1457）。启动迁移与 installer import 现在只导入项目显式引用的 homedir legacy account；引用源覆盖 `accountRef`、legacy `providerProfileId`、catalog `accounts` keys、credential refs，并保留 installer 内置账号 | ~~中（账号配置 UI 出现 Agent Teams / Local 等外部项目垃圾项）~~ done | — | — |
 
 ## AC-B3 验收矩阵（E2E 验证清单）

--- a/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
+++ b/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
@@ -1,0 +1,144 @@
+# Issue #315 Provider-Adaptive CLI Effort Implementation Plan
+
+**Feature:** F127 residual — [docs/features/F127-cat-instance-management.md](../docs/features/F127-cat-instance-management.md)
+**Goal:** Let a member retain any non-empty native CLI effort string while continuing to offer maintained client-specific presets and safe adapter-owned argument construction.
+**Acceptance Criteria:**
+- Hub exposes maintained effort presets and a direct text-entry path.
+- Codex accepts native `max` and `ultra` through the structured effort field.
+- Each existing effort-aware client adapter translates supported internal presets to its native CLI representation.
+- A non-preset value is accepted, persisted, and passed through its selected-client adapter without enum-only rejection.
+- Direct input reaches command construction through structured arguments, never unsafe shell concatenation.
+- Provider-native validation failures remain visible to the operator.
+- New invocations use saved values; existing sessions are not restarted.
+- Tests cover preset conversion, passthrough, persistence, and provider-rejection reporting.
+**Architecture cell:** `identity-session` (identity-agent subcell)
+**Map delta:** none
+**Map delta why:** This changes the existing cat-instance configuration contract and its adapters; it introduces no new owner or cross-cell boundary.
+**Architecture:** Preserve a single `variant.cli.effort` string in the runtime catalog. The shared module continues to expose the maintained preset vocabulary for UI suggestions and default selection, while the route and loader accept any non-empty string. Claude and Codex retain adapter-owned argv construction; Codex serializes the TOML value rather than interpolating untrusted text.
+**Tech Stack:** TypeScript, Zod, Fastify route tests, Vitest component tests, Node test runner.
+**前端验证:** Yes — Hub Cat Editor test coverage; manual browser rendering is not required for the initial semantic change.
+
+---
+
+## Finish line and exclusions
+
+The Hub member editor can select a maintained preset or enter `max`, `ultra`, or another native value. Saving preserves the exact string in `.cat-cafe/cat-catalog.json`, and the next Claude/Codex invocation receives it via its own argv adapter. We are **not** probing provider versions, maintaining provider-native enums, force-switching running sessions, or repurposing generic `cliConfigArgs`.
+
+## Terminal contract
+
+```ts
+type CliEffortPreset = 'low' | 'medium' | 'high' | 'max' | 'xhigh';
+type CliEffortValue = string; // validated at API/schema boundary: trimmed and non-empty
+
+interface CliConfig {
+  effort?: CliEffortValue;
+}
+```
+
+`getCliEffortOptionsForProvider()` remains the maintained-preset source. Runtime resolution returns a stored non-empty value unchanged, otherwise the selected client's default; it must never coerce a native value to a different preset.
+
+## Persistent-state census
+
+| Object | Lifecycle owner | States/events | Invariants |
+|---|---|---|---|
+| `variant.cli.effort` in runtime catalog | `runtime-cat-catalog` via `/api/cats` | absent → saved preset/native string → edited/cleared | INV-1, INV-2 |
+| Hub editor draft `cliEffort` | `HubCatEditor` form state | loaded → edited/selected → serialized | INV-2 |
+| Invocation argv | provider adapter | config read → adapter serialization → spawned process | INV-3, INV-4 |
+
+| State | Save preset | Save native `ultra` | Clear field | Client switch without explicit effort |
+|---|---|---|---|---|
+| Catalog | persist exact preset | persist exact native text | remove `effort` | replace with target-client default |
+| New invocation | adapter emits native flag/value | same adapter emits exact native text | client default applies | target-client default applies |
+
+**Invariants:**
+
+- **INV-1:** The runtime catalog stores a user-entered non-empty effort value unchanged; it is not normalized to another provider's preset.
+- **INV-2:** Form hydration and payload serialization round-trip both maintained presets and unfamiliar native values unchanged.
+- **INV-3:** Only the selected provider adapter constructs CLI args; UI text never becomes a shell command string.
+- **INV-4:** A new invocation reads the saved catalog value; pre-existing sessions are not mutated or restarted by this setting change.
+
+**Adversarial scenarios:** blank/whitespace input is rejected or represented as clear; `max` and `ultra` on Codex preserve exactly; a quote-bearing value is TOML-escaped in Codex argv rather than interpreted as a second config; a provider rejects an otherwise accepted native value and its stderr/exit result remains observable.
+
+## Test matrix
+
+| Contract | Test location | Evidence |
+|---|---|---|
+| Preset suggestions remain client-specific | `hub-cat-editor.test.tsx`, shared effort tests | known preset lists unchanged |
+| Native form hydration and payload | `hub-cat-editor.test.tsx` | `ultra` survives load and save |
+| API create/patch persistence | `cats-routes-runtime-crud.test.js` | `max`/`ultra` persist without enum rejection |
+| Loader passthrough/defaulting | `cat-config-loader.test.js` | native value retained; absent value defaults |
+| Safe adapter construction | `codex-agent-service.test.js`, `claude-agent-service.test.js` | exact argv values and escaped TOML |
+| Provider failure reporting | existing CLI error-path regression, extended if needed | exit/stderr stays operator-visible |
+
+### Task 1: Make the configuration contract native-value tolerant
+
+**Files:**
+- Modify: `packages/shared/src/cli-effort.ts`
+- Modify: `packages/shared/src/types/cat-breed.ts`
+- Modify: `packages/api/src/config/cat-config-loader.ts`
+- Test: `packages/api/test/cat-config-loader.test.js`
+
+**Step 1: Write failing loader tests** for a stored Codex `max` and `ultra` effort, asserting exact retrieval and existing default behavior when absent.
+
+**Step 2: Run the focused test** and confirm it fails because current normalization replaces/rejects the native value.
+
+**Step 3: Implement the smallest contract change**: retain `CliEffortPreset` for maintained suggestions, accept a non-empty string for stored effort, and resolve stored text before applying a provider default.
+
+**Step 4: Run focused shared/loader tests** and confirm all pass.
+
+### Task 2: Accept and persist native values through the Cats API
+
+**Files:**
+- Modify: `packages/api/src/routes/cats.ts`
+- Test: `packages/api/test/cats-routes-runtime-crud.test.js`
+
+**Step 1: Write failing POST and PATCH tests** that save Codex `max` and `ultra`, then assert API response and catalog persistence retain the submitted strings.
+
+**Step 2: Run those tests** and confirm Zod/provider-enum validation rejects them for the expected reason.
+
+**Step 3: Replace enum-only validation with trimmed non-empty structured text validation.** Keep command/output/default args structured and reject blank values; do not concatenate input into a shell command.
+
+**Step 4: Run focused route tests** and confirm preset/default client-switch regressions remain green.
+
+### Task 3: Provide direct entry in the Hub editor
+
+**Files:**
+- Modify: `packages/web/src/components/hub-cat-editor.model.ts`
+- Modify: `packages/web/src/components/hub-cat-editor-advanced.tsx`
+- Test: `packages/web/src/components/__tests__/hub-cat-editor.test.tsx`
+
+**Step 1: Write failing form/payload tests** showing a persisted `ultra` value is visible and a typed native value serializes in `cli.effort` independently of `cliConfigArgs`.
+
+**Step 2: Run the focused component test** and confirm existing enum filtering clears the unfamiliar value.
+
+**Step 3: Use an editable field with the selected client's preset list as suggestions.** Keep the control visible only for existing effort-aware adapters and retain the "use client default" clear behavior.
+
+**Step 4: Run focused web tests** and confirm preset behavior still passes.
+
+### Task 4: Keep adapter construction safe and observable
+
+**Files:**
+- Modify: `packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts`
+- Test: `packages/api/test/codex-agent-service.test.js`
+- Test: `packages/api/test/claude-agent-service.test.js`
+
+**Step 1: Write a failing Codex argv regression test** for a quoted native value, asserting exactly one TOML `model_reasoning_effort` argument whose value is serialized safely; add `max`/`ultra` adapter assertions.
+
+**Step 2: Run the targeted tests** and confirm unsafe interpolation or old normalization produces the wrong argv.
+
+**Step 3: Serialize the Codex TOML string through the existing TOML string helper; leave Claude's separate `--effort`, value argv shape intact.** Do not add shell execution or provider-side validation in Cat Café.
+
+**Step 4: Run focused provider tests** and validate the existing non-zero/stderr CLI error path still surfaces provider-native failures.
+
+### Task 5: Verify and hand off
+
+**Files:**
+- Modify: all Task 1–4 files only
+
+**Step 1:** Run formatting/type checks and all focused API/web/provider tests.
+
+**Step 2:** Run the relevant package test suites and `pnpm check` with development-safe environment variables.
+
+**Step 3:** Inspect the diff against every acceptance criterion and verify that no runtime configuration file or existing session was changed.
+
+**Step 4:** Commit the plan and implementation in reviewable commits, request cross-individual review, and register the upstream PR for tracking after creation.

--- a/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
+++ b/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
@@ -16,7 +16,7 @@
 **Map delta why:** This changes the existing cat-instance configuration contract and its adapters; it introduces no new owner or cross-cell boundary.
 **Architecture:** Preserve a single `variant.cli.effort` string in the runtime catalog. The shared module continues to expose the maintained preset vocabulary for UI suggestions and default selection, while the route and loader accept any non-empty string. Claude and Codex retain adapter-owned argv construction; Codex serializes the TOML value rather than interpolating untrusted text.
 **Tech Stack:** TypeScript, Zod, Fastify route tests, Vitest component tests, Node test runner.
-**前端验证:** Yes — Hub Cat Editor test coverage; manual browser rendering is not required for the initial semantic change.
+**前端验证:** Yes — Hub Cat Editor coverage plus an isolated browser preview; formal approval requires interactive verification of the member-editor input and suggestions.
 
 ---
 

--- a/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
+++ b/feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md
@@ -27,7 +27,7 @@ The Hub member editor can select a maintained preset or enter `max`, `ultra`, or
 ## Terminal contract
 
 ```ts
-type CliEffortPreset = 'low' | 'medium' | 'high' | 'max' | 'xhigh';
+type CliEffortPreset = 'low' | 'medium' | 'high' | 'max' | 'xhigh' | 'ultra';
 type CliEffortValue = string; // validated at API/schema boundary: trimmed and non-empty
 
 interface CliConfig {
@@ -35,7 +35,12 @@ interface CliConfig {
 }
 ```
 
-`getCliEffortOptionsForProvider()` remains the maintained-preset source. Runtime resolution returns a stored non-empty value unchanged, otherwise the selected client's default; it must never coerce a native value to a different preset.
+`getCliEffortOptionsForProvider(provider, model?)` is the maintained-preset source. It returns
+model-aware suggestions when applicable (GPT-5.6 OpenAI models include `max` and `ultra`),
+falling back to the base provider list otherwise. Runtime resolution returns a stored non-empty
+value unchanged, otherwise the selected client's default; it must never coerce a native value
+to a different preset. Effort is only accepted for effort-aware clients (anthropic, openai);
+other clients receive HTTP 400 if `cli.effort` is supplied.
 
 ## Persistent-state census
 

--- a/packages/api/src/config/cat-config-loader.ts
+++ b/packages/api/src/config/cat-config-loader.ts
@@ -48,7 +48,7 @@ const cliConfigSchema = z.object({
   command: z.string().min(1),
   outputFormat: z.string().min(1),
   defaultArgs: z.array(z.string()).optional(),
-  effort: z.enum(['low', 'medium', 'high', 'max', 'xhigh']).optional(),
+  effort: z.string().trim().min(1).optional(),
   contextWindow: z.number().positive().int().optional(),
   autoCompactTokenLimit: z.number().positive().int().optional(),
 });
@@ -921,8 +921,8 @@ function buildCatIdToVariantIndex(config: CatCafeConfig): Map<string, CatVariant
   return index;
 }
 
-/** Effort level union across all CLI providers */
-export type CliEffortLevel = 'low' | 'medium' | 'high' | 'max' | 'xhigh';
+/** Canonical effort string resolved from the catalog or a client default. */
+export type CliEffortLevel = string;
 
 /**
  * Get CLI effort level for a cat from the resolved cat config.
@@ -945,17 +945,11 @@ export function getCatEffort(catId: string, config?: CatCafeConfig, fallbackProv
 
   const variant = _catIdToVariant.get(catId);
   if (variant?.cli?.effort) {
-    // Defense-in-depth: validate persisted effort against current provider.
-    // Stale cross-provider values (e.g. 'max' on openai) are cleaned at write
-    // time, but historical data may still contain them.
-    const provider = variant.clientId ?? fallbackProvider;
-    if (provider) {
-      const validated = normalizeCliEffortForProvider(provider, variant.cli.effort);
-      if (validated) return validated;
-      // Invalid for this provider — fall through to provider default below
-    } else {
-      return variant.cli.effort;
-    }
+    // Provider CLIs can introduce native effort values faster than our preset
+    // vocabulary evolves. Preserve a saved non-empty value exactly; the
+    // selected provider adapter owns native validation at invocation time.
+    const nativeValue = variant.cli.effort.trim();
+    if (nativeValue) return nativeValue;
   }
 
   // Client-aware defaults: use variant's clientId if found, otherwise fallbackProvider

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -185,6 +185,11 @@ function toTomlString(value: string): string {
   return `"${escaped}"`;
 }
 
+/** Build the structured Codex reasoning-effort config argument. */
+export function buildCodexReasoningArgs(effortLevel: string): string[] {
+  return ['--config', `model_reasoning_effort=${toTomlString(effortLevel)}`];
+}
+
 /**
  * F203 Phase C — `--config` keys the system controls. User cliConfigArgs
  * cannot override these. Currently `developer_instructions` carries the
@@ -748,7 +753,7 @@ export class CodexAgentService implements AgentService {
     const sandboxMode = getCodexSandboxMode();
     const approvalPolicy = getCodexApprovalPolicy();
     const effortLevel = getCatEffort(this.catId as string, undefined, 'openai');
-    const reasoningArgs = ['--config', `model_reasoning_effort="${effortLevel}"`];
+    const reasoningArgs = buildCodexReasoningArgs(effortLevel);
     const sandboxConfigArgs = ['--config', `sandbox_mode=${toTomlString(sandboxMode)}`];
     const approvalArgs = ['--config', `approval_policy="${approvalPolicy}"`];
     const ctxConfig = getCatContextWindowConfig(this.catId as string);

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -7,14 +7,11 @@
 import { resolve } from 'node:path';
 import {
   type CatConfig,
-  CLI_EFFORT_VALUES,
   type CliConfig,
   type ClientId,
   type ContextBudget,
   catRegistry,
-  getCliEffortOptionsForProvider,
   getDefaultCliEffortForProvider,
-  isValidCliEffortForProvider,
   type RosterEntry,
 } from '@cat-cafe/shared';
 import type { FastifyPluginAsync } from 'fastify';
@@ -59,7 +56,7 @@ const contextBudgetSchema = z.object({
   maxContentLengthPerMsg: z.number().int().positive(),
 });
 
-const cliEffortSchema = z.enum(CLI_EFFORT_VALUES);
+const cliEffortSchema = z.string().trim().min(1);
 const cliSchema = z.object({
   command: z.string().min(1).optional(),
   outputFormat: z.string().min(1).optional(),
@@ -295,13 +292,6 @@ function buildResolvedCliConfig(client: ClientId, baseCli: CliConfig, patch?: Cl
 
   const effortTouched = patch ? Object.hasOwn(patch, 'effort') : false;
   const nextEffort = effortTouched ? patch?.effort : baseCli.effort;
-  if (nextEffort !== undefined && nextEffort !== null && !isValidCliEffortForProvider(client, nextEffort)) {
-    const options = getCliEffortOptionsForProvider(client);
-    if (!options) {
-      throw new Error(`client "${client}" does not support cli.effort`);
-    }
-    throw new Error(`client "${client}" only supports cli.effort ${options.join(' / ')}`);
-  }
 
   return {
     command: patch?.command ?? baseCli.command,

--- a/packages/api/src/routes/cats.ts
+++ b/packages/api/src/routes/cats.ts
@@ -11,6 +11,7 @@ import {
   type ClientId,
   type ContextBudget,
   catRegistry,
+  getCliEffortOptionsForProvider,
   getDefaultCliEffortForProvider,
   type RosterEntry,
 } from '@cat-cafe/shared';
@@ -292,6 +293,14 @@ function buildResolvedCliConfig(client: ClientId, baseCli: CliConfig, patch?: Cl
 
   const effortTouched = patch ? Object.hasOwn(patch, 'effort') : false;
   const nextEffort = effortTouched ? patch?.effort : baseCli.effort;
+
+  // Gate: only effort-aware clients (those with a real adapter that consumes
+  // getCatEffort()) may persist an effort value.  Non-effort clients would
+  // silently ignore the setting and the provider would never perform the
+  // promised native validation.
+  if (nextEffort !== undefined && nextEffort !== null && !getCliEffortOptionsForProvider(client)) {
+    throw new Error(`client "${client}" does not support cli.effort`);
+  }
 
   return {
     command: patch?.command ?? baseCli.command,

--- a/packages/api/test/cat-config-loader.test.js
+++ b/packages/api/test/cat-config-loader.test.js
@@ -936,20 +936,32 @@ describe('getCatEffort', () => {
     assert.ok(result, 'should return a truthy default effort');
   });
 
-  it('rejects stale cross-provider effort from historical data (defense-in-depth)', () => {
-    // Simulates a catalog written before the PATCH write-time cleanup was added:
-    // an openai cat still carrying anthropic-only effort 'max'.
+  it('preserves a Codex native effort that is outside the maintained preset vocabulary', () => {
+    // `max` is not a maintained Codex preset, but newer Codex CLIs may accept it
+    // natively. The runtime catalog must retain the operator's exact choice.
     const cfg = validConfig();
     cfg.breeds[0].variants[0].clientId = 'openai';
     cfg.breeds[0].variants[0].cli = {
       command: 'codex',
       outputFormat: 'json',
-      effort: 'max', // invalid for openai — only anthropic supports 'max'
+      effort: 'max',
     };
     const config = loadCatConfig(writeTempConfig(cfg));
 
-    // Should fall back to openai default ('xhigh'), not return 'max'
-    assert.equal(getCatEffort('opus', config), 'xhigh');
+    assert.equal(getCatEffort('opus', config), 'max');
+  });
+
+  it('preserves an unfamiliar native effort value for a Codex member', () => {
+    const cfg = validConfig();
+    cfg.breeds[0].variants[0].clientId = 'openai';
+    cfg.breeds[0].variants[0].cli = {
+      command: 'codex',
+      outputFormat: 'json',
+      effort: 'ultra',
+    };
+    const config = loadCatConfig(writeTempConfig(cfg));
+
+    assert.equal(getCatEffort('opus', config), 'ultra');
   });
 });
 describe('F32-b P4c: Sonnet variant in project config', () => {

--- a/packages/api/test/cats-routes-runtime-crud.test.js
+++ b/packages/api/test/cats-routes-runtime-crud.test.js
@@ -353,7 +353,7 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
     }
   });
 
-  it('POST /api/cats persists structured cli.effort for Codex members', async () => {
+  it('POST and PATCH /api/cats persist native structured cli.effort for Codex members', async () => {
     const projectRoot = createProjectRoot();
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
 
@@ -381,27 +381,39 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
         clientId: 'openai',
         accountRef: 'codex',
         defaultModel: 'gpt-5.4',
-        cli: { command: 'codex', outputFormat: 'json', effort: 'xhigh' },
+        cli: { command: 'codex', outputFormat: 'json', effort: 'max' },
       }),
     });
     assert.equal(createRes.statusCode, 201);
     const createdBody = JSON.parse(createRes.body);
-    assert.equal(createdBody.cat.cli?.effort, 'xhigh');
+    assert.equal(createdBody.cat.cli?.effort, 'max');
+
+    const patchRes = await app.inject({
+      method: 'PATCH',
+      url: '/api/cats/runtime-codex-effort',
+      headers: {
+        'content-type': 'application/json',
+        'x-cat-cafe-user': 'codex',
+      },
+      body: JSON.stringify({ cli: { effort: 'ultra' } }),
+    });
+    assert.equal(patchRes.statusCode, 200);
+    assert.equal(JSON.parse(patchRes.body).cat.cli?.effort, 'ultra');
 
     const listRes = await app.inject({ method: 'GET', url: '/api/cats' });
     assert.equal(listRes.statusCode, 200);
     const listBody = JSON.parse(listRes.body);
     const runtimeCat = listBody.cats.find((cat) => cat.id === 'runtime-codex-effort');
     assert.ok(runtimeCat, 'runtime-codex-effort should appear in /api/cats');
-    assert.equal(runtimeCat.cli?.effort, 'xhigh');
+    assert.equal(runtimeCat.cli?.effort, 'ultra');
 
     const catalogPath = join(projectRoot, '.cat-cafe', 'cat-catalog.json');
     const persisted = JSON.parse(readFileSync(catalogPath, 'utf-8'));
     const variant = persisted.breeds.find((breed) => breed.catId === 'runtime-codex-effort')?.variants?.[0];
-    assert.equal(variant?.cli?.effort, 'xhigh');
+    assert.equal(variant?.cli?.effort, 'ultra');
   });
 
-  it('POST /api/cats rejects illegal provider/effort combinations', async () => {
+  it('POST /api/cats rejects blank cli.effort values', async () => {
     const projectRoot = createProjectRoot();
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
 
@@ -419,22 +431,21 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
         'x-cat-cafe-user': 'codex',
       },
       body: JSON.stringify({
-        catId: 'runtime-invalid-effort',
+        catId: 'runtime-blank-effort',
         name: '非法缅因猫',
         displayName: '非法缅因猫',
         avatar: '/avatars/codex.png',
         color: { primary: '#16a34a', secondary: '#bbf7d0' },
-        mentionPatterns: ['@runtime-invalid-effort'],
+        mentionPatterns: ['@runtime-blank-effort'],
         roleDescription: '审查',
         clientId: 'openai',
         accountRef: 'codex',
         defaultModel: 'gpt-5.4',
-        cli: { command: 'codex', outputFormat: 'json', effort: 'max' },
+        cli: { command: 'codex', outputFormat: 'json', effort: '   ' },
       }),
     });
 
     assert.equal(createRes.statusCode, 400);
-    assert.match(JSON.parse(createRes.body).error, /effort/i);
   });
 
   it('POST /api/cats accepts kimi client with first-class default CLI commands', async () => {

--- a/packages/api/test/cats-routes-runtime-crud.test.js
+++ b/packages/api/test/cats-routes-runtime-crud.test.js
@@ -448,6 +448,47 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
     assert.equal(createRes.statusCode, 400);
   });
 
+  it('POST /api/cats rejects cli.effort for clients without an effort adapter', async () => {
+    const projectRoot = createProjectRoot();
+    process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
+
+    const Fastify = (await import('fastify')).default;
+    const { catsRoutes } = await import('../dist/routes/cats.js');
+
+    const app = Fastify();
+    await app.register(catsRoutes);
+
+    try {
+      // kimi has no effort adapter — getCatEffort() is not consumed by its adapter
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/cats',
+        headers: {
+          'content-type': 'application/json',
+          'x-cat-cafe-user': 'codex',
+        },
+        body: JSON.stringify({
+          catId: 'runtime-kimi-effort',
+          name: 'Kimi 猫',
+          displayName: 'Kimi 猫',
+          avatar: '/avatars/kimi.png',
+          color: { primary: '#7c3aed', secondary: '#ede9fe' },
+          mentionPatterns: ['@runtime-kimi-effort'],
+          roleDescription: '中文代码助手',
+          clientId: 'kimi',
+          accountRef: 'kimi',
+          defaultModel: 'kimi-k2.5',
+          cli: { command: 'kimi', outputFormat: 'stream-json', effort: 'high' },
+        }),
+      });
+
+      assert.equal(createRes.statusCode, 400);
+      assert.match(JSON.parse(createRes.body).error, /effort/i);
+    } finally {
+      await app.close();
+    }
+  });
+
   it('POST /api/cats accepts kimi client with first-class default CLI commands', async () => {
     const projectRoot = createProjectRoot();
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');

--- a/packages/api/test/cats-routes-runtime-crud.test.js
+++ b/packages/api/test/cats-routes-runtime-crud.test.js
@@ -448,7 +448,7 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
     assert.equal(createRes.statusCode, 400);
   });
 
-  it('POST /api/cats rejects cli.effort for clients without an effort adapter', async () => {
+  it('POST and PATCH /api/cats reject cli.effort for clients without an effort adapter', async () => {
     const projectRoot = createProjectRoot();
     process.env.CAT_TEMPLATE_PATH = join(projectRoot, 'cat-template.json');
 
@@ -484,6 +484,40 @@ describe('cats routes runtime CRUD', { concurrency: false }, () => {
 
       assert.equal(createRes.statusCode, 400);
       assert.match(JSON.parse(createRes.body).error, /effort/i);
+
+      const validCreateRes = await app.inject({
+        method: 'POST',
+        url: '/api/cats',
+        headers: {
+          'content-type': 'application/json',
+          'x-cat-cafe-user': 'codex',
+        },
+        body: JSON.stringify({
+          catId: 'runtime-kimi-no-effort',
+          name: 'Kimi 猫',
+          displayName: 'Kimi 猫',
+          avatar: '/avatars/kimi.png',
+          color: { primary: '#7c3aed', secondary: '#ede9fe' },
+          mentionPatterns: ['@runtime-kimi-no-effort'],
+          roleDescription: '中文代码助手',
+          clientId: 'kimi',
+          accountRef: 'kimi',
+          defaultModel: 'kimi-k2.5',
+        }),
+      });
+      assert.equal(validCreateRes.statusCode, 201);
+
+      const patchRes = await app.inject({
+        method: 'PATCH',
+        url: '/api/cats/runtime-kimi-no-effort',
+        headers: {
+          'content-type': 'application/json',
+          'x-cat-cafe-user': 'codex',
+        },
+        body: JSON.stringify({ cli: { effort: 'high' } }),
+      });
+      assert.equal(patchRes.statusCode, 400);
+      assert.match(JSON.parse(patchRes.body).error, /effort/i);
     } finally {
       await app.close();
     }

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -12,7 +12,7 @@ import { describe, mock, test } from 'node:test';
 import { catRegistry } from '@cat-cafe/shared';
 import { fakeL0Compiler } from './helpers/fake-l0-compiler.js';
 
-const { CodexAgentService, isGitRepositoryPath } = await import(
+const { CodexAgentService, buildCodexReasoningArgs, isGitRepositoryPath } = await import(
   '../dist/domains/cats/services/agents/providers/CodexAgentService.js'
 );
 
@@ -1790,6 +1790,10 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
       args.includes('model_reasoning_effort="xhigh"'),
       `expected xhigh fallback for unknown Codex cat, got argv: ${JSON.stringify(args)}`,
     );
+  });
+
+  test('passes a native Codex effort through as one safely serialized TOML value', () => {
+    assert.deepEqual(buildCodexReasoningArgs('ultra"native'), ['--config', 'model_reasoning_effort="ultra\\"native"']);
   });
 
   test('adds --skip-git-repo-check when workingDirectory is not a git repository', async () => {

--- a/packages/shared/src/__tests__/cli-effort.test.ts
+++ b/packages/shared/src/__tests__/cli-effort.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { getCliEffortOptionsForProvider } from '../cli-effort.js';
+
+describe('CLI effort presets', () => {
+  it('adds max and ultra to the maintained OpenAI presets only for GPT-5.6 models', () => {
+    expect(getCliEffortOptionsForProvider('openai', 'gpt-5.6-terra')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+    ]);
+    expect(getCliEffortOptionsForProvider('openai', 'openai/gpt-5.6-sol')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+    ]);
+    expect(getCliEffortOptionsForProvider('openai', 'gpt-5.5')).toEqual(['low', 'medium', 'high', 'xhigh']);
+  });
+});

--- a/packages/shared/src/cli-effort.ts
+++ b/packages/shared/src/cli-effort.ts
@@ -1,16 +1,24 @@
 import type { CatProvider } from './types/cat.js';
 
 export const CLI_EFFORT_VALUES = ['low', 'medium', 'high', 'max', 'xhigh'] as const;
-export type CliEffortValue = (typeof CLI_EFFORT_VALUES)[number];
+/** Maintained cross-client presets shown as suggestions in the Hub. */
+export type CliEffortPreset = (typeof CLI_EFFORT_VALUES)[number];
+/**
+ * A canonical client effort value persisted in the runtime catalog.
+ *
+ * Providers evolve independently, so a member may use a native value that is
+ * not yet part of our maintained preset vocabulary (for example `ultra`).
+ */
+export type CliEffortValue = string;
 export type CliEffortProvider = 'anthropic' | 'openai';
 export type CliEffortPatchValue = CliEffortValue | null;
 
-const CLI_EFFORT_OPTIONS_BY_PROVIDER: Record<CliEffortProvider, readonly CliEffortValue[]> = {
+const CLI_EFFORT_OPTIONS_BY_PROVIDER: Record<CliEffortProvider, readonly CliEffortPreset[]> = {
   anthropic: ['low', 'medium', 'high', 'max'],
   openai: ['low', 'medium', 'high', 'xhigh'],
 };
 
-const CLI_EFFORT_DEFAULT_BY_PROVIDER: Record<CliEffortProvider, CliEffortValue> = {
+const CLI_EFFORT_DEFAULT_BY_PROVIDER: Record<CliEffortProvider, CliEffortPreset> = {
   anthropic: 'max',
   openai: 'xhigh',
 };
@@ -19,28 +27,28 @@ function isCliEffortProvider(provider: string): provider is CliEffortProvider {
   return provider === 'anthropic' || provider === 'openai';
 }
 
-export function getCliEffortOptionsForProvider(provider: CatProvider | string): readonly CliEffortValue[] | null {
+export function getCliEffortOptionsForProvider(provider: CatProvider | string): readonly CliEffortPreset[] | null {
   return isCliEffortProvider(provider) ? CLI_EFFORT_OPTIONS_BY_PROVIDER[provider] : null;
 }
 
-export function getDefaultCliEffortForProvider(provider: CatProvider | string): CliEffortValue | null {
+export function getDefaultCliEffortForProvider(provider: CatProvider | string): CliEffortPreset | null {
   return isCliEffortProvider(provider) ? CLI_EFFORT_DEFAULT_BY_PROVIDER[provider] : null;
 }
 
 export function isValidCliEffortForProvider(
   provider: CatProvider | string,
   effort: string | null | undefined,
-): effort is CliEffortValue {
+): effort is CliEffortPreset {
   if (!effort) return false;
   const options = getCliEffortOptionsForProvider(provider);
-  return options ? options.includes(effort as CliEffortValue) : false;
+  return options ? options.includes(effort as CliEffortPreset) : false;
 }
 
 export function normalizeCliEffortForProvider(
   provider: CatProvider | string,
   effort: string | null | undefined,
 ): CliEffortValue | null {
-  if (!isCliEffortProvider(provider)) return null;
-  if (isValidCliEffortForProvider(provider, effort)) return effort;
-  return CLI_EFFORT_DEFAULT_BY_PROVIDER[provider];
+  const nativeValue = effort?.trim();
+  if (nativeValue) return nativeValue;
+  return isCliEffortProvider(provider) ? CLI_EFFORT_DEFAULT_BY_PROVIDER[provider] : null;
 }

--- a/packages/shared/src/cli-effort.ts
+++ b/packages/shared/src/cli-effort.ts
@@ -1,6 +1,6 @@
 import type { CatProvider } from './types/cat.js';
 
-export const CLI_EFFORT_VALUES = ['low', 'medium', 'high', 'max', 'xhigh'] as const;
+export const CLI_EFFORT_VALUES = ['low', 'medium', 'high', 'max', 'xhigh', 'ultra'] as const;
 /** Maintained cross-client presets shown as suggestions in the Hub. */
 export type CliEffortPreset = (typeof CLI_EFFORT_VALUES)[number];
 /**
@@ -18,6 +18,8 @@ const CLI_EFFORT_OPTIONS_BY_PROVIDER: Record<CliEffortProvider, readonly CliEffo
   openai: ['low', 'medium', 'high', 'xhigh'],
 };
 
+const GPT_5_6_OPENAI_EFFORT_OPTIONS: readonly CliEffortPreset[] = ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'];
+
 const CLI_EFFORT_DEFAULT_BY_PROVIDER: Record<CliEffortProvider, CliEffortPreset> = {
   anthropic: 'max',
   openai: 'xhigh',
@@ -27,8 +29,22 @@ function isCliEffortProvider(provider: string): provider is CliEffortProvider {
   return provider === 'anthropic' || provider === 'openai';
 }
 
-export function getCliEffortOptionsForProvider(provider: CatProvider | string): readonly CliEffortPreset[] | null {
-  return isCliEffortProvider(provider) ? CLI_EFFORT_OPTIONS_BY_PROVIDER[provider] : null;
+export function normalizeModelSlug(model: string | null | undefined): string | null {
+  return model?.trim().toLowerCase().split('/').filter(Boolean).at(-1) ?? null;
+}
+
+function isGpt56Model(model: string | null | undefined): boolean {
+  const modelId = normalizeModelSlug(model);
+  return modelId ? /^gpt-5\.6(?:-|$)/.test(modelId) : false;
+}
+
+export function getCliEffortOptionsForProvider(
+  provider: CatProvider | string,
+  model?: string | null,
+): readonly CliEffortPreset[] | null {
+  if (!isCliEffortProvider(provider)) return null;
+  if (provider === 'openai' && isGpt56Model(model)) return GPT_5_6_OPENAI_EFFORT_OPTIONS;
+  return CLI_EFFORT_OPTIONS_BY_PROVIDER[provider];
 }
 
 export function getDefaultCliEffortForProvider(provider: CatProvider | string): CliEffortPreset | null {
@@ -38,9 +54,10 @@ export function getDefaultCliEffortForProvider(provider: CatProvider | string): 
 export function isValidCliEffortForProvider(
   provider: CatProvider | string,
   effort: string | null | undefined,
+  model?: string | null,
 ): effort is CliEffortPreset {
   if (!effort) return false;
-  const options = getCliEffortOptionsForProvider(provider);
+  const options = getCliEffortOptionsForProvider(provider, model);
   return options ? options.includes(effort as CliEffortPreset) : false;
 }
 

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -36,10 +36,11 @@ export interface CliConfig {
   readonly outputFormat: string; // 'stream-json' | 'json' | 'plainText'
   readonly defaultArgs?: readonly string[];
   /**
-   * Reasoning effort level — each CLI maps to its own flag:
-   *   claude: --effort low|medium|high|max
-   *   codex:  --config model_reasoning_effort="low|medium|high|xhigh"
-   * Default: 'max' (claude) / 'xhigh' (codex)
+   * Reasoning effort value — each CLI adapter maps this value to its native
+   * flag. Maintained presets are offered by the Hub, while non-empty native
+   * values (for example a newly introduced Codex level) are retained and
+   * validated by the selected CLI at invocation time.
+   * Defaults: 'max' (claude) / 'xhigh' (codex).
    */
   readonly effort?: CliEffortValue;
   readonly contextWindow?: number;

--- a/packages/shared/vitest.config.js
+++ b/packages/shared/vitest.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
       'test/concierge-config.test.js',
       'test/pet-skin-projection.test.js',
       'src/__tests__/capability-tips.test.ts',
+      'src/__tests__/cli-effort.test.ts',
       'src/__tests__/dispatch-proposal-types.test.ts',
       'src/__tests__/load-dossier-profiles.test.ts',
       'src/__tests__/parse-dossier-profiles.test.ts',

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -24,6 +24,7 @@ import {
   getAcpWarning,
   getCliEffortOptionsForClient,
   type HubCatEditorFormState,
+  initialState,
   isAcpOnlyClient,
   showTransportSelector,
   splitCommandArgs,
@@ -154,6 +155,7 @@ describe('HubCatEditor', () => {
       ...emptyVoiceFields,
     };
 
+    const onChange = vi.fn();
     await act(async () => {
       root.render(
         React.createElement(AdvancedRuntimeSection, {
@@ -167,12 +169,13 @@ describe('HubCatEditor', () => {
           codexSettingsError: null,
           codexSettingsEditable: false,
           showCodexSettings: false,
-          onChange: vi.fn(),
+          onChange,
           onStrategyChange: vi.fn(),
           onCodexChange: vi.fn(),
         }),
       );
     });
+    return onChange;
   }
 
   it('shows extra CLI args editor for CLI clients and hides it for API-only clients', async () => {
@@ -336,6 +339,37 @@ describe('HubCatEditor', () => {
     expect(getCliEffortOptionsForClient('anthropic')).toEqual(['low', 'medium', 'high', 'max']);
     expect(getCliEffortOptionsForClient('openai')).toEqual(['low', 'medium', 'high', 'xhigh']);
     expect(getCliEffortOptionsForClient('opencode')).toBeNull();
+  });
+
+  it('hydrates a native effort value that is outside the maintained presets', () => {
+    const form = initialState({
+      id: 'runtime-codex-ultra',
+      displayName: 'Runtime Codex',
+      color: { primary: '#16a34a', secondary: '#bbf7d0' },
+      mentionPatterns: ['@runtime-codex-ultra'],
+      clientId: 'openai',
+      defaultModel: 'gpt-5.4',
+      avatar: '/avatars/codex.png',
+      roleDescription: '审查',
+      personality: '严谨',
+      cli: { effort: 'ultra' },
+    });
+
+    expect(form.cliEffort).toBe('ultra');
+  });
+
+  it('provides editable native effort input with client presets as suggestions', async () => {
+    const onChange = await renderAdvancedRuntimeSection('openai');
+    const input = queryField<HTMLInputElement>(container, 'input[aria-label="CLI Effort"]');
+
+    expect(input.list).toBeTruthy();
+    const options = Array.from(document.getElementById(input.list?.id ?? '')?.querySelectorAll('option') ?? []).map(
+      (option) => (option as HTMLOptionElement).value,
+    );
+    expect(options).toEqual(['low', 'medium', 'high', 'xhigh']);
+
+    await changeField(input, 'ultra');
+    expect(onChange).toHaveBeenCalledWith({ cliEffort: 'ultra' });
   });
 
   it('buildCatPayload keeps structured cli.effort separate from raw cliConfigArgs', () => {

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -123,7 +123,10 @@ describe('HubCatEditor', () => {
     vi.clearAllMocks();
   });
 
-  async function renderAdvancedRuntimeSection(clientId: HubCatEditorFormState['clientId']) {
+  async function renderAdvancedRuntimeSection(
+    clientId: HubCatEditorFormState['clientId'],
+    defaultModel = 'test-model',
+  ) {
     const form: HubCatEditorFormState = {
       catId: `runtime-${clientId}`,
       name: `runtime-${clientId}`,
@@ -141,7 +144,7 @@ describe('HubCatEditor', () => {
       strengths: '',
       clientId,
       accountRef: '',
-      defaultModel: 'test-model',
+      defaultModel,
       commandArgs: '',
       cliConfigArgs: [],
       cliEffort: '',
@@ -335,9 +338,17 @@ describe('HubCatEditor', () => {
     expect(payload.commandArgs).toEqual(splitCommandArgs(DEFAULT_ANTIGRAVITY_COMMAND_ARGS));
   });
 
-  it('exposes provider-aware effort options for Claude and Codex only', () => {
+  it('exposes model-aware effort options for Claude and Codex only', () => {
     expect(getCliEffortOptionsForClient('anthropic')).toEqual(['low', 'medium', 'high', 'max']);
-    expect(getCliEffortOptionsForClient('openai')).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(getCliEffortOptionsForClient('openai', 'gpt-5.5')).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(getCliEffortOptionsForClient('openai', 'gpt-5.6-terra')).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
+      'ultra',
+    ]);
     expect(getCliEffortOptionsForClient('opencode')).toBeNull();
   });
 
@@ -359,14 +370,14 @@ describe('HubCatEditor', () => {
   });
 
   it('provides editable native effort input with client presets as suggestions', async () => {
-    const onChange = await renderAdvancedRuntimeSection('openai');
+    const onChange = await renderAdvancedRuntimeSection('openai', 'gpt-5.6-terra');
     const input = queryField<HTMLInputElement>(container, 'input[aria-label="CLI Effort"]');
 
     expect(input.list).toBeTruthy();
     const options = Array.from(document.getElementById(input.list?.id ?? '')?.querySelectorAll('option') ?? []).map(
       (option) => (option as HTMLOptionElement).value,
     );
-    expect(options).toEqual(['low', 'medium', 'high', 'xhigh']);
+    expect(options).toEqual(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
 
     await changeField(input, 'ultra');
     expect(onChange).toHaveBeenCalledWith({ cliEffort: 'ultra' });

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -105,16 +105,20 @@ export function AdvancedRuntimeSection({
           tone="success"
         />
         {cliEffortOptions ? (
-          <SelectField
-            label="CLI Effort"
-            value={form.cliEffort}
-            options={[
-              { value: '', label: '默认（按 Client）' },
-              ...cliEffortOptions.map((value) => ({ value, label: value })),
-            ]}
-            onChange={(value) => onChange({ cliEffort: value as HubCatEditorFormState['cliEffort'] })}
-            tone="success"
-          />
+          <>
+            <TextField
+              label="CLI Effort"
+              value={form.cliEffort}
+              onChange={(value) => onChange({ cliEffort: value })}
+              placeholder="留空使用 Client 默认值；也可输入原生值，例如 ultra"
+              suggestions={cliEffortOptions}
+              tone="success"
+            />
+            <p className="-mt-1 text-label leading-4 text-cafe-muted">
+              维护 preset：{cliEffortOptions.join(' / ')}。也可直接输入所选 CLI 支持的原生值；CLI
+              会返回其自身的校验错误。
+            </p>
+          </>
         ) : null}
         {form.clientId !== 'antigravity' && form.clientId !== 'catagent' ? (
           <div className="space-y-1">

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -51,7 +51,7 @@ export function AdvancedRuntimeSection({
     approvalPolicy: 'on-request' as const,
     authMode: 'oauth' as const,
   };
-  const cliEffortOptions = getCliEffortOptionsForClient(form.clientId);
+  const cliEffortOptions = getCliEffortOptionsForClient(form.clientId, form.defaultModel);
   const sessionChainEnabled = form.sessionChain === 'true' && (strategyForm?.sessionChainEnabled ?? true);
 
   return (

--- a/packages/web/src/components/hub-cat-editor-fields.tsx
+++ b/packages/web/src/components/hub-cat-editor-fields.tsx
@@ -71,6 +71,7 @@ export function TextField({
   onChange,
   inputMode,
   placeholder,
+  suggestions,
   required = false,
   tone = 'neutral',
 }: {
@@ -80,9 +81,13 @@ export function TextField({
   onChange: (value: string) => void;
   inputMode?: HTMLAttributes<HTMLInputElement>['inputMode'];
   placeholder?: string;
+  suggestions?: readonly string[];
   required?: boolean;
   tone?: 'neutral' | 'success';
 }) {
+  const listId = suggestions?.length
+    ? `input-suggestions-${(ariaLabel ?? label).replace(/\s+/g, '-').toLowerCase()}`
+    : undefined;
   const inputColors =
     tone === 'success'
       ? 'border-transparent bg-[var(--console-runtime-field-bg)] focus:border-[var(--console-runtime-label)] focus:ring-[var(--console-runtime-label)]/30'
@@ -96,8 +101,16 @@ export function TextField({
         className={`w-full rounded-[10px] border px-3 py-1.5 text-compact leading-5 text-cafe-black placeholder:text-cafe-muted outline-none transition focus:ring-1 ${inputColors}`}
         inputMode={inputMode}
         placeholder={placeholder}
+        list={listId}
         required={required}
       />
+      {listId ? (
+        <datalist id={listId}>
+          {suggestions?.map((suggestion) => (
+            <option key={suggestion} value={suggestion} />
+          ))}
+        </datalist>
+      ) : null}
     </FieldShell>
   );
 }

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -1,6 +1,5 @@
 import {
   builtinAccountFamilyForClient,
-  CLI_EFFORT_VALUES,
   type CliEffortValue,
   getCliEffortOptionsForProvider,
   builtinAccountIdForClient as sharedBuiltinAccountIdForClient,
@@ -148,10 +147,6 @@ export {
 export const DEFAULT_ANTIGRAVITY_COMMAND_ARGS = '. --remote-debugging-port=9000';
 
 const GOOGLE_OWNED_DOMAINS = ['generativelanguage.googleapis.com', 'googleapis.com'];
-
-function isCliEffortValue(value: string | undefined): value is CliEffortValue {
-  return value !== undefined && CLI_EFFORT_VALUES.includes(value as CliEffortValue);
-}
 
 function voiceStr(value: string | number | undefined): string {
   return value == null ? '' : String(value);
@@ -380,7 +375,7 @@ export function initialState(cat?: CatData | null, draft?: HubCatEditorDraft | n
     defaultModel: cat?.defaultModel ?? createDraft?.defaultModel ?? '',
     commandArgs: cat?.commandArgs?.join(' ') ?? createDraft?.commandArgs ?? '',
     cliConfigArgs: [...(cat?.cliConfigArgs ?? [])],
-    cliEffort: isCliEffortValue(persistedCliEffort) ? persistedCliEffort : '',
+    cliEffort: persistedCliEffort ?? '',
     provider: cat?.provider ?? '',
     acpEnabled:
       Boolean(acpConfig) || (cat?.clientId as ClientId | undefined) === 'acp' || createDraft?.clientId === 'acp',

--- a/packages/web/src/components/hub-cat-editor.model.ts
+++ b/packages/web/src/components/hub-cat-editor.model.ts
@@ -152,8 +152,11 @@ function voiceStr(value: string | number | undefined): string {
   return value == null ? '' : String(value);
 }
 
-export function getCliEffortOptionsForClient(client: ClientValue): readonly CliEffortValue[] | null {
-  return getCliEffortOptionsForProvider(client);
+export function getCliEffortOptionsForClient(
+  client: ClientValue,
+  defaultModel?: string | null,
+): readonly CliEffortValue[] | null {
+  return getCliEffortOptionsForProvider(client, defaultModel);
 }
 
 export function splitMentionPatterns(raw: string): string[] {

--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -763,6 +763,22 @@
     "owner": "opus-48"
   },
   {
+    "id": "feature-f127-native-cli-effort",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F127-cat-instance-management.md", "anchor": "R-11" },
+    "structureSource": { "path": "docs/features/F127-cat-instance-management.md", "anchor": "遗留项" },
+    "bodySource": { "path": "docs/features/F127-cat-instance-management.md", "anchor": "R-11" },
+    "contexts": ["concierge_open", "feature_dev"],
+    "audience": ["cvo"],
+    "body": "在 Hub 成员的「高级运行时参数」里，CLI Effort 可选 preset，也可输入 Codex 等 CLI 的原生值（如 ultra）；保存后从下一次调用生效。",
+    "action": {
+      "type": "open_source",
+      "label": "查看成员配置说明",
+      "sourceRef": { "path": "docs/features/F127-cat-instance-management.md", "anchor": "R-11" }
+    },
+    "owner": "codex"
+  },
+  {
     "id": "feature-f245-friction-eval-rollup",
     "kind": "feature",
     "sourceRef": { "path": "docs/features/F245-friction-signal-eval.md", "anchor": "Friction Signal Eval" },

--- a/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
+++ b/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
@@ -47,9 +47,9 @@ Please verify that the diff matches `Map delta: none` and does not introduce a p
 
 Scope verdict: required.
 
-- Isolated preview: `WORKTREE_PORT_OFFSET=-10 pnpm dev:direct` started Redis `6388`, API `3112`, and Web `5112`; both Web `/` and API `/health` returned HTTP 200. The Hub preview was opened at `5112`, then the service and ports were stopped cleanly.
-- The in-app browser control surface was unavailable in this environment, so no persistent catalog mutation was made in an already-populated dev Redis. The direct-entry rendering and state serialization are covered by `hub-cat-editor.test.tsx` (60 passing tests); POST/PATCH persistence is covered in the isolated API test-home suite (269 passing tests).
-- The feature plan explicitly marks manual browser rendering as not required for this initial semantic change. Reviewer should still inspect the input/datalist UX and save-path coverage.
+- Latest isolated author preview: `WORKTREE_PORT_OFFSET=-30 pnpm dev:direct -- --memory` used memory-only storage, API `3132`, and Web `5132`; both Web `/` and API `/health` returned HTTP 200. `cat_cafe_preview_open` opened the Hub preview at `5132`, then the service was stopped and both ports were confirmed free.
+- Dogfood path: a temporary `gpt-5.6-terra` Codex member accepted structured `cli.effort="ultra"` through `POST /api/cats`, and `GET /api/cats` returned the exact model and effort. The memory-only server discarded that temporary state when it stopped.
+- The in-app browser interaction controller is unavailable in this invocation, so this record does **not** claim visual approval. `hub-cat-editor.test.tsx` covers the direct-entry field and GPT-5.6 `max / ultra` suggestions; the formal reviewer must interact with the member editor in an isolated preview before approving.
 
 ## Open Questions
 

--- a/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
+++ b/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
@@ -1,0 +1,135 @@
+# Review Request: #315 provider-adaptive CLI effort
+
+Review-Target-ID: issue-315-provider-adaptive-effort
+Branch: fix/issue-315-provider-adaptive-effort
+SHA: 318d3e6ce7584ef0c4fb258a88ae166c19cb2cfd
+
+## What
+
+The Hub member editor now keeps client-specific effort presets as suggestions while allowing direct native text input. The runtime catalog and Cats API accept and retain any trimmed, non-empty `cli.effort` string. Provider adapters remain responsible for argument construction: Codex serializes the value into one TOML-escaped `--config` argument; Claude keeps its structured `--effort`, value argv pair.
+
+## Why
+
+Provider CLIs evolve independently of our maintained preset vocabulary. Rejecting or normalizing a native value such as Codex `max` or `ultra` prevents a member from using a provider capability until our UI enum catches up.
+
+## Original Requirements
+
+> "Present maintained internal CLI-effort presets appropriate for the selected client. Also allow direct text entry of a native client effort value. Codex must be able to use native values including `max` and `ultra`. Persist the selected or typed canonical string in `variant.cli.effort`. The adapter owns CLI argument construction and escaping."
+
+- Source: [clowder-ai#315](https://github.com/zts212653/clowder-ai/issues/315)
+- Please assess the diff against this extract, including the requirement that existing sessions are not force-switched.
+
+## Tradeoff
+
+We deliberately do not maintain provider-version detection or a second provider-native enum. Presets remain discoverable suggestions; unknown non-empty values are accepted and the selected CLI remains the authority that can reject them. This avoids both release lag and raw shell-string construction.
+
+## Architecture Ownership
+
+Architecture cell: `identity-session` (identity-agent subcell)
+Map delta: none
+Why: This changes the existing cat-instance configuration contract and its existing provider adapters without adding a store, router, queue, or ownership boundary.
+
+Please verify that the diff matches `Map delta: none` and does not introduce a parallel configuration truth source.
+
+## Invariant Matrix
+
+| Invariant | Assertion | Evidence |
+| --- | --- | --- |
+| INV-1 | Runtime catalog preserves a user-entered non-empty effort string unchanged. | loader and Cats route tests |
+| INV-2 | Form hydration and serialization round-trip presets and unfamiliar native values unchanged. | Hub editor component tests |
+| INV-3 | Only the selected provider adapter constructs argv; typed text is never a shell command. | Codex TOML-escaping regression and existing Claude argv tests |
+| INV-4 | Saved effort is read by a new invocation; no existing session is mutated or restarted. | `getCatEffort`/provider invocation tests; no session lifecycle code changed |
+
+## E2E User Path Evidence
+
+Scope verdict: required.
+
+- Isolated preview: `WORKTREE_PORT_OFFSET=-10 pnpm dev:direct` started Redis `6388`, API `3112`, and Web `5112`; both Web `/` and API `/health` returned HTTP 200. The Hub preview was opened at `5112`, then the service and ports were stopped cleanly.
+- The in-app browser control surface was unavailable in this environment, so no persistent catalog mutation was made in an already-populated dev Redis. The direct-entry rendering and state serialization are covered by `hub-cat-editor.test.tsx` (60 passing tests); POST/PATCH persistence is covered in the isolated API test-home suite (269 passing tests).
+- The feature plan explicitly marks manual browser rendering as not required for this initial semantic change. Reviewer should still inspect the input/datalist UX and save-path coverage.
+
+## Open Questions
+
+### Technical OQ
+
+1. Does widening `CliEffortValue` to `string` leave any consumer that still incorrectly assumes the preset-only union?
+2. Is the Codex TOML escaping sufficient for control characters, quotes, and backslashes while preserving exactly one config value?
+3. Do existing sanitized CLI exit/error paths remain adequate when a provider rejects an accepted native effort value?
+
+### Value OQ
+
+None.
+
+## Fresh-Context Findings
+
+Agent: [砚砚/gpt-5.6-terra🐾] (new continuation session)
+SHA scanned: 318d3e6ce
+Total findings: 0 (0 P1, 0 P2, 0 P3)
+
+The scan re-read #315, the complete diff, loader/API/adapter call sites, and the fallback/security surface. It is a finding generator only, not an approval.
+
+## Next Action
+
+Please perform an independent cross-family review of the current SHA. Give an explicit `APPROVE` or `REQUEST-CHANGES` verdict and label every finding P1/P2/P3. Focus on the invariant matrix, unknown-value passthrough, safe argv serialization, and the shared type's blast radius.
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/issue-315-provider-adaptive-effort/opus`
+- Start command: `pnpm review:start`
+- Ports: assigned by the review launcher; do not use runtime ports `3003`/`3004`.
+
+Before running target API tests in a clean sandbox:
+
+```bash
+unset NODE_ENV
+pnpm install --frozen-lockfile
+pnpm --filter @cat-cafe/shared build
+pnpm --filter @cat-cafe/api run build
+```
+
+## Quality-Gate Evidence
+
+### Acceptance coverage
+
+| #315 requirement | Evidence |
+| --- | --- |
+| Presets plus direct entry | editable `TextField` with datalist suggestions; Web regression |
+| Codex `max`/`ultra` | loader/API passthrough coverage; native-value adapter assertion |
+| Non-preset persistence | Cats route and loader tests |
+| Safe structured args | `buildCodexReasoningArgs()` uses TOML string escaping; no shell concatenation |
+| Native failure visibility | existing Codex/Claude CLI error-path regressions pass in the targeted suite |
+| New invocation only | configuration resolution/provider invocation path only; no session lifecycle edits |
+
+### Commands actually run
+
+```bash
+# Isolated API test-home prelude
+pnpm --filter @cat-cafe/api run build
+cd packages/api
+CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh \
+  node --import "$(pwd)/test/helpers/setup-cat-registry.js" --test --test-timeout=60000 \
+  test/cat-config-loader.test.js test/cats-routes-runtime-crud.test.js \
+  test/codex-agent-service.test.js test/claude-agent-service.test.js
+# Result: build 0; 269 passed, 0 failed
+
+cd ../../
+pnpm --dir packages/web exec node scripts/run-with-node-env-test.mjs \
+  pnpm exec vitest run src/components/__tests__/hub-cat-editor.test.tsx \
+  --pool=forks --no-file-parallelism
+# Result: 60 passed, 0 failed
+
+pnpm lint                         # exit 0 (pre-existing warnings only)
+pnpm check                        # exit 0
+pnpm -r --if-present run build    # exit 0
+```
+
+`pnpm test` exits 1 on the unmodified upstream baseline: `origin/main` lacks `.claude/settings.json`, `.claude/hooks/shared-doc-push-guard.sh`, and `scripts/signal-fetcher-launchd.sh`; the #315 diff touches none of these paths. The failure is recorded, not waived as a green result.
+
+`scripts/check-fallback-layers.mjs` is absent from this open-source checkout. A diff audit found no added `try`/`catch` or multi-layer fallback chain; the three added `??` uses are single-level UI/default expressions.
+
+Artifact hygiene: no root-level media/design artifacts in either the worktree or committed diff. No matching `.pen` file exists.
+
+## Related Documents
+
+- Plan: `feature-specs/2026-07-10-issue-315-provider-adaptive-effort.md`
+- Feature: `docs/features/F127-cat-instance-management.md` (R-11)

--- a/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
+++ b/review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md
@@ -2,7 +2,10 @@
 
 Review-Target-ID: issue-315-provider-adaptive-effort
 Branch: fix/issue-315-provider-adaptive-effort
-SHA: 318d3e6ce7584ef0c4fb258a88ae166c19cb2cfd
+Implementation-SHA: 318d3e6ce7584ef0c4fb258a88ae166c19cb2cfd
+Note: This SHA identifies the original implementation commit. The current PR HEAD
+may differ due to main-sync merges and review-round fixes. Always verify against
+the actual PR HEAD for approval evidence.
 
 ## What
 


### PR DESCRIPTION
## Summary

Closes #315.

- **Shared type**: `CliEffortValue` widened from a closed enum to `string`; `CliEffortPreset` retains the maintained vocabulary for Hub suggestions
- **API/Loader**: Zod validates non-empty (`z.string().trim().min(1)`); `getCatEffort` preserves exact persisted values without cross-provider normalization
- **Hub UI**: Effort field changed from `<select>` to editable `<input>` with `<datalist>` preset suggestions — users can enter native values like `max` or `ultra`
- **Codex adapter**: Extracted `buildCodexReasoningArgs()` using existing `toTomlString()` for safe TOML serialization — no shell interpolation

### Invariants

1. Non-empty effort persists unchanged in the runtime catalog (no silent normalization)
2. Maintained presets are suggestions only; unknown native values pass through
3. Only the selected adapter constructs CLI args; Codex uses TOML escaping
4. Settings apply to new invocations only; existing sessions are not restarted

## Test plan

- [x] Loader: native `max`/`ultra` preserved, absent values default correctly (`cat-config-loader.test.js`)
- [x] API: POST/PATCH persist native values, blank rejected (`cats-routes-runtime-crud.test.js`)
- [x] Codex adapter: TOML-escaped argv, quote-bearing value safe (`codex-agent-service.test.js` — 212/212)
- [x] Hub: native value hydration, editable input with preset datalist (`hub-cat-editor.test.tsx` — 60/60)
- [x] `pnpm lint` / `pnpm check` / `pnpm -r build` / `tsc --noEmit` — all pass
- [ ] Full `pnpm test` has pre-existing baseline blocker (#1013: missing `signal-fetcher-launchd.sh`), same on `origin/main`

**Cross-family review**: APPROVED by 布偶猫/宪宪 (claude-opus-4-6) — no P1/P2 findings.
Review notes: `review-notes/2026-07-10-issue-315-provider-adaptive-effort-review-request.md`

🐾 Implementation by 缅因猫/砚砚 (gpt-5.6-terra), reviewed by 布偶猫/宪宪 (claude-opus-4-6)

## Maintainer merge-gate risk assessment

- **Behavior:** Changes member-level CLI effort suggestions, persistence, and subsequent invocation arguments; it does not restart or mutate existing sessions.
- **Data:** Stores one trimmed non-empty string in the runtime catalog; clearing removes the field. No migration or production-data rewrite.
- **Security:** User input reaches providers only through adapter-owned structured argv; Codex values use TOML escaping and no shell interpolation.
- **Contract:** Maintained provider/model presets remain suggestions; unsupported clients return HTTP 400; provider-native validation errors remain observable.
- **Irreversible:** Source merge is squash-only. Post-merge Cat Café intake is a separate manual-port flow, not a blind cherry-pick.

Independent exact-HEAD review: APPROVED at `e0a8672b53ee84049f60fde124780aa3f3330864`. Exact-HEAD CI: Lint, Windows, Build, Public Test, and Directory Size Guard all green.