### PR TITLE
fix(governance): read registry from persistent workspace

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -69,7 +69,10 @@ import { resolveActiveProjectRoot } from '../../../../../utils/active-project-ro
 import { resolveCliCommand } from '../../../../../utils/cli-resolve.js';
 import { DEFAULT_CLI_TIMEOUT_MS, resolveCliTimeoutMs } from '../../../../../utils/cli-timeout.js';
 import { findMonorepoRoot, isSameProject } from '../../../../../utils/monorepo-root.js';
-import { resolvePersistentProjectPathDetailed } from '../../../../../utils/persistent-project-path.js';
+import {
+  redirectRuntimeProjectPath,
+  resolvePersistentProjectPathDetailed,
+} from '../../../../../utils/persistent-project-path.js';
 import { pathsEqual } from '../../../../../utils/project-path.js';
 import { tcpProbe } from '../../../../../utils/tcp-probe.js';
 import type { AgentPaneRegistry } from '../../../../terminal/agent-pane-registry.js';
@@ -1406,7 +1409,10 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
     // Bootstrap is handled by Console's explicit init button (projects-setup.ts).
     // invokeCat only gates — checkGovernancePreflight is the real guard.
     if (workingDirectory && !isSameProject(workingDirectory, hostProjectRoot)) {
-      const catCafeRoot = hostProjectRoot;
+      // Project setup writes the registry under the persistent workspace when
+      // the API runs from a disposable checkout. Read from that same root.
+      const catCafeRoot = await redirectRuntimeProjectPath(hostProjectRoot);
+      if (!catCafeRoot) throw new Error('Unable to resolve persistent Cat Cafe root for governance preflight');
       const { checkGovernancePreflight } = await import('../../../../../config/governance/governance-preflight.js');
       const catEntry = catRegistry.tryGet(catId as string);
       const preflight = await checkGovernancePreflight(workingDirectory, catCafeRoot, catEntry?.config.clientId);

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -18,6 +18,7 @@ const hasSourceStagingContent = existsSync(
 
 import { afterEach, before, beforeEach, describe, it, mock } from 'node:test';
 import { catRegistry } from '@cat-cafe/shared';
+import { GovernanceBootstrapService } from '../dist/config/governance/governance-bootstrap.js';
 
 function assertStagingPromptContract(prompt, mode) {
   if (hasSourceStagingContent) {
@@ -7083,6 +7084,68 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     );
     assert.equal(optionsSeen.length, 1, `service should be invoked once, got messages: ${JSON.stringify(msgs)}`);
     assert.equal(optionsSeen[0]?.workingDirectory, projectRoot);
+  });
+
+  it('reads external-project governance from the persistent workspace when invoked from a runtime checkout', async () => {
+    const previousCwd = process.cwd();
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    const runtimeRoot = await realpath(await mkdtemp(join(tmpdir(), 'governance-runtime-root-')));
+    const workspaceRoot = await realpath(await mkdtemp(join(tmpdir(), 'governance-workspace-root-')));
+    const externalProject = await realpath(await mkdtemp(join(tmpdir(), 'governance-external-project-')));
+    await Promise.all([
+      writeFile(join(runtimeRoot, 'pnpm-workspace.yaml'), 'packages: []\n'),
+      writeFile(join(workspaceRoot, 'pnpm-workspace.yaml'), 'packages: []\n'),
+    ]);
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+    process.chdir(runtimeRoot);
+
+    const bootstrap = new GovernanceBootstrapService(workspaceRoot);
+    await bootstrap.bootstrap(externalProject, { dryRun: false });
+
+    let invokedService = false;
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke() {
+        invokedService = true;
+        yield { type: 'done', catId: 'codex', timestamp: Date.now() };
+      },
+    };
+    const deps = {
+      ...makeDeps(),
+      threadStore: {
+        get: async () => ({ projectPath: externalProject, createdBy: 'user1' }),
+        updateParticipantActivity: async () => {},
+      },
+    };
+
+    try {
+      const msgs = await collect(
+        invokeSingleCat(deps, {
+          catId: 'codex',
+          service,
+          prompt: 'invoke initialized external project',
+          userId: 'user1',
+          threadId: 'thread-persistent-governance-root',
+          isLastCat: true,
+        }),
+      );
+
+      assert.equal(invokedService, true, 'the initialized external project should reach the agent service');
+      assert.equal(
+        msgs.some((m) => m.type === 'system_info' && m.content?.includes('governance_blocked')),
+        false,
+        'dispatch must read the registry written under the persistent workspace',
+      );
+    } finally {
+      process.chdir(previousCwd);
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
+      await Promise.all([rmWithRetry(runtimeRoot), rmWithRetry(workspaceRoot), rmWithRetry(externalProject)]);
+    }
   });
 
   it('migrates a legacy runtime-root thread before invoking the agent', async () => {


### PR DESCRIPTION
## Summary

- Resolve the Cat Cafe root used by invocation governance preflight through the persistent workspace mapping.
- Keep every other runtime-root behavior unchanged.
- Add a regression test for split runtime/workspace/external-project deployments.

## Root cause

Project setup and governance confirmation write registry state under the persistent workspace when the API runs from a disposable runtime checkout. Invocation preflight still read from the runtime checkout, so initialization returned success but the next cat invocation treated the project as uninitialized.

This is the second defect behind #1135; #1051 fixed the stale Skills symlink check but did not address the split registry root. The issue should remain open until a Windows/source artifact containing this PR is verified.

## Source provenance

Port of zts212653/cat-cafe#2944, merged as e053ce49dd55f2914377fbeb27f4af87694d706f.

## Validation

- pnpm --filter @cat-cafe/api build
- 184/184 targeted tests passed across project-path, project setup, governance preflight/events, and invokeSingleCat
- pnpm check:capability-tips
- node scripts/check-feature-truth.mjs
- git diff --check
- targeted Biome check: no errors; 19 pre-existing warnings in the touched legacy files

## Risk

Behavioral scope is limited to choosing the registry root for governance preflight. No schema, auth, API contract, dependency, or persisted-data migration changes.

[小太阳·砚砚/GPT-5.6 Sol🐾]