### PR TITLE
fix(web): surface actionable hint on agent-hook 403 instead of bare status code

### DIFF
--- a/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
@@ -25,11 +25,33 @@ function flushPromises() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-function Probe({ onStatus }: { onStatus: (status: string | null) => void }) {
-  const { health } = useAgentHookHealth({ enabled: true });
+function Probe({
+  onStatus,
+  onError,
+}: {
+  onStatus?: (status: string | null) => void;
+  onError?: (error: string | null) => void;
+}) {
+  const { health, error } = useAgentHookHealth({ enabled: true });
   useEffect(() => {
-    onStatus(health?.status ?? null);
+    onStatus?.(health?.status ?? null);
   }, [health?.status, onStatus]);
+  useEffect(() => {
+    onError?.(error);
+  }, [error, onError]);
+  return null;
+}
+
+function SyncProbe({ onError }: { onError: (error: string | null) => void }) {
+  const { error, sync } = useAgentHookHealth({ enabled: false });
+
+  useEffect(() => {
+    void sync();
+  }, [sync]);
+
+  useEffect(() => {
+    onError(error);
+  }, [error, onError]);
   return null;
 }
 
@@ -85,5 +107,43 @@ describe('useAgentHookHealth', () => {
     expect(apiFetch).toHaveBeenCalledTimes(1);
     expect(apiFetch).toHaveBeenCalledWith('/api/agent-hooks/status');
     expect(statuses).toContain('configured');
+  });
+
+  it('maps localhost-only 403 status failures to an actionable hint', async () => {
+    const errors: Array<string | null> = [];
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Agent hook health requires an explicit targetRoot or a local API host' }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<Probe onError={(error) => errors.push(error)} />);
+      await flushPromises();
+      await flushPromises();
+    });
+
+    expect(errors).toContain(
+      'Agent Hook 只支持从本机 localhost 直接访问的 Hub 检测。请改用 http://localhost:3003 打开后重试。',
+    );
+  });
+
+  it('maps localhost-only 403 sync failures to an actionable hint', async () => {
+    const errors: Array<string | null> = [];
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'Agent hook sync requires an explicit targetRoot or a local API host' }),
+    } as Response);
+
+    await act(async () => {
+      root.render(<SyncProbe onError={(error) => errors.push(error)} />);
+      await flushPromises();
+      await flushPromises();
+    });
+
+    expect(errors).toContain(
+      'Agent Hook 同步只支持从本机 localhost 直接访问的 Hub 发起。请改用 http://localhost:3003 打开后重试。',
+    );
   });
 });

--- a/packages/web/src/hooks/useAgentHookHealth.ts
+++ b/packages/web/src/hooks/useAgentHookHealth.ts
@@ -46,6 +46,8 @@ let hasCachedHealth = false;
 let inFlightProjectPath: string | undefined;
 let inFlightStatus: Promise<AgentHookStatusResponse> | null = null;
 
+type AgentHookRequestKind = 'status' | 'sync';
+
 function isAgentHookStatusResponse(value: unknown): value is AgentHookStatusResponse {
   return (
     !!value &&
@@ -53,6 +55,33 @@ function isAgentHookStatusResponse(value: unknown): value is AgentHookStatusResp
     typeof (value as { status?: unknown }).status === 'string' &&
     Array.isArray((value as { targets?: unknown }).targets)
   );
+}
+
+async function readErrorDetail(res: Response): Promise<string | null> {
+  try {
+    const payload = await res.json();
+    const message = payload && typeof payload === 'object' ? (payload as { error?: unknown }).error : null;
+    return typeof message === 'string' && message.trim() ? message.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+function formatAgentHookError(kind: AgentHookRequestKind, status: number, detail: string | null): string {
+  const normalized = detail?.toLowerCase() ?? '';
+
+  if (status === 403 && normalized.includes('local api host')) {
+    return kind === 'status'
+      ? 'Agent Hook 只支持从本机 localhost 直接访问的 Hub 检测。请改用 http://localhost:3003 打开后重试。'
+      : 'Agent Hook 同步只支持从本机 localhost 直接访问的 Hub 发起。请改用 http://localhost:3003 打开后重试。';
+  }
+
+  if (status === 401) {
+    return 'Agent Hook 请求需要有效会话。请刷新页面后重试。';
+  }
+
+  if (detail) return detail;
+  return `agent hook ${kind} failed (${status})`;
 }
 
 async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatusResponse> {
@@ -66,7 +95,10 @@ async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatu
   inFlightProjectPath = projectPath;
   inFlightStatus = apiFetch(url)
     .then(async (res) => {
-      if (!res.ok) throw new Error(`agent hook status failed (${res.status})`);
+      if (!res.ok) {
+        const detail = await readErrorDetail(res);
+        throw new Error(formatAgentHookError('status', res.status, detail));
+      }
       const status = await res.json();
       if (!isAgentHookStatusResponse(status)) throw new Error('agent hook status response is invalid');
       return status;
@@ -90,7 +122,10 @@ async function postAgentHookSync(projectPath?: string): Promise<AgentHookStatusR
     headers: projectPath ? { 'Content-Type': 'application/json' } : undefined,
     body: projectPath ? JSON.stringify({ projectPath }) : undefined,
   });
-  if (!res.ok) throw new Error(`agent hook sync failed (${res.status})`);
+  if (!res.ok) {
+    const detail = await readErrorDetail(res);
+    throw new Error(formatAgentHookError('sync', res.status, detail));
+  }
   const status = await res.json();
   if (!isAgentHookStatusResponse(status)) throw new Error('agent hook sync response is invalid');
   cachedHealth = status;


### PR DESCRIPTION
## Summary
- surface backend 403 details in `useAgentHookHealth` instead of dropping to a bare status code
- map the localhost-only guard failures to actionable `http://localhost:3003` guidance for both status and sync
- add hook tests covering the two 403 paths

## Verification
- `pnpm --filter @cat-cafe/web exec vitest run src/hooks/__tests__/use-agent-hook-health.test.tsx`
- `pnpm exec biome check --diagnostic-level=error packages/web/src/hooks/useAgentHookHealth.ts packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx`
- `env -u WHISPER_URL -u NEXT_PUBLIC_WHISPER_URL -u TTS_URL -u CAT_CAFE_API_URL -u API_SERVER_PORT -u FRONTEND_PORT -u CAT_CAFE_RESPECT_DOTENV_PORTS CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import $(pwd)/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/services-route.test.js` (from `packages/api`)
- `env -u WHISPER_URL -u NEXT_PUBLIC_WHISPER_URL -u CAT_CAFE_API_URL -u API_SERVER_PORT -u FRONTEND_PORT -u CAT_CAFE_RESPECT_DOTENV_PORTS CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1 bash ./scripts/with-test-home.sh node --import $(pwd)/test/helpers/setup-cat-registry.js --test --test-timeout=60000 test/whisper-stt-provider.test.js` (from `packages/api`)

## Notes
- `pnpm gate --no-rebase` did not go fully green in this shell for reasons outside this diff:
  - `tmux` is not installed locally, so the `tmux-*` public API suites hard-fail in setup.
  - shell env overrides (`WHISPER_URL`, `NEXT_PUBLIC_WHISPER_URL`, `TTS_URL`) contaminated unrelated persisted-port API tests until they were unset.
- This diff only touches `packages/web/src/hooks/useAgentHookHealth.ts` and its test file.
