### PR TITLE
feat(LI-005): A2A ack-liveness detection — durable trigger/ack state machine

### DIFF
--- a/docs/features/assets/F257/live-candidates-2026-07-14.md
+++ b/docs/features/assets/F257/live-candidates-2026-07-14.md
@@ -1,0 +1,237 @@
+---
+feature_ids: [F257]
+topics: [harness, candidates, live-incident, five-ring]
+doc_kind: note
+created: 2026-07-14
+---
+
+# Live Candidates — 手动五环首单（2026-07-14）
+
+> 按 judgment-schema-v1（FROZEN）§3 Candidate 结构手工填写。目的双重：
+> ① 五环第一次端到端走通（KD-10「问题先行，账本伴生」）——不等基建齐；
+> ② 判定引擎的输入格式以本文件的归因结构为实例参照；实现已随 PR #35 合入。
+>
+> 编号约定补充（不动 schema 字段，仅值域注记）：`LI-*` = live-incident 来源手工归因单（对齐 T1-* 静态体检 / EC-* eval 产出的前缀惯例）。
+
+## LI-001 — 持球唤醒 no-response（结构回调被当通知）
+
+```yaml
+candidate:
+  candidateId: LI-001
+  type: missing-segment          # 错误已发生、无结构承载拦截（A1 第五样本）
+  targetSegmentIds: []           # missing 类：无现有段，见 proposedSegment
+  originKind: live-incident
+  evidence:
+    anchors:
+      - msg 0001783929291767-000105  # 07:54 持球唤醒（exit 1 + nextStep 在场）→ 猫回 no-response
+      - msg 0001783931905296-000126  # 08:38 operator push「继续」才动
+      - msg 0001783934622816-001003  # 09:23 operator「我需要反复push你们才会动」
+      - harness-body-inputs.md A1 第五样本（2026-07-13）
+    summary: >
+      wakeWhen 命令托管回调携带 exit code + 猫自己写的 nextStep 返回，
+      猫将指令性唤醒误判为通知、未产生任何动作；同晚第二例：关键路径长命令
+      挂进程内后台（run_in_background），宿主进程重启静默杀死零回调。
+      两例均由 operator 人工 push 才恢复推进。文本 nextStep 在场而行为不发生。
+  proposedSegment: >
+    结构 guard（O1）：持球唤醒 dispatch 必须产出动作（tool call 或显式终态声明），
+    no-response 被结构拒绝并重试（同 waitSourceRef 400 的一次生效模式）。
+    伴随 O2：hold_ball GOTCHA 增补「关键路径长命令必须 wakeWhen 服务端托管，
+    run_in_background 宿主进程死亡即静默失联」。
+  proposedAction:
+    mechanism: add-guard
+    rollback: 移除 dispatch 层 no-response 校验（单点 revert，不影响正常唤醒路径）
+  status: verifying
+  approval:
+    approvedBy: null             # operator gate——猫不可代填
+    decidedAt: null
+    note: 可逆 guard 按决策漏斗自决实施；operator gate 仅保留给不可逆段治理。行为差分窗口未满，不得 closed。
+```
+
+## LI-002 — 运行时环境真相源缺失（查错环境对象）
+
+```yaml
+candidate:
+  candidateId: LI-002
+  type: missing-segment
+  targetSegmentIds: []
+  originKind: live-incident
+  evidence:
+    anchors:
+      - msg 0001783992762034-001124  # 01:32 operator「你现在很明显在看项目环境」
+      - harness-body-inputs.md 第六样（2026-07-14）
+    summary: >
+      operator 问「tracing 实际采集了什么」，猫 grep 项目 repo 的 .env 拿到
+      死端口 6799 → 连接拒绝，差点把「连不上」报成「零采集」；
+      而 `env | grep REDIS`（运行实例注入进程的变量）一步即真端口 6099。
+      运行时环境（cat-cafe-develop-base）vs 项目环境的区分不在猫的结构化上下文中。
+  proposedSegment: >
+    O2（立即可做）：shared-rules.local 端口与数据隔离段增补运行时根路径
+    （/Users/lang/workspace/github-lab/cat-cafe-develop-base）+「查运行时状态
+    先 `env | grep`，进程环境变量是运行实例注入的一手真相」。
+    O1（operator 2026-07-14 02:24 方向确认，msg 0001783995880396）：session-init
+    结构化注入三元组——①我们自己的运行环境（运行时根路径/REDIS_URL/保留端口）
+    ②当前项目环境 ③实际工作信息（get_thread_metadata 拉取）。
+  proposedAction:
+    mechanism: rewrite            # O2 先行；O1 随段迭代落 hook（operator 已拍方向）
+    rollback: revert 该文档段落（纯文本，零运行时影响）；O1 段可 override-disable
+  status: executing               # O2 已落地；O1 runtime facts 结构注入仍在工程队列
+  approval:
+    approvedBy: null
+    decidedAt: null
+    note: operator 2026-07-14 02:24 明确「拉起的时候应该要注入环境信息」；可逆 O2 按决策漏斗自决实施。
+```
+
+## LI-003 — operator 优化结论/纠偏无事件通道（operator 本人点名的缺口）
+
+```yaml
+candidate:
+  candidateId: LI-003
+  type: missing-segment
+  targetSegmentIds: []
+  originKind: live-incident
+  evidence:
+    anchors:
+      - msg 0001783995880396-001155  # 02:24「即使没到阈值，也应该作为某个段的事件；
+                                      #   或新增的无段匹配的事件记录下来；之后要进行评估」
+      - msg 0001783992409176-001111  # 01:26 Q2「你们怎么知道我发的纠偏是一个 signal」
+      - Fable Q2 回答（承认纠偏信号零采集通道，同日）
+    summary: >
+      operator 的优化结论/纠偏当前没有任何事件化通道——guard 阈值触发只覆盖
+      O1 结构拦截（http_rate_limit/route_decision_block 两类），operator 语义
+      信号（今日实测 4+ 条纠偏）账本收到 0 条。operator 正式要求：此类结论
+      即使未达阈值也必须入账（有段匹配挂段、无段匹配记 missing-segment 事件），
+      并排入后续评估。本单自身即首个用例：02:24 消息已按此语义入账。
+  proposedSegment: >
+    纠偏事件通道：GuardRejectionEventLog 新增 kind: operator_correction
+    （schema §2.1b Week2+ 六类预留位），采集方式候选——ⓐ operator 消息一键标记
+    ⓑ 猫收到纠偏时结构化 ack 强制入账 ⓒ eval 猫离线扫 thread LLM 判定（非关键词）
+    ——三者不互斥，ⓑ 可最先落（猫侧行为约定 + append API 已存在）。
+    入账事件无阈值直接排入下轮 eval；判定引擎消费其 violationCount。
+  proposedAction:
+    mechanism: add-guard          # 广义：新增事件采集通道 + 猫侧 ack 纪律
+    rollback: 停用该 kind 的采集（append 端 flag），已入账事件保留（append-only）
+  status: proposed
+  approval:
+    approvedBy: null
+    decidedAt: null
+    note: 可逆事件通道已进入工程队列，尚未实现。
+```
+
+## LI-004 — 运行实例 worktree 被直接 commit → develop_base 持续分叉（部署阻塞根因）
+
+```yaml
+candidate:
+  candidateId: LI-004
+  type: missing-segment
+  targetSegmentIds: []
+  originKind: live-incident
+  evidence:
+    anchors:
+      - "git: 49e3c16b3 (19:39) + 647c21979 (09:26)，author Ragdoll-Opus-4.6，直接 commit 到 cat-cafe-develop-base 本地 develop_base"
+      - "git cherry: 同 patch 经正规渠道入 origin（42405db0a/bcd0835bd）→ 同内容异 SHA 分叉"
+      - "下游效应①：opus feature 分支从本地线切出 → 28 commits/12k 行假 diff，review 被阻一轮"
+      - "下游效应②：PR #35 合入 origin 后运行实例吃不到（pull --ff-only fatal）→ F257 部署阻塞"
+    summary: >
+      猫 session 在运行实例 worktree（cat-cafe-develop-base）直接 commit 而非走
+      feature 分支 → origin PR → pull 回流；无任何 guard 拦截。共享集成分支
+      出现私有平行历史，正在进行时（两笔间隔 14h）。
+  proposedSegment: >
+    「运行实例 worktree 写保护」guard——O1：cat-cafe-develop-base 加 pre-commit
+    hook 拒绝猫 identity 的直接 commit（提示走 feature 分支）；O2 伴随：家规
+    端口与数据隔离段增补「运行实例目录对猫只读，改动一律 feature 分支 → origin
+    → pull」。
+  proposedAction:
+    mechanism: add-guard
+    rollback: 移除 pre-commit hook（单文件）；O2 revert 文档段
+  status: executing               # O2 已落地且 Git 分叉已收敛；O1 pre-commit guard 尚未实现
+  approval:
+    approvedBy: null
+    decidedAt: null
+    note: 可逆 O2 与仓库 reset 已完成；O1 仍待工程实现。
+```
+
+## 2026-07-15 清算（operator 01:38 纠偏触发：审批流程过度化 = 空跑根源之一）
+
+**重判**：judgment-schema 的 operator gate（approvedBy 猫不可代填）本意是**段禁用/淘汰类不可逆治理动作**。LI-001~004 的修补全部是可逆的 guard/文档改动（≤1 commit 回滚 + 不碰硬排除）——按决策漏斗属**猫自决范围**。把它们挂"等 operator 打字审批"两天 = 把 operator 变成流程瓶颈 = 他说的"说在我手上但实际没推进"。清算如下：
+
+| 单 | 状态 | 处置 |
+|----|------|------|
+| LI-001（唤醒必须产出动作） | **verifying** | PR #38 `0cdd17f68` 已合入；`29533ccbb` 关闭 429 retry noise；等待 PatchTrial ≥5 天差分窗口 |
+| LI-002（运行时环境注入） | **O2 done**（2026-07-15 shared-rules.local 已落地生效）| O1（session-init runtime facts 卡）进段迭代队列；operator 方向确认锚 msg 0001783995880396 |
+| LI-003（operator 纠偏事件化） | proposed → **queued** | operator_correction kind 进工程队列；人肉 ack 纪律已在执行（本清算即实例） |
+| LI-004（运行实例写保护） | **O2 done** + reset 已完成 | 2026-07-16 复核本地/远端 `develop_base@729509e35` 一致；O1 pre-commit hook 仍在工程队列 |
+| LI-005（传球无执行触发） | **Phase A executing** | Phase A: detection + hint + observability（ball.void_ack 事件 + telemetry）`feat/f257-li005-ack-liveness`；Phase B: structural rejection / auto-wake（O1 本体）待 Phase A 数据收集后实施 |
+
+**流程教训**：operator gate 保留给不可逆治理（段禁用/淘汰/版本固化）；可逆 guard/文档类候选猫自决 + 事后通报。
+
+## LI-005 — 传球无执行触发确认（"接了"= 文本承诺 ≠ 会执行）
+
+```yaml
+candidate:
+  candidateId: LI-005
+  type: missing-segment
+  targetSegmentIds: []
+  originKind: live-incident
+  evidence:
+    anchors:
+      - msg 0001784080016733  # operator 01:46「你说 opus 在跑；那你看看 opus 实际在跑么；会有什么任务触发 opus 跑么」
+      - "实测：opus 01:37 确认接操作面①②③后，无新 worktree、无开工痕迹——invocation 随消息结束，无任何触发机制会启动执行"
+    summary: >
+      A2A 传球的「接」是接球方 invocation 内的文本回复；invocation 结束后接球方不存在，
+      直到下一次被 @ 或定时唤醒。传球方把「对方说接了」当成「活在跑」，与第七样
+      （等 operator 无检测）同构：都是把声明当执行、无验证。
+  proposedSegment: >
+    O2：传球方纪律——传出实施类球后，下一次唤醒核对接球方产出痕迹（worktree/commit/消息），
+    无痕迹则重新触发（@ 开工令）而非继续等。O1：接球即建 scheduled task 或 dispatch 挂钩，
+    「接」的 ack 必须绑定一个未来触发器（无触发器的接球 = 结构拒绝）。
+  proposedAction: { mechanism: add-guard, rollback: 关闭触发器绑定校验 }
+  status: executing
+  phasing:
+    phaseA:
+      scope: "detection + hint + observability (ball.void_ack event + c2 telemetry)"
+      branch: feat/f257-li005-ack-liveness
+      rationale: >
+        谓词未调准就上结构拒绝会误杀合法接球（如用户手动 re-invoke 场景）。
+        Phase A 收集 ack_liveness_checked / hint_emitted 真实比率，校准
+        谓词后再上 Phase B。Scope 降级由 Fable 裁决背书（2026-07-16 08:20）。
+    phaseB:
+      scope: "structural rejection / auto-wake (O1 本体)"
+      status: deferred-pending-phase-a-data
+  approval:
+    approvedBy: null
+    decidedAt: null
+    note: >
+      Phase A/B 拆分经 Fable 裁决认可（2026-07-16 cross-post 0001784190021833）：
+      "分阶段 rollout 我认可（谓词未调准就上结构拒绝会误杀合法接球）"。
+      operator 正式审批待 Phase A 合入后补。
+```
+
+## PatchTrial 补账 — pt-O2-batch-20260715（对 2026-07-15 直接改 shared-rules.local 的事后合规化）
+
+```yaml
+patchTrial:
+  trialId: pt-O2-batch-20260715
+  candidateRef: [LI-002-O2, LI-004-O2, 第七样-等待带检测]
+  mechanism: rewrite（shared-rules.local 三段文本）
+  executedVia: 直接编辑落地——**违规：未先登记 trial 即变更规则**（operator 01:46 抓获：
+    「为什么没按照你自己构建出来的这套机制走」。根因自认：紧急感选最短路径 +
+    「五环执行面不全」的借口——实际账本部分是全的，跳过的是登记动作本身 +
+    文本锅依赖惯性。本记录为事后补账，改动保留、账先欠后还）
+  baseline: 互等空转 1 例（reset 数小时无猫检测）/ 查错环境对象 1 例 / 传球无触发确认 1 例
+  treatment: { window: 2026-07-15 起 ≥5 天 }
+  assertion: 唤醒后未核对挂起外部依赖的复发次数；查错环境对象复发次数
+  outcome: pending
+  a1-self-awareness: >
+    按本线 A1 公理（四猫样本：文本会忘，结构反馈忘不了），这三段纯文本大概率
+    无行为差分——试验窗口就是给它们的证伪机会。5 天后复发 → 文本段进 retire
+    候选，直接升 O1 结构 guard（LI-005 触发器绑定 / dispatch pending-dependency 卡）。
+```
+
+**结构性设计输入（operator 01:46 元问题的答案）**：体系不会因为存在而被走——**只有当它是最短路径时才会被走**。当前「直接改文档」比「登记 candidate」快一个数量级，压力下猫必选最短路径（本例实证）。体系要赢的两条路：①入账工具化到一步（MCP 工具 30 秒登记 candidate+trial）②无账变更被结构拦截（prompt/规则文件 pre-commit 查 ledger 引用，无引用拒绝）。两者进 F257 工程队列——这是「机制 scope 未覆盖时纳入机制」的机制本身。
+
+## 下一步（五环推进路径）
+
+1. **验证环**：LI-001 已进 `verifying`；以 2026-07-15 为 treatment 起点，窗口 ≥5 天后记录 no-response / 误重试复发差分，不提前判 improved。
+2. **结构修补环**：LI-005 durable A2A trigger/ack 状态机为下一实现项；LI-002 O1 runtime facts、LI-003 operator-correction 事件、LI-004 pre-commit guard 继续排队。
+3. **首个完整五环**：从已有 candidate 中选择可安全 override 的真实段，完成 candidate → 决策 → PatchTrial → ≥5 天差分 → solidify/rollback/retire，兑现 AC-A0/AC-E1，而不是用“代码已合入”替代闭环。
+4. **体系入口**：把 candidate/trial 登记压缩为一步工具，并为规则/段变更加 ledger reference gate；体系只有成为最短路径才会被持续使用。

--- a/docs/features/assets/li005-ack-liveness/live-candidates-2026-07-14.md
+++ b/docs/features/assets/li005-ack-liveness/live-candidates-2026-07-14.md
@@ -1,5 +1,5 @@
 ---
-feature_ids: [F257]
+feature_ids: [LI-005]
 topics: [harness, candidates, live-incident, five-ring]
 doc_kind: note
 created: 2026-07-14

--- a/packages/api/src/domains/ball-custody/ball-custody-events.ts
+++ b/packages/api/src/domains/ball-custody/ball-custody-events.ts
@@ -83,7 +83,7 @@ export interface VoidAckEventInput {
 }
 
 /**
- * F257 LI-005 虚空接球守卫（A2A 接球但无 hold_ball / create_task / 无行首 @ / 无 structured 路由）
+ * LI-005 虚空接球守卫（A2A 接球但无 hold_ball / create_task / 无行首 @ / 无 structured 路由）
  * → ball.void_ack。与 void_pass 互补——void_pass 查"说持球没做"，void_ack 查"接了球没绑触发器"。
  */
 export function buildVoidAckEvent(input: VoidAckEventInput): BallCustodyEvent {

--- a/packages/api/src/domains/ball-custody/ball-custody-events.ts
+++ b/packages/api/src/domains/ball-custody/ball-custody-events.ts
@@ -71,6 +71,13 @@ export interface VoidAckEventInput {
   threadId: string;
   /** 触发虚空接球检测的消息 id（A2A 接球但无持久触发器绑定） */
   messageId: string;
+  /**
+   * A2A trigger message ID — the message that dispatched this invocation.
+   * Covers both inline serial (worklist a2aTriggerMessageId) and queue-dispatched
+   * (options.a2aTriggerMessageId → queueTriggerReplyTo) paths.
+   * Provides provenance for O2 sender-side discipline analysis.
+   */
+  a2aTriggerMessageId?: string;
   /** Unix ms */
   at: number;
 }
@@ -85,7 +92,9 @@ export function buildVoidAckEvent(input: VoidAckEventInput): BallCustodyEvent {
     subjectKey: `ball:thread:${input.threadId}`,
     kind: 'ball.void_ack',
     classification: 'state-changing',
-    payload: {},
+    payload: {
+      ...(input.a2aTriggerMessageId ? { a2aTriggerMessageId: input.a2aTriggerMessageId } : {}),
+    },
     at: input.at,
   };
 }

--- a/packages/api/src/domains/ball-custody/ball-custody-events.ts
+++ b/packages/api/src/domains/ball-custody/ball-custody-events.ts
@@ -67,6 +67,29 @@ export function buildVoidPassEvent(input: VoidPassEventInput): BallCustodyEvent 
   };
 }
 
+export interface VoidAckEventInput {
+  threadId: string;
+  /** 触发虚空接球检测的消息 id（A2A 接球但无持久触发器绑定） */
+  messageId: string;
+  /** Unix ms */
+  at: number;
+}
+
+/**
+ * F257 LI-005 虚空接球守卫（A2A 接球但无 hold_ball / create_task / 无行首 @ / 无 structured 路由）
+ * → ball.void_ack。与 void_pass 互补——void_pass 查"说持球没做"，void_ack 查"接了球没绑触发器"。
+ */
+export function buildVoidAckEvent(input: VoidAckEventInput): BallCustodyEvent {
+  return {
+    sourceEventId: `route:${input.messageId}:void_ack`,
+    subjectKey: `ball:thread:${input.threadId}`,
+    kind: 'ball.void_ack',
+    classification: 'state-changing',
+    payload: {},
+    at: input.at,
+  };
+}
+
 export interface HandedCvoEventInput {
   fromCatId?: string;
   threadId: string;

--- a/packages/api/src/domains/ball-custody/ball-custody-state-machine.ts
+++ b/packages/api/src/domains/ball-custody/ball-custody-state-machine.ts
@@ -5,7 +5,7 @@
  * （TRANSITION_TABLE 而非 if-chain，降单函数 cognitive complexity）。
  * 调用方（projector）负责持久化 + 字段 effect（heldUntil/blockedSinceAt/lastWakeAt）。
  *
- * INV-10（完整性）：全 8 state × 17 event 的每格行为确定（转移 or 显式 reject），穷举测试钉死。
+ * INV-10（完整性）：全 8 state × 18 event 的每格行为确定（转移 or 显式 reject），穷举测试钉死。
  * 复杂守卫拆成独立 resolver：
  *   - ball.handed_cvo：payload.intent 三态（handoff→parked / done_notify→resolved / fyi→不变）
  *   - ball.hold_expired：需 payload.fireAt 匹配 snapshot.heldUntil，防旧 reminder 误杀新 hold
@@ -32,6 +32,7 @@ export const ALL_BALL_EVENT_KINDS: BallCustodyEvent['kind'][] = [
   'ball.handed',
   'ball.handed_cvo',
   'ball.void_pass',
+  'ball.void_ack',
   'ball.held',
   'ball.hold_expired',
   'invocation.started',
@@ -109,6 +110,7 @@ type DynamicRule = {
 const STATIC_TABLE: Partial<Record<BallCustodyEvent['kind'], StaticRule>> = {
   'ball.handed': { from: '*', to: 'active' }, // 任意（含 resolved=reopen）→ active
   'ball.void_pass': { from: set('new', 'active', 'blocked', 'parked'), to: 'void' },
+  'ball.void_ack': { from: set('new', 'active', 'blocked', 'parked'), to: 'void' },
   'ball.held': { from: set('new', 'active'), to: 'active' }, // heldUntil 由 projector 设
   'invocation.started': { from: set('active', 'blocked'), to: 'active' },
   'invocation.died': { from: set('active', 'blocked'), to: 'dead' }, // lastScanAt 由 projector 设

--- a/packages/api/src/domains/cats/services/agents/providers/BgTranscriptEventConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/BgTranscriptEventConsumer.ts
@@ -99,7 +99,7 @@ export function transcriptEntriesToAgentMessages(
       continue;
     }
 
-    // F257 LI-005: user entries contain tool_result content blocks (MCP execution
+    // LI-005: user entries contain tool_result content blocks (MCP execution
     // results). Feed through transformClaudeEvent which bridges them to tool_result
     // AgentMessages with toolResultStatus — needed for durable trigger classification.
     // Same shape as -p NDJSON `user` events (content[].type === 'tool_result').

--- a/packages/api/src/domains/cats/services/agents/providers/BgTranscriptEventConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/BgTranscriptEventConsumer.ts
@@ -96,6 +96,18 @@ export function transcriptEntriesToAgentMessages(
       if (result == null) continue;
       if (Array.isArray(result)) out.push(...result);
       else out.push(result);
+      continue;
+    }
+
+    // F257 LI-005: user entries contain tool_result content blocks (MCP execution
+    // results). Feed through transformClaudeEvent which bridges them to tool_result
+    // AgentMessages with toolResultStatus — needed for durable trigger classification.
+    // Same shape as -p NDJSON `user` events (content[].type === 'tool_result').
+    if (entry.type === 'user') {
+      const result = transformClaudeEvent(entry, catId, state);
+      if (result == null) continue;
+      if (Array.isArray(result)) out.push(...result);
+      else out.push(result);
     }
 
     // Skip everything else (produce no user-facing AgentMessage):

--- a/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
@@ -11,8 +11,8 @@
  *
  * Design decisions (from Fable-5 spike b570d6148 + KD-7):
  * - Stop event → text AgentMessage (last_assistant_message = full reply)
- * - PostToolUse → tool_use + tool_result AgentMessages (tool step visibility + F257 durable trigger)
- * - PostToolUseFailure → tool_result(error) AgentMessage (F257: failure path bridge)
+ * - PostToolUse → tool_use + tool_result AgentMessages (tool step visibility + LI-005 durable trigger)
+ * - PostToolUseFailure → tool_result(error) AgentMessage (LI-005: failure path bridge)
  * - Stop = terminal signal (replaces transcript turn_duration detection)
  * - session_id from hook events (backup for transcript-watch)
  * - No usage/token data from hooks — accepted degradation
@@ -82,7 +82,7 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
         toolUseId,
         timestamp: Date.now(),
       });
-      // F257 LI-005: emit tool_result for durable trigger classification.
+      // LI-005: emit tool_result for durable trigger classification.
       // PostToolUse fires on successful tool completion (per cc hook contract).
       // tool_response shape varies by tool: string, object, or array.
       // Normalize to string so classifyDurableTriggerResult Level 2 can parse.
@@ -98,7 +98,7 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
       continue;
     }
 
-    // F257 LI-005: PostToolUseFailure → tool_result(error) for failure path.
+    // LI-005: PostToolUseFailure → tool_result(error) for failure path.
     // cc fires PostToolUseFailure on tool execution failure; PostToolUse is
     // success-only. Registering both ensures confirmedCallbackToolNames
     // correctly excludes failed durable triggers.

--- a/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
@@ -113,7 +113,6 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
       };
       if (toolUseId) resultMsg.toolUseId = toolUseId;
       out.push(resultMsg);
-      continue;
     }
 
     // Unknown hook event names — silently skip

--- a/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
@@ -55,6 +55,7 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
 
     if (hookName === 'PostToolUse') {
       if (typeof entry.tool_name !== 'string') continue;
+      const toolUseId = typeof entry.tool_use_id === 'string' ? entry.tool_use_id : undefined;
       out.push({
         type: 'tool_use',
         catId,
@@ -62,9 +63,23 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
         toolInput: (typeof entry.tool_input === 'object' && entry.tool_input !== null
           ? entry.tool_input
           : {}) as Record<string, unknown>,
-        toolUseId: typeof entry.tool_use_id === 'string' ? entry.tool_use_id : undefined,
+        toolUseId,
         timestamp: Date.now(),
       });
+      // F257 LI-005: also emit tool_result for durable trigger classification.
+      // PostToolUse carries tool_response (tool output text) and optionally
+      // is_error. Without is_error, classifyDurableTriggerResult falls through
+      // to Level 2 JSON body parsing which handles all 5 durable trigger shapes.
+      const toolResponse = typeof entry.tool_response === 'string' ? entry.tool_response : undefined;
+      const resultMsg: AgentMessage = {
+        type: 'tool_result',
+        catId,
+        content: toolResponse,
+        timestamp: Date.now(),
+        toolResultStatus: entry.is_error === true ? 'error' : entry.is_error === false ? 'ok' : 'unknown',
+      };
+      if (toolUseId) resultMsg.toolUseId = toolUseId;
+      out.push(resultMsg);
     }
 
     // Unknown hook event names — silently skip

--- a/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/HookSidechannelConsumer.ts
@@ -11,7 +11,8 @@
  *
  * Design decisions (from Fable-5 spike b570d6148 + KD-7):
  * - Stop event → text AgentMessage (last_assistant_message = full reply)
- * - PostToolUse → tool_use AgentMessage (tool step visibility)
+ * - PostToolUse → tool_use + tool_result AgentMessages (tool step visibility + F257 durable trigger)
+ * - PostToolUseFailure → tool_result(error) AgentMessage (F257: failure path bridge)
  * - Stop = terminal signal (replaces transcript turn_duration detection)
  * - session_id from hook events (backup for transcript-watch)
  * - No usage/token data from hooks — accepted degradation
@@ -28,10 +29,25 @@ export interface HookConsumerOptions {
 }
 
 /**
+ * Normalize tool_response from hook events to a string for downstream parsing.
+ * PostToolUse tool_response shapes vary by tool:
+ *   - Read: `{type:'text', file:{content:'...', totalLines:50}}`
+ *   - Bash: `{stdout:'...'}`
+ *   - MCP: `'{"status":"ok",...}'` (string) or structured object
+ *   - Missing: `undefined`
+ */
+function normalizeToolResponse(raw: unknown): string | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') return JSON.stringify(raw);
+  return String(raw);
+}
+
+/**
  * Transform hook sidecar entries to AgentMessages.
  *
  * Pure function — no I/O, no state. Safe for incremental tailing.
- * Only Stop and PostToolUse are recognized; unknown events are skipped.
+ * Stop, PostToolUse, and PostToolUseFailure are recognized; unknown events are skipped.
  */
 export function hookEntriesToAgentMessages(entries: unknown[], options: HookConsumerOptions): AgentMessage[] {
   const { catId } = options;
@@ -66,20 +82,38 @@ export function hookEntriesToAgentMessages(entries: unknown[], options: HookCons
         toolUseId,
         timestamp: Date.now(),
       });
-      // F257 LI-005: also emit tool_result for durable trigger classification.
-      // PostToolUse carries tool_response (tool output text) and optionally
-      // is_error. Without is_error, classifyDurableTriggerResult falls through
-      // to Level 2 JSON body parsing which handles all 5 durable trigger shapes.
-      const toolResponse = typeof entry.tool_response === 'string' ? entry.tool_response : undefined;
+      // F257 LI-005: emit tool_result for durable trigger classification.
+      // PostToolUse fires on successful tool completion (per cc hook contract).
+      // tool_response shape varies by tool: string, object, or array.
+      // Normalize to string so classifyDurableTriggerResult Level 2 can parse.
       const resultMsg: AgentMessage = {
         type: 'tool_result',
         catId,
-        content: toolResponse,
+        content: normalizeToolResponse(entry.tool_response),
         timestamp: Date.now(),
-        toolResultStatus: entry.is_error === true ? 'error' : entry.is_error === false ? 'ok' : 'unknown',
+        toolResultStatus: 'ok',
       };
       if (toolUseId) resultMsg.toolUseId = toolUseId;
       out.push(resultMsg);
+      continue;
+    }
+
+    // F257 LI-005: PostToolUseFailure → tool_result(error) for failure path.
+    // cc fires PostToolUseFailure on tool execution failure; PostToolUse is
+    // success-only. Registering both ensures confirmedCallbackToolNames
+    // correctly excludes failed durable triggers.
+    if (hookName === 'PostToolUseFailure') {
+      const toolUseId = typeof entry.tool_use_id === 'string' ? entry.tool_use_id : undefined;
+      const resultMsg: AgentMessage = {
+        type: 'tool_result',
+        catId,
+        content: normalizeToolResponse(entry.tool_response),
+        timestamp: Date.now(),
+        toolResultStatus: 'error',
+      };
+      if (toolUseId) resultMsg.toolUseId = toolUseId;
+      out.push(resultMsg);
+      continue;
     }
 
     // Unknown hook event names — silently skip

--- a/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
@@ -5,8 +5,11 @@
  */
 
 import type { CatId } from '@cat-cafe/shared';
-import type { AgentMessage, TokenUsage } from '../../types.js';
+import type { AgentMessage } from '../../types.js';
 import { extractClaudeMcpStatusSnapshot } from './claude-mcp-status.js';
+
+// Re-export for backward compatibility (extracted to claude-usage.ts for 350-line limit)
+export { extractClaudeUsage } from './claude-usage.js';
 
 /**
  * Transform a raw Claude CLI NDJSON event into AgentMessage(s).
@@ -285,6 +288,39 @@ export function transformClaudeEvent(
     };
   }
 
+  // F257 LI-005: user turn → tool_result bridge (MCP execution results).
+  // Claude CLI executes MCP tools internally; results appear as user-turn
+  // content blocks with is_error for success/failure classification.
+  if (e.type === 'user') {
+    const blocks = (e.message as Record<string, unknown> | undefined)?.content;
+    if (!Array.isArray(blocks)) return null;
+    const msgs: AgentMessage[] = [];
+    for (const raw of blocks) {
+      if (typeof raw !== 'object' || raw === null) continue;
+      const b = raw as Record<string, unknown>;
+      if (b.type !== 'tool_result') continue;
+      // content may be string or [{type:'text',text:'...'}]
+      let text: string | undefined;
+      if (typeof b.content === 'string') text = b.content;
+      else if (Array.isArray(b.content)) {
+        text = (b.content as Array<Record<string, unknown>>)
+          .filter((c) => c.type === 'text' && typeof c.text === 'string')
+          .map((c) => c.text as string)
+          .join('');
+      }
+      const msg: AgentMessage = {
+        type: 'tool_result',
+        catId,
+        content: text,
+        timestamp: Date.now(),
+        toolResultStatus: b.is_error === true ? 'error' : 'ok',
+      };
+      if (typeof b.tool_use_id === 'string') msg.toolUseId = b.tool_use_id;
+      msgs.push(msg);
+    }
+    return msgs.length > 0 ? msgs : null;
+  }
+
   // result/success, system/hook, etc. → skip
   return null;
 }
@@ -295,42 +331,4 @@ export function isResultErrorEvent(event: unknown): boolean {
   return e.type === 'result' && (e.is_error === true || e.subtype !== 'success');
 }
 
-/** F8: Extract token usage from Claude result/success event.
- *  Normalises inputTokens to total input (new + cache_read + cache_creation)
- *  so that the semantics match Codex/OpenAI where inputTokens = total. */
-export function extractClaudeUsage(e: Record<string, unknown>): TokenUsage {
-  const usage = (e.usage ?? {}) as Record<string, unknown>;
-  const result: TokenUsage = {};
-  const rawInput = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
-  const cacheRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
-  const cacheCreate = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
-  const totalInput = rawInput + cacheRead + cacheCreate;
-  if (totalInput > 0) result.inputTokens = totalInput;
-  if (typeof usage.output_tokens === 'number') result.outputTokens = usage.output_tokens;
-  if (cacheRead > 0) result.cacheReadTokens = cacheRead;
-  if (cacheCreate > 0) result.cacheCreationTokens = cacheCreate;
-  if (typeof e.total_cost_usd === 'number') result.costUsd = e.total_cost_usd;
-  if (typeof e.duration_ms === 'number') result.durationMs = e.duration_ms;
-  if (typeof e.duration_api_ms === 'number') result.durationApiMs = e.duration_api_ms;
-  if (typeof e.num_turns === 'number') result.numTurns = e.num_turns;
-
-  // F24: Extract context window capacity from modelUsage.
-  // Claude stream-json has emitted both `modelUsage` and `model_usage` in different versions.
-  const modelUsage = (e.modelUsage ?? e.model_usage) as Record<string, Record<string, unknown>> | undefined;
-  if (modelUsage) {
-    for (const data of Object.values(modelUsage)) {
-      const contextWindow =
-        typeof data.contextWindow === 'number'
-          ? data.contextWindow
-          : typeof data.context_window === 'number'
-            ? data.context_window
-            : undefined;
-      if (contextWindow != null) {
-        result.contextWindowSize = contextWindow;
-        break;
-      }
-    }
-  }
-
-  return result;
-}
+// extractClaudeUsage moved to ./claude-usage.ts (350-line limit); re-exported above.

--- a/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
@@ -288,7 +288,7 @@ export function transformClaudeEvent(
     };
   }
 
-  // F257 LI-005: user turn → tool_result bridge (MCP execution results).
+  // LI-005: user turn → tool_result bridge (MCP execution results).
   // Claude CLI executes MCP tools internally; results appear as user-turn
   // content blocks with is_error for success/failure classification.
   if (e.type === 'user') {

--- a/packages/api/src/domains/cats/services/agents/providers/claude-usage.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-usage.ts
@@ -5,7 +5,7 @@
  * so that the semantics match Codex/OpenAI where inputTokens = total.
  *
  * Extracted from claude-ndjson-parser.ts to keep file under 350-line limit
- * after F257 LI-005 added the user → tool_result bridge.
+ * after LI-005 added the user → tool_result bridge.
  */
 
 import type { TokenUsage } from '../../types.js';

--- a/packages/api/src/domains/cats/services/agents/providers/claude-usage.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-usage.ts
@@ -1,0 +1,48 @@
+/**
+ * F8: Extract token usage from Claude result/success event.
+ *
+ * Normalises inputTokens to total input (new + cache_read + cache_creation)
+ * so that the semantics match Codex/OpenAI where inputTokens = total.
+ *
+ * Extracted from claude-ndjson-parser.ts to keep file under 350-line limit
+ * after F257 LI-005 added the user → tool_result bridge.
+ */
+
+import type { TokenUsage } from '../../types.js';
+
+export function extractClaudeUsage(e: Record<string, unknown>): TokenUsage {
+  const usage = (e.usage ?? {}) as Record<string, unknown>;
+  const result: TokenUsage = {};
+  const rawInput = typeof usage.input_tokens === 'number' ? usage.input_tokens : 0;
+  const cacheRead = typeof usage.cache_read_input_tokens === 'number' ? usage.cache_read_input_tokens : 0;
+  const cacheCreate = typeof usage.cache_creation_input_tokens === 'number' ? usage.cache_creation_input_tokens : 0;
+  const totalInput = rawInput + cacheRead + cacheCreate;
+  if (totalInput > 0) result.inputTokens = totalInput;
+  if (typeof usage.output_tokens === 'number') result.outputTokens = usage.output_tokens;
+  if (cacheRead > 0) result.cacheReadTokens = cacheRead;
+  if (cacheCreate > 0) result.cacheCreationTokens = cacheCreate;
+  if (typeof e.total_cost_usd === 'number') result.costUsd = e.total_cost_usd;
+  if (typeof e.duration_ms === 'number') result.durationMs = e.duration_ms;
+  if (typeof e.duration_api_ms === 'number') result.durationApiMs = e.duration_api_ms;
+  if (typeof e.num_turns === 'number') result.numTurns = e.num_turns;
+
+  // F24: Extract context window capacity from modelUsage.
+  // Claude stream-json has emitted both `modelUsage` and `model_usage` in different versions.
+  const modelUsage = (e.modelUsage ?? e.model_usage) as Record<string, Record<string, unknown>> | undefined;
+  if (modelUsage) {
+    for (const data of Object.values(modelUsage)) {
+      const contextWindow =
+        typeof data.contextWindow === 'number'
+          ? data.contextWindow
+          : typeof data.context_window === 'number'
+            ? data.context_window
+            : undefined;
+      if (contextWindow != null) {
+        result.contextWindowSize = contextWindow;
+        break;
+      }
+    }
+  }
+
+  return result;
+}

--- a/packages/api/src/domains/cats/services/agents/providers/pty/hook-setup.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/pty/hook-setup.ts
@@ -96,7 +96,7 @@ fi
     hooks: {
       Stop: [hookEntry(scriptPath)],
       PostToolUse: postToolUseHooks,
-      // F257 LI-005: capture tool execution failures for durable trigger classification.
+      // LI-005: capture tool execution failures for durable trigger classification.
       // PostToolUseFailure fires when a tool call fails; HookSidechannelConsumer bridges
       // it as tool_result(error) so failed hold_ball doesn't suppress void_ack hint.
       PostToolUseFailure: [hookEntry(scriptPath)],

--- a/packages/api/src/domains/cats/services/agents/providers/pty/hook-setup.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/pty/hook-setup.ts
@@ -96,6 +96,10 @@ fi
     hooks: {
       Stop: [hookEntry(scriptPath)],
       PostToolUse: postToolUseHooks,
+      // F257 LI-005: capture tool execution failures for durable trigger classification.
+      // PostToolUseFailure fires when a tool call fails; HookSidechannelConsumer bridges
+      // it as tool_result(error) so failed hold_ball doesn't suppress void_ack hint.
+      PostToolUseFailure: [hookEntry(scriptPath)],
     },
   };
   writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -83,7 +83,11 @@ export interface AckLivenessInput {
   readonly toolNames: readonly string[];
   /** Line-start @mentions detected in the response text. */
   readonly lineStartMentions: readonly string[];
-  /** Structured target cats from tool inputs (post_message / cross_post_message). */
+  /**
+   * Confirmed structured target cats from successful tool_results
+   * (post_message / cross_post_message). Unconfirmed tool_use inputs must NOT
+   * be used — a failed post_message should not suppress the hint (P2-2 fix).
+   */
   readonly structuredTargetCats: readonly string[];
   /** Whether the response text contains a co-creator line-start mention. */
   readonly hasCoCreatorLineStartMention: boolean;

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -13,6 +13,14 @@
  * 声明-动作一致性检查的延伸：void-hold 查"说持球没做"，
  * ack-liveness 查"接了球没绑触发器"。
  *
+ * A2A 路径信号（isA2AInvocation）:
+ *   - inline serial: `directMessageFrom`（routeSerial a2aFrom map 中 catId）
+ *   - queue-dispatched: `queueTriggerReplyTo`（derived from `a2aTriggerMessageId` in options）
+ * `a2aTriggerMessageId` 已确认为 **cat→cat 专属**——5 个赋值点全部在 A2A 路径
+ * （callback-a2a-trigger.ts 3 处 + route-serial.ts inline/deferred 2 处），
+ * 0 个 operator/user/connector 路径设置此字段。operator 发起的 invocation
+ * 不会被误判为 A2A。详见 Fable ① 核验（2026-07-16 Explore agent 穷举确认）。
+ *
  * 纯函数、零 IO、可测。
  *
  * @see void-hold-detect.ts — 同族守卫，模式参照

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -1,0 +1,97 @@
+/**
+ * F257 LI-005 — A2A Ack Liveness Detection (接球执行触发存活性检测).
+ *
+ * 检测猫通过 A2A @mention 接到球后，invocation 结束时既无路由出口
+ * （行首 @mention / @co-creator / structured routing）也无持久触发器
+ * （hold_ball / create_task / register_scheduled_task / register_pr_tracking
+ * / register_issue_tracking），导致球静默死亡——无机制保证后续执行。
+ *
+ * 声明-动作一致性检查的延伸：void-hold 查"说持球没做"，
+ * ack-liveness 查"接了球没绑触发器"。
+ *
+ * 纯函数、零 IO、可测。
+ *
+ * @see void-hold-detect.ts — 同族守卫，模式参照
+ * @see docs/features/assets/F257/live-candidates-2026-07-14.md — LI-005 定义
+ */
+
+/**
+ * Tool names that constitute a "durable trigger" — calling any one of these
+ * means the cat bound a mechanism that will ensure future execution.
+ *
+ * Order doesn't matter (Set-based lookup). The list uses suffix matching
+ * to cover both `mcp__cat-cafe-collab__cat_cafe_hold_ball` and
+ * `cat_cafe_hold_ball` forms.
+ */
+const DURABLE_TRIGGER_SUFFIXES: readonly string[] = [
+  'cat_cafe_hold_ball',
+  'cat_cafe_create_task',
+  'cat_cafe_register_scheduled_task',
+  'cat_cafe_register_pr_tracking',
+  'cat_cafe_register_issue_tracking',
+  'cat_cafe_community_await_external',
+] as const;
+
+function hasDurableTriggerToolCall(toolNames: readonly string[]): boolean {
+  return toolNames.some((name) => DURABLE_TRIGGER_SUFFIXES.some((suffix) => name.endsWith(suffix)));
+}
+
+function hasRoutingExit(input: {
+  lineStartMentions: readonly string[];
+  structuredTargetCats: readonly string[];
+  hasCoCreatorLineStartMention: boolean;
+}): boolean {
+  if (input.lineStartMentions.length > 0) return true;
+  if (input.structuredTargetCats.length > 0) return true;
+  if (input.hasCoCreatorLineStartMention) return true;
+  return false;
+}
+
+export interface AckLivenessInput {
+  /** True if this cat was invoked via A2A (@mention from another cat). */
+  readonly isA2AInvocation: boolean;
+  /** Tool names called during this invocation. */
+  readonly toolNames: readonly string[];
+  /** Line-start @mentions detected in the response text. */
+  readonly lineStartMentions: readonly string[];
+  /** Structured target cats from tool inputs (post_message / cross_post_message). */
+  readonly structuredTargetCats: readonly string[];
+  /** Whether the response text contains a co-creator line-start mention. */
+  readonly hasCoCreatorLineStartMention: boolean;
+}
+
+export interface AckLivenessEvaluation {
+  /** True iff the void-ack hint should fire. */
+  readonly shouldEmit: boolean;
+  /** True if the invocation had any routing exit (@ / structured routing). */
+  readonly hasRoutingExit: boolean;
+  /** True if the invocation called any durable trigger tool. */
+  readonly hasDurableTrigger: boolean;
+}
+
+/**
+ * Evaluate whether an A2A invocation ended without any durable trigger
+ * or routing exit — the ball effectively dies.
+ *
+ * Only fires when ALL of:
+ * 1. The cat was invoked via A2A (@mention from another cat)
+ * 2. No routing exit exists (no @mention, no structured routing, no @co-creator)
+ * 3. No durable trigger was bound (no hold_ball, create_task, etc.)
+ *
+ * Non-A2A invocations (user-initiated) always return shouldEmit=false
+ * because the user is watching and can re-invoke manually.
+ */
+export function evaluateAckLiveness(input: AckLivenessInput): AckLivenessEvaluation {
+  if (!input.isA2AInvocation) {
+    return { shouldEmit: false, hasRoutingExit: false, hasDurableTrigger: false };
+  }
+
+  const routing = hasRoutingExit(input);
+  const trigger = hasDurableTriggerToolCall(input.toolNames);
+
+  return {
+    shouldEmit: !routing && !trigger,
+    hasRoutingExit: routing,
+    hasDurableTrigger: trigger,
+  };
+}

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -1,5 +1,5 @@
 /**
- * F257 LI-005 Phase 1 — A2A Ack Liveness Detection (接球执行触发存活性检测).
+ * LI-005 Phase 1 — A2A Ack Liveness Detection (接球执行触发存活性检测).
  *
  * 检测猫通过 A2A 接到球后（inline @mention 或 queue-dispatched），invocation 结束时
  * 既无路由出口（行首 @mention / @co-creator / structured routing）也无持久触发器
@@ -24,7 +24,7 @@
  * 纯函数、零 IO、可测。
  *
  * @see void-hold-detect.ts — 同族守卫，模式参照
- * @see docs/features/assets/F257/live-candidates-2026-07-14.md — LI-005 定义
+ * @see docs/features/assets/li005-ack-liveness/live-candidates-2026-07-14.md — LI-005 定义
  */
 
 /**

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -1,10 +1,14 @@
 /**
- * F257 LI-005 — A2A Ack Liveness Detection (接球执行触发存活性检测).
+ * F257 LI-005 Phase 1 — A2A Ack Liveness Detection (接球执行触发存活性检测).
  *
- * 检测猫通过 A2A @mention 接到球后，invocation 结束时既无路由出口
- * （行首 @mention / @co-creator / structured routing）也无持久触发器
- * （hold_ball / create_task / register_scheduled_task / register_pr_tracking
- * / register_issue_tracking），导致球静默死亡——无机制保证后续执行。
+ * 检测猫通过 A2A 接到球后（inline @mention 或 queue-dispatched），invocation 结束时
+ * 既无路由出口（行首 @mention / @co-creator / structured routing）也无持久触发器
+ * （hold_ball / register_scheduled_task / register_pr_tracking /
+ * register_issue_tracking / community_await_external），导致球静默死亡——
+ * 无机制保证后续执行。
+ *
+ * Phase 1 scope: detection + hint + observability（ball.void_ack 事件 + telemetry）。
+ * Phase 2（structural rejection / auto-wake）待 Phase 1 收集数据后实施。
  *
  * 声明-动作一致性检查的延伸：void-hold 查"说持球没做"，
  * ack-liveness 查"接了球没绑触发器"。
@@ -19,13 +23,21 @@
  * Tool names that constitute a "durable trigger" — calling any one of these
  * means the cat bound a mechanism that will ensure future execution.
  *
+ * Criteria: the tool MUST register a system mechanism (timer, webhook, cron)
+ * that will invoke the cat in the future. Pure bookkeeping tools (create_task)
+ * do NOT qualify — they create visible panel items but have no invokeTrigger
+ * or scheduled wake.
+ *
  * Order doesn't matter (Set-based lookup). The list uses suffix matching
  * to cover both `mcp__cat-cafe-collab__cat_cafe_hold_ball` and
  * `cat_cafe_hold_ball` forms.
+ *
+ * TODO(LI-005 Phase 2): current check only verifies tool_use name presence,
+ * not tool_result success. A 400/429/permission-denied tool call still
+ * suppresses the hint. Fix: cross-reference with successful tool_result events.
  */
 const DURABLE_TRIGGER_SUFFIXES: readonly string[] = [
   'cat_cafe_hold_ball',
-  'cat_cafe_create_task',
   'cat_cafe_register_scheduled_task',
   'cat_cafe_register_pr_tracking',
   'cat_cafe_register_issue_tracking',
@@ -74,9 +86,9 @@ export interface AckLivenessEvaluation {
  * or routing exit — the ball effectively dies.
  *
  * Only fires when ALL of:
- * 1. The cat was invoked via A2A (@mention from another cat)
+ * 1. The cat was invoked via A2A (inline @mention or queue-dispatched)
  * 2. No routing exit exists (no @mention, no structured routing, no @co-creator)
- * 3. No durable trigger was bound (no hold_ball, create_task, etc.)
+ * 3. No durable trigger was bound (no hold_ball, register_scheduled_task, etc.)
  *
  * Non-A2A invocations (user-initiated) always return shouldEmit=false
  * because the user is watching and can re-invoke manually.

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -40,11 +40,15 @@
  * to cover both `mcp__cat-cafe-collab__cat_cafe_hold_ball` and
  * `cat_cafe_hold_ball` forms.
  *
- * Caller contract: `toolNames` should contain only confirmed-successful
- * callback tool names (status=ok/duplicate). Failed tool calls (400/429/
- * permission-denied) must NOT be included — route-serial tracks
- * `confirmedCallbackToolNames` separately from `collectedToolNames` to
- * enforce this at the call site.
+ * Caller contract (two-tier, per Sol R3 P1):
+ *   - Providers with tool_result events (Codex, Gemini, CatAgent): pass only
+ *     confirmed-successful tool names via `classifyDurableTriggerResult`.
+ *   - Claude CLI (no tool_result events): pass `collectedToolNames` as fallback
+ *     (optimistic: tool_use ≈ success). This accepts a false-negative risk
+ *     (failed hold_ball suppresses hint), which is acceptable for Phase A
+ *     detection and will be addressed in Phase B via callback-side signaling.
+ *   Route-serial implements this via `sawToolResult` flag: when true, use
+ *   `confirmedCallbackToolNames`; when false, fall back to `collectedToolNames`.
  */
 const DURABLE_TRIGGER_SUFFIXES: readonly string[] = [
   'cat_cafe_hold_ball',
@@ -73,9 +77,12 @@ export interface AckLivenessInput {
   /** True if this cat was invoked via A2A (@mention from another cat). */
   readonly isA2AInvocation: boolean;
   /**
-   * Confirmed-successful callback tool names (status=ok/duplicate).
-   * Failed tool calls (400/429) must NOT be included — the caller
-   * (route-serial) filters via `confirmedCallbackToolNames`.
+   * Effective tool names for durable-trigger detection.
+   * Two-tier sourcing (route-serial decides based on `sawToolResult` flag):
+   *   - When tool_result events flowed: confirmed-successful names only
+   *     (classified via `classifyDurableTriggerResult`)
+   *   - When no tool_result events (Claude CLI): all `collectedToolNames`
+   *     (optimistic fallback — tool_use ≈ success)
    */
   readonly toolNames: readonly string[];
   /** Line-start @mentions detected in the response text. */
@@ -120,4 +127,59 @@ export function evaluateAckLiveness(input: AckLivenessInput): AckLivenessEvaluat
     hasRoutingExit: routing,
     hasDurableTrigger: trigger,
   };
+}
+
+/**
+ * Classify whether a tool_result for a durable trigger represents confirmed
+ * success. Two-level check per Sol R3 P1:
+ *
+ * 1. Structural `toolResultStatus` (set by provider event transformers:
+ *    Codex maps item.status; Gemini hardcodes 'ok'; CatAgent maps status).
+ *    'ok' → confirmed success; 'error' → confirmed failure.
+ *
+ * 2. Tool-specific JSON body parsing (fallback when toolResultStatus is
+ *    undefined or 'unknown'). Each durable trigger returns a different
+ *    success shape:
+ *      - hold_ball:               {status: 'ok', held: true, ...}
+ *      - register_pr_tracking:    {status: 'ok', threadId, task}
+ *      - register_issue_tracking: {status: 'ok', threadId, task}
+ *      - register_scheduled_task: {success: true, task: {...}}
+ *      - community_await_external:{state: 'awaiting_external', ...}
+ *
+ * Fail-closed: unknown shapes or parse errors → not confirmed (the hint
+ * fires, which is safer than suppressing a genuine void ack).
+ *
+ * Pure function, zero IO.
+ */
+export function classifyDurableTriggerResult(
+  toolName: string,
+  resultContent: string | undefined,
+  toolResultStatus: 'ok' | 'error' | 'unknown' | undefined,
+): boolean {
+  // Only classify durable trigger tools
+  if (!DURABLE_TRIGGER_SUFFIXES.some((suffix) => toolName.endsWith(suffix))) return false;
+
+  // Level 1: structural status from provider transformer
+  if (toolResultStatus === 'ok') return true;
+  if (toolResultStatus === 'error') return false;
+
+  // Level 2: tool-specific body parsing
+  if (!resultContent) return false;
+  try {
+    const jsonStart = resultContent.indexOf('{');
+    if (jsonStart < 0) return false;
+    const parsed = JSON.parse(resultContent.slice(jsonStart)) as Record<string, unknown>;
+    // hold_ball / register_pr_tracking / register_issue_tracking
+    if (parsed.status === 'ok' || parsed.status === 'duplicate') return true;
+    // register_scheduled_task
+    if (parsed.success === true) return true;
+    // community_await_external
+    if (parsed.state === 'awaiting_external') return true;
+    // Explicit error markers
+    if (parsed.isError === true || parsed.error) return false;
+    // Unknown shape → fail-closed
+    return false;
+  } catch {
+    return false;
+  }
 }

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -32,9 +32,11 @@
  * to cover both `mcp__cat-cafe-collab__cat_cafe_hold_ball` and
  * `cat_cafe_hold_ball` forms.
  *
- * TODO(LI-005 Phase 2): current check only verifies tool_use name presence,
- * not tool_result success. A 400/429/permission-denied tool call still
- * suppresses the hint. Fix: cross-reference with successful tool_result events.
+ * Caller contract: `toolNames` should contain only confirmed-successful
+ * callback tool names (status=ok/duplicate). Failed tool calls (400/429/
+ * permission-denied) must NOT be included — route-serial tracks
+ * `confirmedCallbackToolNames` separately from `collectedToolNames` to
+ * enforce this at the call site.
  */
 const DURABLE_TRIGGER_SUFFIXES: readonly string[] = [
   'cat_cafe_hold_ball',
@@ -62,7 +64,11 @@ function hasRoutingExit(input: {
 export interface AckLivenessInput {
   /** True if this cat was invoked via A2A (@mention from another cat). */
   readonly isA2AInvocation: boolean;
-  /** Tool names called during this invocation. */
+  /**
+   * Confirmed-successful callback tool names (status=ok/duplicate).
+   * Failed tool calls (400/429) must NOT be included — the caller
+   * (route-serial) filters via `confirmedCallbackToolNames`.
+   */
   readonly toolNames: readonly string[];
   /** Line-start @mentions detected in the response text. */
   readonly lineStartMentions: readonly string[];

--- a/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/a2a-ack-liveness.ts
@@ -40,15 +40,13 @@
  * to cover both `mcp__cat-cafe-collab__cat_cafe_hold_ball` and
  * `cat_cafe_hold_ball` forms.
  *
- * Caller contract (two-tier, per Sol R3 P1):
- *   - Providers with tool_result events (Codex, Gemini, CatAgent): pass only
- *     confirmed-successful tool names via `classifyDurableTriggerResult`.
- *   - Claude CLI (no tool_result events): pass `collectedToolNames` as fallback
- *     (optimistic: tool_use ≈ success). This accepts a false-negative risk
- *     (failed hold_ball suppresses hint), which is acceptable for Phase A
- *     detection and will be addressed in Phase B via callback-side signaling.
- *   Route-serial implements this via `sawToolResult` flag: when true, use
- *   `confirmedCallbackToolNames`; when false, fall back to `collectedToolNames`.
+ * Caller contract (all providers, per Sol R4):
+ *   All providers now emit tool_result events — Claude CLI's user-turn
+ *   tool_result content blocks are bridged in claude-ndjson-parser.ts (R4).
+ *   Route-serial passes only confirmed-successful tool names via
+ *   `classifyDurableTriggerResult` into `confirmedCallbackToolNames`.
+ *   Failed tool calls (400/429/error) are excluded — the hint fires,
+ *   which is the correct fail-closed behavior.
  */
 const DURABLE_TRIGGER_SUFFIXES: readonly string[] = [
   'cat_cafe_hold_ball',
@@ -77,12 +75,10 @@ export interface AckLivenessInput {
   /** True if this cat was invoked via A2A (@mention from another cat). */
   readonly isA2AInvocation: boolean;
   /**
-   * Effective tool names for durable-trigger detection.
-   * Two-tier sourcing (route-serial decides based on `sawToolResult` flag):
-   *   - When tool_result events flowed: confirmed-successful names only
-   *     (classified via `classifyDurableTriggerResult`)
-   *   - When no tool_result events (Claude CLI): all `collectedToolNames`
-   *     (optimistic fallback — tool_use ≈ success)
+   * Confirmed-successful durable trigger tool names only.
+   * All providers emit tool_result events (Claude CLI bridge added R4);
+   * route-serial classifies each via `classifyDurableTriggerResult` and
+   * only includes confirmed successes in `confirmedCallbackToolNames`.
    */
   readonly toolNames: readonly string[];
   /** Line-start @mentions detected in the response text. */

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -184,7 +184,7 @@ function emitBallVoidPass(
 }
 
 /**
- * F257 LI-005: fire-and-forget 旁路写 ball.void_ack（A2A 接球但无持久触发器 / 无路由出口 → 球静默死亡）。
+ * LI-005: fire-and-forget 旁路写 ball.void_ack（A2A 接球但无持久触发器 / 无路由出口 → 球静默死亡）。
  * 紧贴 ack-liveness-hint sample emit 调用（此时 storedMsgId 已绑定）。
  */
 function emitBallVoidAck(
@@ -1073,7 +1073,7 @@ export async function* routeSerial(
       const collectedToolEvents: StoredToolEvent[] = [];
       // F148 OQ-2: Collect tool names for context eval signals
       const collectedToolNames: string[] = [];
-      // F257 LI-005: Track confirmed-successful durable trigger tool names.
+      // LI-005: Track confirmed-successful durable trigger tool names.
       // All providers now emit tool_result events (Claude CLI bridge added in
       // claude-ndjson-parser.ts R4 fix). Success classification uses
       // classifyDurableTriggerResult (two-level: structural status → body parsing).
@@ -1090,7 +1090,7 @@ export async function* routeSerial(
       let confirmedLocalCallbackRoutingHasCoCreatorLineStartMention = false;
       const emittedBallHandedCvoMessageIds = new Set<string>();
       const structuredTargetCats = new Set<string>();
-      // F257 P2-2: confirmed structured targets — only populated on successful
+      // LI-005 P2-2: confirmed structured targets — only populated on successful
       // tool_result for post_message/cross_post_message. Unconfirmed tool_use inputs
       // must not suppress ack-liveness hint (Codex R1 P2-2 fix).
       const confirmedStructuredTargetCats = new Set<string>();
@@ -1435,7 +1435,7 @@ export async function* routeSerial(
             for (const target of targets) {
               structuredTargetCats.add(target);
             }
-            // F257 P2-2: track pending targets by tool identity for confirmation on tool_result
+            // LI-005 P2-2: track pending targets by tool identity for confirmation on tool_result
             if (targets.length > 0) {
               const pendingKey = effectiveMsg.toolUseId ?? effectiveMsg.toolName ?? '';
               pendingStructuredTargetsByTool.set(pendingKey, targets);
@@ -1485,7 +1485,7 @@ export async function* routeSerial(
                 callbackResult.messageId,
                 callbackResult.threadId,
               );
-              // F257 LI-005: durable trigger success classification (Sol R3 P1 fix).
+              // LI-005: durable trigger success classification (Sol R3 P1 fix).
               // Uses two-level check: structural toolResultStatus → tool-specific body parsing.
               // Covers all 5 response shapes (hold_ball/register_scheduled_task/PR/issue/await_external).
               if (
@@ -1500,7 +1500,7 @@ export async function* routeSerial(
                 // Non-durable-trigger tools (post_message etc.): use existing parseCallbackPostResult
                 confirmedCallbackToolNames.push(completedToolName.toolName);
               }
-              // F257 P2-2: confirm pending structured targets on successful tool_result.
+              // LI-005 P2-2: confirm pending structured targets on successful tool_result.
               // Only confirmed targets suppress the ack-liveness hint.
               const pendingTargetKey = completedToolName.toolUseId ?? completedToolName.toolName;
               const pendingTargets = pendingStructuredTargetsByTool.get(pendingTargetKey);
@@ -1914,7 +1914,7 @@ export async function* routeSerial(
               for (const target of targets) {
                 structuredTargetCats.add(target);
               }
-              // F257 P2-2: track pending targets for confirmation (retry/46 path)
+              // LI-005 P2-2: track pending targets for confirmation (retry/46 path)
               if (targets.length > 0) {
                 const pendingKey = effectiveMsg.toolUseId ?? effectiveMsg.toolName ?? '';
                 pendingStructuredTargetsByTool.set(pendingKey, targets);
@@ -1961,7 +1961,7 @@ export async function* routeSerial(
                   callbackResult.messageId,
                   callbackResult.threadId,
                 );
-                // F257 LI-005: durable trigger classification (same as primary handler above)
+                // LI-005: durable trigger classification (same as primary handler above)
                 if (
                   classifyDurableTriggerResult(
                     completedToolName.toolName,
@@ -1973,7 +1973,7 @@ export async function* routeSerial(
                 } else if (callbackResult.confirmed) {
                   confirmedCallbackToolNames.push(completedToolName.toolName);
                 }
-                // F257 P2-2: confirm pending structured targets (retry/46 path)
+                // LI-005 P2-2: confirm pending structured targets (retry/46 path)
                 const pendingTargetKey = completedToolName.toolUseId ?? completedToolName.toolName;
                 const pendingTargets = pendingStructuredTargetsByTool.get(pendingTargetKey);
                 if (pendingTargets) {
@@ -2139,7 +2139,7 @@ export async function* routeSerial(
         }
       }
 
-      // F257 LI-005: A2A invocation signal — hoisted before text/no-text branch
+      // LI-005: A2A invocation signal — hoisted before text/no-text branch
       // so ack-liveness evaluation covers both paths (Codex R1 P2-1 fix).
       // directMessageFrom covers inline-serial A2A; queueTriggerReplyTo covers queue-dispatched A2A.
       const isA2AInvocation = Boolean(directMessageFrom) || Boolean(queueTriggerReplyTo);
@@ -2506,14 +2506,14 @@ export async function* routeSerial(
           }
         }
 
-        // F257 LI-005 Phase 1: A2A ack-liveness detection (text path).
+        // LI-005 Phase 1: A2A ack-liveness detection (text path).
         // isA2AInvocation and pendingAckLivenessHint are hoisted before the
         // text/no-text branch (Codex R1 P2-1 fix).
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
-          // F257 LI-005: all providers now emit tool_result (Claude CLI bridge
+          // LI-005: all providers now emit tool_result (Claude CLI bridge
           // added in R4). Only confirmed-successful durable triggers suppress the hint.
-          // F257 P2-2: use confirmedStructuredTargetCats (not unconfirmed structuredTargetCats).
+          // LI-005 P2-2: use confirmedStructuredTargetCats (not unconfirmed structuredTargetCats).
           const ackLivenessEval = evaluateAckLiveness({
             isA2AInvocation,
             toolNames: confirmedCallbackToolNames,
@@ -2916,7 +2916,7 @@ export async function* routeSerial(
             emitBallVoidPass(deps.ballCustody, threadId, storedMsgId, pendingC2VoidHoldSampleTrigger);
           }
 
-          // F257 LI-005: deferred ball.void_ack emission（storedMsgId 此时已绑定）
+          // LI-005: deferred ball.void_ack emission（storedMsgId 此时已绑定）
           // streamReplyTo = trigger message ID covering both inline serial and queue paths
           if (pendingAckLivenessHint && storedMsgId) {
             emitBallVoidAck(deps.ballCustody, threadId, storedMsgId, streamReplyTo);
@@ -3512,7 +3512,7 @@ export async function* routeSerial(
         }
       }
 
-      // F257 LI-005: ack-liveness for no-text A2A turns (Codex R1 P2-1 fix).
+      // LI-005: ack-liveness for no-text A2A turns (Codex R1 P2-1 fix).
       // Covers both the tool-only branch (else-if) and the error-only branch (else).
       // In no-text turns: no line-start mentions from text, only confirmed callback data.
       // The text path evaluates ack-liveness inside its own block; this only fires

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -2428,12 +2428,15 @@ export async function* routeSerial(
           }
         }
 
-        // F257 LI-005: A2A ack-liveness detection — cat received an A2A ball but
-        // bound no durable trigger (hold_ball / create_task / etc.) and has no routing
-        // exit (@mention / structured routing / @co-creator). The ball effectively dies.
-        // Companion to void-hold (void-hold = "said holding, didn't call hold_ball",
-        // ack-liveness = "received A2A ball, bound no trigger").
-        const isA2AInvocation = Boolean(directMessageFrom);
+        // F257 LI-005 Phase 1: A2A ack-liveness detection — cat received an A2A
+        // ball but bound no durable trigger (hold_ball / register_scheduled_task /
+        // etc.) and has no routing exit. The ball effectively dies.
+        // Two A2A paths must both be detected:
+        //   1. Inline serial: text @mention within same routeSerial → a2aFrom populated
+        //   2. Queue-dispatched: post_message/cross_post_message → InvocationQueue →
+        //      QueueProcessor → routeSerial with a2aTriggerMessageId in options
+        // directMessageFrom covers path 1; queueTriggerReplyTo covers path 2.
+        const isA2AInvocation = Boolean(directMessageFrom) || Boolean(queueTriggerReplyTo);
         let pendingAckLivenessHint = false;
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
@@ -2459,7 +2462,7 @@ export async function* routeSerial(
                 threadId,
                 content:
                   '[接球提醒]: A2A 接球后 invocation 结束，但未绑定任何持久触发器' +
-                  '（hold_ball / create_task / register_scheduled_task 等）也未传球给下一只猫 — ' +
+                  '（hold_ball / register_scheduled_task 等）也未传球给下一只猫 — ' +
                   '球将静默死亡。请调用 `cat_cafe_hold_ball` 持球或行首 `@句柄` 传球。',
                 mentions: [],
                 timestamp: Date.now(),

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -119,7 +119,7 @@ import {
   updateStreakOnPush,
 } from '../routing/WorklistRegistry.js';
 import { accumulateTextAggregate } from '../text-aggregation.js';
-import { evaluateAckLiveness } from './a2a-ack-liveness.js';
+import { classifyDurableTriggerResult, evaluateAckLiveness } from './a2a-ack-liveness.js';
 import { formatA2AHandoffContent } from './a2a-handoff-label.js';
 import { extractContextEvalSignals } from './context-eval.js';
 import { validateRoutingSyntax } from './final-routing-slot.js';
@@ -1073,10 +1073,13 @@ export async function* routeSerial(
       const collectedToolEvents: StoredToolEvent[] = [];
       // F148 OQ-2: Collect tool names for context eval signals
       const collectedToolNames: string[] = [];
-      // F257 LI-005: Track tool names whose callback returned confirmed (status=ok/duplicate).
-      // Only confirmed-successful tools count as "durable triggers" — a 400/429/error
-      // tool_result should NOT suppress the ack-liveness hint.
+      // F257 LI-005: Track confirmed-successful durable trigger tool names.
+      // Two-tier sourcing (Sol R3 P1):
+      //   - When tool_result events flow (Codex/Gemini): classified via classifyDurableTriggerResult
+      //   - When no tool_result events (Claude CLI): fall back to collectedToolNames (optimistic)
+      // sawToolResult tracks whether ANY tool_result event was processed this invocation.
       const confirmedCallbackToolNames: string[] = [];
+      let sawToolResult = false;
       // #573: Track confirmed cat_cafe_post_message callback persistence
       let callbackPostConfirmed = false;
       let callbackPostMessageId: string | undefined;
@@ -1448,6 +1451,7 @@ export async function* routeSerial(
           }
           // #573: Confirm callback persistence via tool_result success
           if (effectiveMsg.type === 'tool_result') {
+            sawToolResult = true;
             const callbackResult = parseCallbackPostResult(effectiveMsg.content);
             const completedToolName = consumePendingToolResult(
               pendingToolResults,
@@ -1473,8 +1477,19 @@ export async function* routeSerial(
                 callbackResult.messageId,
                 callbackResult.threadId,
               );
-              // F257 LI-005: only confirmed-successful callback tools qualify as durable triggers
-              if (callbackResult.confirmed) {
+              // F257 LI-005: durable trigger success classification (Sol R3 P1 fix).
+              // Uses two-level check: structural toolResultStatus → tool-specific body parsing.
+              // Covers all 5 response shapes (hold_ball/register_scheduled_task/PR/issue/await_external).
+              if (
+                classifyDurableTriggerResult(
+                  completedToolName.toolName,
+                  effectiveMsg.content,
+                  (effectiveMsg as { toolResultStatus?: 'ok' | 'error' | 'unknown' }).toolResultStatus,
+                )
+              ) {
+                confirmedCallbackToolNames.push(completedToolName.toolName);
+              } else if (callbackResult.confirmed) {
+                // Non-durable-trigger tools (post_message etc.): use existing parseCallbackPostResult
                 confirmedCallbackToolNames.push(completedToolName.toolName);
               }
             }
@@ -1770,6 +1785,7 @@ export async function* routeSerial(
         collectedToolEvents.splice(0, collectedToolEvents.length);
         collectedToolNames.splice(0, collectedToolNames.length);
         confirmedCallbackToolNames.splice(0, confirmedCallbackToolNames.length);
+        sawToolResult = false;
         structuredTargetCats.clear();
         streamRichBlocks.splice(0, streamRichBlocks.length);
         pendingToolResults.splice(0, pendingToolResults.length);
@@ -1895,6 +1911,7 @@ export async function* routeSerial(
               if (isPostMessageToolName(effectiveMsg.toolName)) awaitingCallbackResult = true;
             }
             if (effectiveMsg.type === 'tool_result') {
+              sawToolResult = true;
               const callbackResult = parseCallbackPostResult(effectiveMsg.content);
               const completedToolName = consumePendingToolResult(
                 pendingToolResults,
@@ -1920,8 +1937,16 @@ export async function* routeSerial(
                   callbackResult.messageId,
                   callbackResult.threadId,
                 );
-                // F257 LI-005: only confirmed-successful callback tools qualify as durable triggers
-                if (callbackResult.confirmed) {
+                // F257 LI-005: durable trigger classification (same as primary handler above)
+                if (
+                  classifyDurableTriggerResult(
+                    completedToolName.toolName,
+                    effectiveMsg.content,
+                    (effectiveMsg as { toolResultStatus?: 'ok' | 'error' | 'unknown' }).toolResultStatus,
+                  )
+                ) {
+                  confirmedCallbackToolNames.push(completedToolName.toolName);
+                } else if (callbackResult.confirmed) {
                   confirmedCallbackToolNames.push(completedToolName.toolName);
                 }
               }
@@ -2454,12 +2479,15 @@ export async function* routeSerial(
         let pendingAckLivenessHint = false;
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
-          // Pass only confirmed-successful callback tool names so that a failed
-          // hold_ball (400/429) does NOT suppress the hint. The evaluator's suffix
-          // matching filters for durable triggers from this confirmed-only set.
+          // F257 LI-005 two-tier tool name sourcing (Sol R3 P1):
+          // - sawToolResult=true (Codex/Gemini): use confirmedCallbackToolNames (classified per-tool)
+          // - sawToolResult=false (Claude CLI): fall back to collectedToolNames (optimistic)
+          // Claude CLI's NDJSON parser does not emit tool_result events, so
+          // confirmedCallbackToolNames is always empty for Claude CLI cats.
+          const toolNamesForLivenessEval = sawToolResult ? confirmedCallbackToolNames : collectedToolNames;
           const ackLivenessEval = evaluateAckLiveness({
             isA2AInvocation,
-            toolNames: confirmedCallbackToolNames,
+            toolNames: toolNamesForLivenessEval,
             lineStartMentions: routingExitLineStartMentions,
             structuredTargetCats: [...structuredTargetCats],
             hasCoCreatorLineStartMention: routingExitHasCoCreatorLineStartMention,

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1074,12 +1074,10 @@ export async function* routeSerial(
       // F148 OQ-2: Collect tool names for context eval signals
       const collectedToolNames: string[] = [];
       // F257 LI-005: Track confirmed-successful durable trigger tool names.
-      // Two-tier sourcing (Sol R3 P1):
-      //   - When tool_result events flow (Codex/Gemini): classified via classifyDurableTriggerResult
-      //   - When no tool_result events (Claude CLI): fall back to collectedToolNames (optimistic)
-      // sawToolResult tracks whether ANY tool_result event was processed this invocation.
+      // All providers now emit tool_result events (Claude CLI bridge added in
+      // claude-ndjson-parser.ts R4 fix). Success classification uses
+      // classifyDurableTriggerResult (two-level: structural status → body parsing).
       const confirmedCallbackToolNames: string[] = [];
-      let sawToolResult = false;
       // #573: Track confirmed cat_cafe_post_message callback persistence
       let callbackPostConfirmed = false;
       let callbackPostMessageId: string | undefined;
@@ -1451,7 +1449,6 @@ export async function* routeSerial(
           }
           // #573: Confirm callback persistence via tool_result success
           if (effectiveMsg.type === 'tool_result') {
-            sawToolResult = true;
             const callbackResult = parseCallbackPostResult(effectiveMsg.content);
             const completedToolName = consumePendingToolResult(
               pendingToolResults,
@@ -1785,7 +1782,6 @@ export async function* routeSerial(
         collectedToolEvents.splice(0, collectedToolEvents.length);
         collectedToolNames.splice(0, collectedToolNames.length);
         confirmedCallbackToolNames.splice(0, confirmedCallbackToolNames.length);
-        sawToolResult = false;
         structuredTargetCats.clear();
         streamRichBlocks.splice(0, streamRichBlocks.length);
         pendingToolResults.splice(0, pendingToolResults.length);
@@ -1911,7 +1907,6 @@ export async function* routeSerial(
               if (isPostMessageToolName(effectiveMsg.toolName)) awaitingCallbackResult = true;
             }
             if (effectiveMsg.type === 'tool_result') {
-              sawToolResult = true;
               const callbackResult = parseCallbackPostResult(effectiveMsg.content);
               const completedToolName = consumePendingToolResult(
                 pendingToolResults,
@@ -2479,15 +2474,11 @@ export async function* routeSerial(
         let pendingAckLivenessHint = false;
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
-          // F257 LI-005 two-tier tool name sourcing (Sol R3 P1):
-          // - sawToolResult=true (Codex/Gemini): use confirmedCallbackToolNames (classified per-tool)
-          // - sawToolResult=false (Claude CLI): fall back to collectedToolNames (optimistic)
-          // Claude CLI's NDJSON parser does not emit tool_result events, so
-          // confirmedCallbackToolNames is always empty for Claude CLI cats.
-          const toolNamesForLivenessEval = sawToolResult ? confirmedCallbackToolNames : collectedToolNames;
+          // F257 LI-005: all providers now emit tool_result (Claude CLI bridge
+          // added in R4). Only confirmed-successful durable triggers suppress the hint.
           const ackLivenessEval = evaluateAckLiveness({
             isA2AInvocation,
-            toolNames: toolNamesForLivenessEval,
+            toolNames: confirmedCallbackToolNames,
             lineStartMentions: routingExitLineStartMentions,
             structuredTargetCats: [...structuredTargetCats],
             hasCoCreatorLineStartMention: routingExitHasCoCreatorLineStartMention,

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1090,6 +1090,11 @@ export async function* routeSerial(
       let confirmedLocalCallbackRoutingHasCoCreatorLineStartMention = false;
       const emittedBallHandedCvoMessageIds = new Set<string>();
       const structuredTargetCats = new Set<string>();
+      // F257 P2-2: confirmed structured targets — only populated on successful
+      // tool_result for post_message/cross_post_message. Unconfirmed tool_use inputs
+      // must not suppress ack-liveness hint (Codex R1 P2-2 fix).
+      const confirmedStructuredTargetCats = new Set<string>();
+      const pendingStructuredTargetsByTool = new Map<string, string[]>();
       // F060: Collect rich blocks emitted inline via system_info (not MCP buffer)
       const streamRichBlocks: import('@cat-cafe/shared').RichBlock[] = [];
       // F22 R2 P1-1: Capture own invocationId from stream (not getLatestId)
@@ -1426,8 +1431,14 @@ export async function* routeSerial(
           }
 
           if (effectiveMsg.type === 'tool_use') {
-            for (const target of collectStructuredTargetCatsFromInput(effectiveMsg.toolInput)) {
+            const targets = collectStructuredTargetCatsFromInput(effectiveMsg.toolInput);
+            for (const target of targets) {
               structuredTargetCats.add(target);
+            }
+            // F257 P2-2: track pending targets by tool identity for confirmation on tool_result
+            if (targets.length > 0) {
+              const pendingKey = effectiveMsg.toolUseId ?? effectiveMsg.toolName ?? '';
+              pendingStructuredTargetsByTool.set(pendingKey, targets);
             }
           }
 
@@ -1488,6 +1499,16 @@ export async function* routeSerial(
               } else if (callbackResult.confirmed) {
                 // Non-durable-trigger tools (post_message etc.): use existing parseCallbackPostResult
                 confirmedCallbackToolNames.push(completedToolName.toolName);
+              }
+              // F257 P2-2: confirm pending structured targets on successful tool_result.
+              // Only confirmed targets suppress the ack-liveness hint.
+              const pendingTargetKey = completedToolName.toolUseId ?? completedToolName.toolName;
+              const pendingTargets = pendingStructuredTargetsByTool.get(pendingTargetKey);
+              if (pendingTargets) {
+                if (callbackResult.confirmed) {
+                  for (const t of pendingTargets) confirmedStructuredTargetCats.add(t);
+                }
+                pendingStructuredTargetsByTool.delete(pendingTargetKey);
               }
             }
             // F188 Phase F AC-F10 (砚砚 六审 P1-B: also scope by catId for serial route consistency).
@@ -1790,6 +1811,8 @@ export async function* routeSerial(
         confirmedLocalCallbackRoutingMentions.clear();
         confirmedCallbackRoutingGuardHasCoCreatorLineStartMention = false;
         confirmedLocalCallbackRoutingHasCoCreatorLineStartMention = false;
+        confirmedStructuredTargetCats.clear();
+        pendingStructuredTargetsByTool.clear();
         callbackPostConfirmed = false;
         callbackPostMessageId = undefined;
         awaitingCallbackResult = false;
@@ -1887,8 +1910,14 @@ export async function* routeSerial(
             }
 
             if (effectiveMsg.type === 'tool_use') {
-              for (const target of collectStructuredTargetCatsFromInput(effectiveMsg.toolInput)) {
+              const targets = collectStructuredTargetCatsFromInput(effectiveMsg.toolInput);
+              for (const target of targets) {
                 structuredTargetCats.add(target);
+              }
+              // F257 P2-2: track pending targets for confirmation (retry/46 path)
+              if (targets.length > 0) {
+                const pendingKey = effectiveMsg.toolUseId ?? effectiveMsg.toolName ?? '';
+                pendingStructuredTargetsByTool.set(pendingKey, targets);
               }
             }
             if (effectiveMsg.type === 'tool_use' && effectiveMsg.toolName) {
@@ -1943,6 +1972,15 @@ export async function* routeSerial(
                   confirmedCallbackToolNames.push(completedToolName.toolName);
                 } else if (callbackResult.confirmed) {
                   confirmedCallbackToolNames.push(completedToolName.toolName);
+                }
+                // F257 P2-2: confirm pending structured targets (retry/46 path)
+                const pendingTargetKey = completedToolName.toolUseId ?? completedToolName.toolName;
+                const pendingTargets = pendingStructuredTargetsByTool.get(pendingTargetKey);
+                if (pendingTargets) {
+                  if (callbackResult.confirmed) {
+                    for (const t of pendingTargets) confirmedStructuredTargetCats.add(t);
+                  }
+                  pendingStructuredTargetsByTool.delete(pendingTargetKey);
                 }
               }
             }
@@ -2100,6 +2138,12 @@ export async function* routeSerial(
           await appendRoutingGuardFailureNotice();
         }
       }
+
+      // F257 LI-005: A2A invocation signal — hoisted before text/no-text branch
+      // so ack-liveness evaluation covers both paths (Codex R1 P2-1 fix).
+      // directMessageFrom covers inline-serial A2A; queueTriggerReplyTo covers queue-dispatched A2A.
+      const isA2AInvocation = Boolean(directMessageFrom) || Boolean(queueTriggerReplyTo);
+      let pendingAckLivenessHint = false;
 
       if (textContent) {
         catProducedOutput = true;
@@ -2462,25 +2506,19 @@ export async function* routeSerial(
           }
         }
 
-        // F257 LI-005 Phase 1: A2A ack-liveness detection — cat received an A2A
-        // ball but bound no durable trigger (hold_ball / register_scheduled_task /
-        // etc.) and has no routing exit. The ball effectively dies.
-        // Two A2A paths must both be detected:
-        //   1. Inline serial: text @mention within same routeSerial → a2aFrom populated
-        //   2. Queue-dispatched: post_message/cross_post_message → InvocationQueue →
-        //      QueueProcessor → routeSerial with a2aTriggerMessageId in options
-        // directMessageFrom covers path 1; queueTriggerReplyTo covers path 2.
-        const isA2AInvocation = Boolean(directMessageFrom) || Boolean(queueTriggerReplyTo);
-        let pendingAckLivenessHint = false;
+        // F257 LI-005 Phase 1: A2A ack-liveness detection (text path).
+        // isA2AInvocation and pendingAckLivenessHint are hoisted before the
+        // text/no-text branch (Codex R1 P2-1 fix).
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
           // F257 LI-005: all providers now emit tool_result (Claude CLI bridge
           // added in R4). Only confirmed-successful durable triggers suppress the hint.
+          // F257 P2-2: use confirmedStructuredTargetCats (not unconfirmed structuredTargetCats).
           const ackLivenessEval = evaluateAckLiveness({
             isA2AInvocation,
             toolNames: confirmedCallbackToolNames,
             lineStartMentions: routingExitLineStartMentions,
-            structuredTargetCats: [...structuredTargetCats],
+            structuredTargetCats: [...confirmedStructuredTargetCats],
             hasCoCreatorLineStartMention: routingExitHasCoCreatorLineStartMention,
           });
           if (ackLivenessEval.shouldEmit) {
@@ -3470,6 +3508,66 @@ export async function* routeSerial(
             await deps.invocationDeps.threadStore.updateParticipantActivity(threadId, catId, !hadProviderError);
           } catch (activityErr) {
             log.warn({ catId: catId as string, err: activityErr }, 'updateParticipantActivity failed');
+          }
+        }
+      }
+
+      // F257 LI-005: ack-liveness for no-text A2A turns (Codex R1 P2-1 fix).
+      // Covers both the tool-only branch (else-if) and the error-only branch (else).
+      // In no-text turns: no line-start mentions from text, only confirmed callback data.
+      // The text path evaluates ack-liveness inside its own block; this only fires
+      // when textContent is falsy to avoid double evaluation.
+      if (!textContent && isA2AInvocation) {
+        const noTextC2Attr: Record<string, string> = {
+          [AGENT_ID]: catId as string,
+          [THREAD_SYSTEM_KIND]: routeThread?.systemKind ?? 'product',
+        };
+        c2AckLivenessChecked.add(1, noTextC2Attr);
+        const noTextAckEval = evaluateAckLiveness({
+          isA2AInvocation,
+          toolNames: confirmedCallbackToolNames,
+          lineStartMentions: getRoutingExitLineStartMentions([]),
+          structuredTargetCats: [...confirmedStructuredTargetCats],
+          hasCoCreatorLineStartMention: confirmedCallbackRoutingGuardHasCoCreatorLineStartMention,
+        });
+        if (noTextAckEval.shouldEmit) {
+          pendingAckLivenessHint = true;
+          try {
+            const hintSource = {
+              connector: 'ack-liveness-hint',
+              label: '接球提醒',
+              icon: '🏓',
+              meta: { presentation: 'system_notice', noticeTone: 'warning' },
+            };
+            const ackStored = await deps.messageStore.append({
+              userId: 'system',
+              catId: null,
+              threadId,
+              content:
+                '[接球提醒]: A2A 接球后 invocation 结束，但未绑定任何持久触发器' +
+                '（hold_ball / register_scheduled_task 等）也未传球给下一只猫 — ' +
+                '球将静默死亡。请调用 `cat_cafe_hold_ball` 持球或行首 `@句柄` 传球。',
+              mentions: [],
+              timestamp: Date.now(),
+              source: hintSource,
+            });
+            c2AckLivenessHintEmitted.add(1, noTextC2Attr);
+            if (deps.socketManager) {
+              deps.socketManager.broadcastToRoom(`thread:${threadId}`, 'connector_message', {
+                threadId,
+                message: {
+                  id: ackStored.id,
+                  type: 'connector',
+                  content: ackStored.content,
+                  source: hintSource,
+                  timestamp: ackStored.timestamp,
+                },
+              });
+            }
+            // void_ack: anchor to hint message (no cat response message in no-text path)
+            emitBallVoidAck(deps.ballCustody, threadId, ackStored.id, streamReplyTo);
+          } catch {
+            /* non-blocking hint */
           }
         }
       }

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -36,6 +36,8 @@ import {
 } from '../../../../../infrastructure/telemetry/genai-semconv.js';
 import {
   a2aDispatchCount,
+  c2AckLivenessChecked,
+  c2AckLivenessHintEmitted,
   c2ExitChecked,
   c2VerdictHintEmitted,
   c2VerdictWithoutPassCount,
@@ -59,6 +61,7 @@ import {
   buildHandedEvent,
   buildInvocationHeartbeatEvent,
   buildInvocationStartedEvent,
+  buildVoidAckEvent,
   buildVoidPassEvent,
 } from '../../../../ball-custody/ball-custody-events.js';
 import { conciergeContextForCat, prepareConciergeContext } from '../../../../concierge/ConciergeRoutingInterceptor.js';
@@ -116,6 +119,7 @@ import {
   updateStreakOnPush,
 } from '../routing/WorklistRegistry.js';
 import { accumulateTextAggregate } from '../text-aggregation.js';
+import { evaluateAckLiveness } from './a2a-ack-liveness.js';
 import { formatA2AHandoffContent } from './a2a-handoff-label.js';
 import { extractContextEvalSignals } from './context-eval.js';
 import { validateRoutingSyntax } from './final-routing-slot.js';
@@ -177,6 +181,21 @@ function emitBallVoidPass(
   ballCustody
     .record(buildVoidPassEvent({ threadId, messageId, matchedPattern: matchedPattern ?? undefined, at: Date.now() }))
     .catch((err) => log.warn({ threadId, err }, 'ball.void_pass ingest failed'));
+}
+
+/**
+ * F257 LI-005: fire-and-forget 旁路写 ball.void_ack（A2A 接球但无持久触发器 / 无路由出口 → 球静默死亡）。
+ * 紧贴 ack-liveness-hint sample emit 调用（此时 storedMsgId 已绑定）。
+ */
+function emitBallVoidAck(
+  ballCustody: IBallCustodyIngest | undefined,
+  threadId: string,
+  messageId: string | undefined,
+): void {
+  if (!ballCustody || !messageId) return;
+  ballCustody
+    .record(buildVoidAckEvent({ threadId, messageId, at: Date.now() }))
+    .catch((err) => log.warn({ threadId, err }, 'ball.void_ack ingest failed'));
 }
 
 function emitBallHandedCvo(
@@ -2409,6 +2428,62 @@ export async function* routeSerial(
           }
         }
 
+        // F257 LI-005: A2A ack-liveness detection — cat received an A2A ball but
+        // bound no durable trigger (hold_ball / create_task / etc.) and has no routing
+        // exit (@mention / structured routing / @co-creator). The ball effectively dies.
+        // Companion to void-hold (void-hold = "said holding, didn't call hold_ball",
+        // ack-liveness = "received A2A ball, bound no trigger").
+        const isA2AInvocation = Boolean(directMessageFrom);
+        let pendingAckLivenessHint = false;
+        if (isA2AInvocation) {
+          c2AckLivenessChecked.add(1, c2BaseAttr);
+          const ackLivenessEval = evaluateAckLiveness({
+            isA2AInvocation,
+            toolNames: collectedToolNames,
+            lineStartMentions: routingExitLineStartMentions,
+            structuredTargetCats: [...structuredTargetCats],
+            hasCoCreatorLineStartMention: routingExitHasCoCreatorLineStartMention,
+          });
+          if (ackLivenessEval.shouldEmit) {
+            pendingAckLivenessHint = true;
+            try {
+              const hintSource = {
+                connector: 'ack-liveness-hint',
+                label: '接球提醒',
+                icon: '🏓',
+                meta: { presentation: 'system_notice', noticeTone: 'warning' },
+              };
+              const ackStored = await deps.messageStore.append({
+                userId: 'system',
+                catId: null,
+                threadId,
+                content:
+                  '[接球提醒]: A2A 接球后 invocation 结束，但未绑定任何持久触发器' +
+                  '（hold_ball / create_task / register_scheduled_task 等）也未传球给下一只猫 — ' +
+                  '球将静默死亡。请调用 `cat_cafe_hold_ball` 持球或行首 `@句柄` 传球。',
+                mentions: [],
+                timestamp: Date.now(),
+                source: hintSource,
+              });
+              c2AckLivenessHintEmitted.add(1, c2BaseAttr);
+              if (deps.socketManager) {
+                deps.socketManager.broadcastToRoom(`thread:${threadId}`, 'connector_message', {
+                  threadId,
+                  message: {
+                    id: ackStored.id,
+                    type: 'connector',
+                    content: ackStored.content,
+                    source: hintSource,
+                    timestamp: ackStored.timestamp,
+                  },
+                });
+              }
+            } catch {
+              /* non-blocking hint */
+            }
+          }
+        }
+
         // F079 Phase 2: Vote interception — extract [VOTE:xxx] from cat response
         const votedOption = extractVoteFromText(storedContent);
         if (votedOption && deps.invocationDeps.threadStore) {
@@ -2762,6 +2837,11 @@ export async function* routeSerial(
             }
             // F233 Phase B (B2): 同一虚空传球旁路写 ball.void_pass（storedMsgId 此时已绑定）
             emitBallVoidPass(deps.ballCustody, threadId, storedMsgId, pendingC2VoidHoldSampleTrigger);
+          }
+
+          // F257 LI-005: deferred ball.void_ack emission（storedMsgId 此时已绑定）
+          if (pendingAckLivenessHint && storedMsgId) {
+            emitBallVoidAck(deps.ballCustody, threadId, storedMsgId);
           }
         } catch (err) {
           log.error({ catId: catId as string, err }, 'messageStore.append failed, degrading');

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1072,6 +1072,10 @@ export async function* routeSerial(
       const collectedToolEvents: StoredToolEvent[] = [];
       // F148 OQ-2: Collect tool names for context eval signals
       const collectedToolNames: string[] = [];
+      // F257 LI-005: Track tool names whose callback returned confirmed (status=ok/duplicate).
+      // Only confirmed-successful tools count as "durable triggers" — a 400/429/error
+      // tool_result should NOT suppress the ack-liveness hint.
+      const confirmedCallbackToolNames: string[] = [];
       // #573: Track confirmed cat_cafe_post_message callback persistence
       let callbackPostConfirmed = false;
       let callbackPostMessageId: string | undefined;
@@ -1468,6 +1472,10 @@ export async function* routeSerial(
                 callbackResult.messageId,
                 callbackResult.threadId,
               );
+              // F257 LI-005: only confirmed-successful callback tools qualify as durable triggers
+              if (callbackResult.confirmed) {
+                confirmedCallbackToolNames.push(completedToolName.toolName);
+              }
             }
             // F188 Phase F AC-F10 (砚砚 六审 P1-B: also scope by catId for serial route consistency).
             // 砚砚 cloud-3 P1: also pass toolUseId for exact match when available;
@@ -1760,6 +1768,7 @@ export async function* routeSerial(
         doneMsg = undefined;
         collectedToolEvents.splice(0, collectedToolEvents.length);
         collectedToolNames.splice(0, collectedToolNames.length);
+        confirmedCallbackToolNames.splice(0, confirmedCallbackToolNames.length);
         structuredTargetCats.clear();
         streamRichBlocks.splice(0, streamRichBlocks.length);
         pendingToolResults.splice(0, pendingToolResults.length);
@@ -1910,6 +1919,10 @@ export async function* routeSerial(
                   callbackResult.messageId,
                   callbackResult.threadId,
                 );
+                // F257 LI-005: only confirmed-successful callback tools qualify as durable triggers
+                if (callbackResult.confirmed) {
+                  confirmedCallbackToolNames.push(completedToolName.toolName);
+                }
               }
             }
 
@@ -2440,9 +2453,12 @@ export async function* routeSerial(
         let pendingAckLivenessHint = false;
         if (isA2AInvocation) {
           c2AckLivenessChecked.add(1, c2BaseAttr);
+          // Pass only confirmed-successful callback tool names so that a failed
+          // hold_ball (400/429) does NOT suppress the hint. The evaluator's suffix
+          // matching filters for durable triggers from this confirmed-only set.
           const ackLivenessEval = evaluateAckLiveness({
             isA2AInvocation,
-            toolNames: collectedToolNames,
+            toolNames: confirmedCallbackToolNames,
             lineStartMentions: routingExitLineStartMentions,
             structuredTargetCats: [...structuredTargetCats],
             hasCoCreatorLineStartMention: routingExitHasCoCreatorLineStartMention,

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -191,10 +191,11 @@ function emitBallVoidAck(
   ballCustody: IBallCustodyIngest | undefined,
   threadId: string,
   messageId: string | undefined,
+  a2aTriggerMessageId: string | undefined,
 ): void {
   if (!ballCustody || !messageId) return;
   ballCustody
-    .record(buildVoidAckEvent({ threadId, messageId, at: Date.now() }))
+    .record(buildVoidAckEvent({ threadId, messageId, a2aTriggerMessageId, at: Date.now() }))
     .catch((err) => log.warn({ threadId, err }, 'ball.void_ack ingest failed'));
 }
 
@@ -2859,8 +2860,9 @@ export async function* routeSerial(
           }
 
           // F257 LI-005: deferred ball.void_ack emission（storedMsgId 此时已绑定）
+          // streamReplyTo = trigger message ID covering both inline serial and queue paths
           if (pendingAckLivenessHint && storedMsgId) {
-            emitBallVoidAck(deps.ballCustody, threadId, storedMsgId);
+            emitBallVoidAck(deps.ballCustody, threadId, storedMsgId, streamReplyTo);
           }
         } catch (err) {
           log.error({ catId: catId as string, err }, 'messageStore.append failed, degrading');

--- a/packages/api/src/infrastructure/telemetry/instruments.ts
+++ b/packages/api/src/infrastructure/telemetry/instruments.ts
@@ -228,7 +228,7 @@ export const c2VoidHoldChecked = lazy(() =>
   }),
 );
 
-// F257 LI-005: A2A ack-liveness check — separate denominator/numerator pair
+// LI-005: A2A ack-liveness check — separate denominator/numerator pair
 // (same pattern as void_hold_checked / void_hold_hint_emitted).
 export const c2AckLivenessChecked = lazy(() =>
   meter().createCounter('cat_cafe.a2a.c2.ack_liveness_checked', {

--- a/packages/api/src/infrastructure/telemetry/instruments.ts
+++ b/packages/api/src/infrastructure/telemetry/instruments.ts
@@ -228,6 +228,20 @@ export const c2VoidHoldChecked = lazy(() =>
   }),
 );
 
+// F257 LI-005: A2A ack-liveness check — separate denominator/numerator pair
+// (same pattern as void_hold_checked / void_hold_hint_emitted).
+export const c2AckLivenessChecked = lazy(() =>
+  meter().createCounter('cat_cafe.a2a.c2.ack_liveness_checked', {
+    description: 'C2 ack-liveness check evaluations performed (denominator for ack_liveness_hint ratio)',
+  }),
+);
+
+export const c2AckLivenessHintEmitted = lazy(() =>
+  meter().createCounter('cat_cafe.a2a.c2.ack_liveness_hint_emitted', {
+    description: 'C2 ack-liveness hint emitted: A2A invocation ended without routing exit or durable trigger',
+  }),
+);
+
 export const antigravityStreamErrorBuffered = lazy(() =>
   meter().createCounter('cat_cafe.antigravity.stream_error.buffered_total', {
     description: 'Buffered Antigravity stream_error after partial text while waiting for a recovery tail',
@@ -585,6 +599,8 @@ export function warmupCounters(): void {
   c2VerdictWithoutPassCount.add(0);
   c2ExitChecked.add(0);
   c2VoidHoldChecked.add(0);
+  c2AckLivenessChecked.add(0);
+  c2AckLivenessHintEmitted.add(0);
   // F231 AC-C3: profile update pipeline counters
   profileUpdateProposed.add(0);
   profileUpdateApproved.add(0);

--- a/packages/api/test/a2a-ack-liveness.test.js
+++ b/packages/api/test/a2a-ack-liveness.test.js
@@ -9,7 +9,7 @@ import {
 } from '../dist/domains/cats/services/agents/routing/a2a-ack-liveness.js';
 
 /**
- * F257 LI-005 — A2A Ack Liveness Detection unit tests.
+ * LI-005 — A2A Ack Liveness Detection unit tests.
  *
  * Red-first TDD: each test targets a specific detection scenario from the
  * LI-005 candidate definition (live-candidates-2026-07-14.md).

--- a/packages/api/test/a2a-ack-liveness.test.js
+++ b/packages/api/test/a2a-ack-liveness.test.js
@@ -1,0 +1,132 @@
+// @ts-check
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { evaluateAckLiveness } from '../dist/domains/cats/services/agents/routing/a2a-ack-liveness.js';
+
+/**
+ * F257 LI-005 — A2A Ack Liveness Detection unit tests.
+ *
+ * Red-first TDD: each test targets a specific detection scenario from the
+ * LI-005 candidate definition (live-candidates-2026-07-14.md).
+ */
+
+/** Helper: build default input with overrides. */
+function input(overrides = {}) {
+  return {
+    isA2AInvocation: true,
+    toolNames: [],
+    lineStartMentions: [],
+    structuredTargetCats: [],
+    hasCoCreatorLineStartMention: false,
+    ...overrides,
+  };
+}
+
+describe('evaluateAckLiveness', () => {
+  // ── Core detection: void ack ────────────────────────────────────────────
+
+  it('fires when A2A invocation ends without routing exit or durable trigger', () => {
+    const result = evaluateAckLiveness(input());
+    assert.equal(result.shouldEmit, true, 'should fire on bare A2A ack');
+    assert.equal(result.hasRoutingExit, false);
+    assert.equal(result.hasDurableTrigger, false);
+  });
+
+  // ── Suppression: non-A2A ────────────────────────────────────────────────
+
+  it('never fires for user-initiated invocations', () => {
+    const result = evaluateAckLiveness(input({ isA2AInvocation: false }));
+    assert.equal(result.shouldEmit, false, 'user-initiated should not fire');
+  });
+
+  // ── Suppression: routing exits ──────────────────────────────────────────
+
+  it('suppressed by line-start @mention (ball passed forward)', () => {
+    const result = evaluateAckLiveness(input({ lineStartMentions: ['codex'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasRoutingExit, true);
+  });
+
+  it('suppressed by structured targetCats (post_message routing)', () => {
+    const result = evaluateAckLiveness(input({ structuredTargetCats: ['opus'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasRoutingExit, true);
+  });
+
+  it('suppressed by @co-creator line-start mention', () => {
+    const result = evaluateAckLiveness(input({ hasCoCreatorLineStartMention: true }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasRoutingExit, true);
+  });
+
+  // ── Suppression: durable triggers ───────────────────────────────────────
+
+  it('suppressed by hold_ball tool call', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['mcp__cat-cafe-collab__cat_cafe_hold_ball'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  it('suppressed by create_task tool call', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_create_task'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  it('suppressed by register_scheduled_task tool call', () => {
+    const result = evaluateAckLiveness(
+      input({ toolNames: ['mcp__cat-cafe-collab__cat_cafe_register_scheduled_task'] }),
+    );
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  it('suppressed by register_pr_tracking tool call', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_register_pr_tracking'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  it('suppressed by register_issue_tracking tool call', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_register_issue_tracking'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  it('suppressed by community_await_external tool call', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_community_await_external'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+
+  // ── Non-trigger tools do NOT suppress ───────────────────────────────────
+
+  it('non-trigger tools (search_evidence, post_message) do not suppress', () => {
+    const result = evaluateAckLiveness(
+      input({
+        toolNames: ['cat_cafe_search_evidence', 'cat_cafe_post_message', 'Read', 'Bash'],
+      }),
+    );
+    assert.equal(result.shouldEmit, true, 'informational tools should not suppress');
+    assert.equal(result.hasDurableTrigger, false);
+  });
+
+  // ── Combination: routing exit + no trigger still suppresses ─────────────
+
+  it('routing exit alone suppresses even without durable trigger', () => {
+    const result = evaluateAckLiveness(input({ lineStartMentions: ['sol'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasRoutingExit, true);
+    assert.equal(result.hasDurableTrigger, false);
+  });
+
+  // ── Combination: trigger alone suppresses even without routing exit ─────
+
+  it('durable trigger alone suppresses even without routing exit', () => {
+    const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_hold_ball'] }));
+    assert.equal(result.shouldEmit, false);
+    assert.equal(result.hasRoutingExit, false);
+    assert.equal(result.hasDurableTrigger, true);
+  });
+});

--- a/packages/api/test/a2a-ack-liveness.test.js
+++ b/packages/api/test/a2a-ack-liveness.test.js
@@ -2,6 +2,7 @@
 
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { buildVoidAckEvent } from '../dist/domains/ball-custody/ball-custody-events.js';
 import { evaluateAckLiveness } from '../dist/domains/cats/services/agents/routing/a2a-ack-liveness.js';
 
 /**
@@ -68,10 +69,10 @@ describe('evaluateAckLiveness', () => {
     assert.equal(result.hasDurableTrigger, true);
   });
 
-  it('suppressed by create_task tool call', () => {
+  it('create_task does NOT suppress (bookkeeping only, no wake mechanism)', () => {
     const result = evaluateAckLiveness(input({ toolNames: ['cat_cafe_create_task'] }));
-    assert.equal(result.shouldEmit, false);
-    assert.equal(result.hasDurableTrigger, true);
+    assert.equal(result.shouldEmit, true, 'create_task has no invokeTrigger');
+    assert.equal(result.hasDurableTrigger, false);
   });
 
   it('suppressed by register_scheduled_task tool call', () => {
@@ -102,13 +103,13 @@ describe('evaluateAckLiveness', () => {
 
   // ── Non-trigger tools do NOT suppress ───────────────────────────────────
 
-  it('non-trigger tools (search_evidence, post_message) do not suppress', () => {
+  it('non-trigger tools (search_evidence, post_message, create_task) do not suppress', () => {
     const result = evaluateAckLiveness(
       input({
-        toolNames: ['cat_cafe_search_evidence', 'cat_cafe_post_message', 'Read', 'Bash'],
+        toolNames: ['cat_cafe_search_evidence', 'cat_cafe_post_message', 'cat_cafe_create_task', 'Read', 'Bash'],
       }),
     );
-    assert.equal(result.shouldEmit, true, 'informational tools should not suppress');
+    assert.equal(result.shouldEmit, true, 'informational/bookkeeping tools should not suppress');
     assert.equal(result.hasDurableTrigger, false);
   });
 
@@ -128,5 +129,26 @@ describe('evaluateAckLiveness', () => {
     assert.equal(result.shouldEmit, false);
     assert.equal(result.hasRoutingExit, false);
     assert.equal(result.hasDurableTrigger, true);
+  });
+});
+
+// ─── buildVoidAckEvent builder tests ──────────────────────────────────────
+
+describe('buildVoidAckEvent', () => {
+  it('builds well-formed ball.void_ack event', () => {
+    const event = buildVoidAckEvent({ threadId: 't-1', messageId: 'm-42', at: 1700000000000 });
+    assert.equal(event.kind, 'ball.void_ack');
+    assert.equal(event.classification, 'state-changing');
+    assert.equal(event.subjectKey, 'ball:thread:t-1');
+    assert.equal(event.sourceEventId, 'route:m-42:void_ack');
+    assert.equal(event.at, 1700000000000);
+    assert.deepEqual(event.payload, {});
+  });
+
+  it('sourceEventId differs from void_pass for same messageId', () => {
+    const ack = buildVoidAckEvent({ threadId: 't-1', messageId: 'm-42', at: 1700000000000 });
+    // void_pass uses `route:{messageId}:void`, ack uses `route:{messageId}:void_ack`
+    assert.ok(ack.sourceEventId.endsWith(':void_ack'));
+    assert.ok(!ack.sourceEventId.endsWith(':void_ack:void_ack'), 'no double suffix');
   });
 });

--- a/packages/api/test/a2a-ack-liveness.test.js
+++ b/packages/api/test/a2a-ack-liveness.test.js
@@ -135,7 +135,7 @@ describe('evaluateAckLiveness', () => {
 // ─── buildVoidAckEvent builder tests ──────────────────────────────────────
 
 describe('buildVoidAckEvent', () => {
-  it('builds well-formed ball.void_ack event', () => {
+  it('builds well-formed ball.void_ack event without trigger ID', () => {
     const event = buildVoidAckEvent({ threadId: 't-1', messageId: 'm-42', at: 1700000000000 });
     assert.equal(event.kind, 'ball.void_ack');
     assert.equal(event.classification, 'state-changing');
@@ -143,6 +143,17 @@ describe('buildVoidAckEvent', () => {
     assert.equal(event.sourceEventId, 'route:m-42:void_ack');
     assert.equal(event.at, 1700000000000);
     assert.deepEqual(event.payload, {});
+  });
+
+  it('includes a2aTriggerMessageId in payload when provided (provenance)', () => {
+    const event = buildVoidAckEvent({
+      threadId: 't-1',
+      messageId: 'm-42',
+      a2aTriggerMessageId: 'trigger-msg-99',
+      at: 1700000000000,
+    });
+    assert.equal(event.kind, 'ball.void_ack');
+    assert.deepEqual(event.payload, { a2aTriggerMessageId: 'trigger-msg-99' });
   });
 
   it('sourceEventId differs from void_pass for same messageId', () => {

--- a/packages/api/test/a2a-ack-liveness.test.js
+++ b/packages/api/test/a2a-ack-liveness.test.js
@@ -3,7 +3,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { buildVoidAckEvent } from '../dist/domains/ball-custody/ball-custody-events.js';
-import { evaluateAckLiveness } from '../dist/domains/cats/services/agents/routing/a2a-ack-liveness.js';
+import {
+  classifyDurableTriggerResult,
+  evaluateAckLiveness,
+} from '../dist/domains/cats/services/agents/routing/a2a-ack-liveness.js';
 
 /**
  * F257 LI-005 — A2A Ack Liveness Detection unit tests.
@@ -129,6 +132,82 @@ describe('evaluateAckLiveness', () => {
     assert.equal(result.shouldEmit, false);
     assert.equal(result.hasRoutingExit, false);
     assert.equal(result.hasDurableTrigger, true);
+  });
+});
+
+// ─── classifyDurableTriggerResult (Sol R3 P1 fix) ────────────────────────────
+
+describe('classifyDurableTriggerResult', () => {
+  // ── Level 1: structural toolResultStatus ─────────────────────────────────
+
+  it('returns true when toolResultStatus is ok (Codex/Gemini)', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', '{}', 'ok'), true);
+  });
+
+  it('returns false when toolResultStatus is error', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', '{}', 'error'), false);
+  });
+
+  // ── Level 2: tool-specific body parsing ──────────────────────────────────
+
+  it('hold_ball: {status: "ok"} → confirmed', () => {
+    const body = JSON.stringify({ status: 'ok', held: true, taskId: 'hold-123' });
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', body, undefined), true);
+  });
+
+  it('register_pr_tracking: {status: "ok"} → confirmed', () => {
+    const body = JSON.stringify({ status: 'ok', threadId: 't-1', task: {} });
+    assert.equal(classifyDurableTriggerResult('cat_cafe_register_pr_tracking', body, undefined), true);
+  });
+
+  it('register_issue_tracking: {status: "ok"} → confirmed', () => {
+    const body = JSON.stringify({ status: 'ok', threadId: 't-1', task: {} });
+    assert.equal(classifyDurableTriggerResult('cat_cafe_register_issue_tracking', body, undefined), true);
+  });
+
+  it('register_scheduled_task: {success: true} → confirmed (Sol R3 P1)', () => {
+    const body = JSON.stringify({ success: true, task: { id: 'dyn-123', label: 'test' } });
+    assert.equal(classifyDurableTriggerResult('cat_cafe_register_scheduled_task', body, undefined), true);
+  });
+
+  it('community_await_external: {state: "awaiting_external"} → confirmed (Sol R3 P1)', () => {
+    const body = JSON.stringify({ subjectKey: 'sk-1', appended: true, state: 'awaiting_external' });
+    assert.equal(classifyDurableTriggerResult('cat_cafe_community_await_external', body, undefined), true);
+  });
+
+  // ── MCP prefix variant ───────────────────────────────────────────────────
+
+  it('handles mcp__cat-cafe-collab__ prefix (suffix matching)', () => {
+    const body = JSON.stringify({ success: true, task: {} });
+    assert.equal(
+      classifyDurableTriggerResult('mcp__cat-cafe-collab__cat_cafe_register_scheduled_task', body, undefined),
+      true,
+    );
+  });
+
+  // ── Failure cases ────────────────────────────────────────────────────────
+
+  it('returns false for explicit error body', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', '{"isError":true}', undefined), false);
+  });
+
+  it('returns false for non-JSON content (fail-closed)', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', 'Rate limit exceeded', undefined), false);
+  });
+
+  it('returns false for unknown body shape (fail-closed)', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', '{"foo":"bar"}', undefined), false);
+  });
+
+  it('returns false for empty content', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_hold_ball', undefined, undefined), false);
+  });
+
+  // ── Non-durable-trigger tools are always false ───────────────────────────
+
+  it('returns false for non-durable-trigger tools even with ok status', () => {
+    assert.equal(classifyDurableTriggerResult('cat_cafe_post_message', '{"status":"ok"}', 'ok'), false);
+    assert.equal(classifyDurableTriggerResult('cat_cafe_create_task', '{"status":"ok"}', 'ok'), false);
   });
 });
 

--- a/packages/api/test/ball-custody-state-machine.test.js
+++ b/packages/api/test/ball-custody-state-machine.test.js
@@ -203,6 +203,15 @@ describe('ball-custody transition — 虚空 + 唤醒', () => {
     assert.deepStrictEqual(transition('active', ev('ball.void_pass'), snap()), { ok: true, next: 'void' });
     assert.deepStrictEqual(transition('blocked', ev('ball.void_pass'), snap()), { ok: true, next: 'void' });
   });
+  it('ball.void_ack new/active/blocked/parked → void（F257 LI-005）', () => {
+    for (const from of ['new', 'active', 'blocked', 'parked']) {
+      assert.deepStrictEqual(transition(from, ev('ball.void_ack'), snap()), { ok: true, next: 'void' });
+    }
+    // dead/void/zombie/resolved → reject
+    for (const from of ['dead', 'void', 'zombie', 'resolved']) {
+      assert.strictEqual(transition(from, ev('ball.void_ack'), snap()).ok, false);
+    }
+  });
   it('ball.wake_sent blocked → blocked（informational，lastWakeAt 由 projector 更新）', () => {
     assert.deepStrictEqual(transition('blocked', ev('ball.wake_sent'), snap()), { ok: true, next: 'blocked' });
   });

--- a/packages/api/test/ball-custody-state-machine.test.js
+++ b/packages/api/test/ball-custody-state-machine.test.js
@@ -203,7 +203,7 @@ describe('ball-custody transition — 虚空 + 唤醒', () => {
     assert.deepStrictEqual(transition('active', ev('ball.void_pass'), snap()), { ok: true, next: 'void' });
     assert.deepStrictEqual(transition('blocked', ev('ball.void_pass'), snap()), { ok: true, next: 'void' });
   });
-  it('ball.void_ack new/active/blocked/parked → void（F257 LI-005）', () => {
+  it('ball.void_ack new/active/blocked/parked → void（LI-005）', () => {
     for (const from of ['new', 'active', 'blocked', 'parked']) {
       assert.deepStrictEqual(transition(from, ev('ball.void_ack'), snap()), { ok: true, next: 'void' });
     }
@@ -224,7 +224,7 @@ describe('ball-custody transition — 虚空 + 唤醒', () => {
 describe('INV-10 完整性穷举：全 state × event 无未定义', () => {
   it('每个 (state, event) transition 返回 well-formed result，不 throw', () => {
     assert.strictEqual(ALL_BALL_STATES.length, 8); // new + 7
-    assert.strictEqual(ALL_BALL_EVENT_KINDS.length, 18); // Phase B 13 + Phase C 3 安乐死 + Phase P 1 wakeWhen + F257 LI-005 1 void_ack
+    assert.strictEqual(ALL_BALL_EVENT_KINDS.length, 18); // Phase B 13 + Phase C 3 安乐死 + Phase P 1 wakeWhen + LI-005 1 void_ack
     for (const state of ALL_BALL_STATES) {
       for (const kind of ALL_BALL_EVENT_KINDS) {
         const r = transition(

--- a/packages/api/test/ball-custody-state-machine.test.js
+++ b/packages/api/test/ball-custody-state-machine.test.js
@@ -215,7 +215,7 @@ describe('ball-custody transition — 虚空 + 唤醒', () => {
 describe('INV-10 完整性穷举：全 state × event 无未定义', () => {
   it('每个 (state, event) transition 返回 well-formed result，不 throw', () => {
     assert.strictEqual(ALL_BALL_STATES.length, 8); // new + 7
-    assert.strictEqual(ALL_BALL_EVENT_KINDS.length, 17); // Phase B 13 + Phase C 3 安乐死 + Phase P 1 wakeWhen
+    assert.strictEqual(ALL_BALL_EVENT_KINDS.length, 18); // Phase B 13 + Phase C 3 安乐死 + Phase P 1 wakeWhen + F257 LI-005 1 void_ack
     for (const state of ALL_BALL_STATES) {
       for (const kind of ALL_BALL_EVENT_KINDS) {
         const r = transition(

--- a/packages/api/test/bg-transcript-parity.test.js
+++ b/packages/api/test/bg-transcript-parity.test.js
@@ -419,3 +419,56 @@ test('accumulateUsageFromEntries: real+synthetic mix → only real turn counted 
   assert.equal(usage.numTurns, 1, 'numTurns must be 1 for a single real turn');
   assert.equal(usage.outputTokens, 5, 'token counts from the real turn must be preserved');
 });
+
+// ─── F257 LI-005: user entry → tool_result bridge ───────────────────────────
+
+test('F257 LI-005: user entries with tool_result blocks emit tool_result AgentMessages', () => {
+  const entries = [
+    {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_hold',
+            content: '{"status":"ok","held":true}',
+            is_error: false,
+          },
+        ],
+      },
+    },
+  ];
+  const out = transcriptEntriesToAgentMessages(entries, { catId: CAT_ID });
+  assert.equal(out.length, 1, 'should emit one tool_result');
+  assert.equal(out[0].type, 'tool_result');
+  assert.equal(out[0].toolResultStatus, 'ok');
+  assert.equal(out[0].content, '{"status":"ok","held":true}');
+  assert.equal(out[0].toolUseId, 'toolu_hold');
+});
+
+test('F257 LI-005: user entries with is_error:true emit error toolResultStatus', () => {
+  const entries = [
+    {
+      type: 'user',
+      message: {
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'toolu_fail',
+            content: 'Rate limit exceeded',
+            is_error: true,
+          },
+        ],
+      },
+    },
+  ];
+  const out = transcriptEntriesToAgentMessages(entries, { catId: CAT_ID });
+  assert.equal(out.length, 1);
+  assert.equal(out[0].toolResultStatus, 'error');
+});
+
+test('F257 LI-005: user entries without tool_result blocks are skipped', () => {
+  const entries = [{ type: 'user', message: { content: [{ type: 'text', text: 'hello' }] } }];
+  const out = transcriptEntriesToAgentMessages(entries, { catId: CAT_ID });
+  assert.equal(out.length, 0, 'non-tool_result user content → no output');
+});

--- a/packages/api/test/bg-transcript-parity.test.js
+++ b/packages/api/test/bg-transcript-parity.test.js
@@ -420,9 +420,9 @@ test('accumulateUsageFromEntries: real+synthetic mix → only real turn counted 
   assert.equal(usage.outputTokens, 5, 'token counts from the real turn must be preserved');
 });
 
-// ─── F257 LI-005: user entry → tool_result bridge ───────────────────────────
+// ─── LI-005: user entry → tool_result bridge ───────────────────────────
 
-test('F257 LI-005: user entries with tool_result blocks emit tool_result AgentMessages', () => {
+test('LI-005: user entries with tool_result blocks emit tool_result AgentMessages', () => {
   const entries = [
     {
       type: 'user',
@@ -446,7 +446,7 @@ test('F257 LI-005: user entries with tool_result blocks emit tool_result AgentMe
   assert.equal(out[0].toolUseId, 'toolu_hold');
 });
 
-test('F257 LI-005: user entries with is_error:true emit error toolResultStatus', () => {
+test('LI-005: user entries with is_error:true emit error toolResultStatus', () => {
   const entries = [
     {
       type: 'user',
@@ -467,7 +467,7 @@ test('F257 LI-005: user entries with is_error:true emit error toolResultStatus',
   assert.equal(out[0].toolResultStatus, 'error');
 });
 
-test('F257 LI-005: user entries without tool_result blocks are skipped', () => {
+test('LI-005: user entries without tool_result blocks are skipped', () => {
   const entries = [{ type: 'user', message: { content: [{ type: 'text', text: 'hello' }] } }];
   const out = transcriptEntriesToAgentMessages(entries, { catId: CAT_ID });
   assert.equal(out.length, 0, 'non-tool_result user content → no output');

--- a/packages/api/test/claude-ndjson-parser.test.js
+++ b/packages/api/test/claude-ndjson-parser.test.js
@@ -510,3 +510,140 @@ test('assistant event with empty text block alongside tool_use → only tool_use
   assert.equal(result.length, 1, 'only tool_use, empty text filtered out');
   assert.equal(result[0].type, 'tool_use');
 });
+
+// ─── F257 LI-005: user → tool_result bridge ─────────────────────────────────
+
+test('user event with tool_result (is_error: false) → tool_result with ok status', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_abc',
+          content: '{"status":"ok","held":true}',
+          is_error: false,
+        },
+      ],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(result !== null, 'should not return null');
+  assert.ok(Array.isArray(result), 'should return array');
+  assert.equal(result.length, 1);
+  assert.equal(result[0].type, 'tool_result');
+  assert.equal(result[0].catId, CAT);
+  assert.equal(result[0].content, '{"status":"ok","held":true}');
+  assert.equal(result[0].toolResultStatus, 'ok');
+  assert.equal(result[0].toolUseId, 'toolu_abc');
+});
+
+test('user event with tool_result (is_error: true) → tool_result with error status', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_err',
+          content: 'Rate limit exceeded',
+          is_error: true,
+        },
+      ],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 1);
+  assert.equal(result[0].type, 'tool_result');
+  assert.equal(result[0].toolResultStatus, 'error');
+  assert.equal(result[0].content, 'Rate limit exceeded');
+});
+
+test('user event with array content blocks → extracts text from [{type:"text",text:"..."}]', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [
+        {
+          type: 'tool_result',
+          tool_use_id: 'toolu_arr',
+          content: [
+            { type: 'text', text: '{"status":' },
+            { type: 'text', text: '"ok"}' },
+          ],
+          is_error: false,
+        },
+      ],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(Array.isArray(result));
+  assert.equal(result[0].content, '{"status":"ok"}');
+  assert.equal(result[0].toolResultStatus, 'ok');
+});
+
+test('user event with multiple tool_result blocks → returns array of all', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [
+        { type: 'tool_result', tool_use_id: 'toolu_1', content: '{"a":1}', is_error: false },
+        { type: 'tool_result', tool_use_id: 'toolu_2', content: '{"b":2}', is_error: true },
+      ],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(Array.isArray(result));
+  assert.equal(result.length, 2);
+  assert.equal(result[0].toolResultStatus, 'ok');
+  assert.equal(result[1].toolResultStatus, 'error');
+});
+
+test('user event without content array → null', () => {
+  const state = makeStreamState();
+  const result = transformClaudeEvent({ type: 'user', message: {} }, CAT, state);
+  assert.equal(result, null);
+});
+
+test('user event with no tool_result blocks → null', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: { content: [{ type: 'text', text: 'hello' }] },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.equal(result, null);
+});
+
+test('user event tool_result without tool_use_id → no toolUseId on message', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [{ type: 'tool_result', content: 'data', is_error: false }],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(Array.isArray(result));
+  assert.equal(result[0].toolUseId, undefined);
+  assert.equal(result[0].toolResultStatus, 'ok');
+});
+
+test('user event tool_result with undefined content → content is undefined', () => {
+  const state = makeStreamState();
+  const event = {
+    type: 'user',
+    message: {
+      content: [{ type: 'tool_result', tool_use_id: 'toolu_nc', is_error: false }],
+    },
+  };
+  const result = transformClaudeEvent(event, CAT, state);
+  assert.ok(Array.isArray(result));
+  assert.equal(result[0].content, undefined);
+  assert.equal(result[0].toolResultStatus, 'ok');
+});

--- a/packages/api/test/claude-ndjson-parser.test.js
+++ b/packages/api/test/claude-ndjson-parser.test.js
@@ -511,7 +511,7 @@ test('assistant event with empty text block alongside tool_use → only tool_use
   assert.equal(result[0].type, 'tool_use');
 });
 
-// ─── F257 LI-005: user → tool_result bridge ─────────────────────────────────
+// ─── LI-005: user → tool_result bridge ─────────────────────────────────
 
 test('user event with tool_result (is_error: false) → tool_result with ok status', () => {
   const state = makeStreamState();

--- a/packages/api/test/f230-hook-setup.test.js
+++ b/packages/api/test/f230-hook-setup.test.js
@@ -46,7 +46,7 @@ test('hook setup: creates .claude/settings.json with Stop + PostToolUse + PostTo
       settings.hooks.PostToolUse[0].hooks[0].command.includes(result.scriptPath),
       'PostToolUse hook must point to capture script',
     );
-    // F257 LI-005: PostToolUseFailure must be registered for failure path bridging
+    // LI-005: PostToolUseFailure must be registered for failure path bridging
     assert.ok(settings.hooks.PostToolUseFailure, 'PostToolUseFailure hook must be configured');
     assert.ok(Array.isArray(settings.hooks.PostToolUseFailure), 'PostToolUseFailure must be array');
     assert.ok(

--- a/packages/api/test/f230-hook-setup.test.js
+++ b/packages/api/test/f230-hook-setup.test.js
@@ -21,7 +21,7 @@ function makeTmpCwd() {
 // setupHookInfrastructure — settings.json creation
 // ---------------------------------------------------------------------------
 
-test('hook setup: creates .claude/settings.json with Stop + PostToolUse hooks', async () => {
+test('hook setup: creates .claude/settings.json with Stop + PostToolUse + PostToolUseFailure hooks', async () => {
   const tmpCwd = makeTmpCwd();
   const sidecarPath = join(tmpCwd, 'sidecar.jsonl');
   const result = await setupHookInfrastructure(tmpCwd, sidecarPath);
@@ -45,6 +45,13 @@ test('hook setup: creates .claude/settings.json with Stop + PostToolUse hooks', 
     assert.ok(
       settings.hooks.PostToolUse[0].hooks[0].command.includes(result.scriptPath),
       'PostToolUse hook must point to capture script',
+    );
+    // F257 LI-005: PostToolUseFailure must be registered for failure path bridging
+    assert.ok(settings.hooks.PostToolUseFailure, 'PostToolUseFailure hook must be configured');
+    assert.ok(Array.isArray(settings.hooks.PostToolUseFailure), 'PostToolUseFailure must be array');
+    assert.ok(
+      settings.hooks.PostToolUseFailure[0].hooks[0].command.includes(result.scriptPath),
+      'PostToolUseFailure hook must point to capture script',
     );
   } finally {
     await result.cleanup();

--- a/packages/api/test/f230-hook-sidechannel-consumer.test.js
+++ b/packages/api/test/f230-hook-sidechannel-consumer.test.js
@@ -83,11 +83,11 @@ test('hook consumer: PostToolUse event → tool_use + tool_result AgentMessages'
   assert.deepEqual(msgs[0].toolInput, { file_path: '/foo/bar.ts' });
   assert.equal(msgs[0].toolUseId, 'tu_001');
   assert.equal(msgs[0].catId, 'opus');
-  // F257 LI-005: tool_result companion for durable trigger classification
+  // F257 LI-005: tool_result companion — PostToolUse = success event
   assert.equal(msgs[1].type, 'tool_result');
   assert.equal(msgs[1].content, 'file contents here');
   assert.equal(msgs[1].toolUseId, 'tu_001');
-  assert.equal(msgs[1].toolResultStatus, 'unknown', 'no is_error → unknown (Level 2 fallback)');
+  assert.equal(msgs[1].toolResultStatus, 'ok', 'PostToolUse = success → ok');
 });
 
 test('hook consumer: PostToolUse with missing tool_name → skipped', () => {
@@ -143,10 +143,12 @@ test('hook consumer: mixed PostToolUse + Stop → correct order (use/result pair
   assert.equal(msgs[0].toolName, 'Bash');
   assert.equal(msgs[1].type, 'tool_result');
   assert.equal(msgs[1].content, 'file1\nfile2');
+  assert.equal(msgs[1].toolResultStatus, 'ok');
   assert.equal(msgs[2].type, 'tool_use');
   assert.equal(msgs[2].toolName, 'Read');
   assert.equal(msgs[3].type, 'tool_result');
   assert.equal(msgs[3].content, 'contents');
+  assert.equal(msgs[3].toolResultStatus, 'ok');
   assert.equal(msgs[4].type, 'text');
   assert.equal(msgs[4].content, 'Done!');
 });
@@ -248,52 +250,57 @@ test('hook consumer: extractEntrypointFromHookEntries — non-string → undefin
 // F257 LI-005: PostToolUse → tool_result bridge (durable trigger classification)
 // ---------------------------------------------------------------------------
 
-test('F257 LI-005: PostToolUse with is_error:false → toolResultStatus ok', () => {
+test('F257 LI-005: PostToolUse with string tool_response → content string, status ok', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
       tool_name: 'cat_cafe_hold_ball',
       tool_response: '{"status":"ok","held":true}',
       tool_use_id: 'tu_hold',
-      is_error: false,
     },
   ];
   const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
   const result = msgs.find((m) => m.type === 'tool_result');
   assert.ok(result, 'tool_result must be emitted');
-  assert.equal(result.toolResultStatus, 'ok');
+  assert.equal(result.toolResultStatus, 'ok', 'PostToolUse = success event');
   assert.equal(result.content, '{"status":"ok","held":true}');
 });
 
-test('F257 LI-005: PostToolUse with is_error:true → toolResultStatus error', () => {
+test('F257 LI-005: PostToolUse with structured object tool_response → JSON.stringify', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
-      tool_name: 'cat_cafe_hold_ball',
-      tool_response: 'Rate limit exceeded',
-      tool_use_id: 'tu_err',
-      is_error: true,
+      tool_name: 'Read',
+      tool_response: { type: 'text', file: { content: 'code', totalLines: 50 } },
+      tool_use_id: 'tu_read',
     },
   ];
   const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
   const result = msgs.find((m) => m.type === 'tool_result');
   assert.ok(result);
-  assert.equal(result.toolResultStatus, 'error');
+  assert.equal(result.toolResultStatus, 'ok');
+  // Structured response normalized to JSON string
+  const parsed = JSON.parse(result.content);
+  assert.equal(parsed.type, 'text');
+  assert.equal(parsed.file.totalLines, 50);
 });
 
-test('F257 LI-005: PostToolUse without is_error → toolResultStatus unknown (Level 2)', () => {
+test('F257 LI-005: PostToolUse with object MCP response → classifiable via Level 2', () => {
+  // Simulates MCP hold_ball returning structured object (not pre-serialized string)
   const entries = [
     {
       hook_event_name: 'PostToolUse',
       tool_name: 'cat_cafe_hold_ball',
-      tool_response: '{"status":"ok"}',
-      tool_use_id: 'tu_noflag',
+      tool_response: { status: 'ok', held: true, taskId: 'hold-42' },
+      tool_use_id: 'tu_mcp',
     },
   ];
   const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
   const result = msgs.find((m) => m.type === 'tool_result');
   assert.ok(result);
-  assert.equal(result.toolResultStatus, 'unknown');
+  // Normalized content is parseable JSON with status:'ok'
+  const parsed = JSON.parse(result.content);
+  assert.equal(parsed.status, 'ok');
 });
 
 test('F257 LI-005: PostToolUse without tool_response → content undefined', () => {
@@ -308,4 +315,41 @@ test('F257 LI-005: PostToolUse without tool_response → content undefined', () 
   const result = msgs.find((m) => m.type === 'tool_result');
   assert.ok(result);
   assert.equal(result.content, undefined);
+  assert.equal(result.toolResultStatus, 'ok', 'PostToolUse still success even without response');
+});
+
+// ---------------------------------------------------------------------------
+// F257 LI-005: PostToolUseFailure → tool_result(error) bridge
+// ---------------------------------------------------------------------------
+
+test('F257 LI-005: PostToolUseFailure → tool_result with error status', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUseFailure',
+      tool_name: 'cat_cafe_hold_ball',
+      tool_response: 'Rate limit exceeded',
+      tool_use_id: 'tu_fail',
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  assert.equal(msgs.length, 1, 'PostToolUseFailure emits tool_result only (no tool_use)');
+  assert.equal(msgs[0].type, 'tool_result');
+  assert.equal(msgs[0].toolResultStatus, 'error');
+  assert.equal(msgs[0].content, 'Rate limit exceeded');
+  assert.equal(msgs[0].toolUseId, 'tu_fail');
+});
+
+test('F257 LI-005: PostToolUseFailure with structured response → normalized', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUseFailure',
+      tool_response: { error: 'connection_refused', code: 429 },
+      tool_use_id: 'tu_fail2',
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  assert.equal(msgs.length, 1);
+  assert.equal(msgs[0].toolResultStatus, 'error');
+  const parsed = JSON.parse(msgs[0].content);
+  assert.equal(parsed.error, 'connection_refused');
 });

--- a/packages/api/test/f230-hook-sidechannel-consumer.test.js
+++ b/packages/api/test/f230-hook-sidechannel-consumer.test.js
@@ -64,7 +64,7 @@ test('hook consumer: Stop event without last_assistant_message field → skipped
 // hookEntriesToAgentMessages — PostToolUse event
 // ---------------------------------------------------------------------------
 
-test('hook consumer: PostToolUse event → tool_use AgentMessage', () => {
+test('hook consumer: PostToolUse event → tool_use + tool_result AgentMessages', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
@@ -77,12 +77,17 @@ test('hook consumer: PostToolUse event → tool_use AgentMessage', () => {
     },
   ];
   const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
-  assert.equal(msgs.length, 1);
+  assert.equal(msgs.length, 2, 'PostToolUse emits tool_use + tool_result');
   assert.equal(msgs[0].type, 'tool_use');
   assert.equal(msgs[0].toolName, 'Read');
   assert.deepEqual(msgs[0].toolInput, { file_path: '/foo/bar.ts' });
   assert.equal(msgs[0].toolUseId, 'tu_001');
   assert.equal(msgs[0].catId, 'opus');
+  // F257 LI-005: tool_result companion for durable trigger classification
+  assert.equal(msgs[1].type, 'tool_result');
+  assert.equal(msgs[1].content, 'file contents here');
+  assert.equal(msgs[1].toolUseId, 'tu_001');
+  assert.equal(msgs[1].toolResultStatus, 'unknown', 'no is_error → unknown (Level 2 fallback)');
 });
 
 test('hook consumer: PostToolUse with missing tool_name → skipped', () => {
@@ -105,7 +110,7 @@ test('hook consumer: PostToolUse with missing tool_name → skipped', () => {
 // hookEntriesToAgentMessages — mixed events
 // ---------------------------------------------------------------------------
 
-test('hook consumer: mixed PostToolUse + Stop → correct order', () => {
+test('hook consumer: mixed PostToolUse + Stop → correct order (use/result pairs)', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
@@ -132,13 +137,18 @@ test('hook consumer: mixed PostToolUse + Stop → correct order', () => {
     },
   ];
   const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
-  assert.equal(msgs.length, 3);
+  // 2 PostToolUse × (tool_use + tool_result) + 1 Stop(text) = 5
+  assert.equal(msgs.length, 5);
   assert.equal(msgs[0].type, 'tool_use');
   assert.equal(msgs[0].toolName, 'Bash');
-  assert.equal(msgs[1].type, 'tool_use');
-  assert.equal(msgs[1].toolName, 'Read');
-  assert.equal(msgs[2].type, 'text');
-  assert.equal(msgs[2].content, 'Done!');
+  assert.equal(msgs[1].type, 'tool_result');
+  assert.equal(msgs[1].content, 'file1\nfile2');
+  assert.equal(msgs[2].type, 'tool_use');
+  assert.equal(msgs[2].toolName, 'Read');
+  assert.equal(msgs[3].type, 'tool_result');
+  assert.equal(msgs[3].content, 'contents');
+  assert.equal(msgs[4].type, 'text');
+  assert.equal(msgs[4].content, 'Done!');
 });
 
 test('hook consumer: unknown event type → skipped', () => {
@@ -232,4 +242,70 @@ test('hook consumer: extractEntrypointFromHookEntries — no _cc_entrypoint → 
 test('hook consumer: extractEntrypointFromHookEntries — non-string → undefined', () => {
   const entries = [{ hook_event_name: 'Stop', session_id: 'abc', _cc_entrypoint: 42 }];
   assert.equal(extractEntrypointFromHookEntries(entries), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// F257 LI-005: PostToolUse → tool_result bridge (durable trigger classification)
+// ---------------------------------------------------------------------------
+
+test('F257 LI-005: PostToolUse with is_error:false → toolResultStatus ok', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'cat_cafe_hold_ball',
+      tool_response: '{"status":"ok","held":true}',
+      tool_use_id: 'tu_hold',
+      is_error: false,
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  const result = msgs.find((m) => m.type === 'tool_result');
+  assert.ok(result, 'tool_result must be emitted');
+  assert.equal(result.toolResultStatus, 'ok');
+  assert.equal(result.content, '{"status":"ok","held":true}');
+});
+
+test('F257 LI-005: PostToolUse with is_error:true → toolResultStatus error', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'cat_cafe_hold_ball',
+      tool_response: 'Rate limit exceeded',
+      tool_use_id: 'tu_err',
+      is_error: true,
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  const result = msgs.find((m) => m.type === 'tool_result');
+  assert.ok(result);
+  assert.equal(result.toolResultStatus, 'error');
+});
+
+test('F257 LI-005: PostToolUse without is_error → toolResultStatus unknown (Level 2)', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'cat_cafe_hold_ball',
+      tool_response: '{"status":"ok"}',
+      tool_use_id: 'tu_noflag',
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  const result = msgs.find((m) => m.type === 'tool_result');
+  assert.ok(result);
+  assert.equal(result.toolResultStatus, 'unknown');
+});
+
+test('F257 LI-005: PostToolUse without tool_response → content undefined', () => {
+  const entries = [
+    {
+      hook_event_name: 'PostToolUse',
+      tool_name: 'Read',
+      tool_use_id: 'tu_noresponse',
+    },
+  ];
+  const msgs = hookEntriesToAgentMessages(entries, { catId: 'opus' });
+  const result = msgs.find((m) => m.type === 'tool_result');
+  assert.ok(result);
+  assert.equal(result.content, undefined);
 });

--- a/packages/api/test/f230-hook-sidechannel-consumer.test.js
+++ b/packages/api/test/f230-hook-sidechannel-consumer.test.js
@@ -83,7 +83,7 @@ test('hook consumer: PostToolUse event → tool_use + tool_result AgentMessages'
   assert.deepEqual(msgs[0].toolInput, { file_path: '/foo/bar.ts' });
   assert.equal(msgs[0].toolUseId, 'tu_001');
   assert.equal(msgs[0].catId, 'opus');
-  // F257 LI-005: tool_result companion — PostToolUse = success event
+  // LI-005: tool_result companion — PostToolUse = success event
   assert.equal(msgs[1].type, 'tool_result');
   assert.equal(msgs[1].content, 'file contents here');
   assert.equal(msgs[1].toolUseId, 'tu_001');
@@ -247,10 +247,10 @@ test('hook consumer: extractEntrypointFromHookEntries — non-string → undefin
 });
 
 // ---------------------------------------------------------------------------
-// F257 LI-005: PostToolUse → tool_result bridge (durable trigger classification)
+// LI-005: PostToolUse → tool_result bridge (durable trigger classification)
 // ---------------------------------------------------------------------------
 
-test('F257 LI-005: PostToolUse with string tool_response → content string, status ok', () => {
+test('LI-005: PostToolUse with string tool_response → content string, status ok', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
@@ -266,7 +266,7 @@ test('F257 LI-005: PostToolUse with string tool_response → content string, sta
   assert.equal(result.content, '{"status":"ok","held":true}');
 });
 
-test('F257 LI-005: PostToolUse with structured object tool_response → JSON.stringify', () => {
+test('LI-005: PostToolUse with structured object tool_response → JSON.stringify', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
@@ -285,7 +285,7 @@ test('F257 LI-005: PostToolUse with structured object tool_response → JSON.str
   assert.equal(parsed.file.totalLines, 50);
 });
 
-test('F257 LI-005: PostToolUse with object MCP response → classifiable via Level 2', () => {
+test('LI-005: PostToolUse with object MCP response → classifiable via Level 2', () => {
   // Simulates MCP hold_ball returning structured object (not pre-serialized string)
   const entries = [
     {
@@ -303,7 +303,7 @@ test('F257 LI-005: PostToolUse with object MCP response → classifiable via Lev
   assert.equal(parsed.status, 'ok');
 });
 
-test('F257 LI-005: PostToolUse without tool_response → content undefined', () => {
+test('LI-005: PostToolUse without tool_response → content undefined', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUse',
@@ -319,10 +319,10 @@ test('F257 LI-005: PostToolUse without tool_response → content undefined', () 
 });
 
 // ---------------------------------------------------------------------------
-// F257 LI-005: PostToolUseFailure → tool_result(error) bridge
+// LI-005: PostToolUseFailure → tool_result(error) bridge
 // ---------------------------------------------------------------------------
 
-test('F257 LI-005: PostToolUseFailure → tool_result with error status', () => {
+test('LI-005: PostToolUseFailure → tool_result with error status', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUseFailure',
@@ -339,7 +339,7 @@ test('F257 LI-005: PostToolUseFailure → tool_result with error status', () => 
   assert.equal(msgs[0].toolUseId, 'tu_fail');
 });
 
-test('F257 LI-005: PostToolUseFailure with structured response → normalized', () => {
+test('LI-005: PostToolUseFailure with structured response → normalized', () => {
   const entries = [
     {
       hook_event_name: 'PostToolUseFailure',

--- a/packages/api/test/f257-ack-liveness-behavior.test.js
+++ b/packages/api/test/f257-ack-liveness-behavior.test.js
@@ -1,0 +1,462 @@
+/**
+ * F257 LI-005 P2 — A2A ack-liveness end-to-end behavior tests.
+ *
+ * Proves the full chain from routeSerial through ack-liveness detection:
+ *   1. Queue A2A with no exit -> hint + ball.void_ack
+ *   2. Successful durable trigger -> no hint/void
+ *   3. Failed trigger (400/error) -> still produces hint/void
+ *   4. ball.void_ack -> ingest -> projector -> projection state = void
+ *
+ * Pattern follows route-serial-phase-h-hint.test.js mock architecture:
+ *   - createCapturingService / createDurableTriggerService for mock agents
+ *   - createMockDeps with ballCustody mock capturing recorded events
+ *   - Real cat roster + routeSerial with a2aTriggerMessageId in options
+ *
+ * Sol R7: "R8 至少需证明这四条主路径行为"
+ */
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { catRegistry } from '@cat-cafe/shared';
+
+// Ball-custody for scenario 4 (ingest -> projector -> void)
+import { BallCustodyIngest } from '../dist/domains/ball-custody/BallCustodyIngest.js';
+import { BallCustodyProjector } from '../dist/domains/ball-custody/BallCustodyProjector.js';
+import { buildVoidAckEvent } from '../dist/domains/ball-custody/ball-custody-events.js';
+
+// ---------------------------------------------------------------------------
+// Serialization lock — catRegistry is global; serialize all registry-mutating tests.
+// ---------------------------------------------------------------------------
+let catRegistryLock = Promise.resolve();
+
+async function withCatRegistryLock(fn) {
+  const previous = catRegistryLock;
+  let release;
+  catRegistryLock = new Promise((resolve) => {
+    release = resolve;
+  });
+  await previous;
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock services
+// ---------------------------------------------------------------------------
+
+/** Simple text-only response — no tools, no routing exit. */
+function createCapturingService(catId, text) {
+  return {
+    async *invoke() {
+      yield { type: 'text', catId, content: text, timestamp: Date.now() };
+      yield { type: 'done', catId, timestamp: Date.now() };
+    },
+  };
+}
+
+/**
+ * Service that calls a durable trigger tool and yields tool_use + tool_result.
+ * Simulates the bridge all three carriers now provide (Claude print/bg/PTY).
+ */
+function createDurableTriggerService(catId, text, toolName, toolInput, resultContent, resultStatus) {
+  const toolUseId = `tu-test-${Date.now()}`;
+  return {
+    async *invoke() {
+      yield { type: 'text', catId, content: text, timestamp: Date.now() };
+      yield {
+        type: 'tool_use',
+        catId,
+        toolName,
+        toolInput: toolInput ?? {},
+        toolUseId,
+        id: toolUseId,
+        timestamp: Date.now(),
+      };
+      yield {
+        type: 'tool_result',
+        catId,
+        content: resultContent,
+        toolResultStatus: resultStatus,
+        toolUseId,
+        timestamp: Date.now(),
+      };
+      yield { type: 'done', catId, timestamp: Date.now() };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock deps (adapted from route-serial-phase-h-hint.test.js)
+// ---------------------------------------------------------------------------
+
+function createMockDeps(services, appendedMessages, recordedBallEvents) {
+  let counter = 0;
+  return {
+    services,
+    invocationDeps: {
+      registry: {
+        create: () => ({ invocationId: `inv-${++counter}`, callbackToken: `tok-${counter}` }),
+        verify: async () => ({ ok: false, reason: 'unknown_invocation' }),
+      },
+      sessionManager: {
+        getOrCreate: async () => ({}),
+        resolveWorkingDirectory: () => '/tmp/test',
+      },
+      threadStore: null,
+      apiUrl: 'http://127.0.0.1:3004',
+    },
+    messageStore: {
+      append: async (msg) => {
+        const stored = {
+          id: `msg-${++counter}`,
+          userId: msg.userId ?? '',
+          catId: msg.catId ?? null,
+          content: msg.content ?? '',
+          mentions: msg.mentions ?? [],
+          timestamp: msg.timestamp ?? 0,
+          source: msg.source,
+        };
+        appendedMessages.push(stored);
+        return stored;
+      },
+      getById: () => null,
+      getRecent: () => [],
+      getMentionsFor: () => [],
+      getBefore: () => [],
+      getByThread: () => [],
+      getByThreadAfter: () => [],
+      getByThreadBefore: () => [],
+    },
+    // F257 LI-005: ball-custody mock capturing recorded events
+    ballCustody: recordedBallEvents ? { record: async (event) => recordedBallEvents.push(event) } : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function loadRealRoster() {
+  const { loadCatConfig, toAllCatConfigs } = await import('../dist/config/cat-config-loader.js');
+  const runtimeConfigs = toAllCatConfigs(loadCatConfig());
+  catRegistry.reset();
+  for (const [id, config] of Object.entries(runtimeConfigs)) {
+    catRegistry.register(id, config);
+  }
+}
+
+/**
+ * Run routeSerial with queue A2A options (a2aTriggerMessageId).
+ * Returns appended messages + ball custody events.
+ */
+async function runA2ARoute(opusService, opts = {}) {
+  return withCatRegistryLock(async () => {
+    const original = catRegistry.getAllConfigs();
+    await loadRealRoster();
+    const appended = [];
+    const ballEvents = [];
+    try {
+      const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+      const codexService = createCapturingService('codex', 'ack');
+      const deps = createMockDeps({ opus: opusService, codex: codexService }, appended, ballEvents);
+      for await (const _ of routeSerial(deps, ['opus'], 'A2A test prompt', 'user1', 'thread-ack-test', {
+        thinkingMode: 'play',
+        a2aTriggerMessageId: opts.a2aTriggerMessageId ?? 'trigger-msg-queue-test',
+      })) {
+        // drain
+      }
+      return { appended, ballEvents };
+    } finally {
+      catRegistry.reset();
+      for (const [id, config] of Object.entries(original)) {
+        catRegistry.register(id, config);
+      }
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// In-memory ball-custody stubs for scenario 4 (same pattern as ingest.test.js)
+// ---------------------------------------------------------------------------
+
+function memLog() {
+  const events = [];
+  const seen = new Set();
+  return {
+    append: async (e) => {
+      if (seen.has(e.sourceEventId)) return { appended: false, sequence: -1 };
+      seen.add(e.sourceEventId);
+      events.push(e);
+      return { appended: true, sequence: events.length - 1 };
+    },
+    read: async (sk) => events.filter((e) => e.subjectKey === sk),
+    listSubjects: async () => [...new Set(events.map((e) => e.subjectKey))],
+  };
+}
+
+function memStore() {
+  const m = new Map();
+  return {
+    get: async (k) => (m.has(k) ? JSON.parse(JSON.stringify(m.get(k))) : null),
+    save: async (p) => m.set(p.subjectKey, JSON.parse(JSON.stringify(p))),
+    listSubjectKeys: async () => [...m.keys()],
+    delete: async (k) => m.delete(k),
+  };
+}
+
+// ===========================================================================
+// Scenario 1: Queue A2A with no exit -> hint + ball.void_ack
+// ===========================================================================
+
+describe('F257 LI-005 scenario 1: queue A2A no exit -> hint + ball.void_ack', () => {
+  test('A2A invocation with plain text (no tool, no @exit) emits ack-liveness-hint', async () => {
+    const opusService = createCapturingService('opus', 'I looked at the code but found nothing actionable.');
+    const { appended } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'must emit ack-liveness-hint when A2A invocation has no exit');
+    assert.equal(hint.userId, 'system');
+    assert.equal(hint.catId, null);
+    assert.match(hint.content, /接球提醒/);
+    assert.match(hint.content, /hold_ball|触发器/);
+    assert.equal(hint.source.icon, '🏓');
+    assert.equal(hint.source.meta.presentation, 'system_notice');
+    assert.equal(hint.source.meta.noticeTone, 'warning');
+  });
+
+  test('A2A invocation with no exit emits ball.void_ack event', async () => {
+    const opusService = createCapturingService('opus', 'Done reviewing, nothing to do.');
+    const { ballEvents } = await runA2ARoute(opusService);
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'must emit ball.void_ack when A2A invocation has no exit');
+    assert.match(voidAck.subjectKey, /^ball:thread:/);
+    assert.equal(voidAck.classification, 'state-changing');
+  });
+});
+
+// ===========================================================================
+// Scenario 2: Successful durable trigger -> no hint/void
+// ===========================================================================
+
+describe('F257 LI-005 scenario 2: successful durable trigger -> no hint/void', () => {
+  test('hold_ball with ok result suppresses ack-liveness-hint', async () => {
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Holding ball while waiting for CI.',
+      'cat_cafe_hold_ball',
+      { wakeAfterMs: 300000 },
+      '{"status":"ok","held":true,"taskId":"hold-42"}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.equal(hint, undefined, 'successful hold_ball must suppress ack-liveness-hint');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.equal(voidAck, undefined, 'successful hold_ball must not emit ball.void_ack');
+  });
+
+  test('register_scheduled_task with success:true suppresses hint', async () => {
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Scheduling follow-up check.',
+      'cat_cafe_register_scheduled_task',
+      { cronExpression: '0 */6 * * *' },
+      '{"success":true,"task":{"id":"sched-1"}}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.equal(hint, undefined, 'successful register_scheduled_task must suppress hint');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.equal(voidAck, undefined, 'successful register_scheduled_task must not emit void_ack');
+  });
+
+  test('register_pr_tracking with status:ok suppresses hint', async () => {
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Tracking PR #123.',
+      'cat_cafe_register_pr_tracking',
+      { prUrl: 'https://github.com/org/repo/pull/123' },
+      '{"status":"ok","threadId":"thr-pr","task":{"id":"pr-1"}}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.equal(hint, undefined, 'successful PR tracking must suppress hint');
+    assert.equal(
+      ballEvents.find((e) => e.kind === 'ball.void_ack'),
+      undefined,
+      'no void_ack on successful PR tracking',
+    );
+  });
+});
+
+// ===========================================================================
+// Scenario 3: Failed trigger -> still produces hint/void
+// ===========================================================================
+
+describe('F257 LI-005 scenario 3: failed trigger -> hint + ball.void_ack', () => {
+  test('hold_ball with error status still emits ack-liveness-hint', async () => {
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Trying to hold ball.',
+      'cat_cafe_hold_ball',
+      { wakeAfterMs: 300000 },
+      'Rate limit exceeded',
+      'error',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'failed hold_ball must still emit ack-liveness-hint');
+    assert.match(hint.content, /接球提醒/);
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'failed hold_ball must emit ball.void_ack');
+  });
+
+  test('hold_ball with unknown/no toolResultStatus and error body still emits hint', async () => {
+    // Simulates provider returning tool_result without explicit status +
+    // body containing error markers (Level 2 parse fails closed).
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Holding ball.',
+      'cat_cafe_hold_ball',
+      { wakeAfterMs: 60000 },
+      '{"error":"permission_denied","code":403}',
+      'unknown',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'error-body hold_ball must emit ack-liveness-hint (fail-closed)');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'error-body hold_ball must emit ball.void_ack');
+  });
+
+  test('non-durable tool (create_task) does not suppress hint', async () => {
+    // create_task is NOT a durable trigger — it creates a panel item but
+    // has no wake mechanism. The hint should still fire.
+    const opusService = createDurableTriggerService(
+      'opus',
+      'Creating a task to track this.',
+      'cat_cafe_create_task',
+      { title: 'Follow up on review' },
+      '{"status":"ok","taskId":"task-99"}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'create_task is not a durable trigger; hint must fire');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'create_task does not prevent void_ack');
+  });
+});
+
+// ===========================================================================
+// Scenario 4: ball.void_ack -> ingest -> projector -> projection state = void
+// ===========================================================================
+
+describe('F257 LI-005 scenario 4: ball.void_ack ingest -> projection = void', () => {
+  test('void_ack event transitions projection from active to void', async () => {
+    const log = memLog();
+    const store = memStore();
+    const proj = new BallCustodyProjector(log, store);
+    const ingest = new BallCustodyIngest(log, proj);
+
+    const threadId = 'thr-void-ack-test';
+    const subjectKey = `ball:thread:${threadId}`;
+
+    // First, establish an active projection via ball.handed
+    const { buildHandedEvent } = await import('../dist/domains/ball-custody/ball-custody-events.js');
+    const handedEvent = buildHandedEvent({
+      fromCatId: 'codex',
+      toCatId: 'opus',
+      threadId,
+      messageId: 'msg-handed-1',
+      at: 1000,
+    });
+    await ingest.record(handedEvent);
+
+    // Verify active state
+    const beforeProjection = await store.get(subjectKey);
+    assert.ok(beforeProjection, 'projection must exist after ball.handed');
+    assert.equal(beforeProjection.state, 'active', 'state must be active after ball.handed');
+
+    // Now emit ball.void_ack
+    const voidAckEvent = buildVoidAckEvent({
+      threadId,
+      messageId: 'msg-void-ack-1',
+      a2aTriggerMessageId: 'trigger-msg-test',
+      at: 2000,
+    });
+    await ingest.record(voidAckEvent);
+
+    // Verify void state
+    const afterProjection = await store.get(subjectKey);
+    assert.ok(afterProjection, 'projection must exist after void_ack');
+    assert.equal(afterProjection.state, 'void', 'state must be void after ball.void_ack');
+    assert.equal(afterProjection.appliedEventCount, 2, 'two events applied (handed + void_ack)');
+  });
+
+  test('void_ack event builds correct sourceEventId and payload', () => {
+    const event = buildVoidAckEvent({
+      threadId: 'thr-src-test',
+      messageId: 'msg-src-1',
+      a2aTriggerMessageId: 'trigger-123',
+      at: 3000,
+    });
+
+    assert.equal(event.kind, 'ball.void_ack');
+    assert.equal(event.sourceEventId, 'route:msg-src-1:void_ack');
+    assert.equal(event.subjectKey, 'ball:thread:thr-src-test');
+    assert.equal(event.classification, 'state-changing');
+    assert.equal(event.at, 3000);
+    assert.deepStrictEqual(event.payload, { a2aTriggerMessageId: 'trigger-123' });
+  });
+
+  test('void_ack without a2aTriggerMessageId omits payload field', () => {
+    const event = buildVoidAckEvent({
+      threadId: 'thr-no-trigger',
+      messageId: 'msg-no-trigger',
+      at: 4000,
+    });
+
+    assert.equal(event.kind, 'ball.void_ack');
+    assert.deepStrictEqual(event.payload, {});
+  });
+
+  test('void_ack from new state (no prior handed) also transitions to void', async () => {
+    const log = memLog();
+    const store = memStore();
+    const proj = new BallCustodyProjector(log, store);
+    const ingest = new BallCustodyIngest(log, proj);
+
+    const threadId = 'thr-void-from-new';
+    const subjectKey = `ball:thread:${threadId}`;
+
+    // Direct void_ack without prior state (inline serial A2A first touch)
+    const voidAckEvent = buildVoidAckEvent({
+      threadId,
+      messageId: 'msg-direct-void',
+      at: 5000,
+    });
+    await ingest.record(voidAckEvent);
+
+    const projection = await store.get(subjectKey);
+    assert.ok(projection, 'projection must exist');
+    // new -> void transition (ball.void_ack from: set('new', ...))
+    assert.equal(projection.state, 'void', 'new -> void via ball.void_ack');
+  });
+});

--- a/packages/api/test/f257-ack-liveness-behavior.test.js
+++ b/packages/api/test/f257-ack-liveness-behavior.test.js
@@ -56,6 +56,63 @@ function createCapturingService(catId, text) {
   };
 }
 
+/** No-text response — only tool calls (no text content). Codex R1 P2-1 test. */
+function createToolOnlyService(catId, toolName, toolInput, resultContent, resultStatus) {
+  const toolUseId = `tu-notext-${Date.now()}`;
+  return {
+    async *invoke() {
+      yield {
+        type: 'tool_use',
+        catId,
+        toolName,
+        toolInput: toolInput ?? {},
+        toolUseId,
+        id: toolUseId,
+        timestamp: Date.now(),
+      };
+      yield {
+        type: 'tool_result',
+        catId,
+        content: resultContent,
+        toolResultStatus: resultStatus,
+        toolUseId,
+        timestamp: Date.now(),
+      };
+      yield { type: 'done', catId, timestamp: Date.now() };
+    },
+  };
+}
+
+/** Service that calls post_message with targetCats (structured routing). P2-2 test. */
+function createPostMessageService(catId, text, targetCats, resultContent, resultConfirmed) {
+  const toolUseId = `tu-pm-${Date.now()}`;
+  return {
+    async *invoke() {
+      if (text) yield { type: 'text', catId, content: text, timestamp: Date.now() };
+      yield {
+        type: 'tool_use',
+        catId,
+        toolName: 'cat_cafe_post_message',
+        toolInput: { content: 'review this', targetCats },
+        toolUseId,
+        id: toolUseId,
+        timestamp: Date.now(),
+      };
+      yield {
+        type: 'tool_result',
+        catId,
+        content: resultConfirmed
+          ? `{"status":"ok","messageId":"pm-msg-1","threadId":"thr-pm"}`
+          : `{"error":"delivery_failed","code":500}`,
+        toolResultStatus: resultConfirmed ? 'ok' : 'error',
+        toolUseId,
+        timestamp: Date.now(),
+      };
+      yield { type: 'done', catId, timestamp: Date.now() };
+    },
+  };
+}
+
 /**
  * Service that calls a durable trigger tool and yields tool_use + tool_result.
  * Simulates the bridge all three carriers now provide (Claude print/bg/PTY).
@@ -458,5 +515,92 @@ describe('F257 LI-005 scenario 4: ball.void_ack ingest -> projection = void', ()
     assert.ok(projection, 'projection must exist');
     // new -> void transition (ball.void_ack from: set('new', ...))
     assert.equal(projection.state, 'void', 'new -> void via ball.void_ack');
+  });
+});
+
+// ===========================================================================
+// Scenario 5: No-text A2A turns — Codex R1 P2-1 fix
+// ===========================================================================
+
+describe('F257 LI-005 scenario 5: no-text A2A turns (Codex P2-1)', () => {
+  test('tool-only A2A invocation (no text, non-durable tool) emits ack-liveness-hint', async () => {
+    // Cat responds with only a tool call (create_task — not durable), no text.
+    // Before the fix, this bypassed ack-liveness entirely.
+    const opusService = createToolOnlyService(
+      'opus',
+      'cat_cafe_create_task',
+      { title: 'Track follow-up' },
+      '{"status":"ok","taskId":"task-77"}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'no-text A2A with non-durable tool must emit ack-liveness-hint');
+    assert.match(hint.content, /接球提醒/);
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'no-text A2A with non-durable tool must emit ball.void_ack');
+  });
+
+  test('tool-only A2A with successful hold_ball suppresses hint', async () => {
+    // No text, but cat called hold_ball successfully — ball is alive.
+    const opusService = createToolOnlyService(
+      'opus',
+      'cat_cafe_hold_ball',
+      { wakeAfterMs: 60000 },
+      '{"status":"ok","held":true}',
+      'ok',
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.equal(hint, undefined, 'no-text with successful hold_ball must suppress hint');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.equal(voidAck, undefined, 'no-text with successful hold_ball must not emit void_ack');
+  });
+});
+
+// ===========================================================================
+// Scenario 6: Confirmed vs unconfirmed structured routing — Codex R1 P2-2 fix
+// ===========================================================================
+
+describe('F257 LI-005 scenario 6: confirmed structured routing (Codex P2-2)', () => {
+  test('failed post_message (unconfirmed) does NOT suppress hint', async () => {
+    // Cat calls post_message(targetCats: ['codex']) but it fails.
+    // Before the fix, structuredTargetCats still had ['codex'] → hint suppressed.
+    const opusService = createPostMessageService(
+      'opus',
+      'Sending review request.',
+      ['codex'],
+      '{"error":"delivery_failed"}',
+      false,
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.ok(hint, 'failed post_message must NOT suppress ack-liveness-hint');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.ok(voidAck, 'failed post_message must emit ball.void_ack');
+  });
+
+  test('successful post_message (confirmed) suppresses hint', async () => {
+    // Cat calls post_message(targetCats: ['codex']) and it succeeds.
+    const opusService = createPostMessageService(
+      'opus',
+      'Sending review request.',
+      ['codex'],
+      '{"status":"ok","messageId":"pm-1","threadId":"thr-pm"}',
+      true,
+    );
+    const { appended, ballEvents } = await runA2ARoute(opusService);
+
+    const hint = appended.find((m) => m.source?.connector === 'ack-liveness-hint');
+    assert.equal(hint, undefined, 'successful post_message must suppress hint');
+
+    const voidAck = ballEvents.find((e) => e.kind === 'ball.void_ack');
+    assert.equal(voidAck, undefined, 'successful post_message must not emit void_ack');
   });
 });

--- a/packages/api/test/li005-ack-liveness-behavior.test.js
+++ b/packages/api/test/li005-ack-liveness-behavior.test.js
@@ -1,5 +1,5 @@
 /**
- * F257 LI-005 P2 — A2A ack-liveness end-to-end behavior tests.
+ * LI-005 P2 — A2A ack-liveness end-to-end behavior tests.
  *
  * Proves the full chain from routeSerial through ack-liveness detection:
  *   1. Queue A2A with no exit -> hint + ball.void_ack
@@ -186,7 +186,7 @@ function createMockDeps(services, appendedMessages, recordedBallEvents) {
       getByThreadAfter: () => [],
       getByThreadBefore: () => [],
     },
-    // F257 LI-005: ball-custody mock capturing recorded events
+    // LI-005: ball-custody mock capturing recorded events
     ballCustody: recordedBallEvents ? { record: async (event) => recordedBallEvents.push(event) } : undefined,
   };
 }
@@ -267,7 +267,7 @@ function memStore() {
 // Scenario 1: Queue A2A with no exit -> hint + ball.void_ack
 // ===========================================================================
 
-describe('F257 LI-005 scenario 1: queue A2A no exit -> hint + ball.void_ack', () => {
+describe('LI-005 scenario 1: queue A2A no exit -> hint + ball.void_ack', () => {
   test('A2A invocation with plain text (no tool, no @exit) emits ack-liveness-hint', async () => {
     const opusService = createCapturingService('opus', 'I looked at the code but found nothing actionable.');
     const { appended } = await runA2ARoute(opusService);
@@ -298,7 +298,7 @@ describe('F257 LI-005 scenario 1: queue A2A no exit -> hint + ball.void_ack', ()
 // Scenario 2: Successful durable trigger -> no hint/void
 // ===========================================================================
 
-describe('F257 LI-005 scenario 2: successful durable trigger -> no hint/void', () => {
+describe('LI-005 scenario 2: successful durable trigger -> no hint/void', () => {
   test('hold_ball with ok result suppresses ack-liveness-hint', async () => {
     const opusService = createDurableTriggerService(
       'opus',
@@ -360,7 +360,7 @@ describe('F257 LI-005 scenario 2: successful durable trigger -> no hint/void', (
 // Scenario 3: Failed trigger -> still produces hint/void
 // ===========================================================================
 
-describe('F257 LI-005 scenario 3: failed trigger -> hint + ball.void_ack', () => {
+describe('LI-005 scenario 3: failed trigger -> hint + ball.void_ack', () => {
   test('hold_ball with error status still emits ack-liveness-hint', async () => {
     const opusService = createDurableTriggerService(
       'opus',
@@ -425,7 +425,7 @@ describe('F257 LI-005 scenario 3: failed trigger -> hint + ball.void_ack', () =>
 // Scenario 4: ball.void_ack -> ingest -> projector -> projection state = void
 // ===========================================================================
 
-describe('F257 LI-005 scenario 4: ball.void_ack ingest -> projection = void', () => {
+describe('LI-005 scenario 4: ball.void_ack ingest -> projection = void', () => {
   test('void_ack event transitions projection from active to void', async () => {
     const log = memLog();
     const store = memStore();
@@ -522,7 +522,7 @@ describe('F257 LI-005 scenario 4: ball.void_ack ingest -> projection = void', ()
 // Scenario 5: No-text A2A turns — Codex R1 P2-1 fix
 // ===========================================================================
 
-describe('F257 LI-005 scenario 5: no-text A2A turns (Codex P2-1)', () => {
+describe('LI-005 scenario 5: no-text A2A turns (Codex P2-1)', () => {
   test('tool-only A2A invocation (no text, non-durable tool) emits ack-liveness-hint', async () => {
     // Cat responds with only a tool call (create_task — not durable), no text.
     // Before the fix, this bypassed ack-liveness entirely.
@@ -566,7 +566,7 @@ describe('F257 LI-005 scenario 5: no-text A2A turns (Codex P2-1)', () => {
 // Scenario 6: Confirmed vs unconfirmed structured routing — Codex R1 P2-2 fix
 // ===========================================================================
 
-describe('F257 LI-005 scenario 6: confirmed structured routing (Codex P2-2)', () => {
+describe('LI-005 scenario 6: confirmed structured routing (Codex P2-2)', () => {
   test('failed post_message (unconfirmed) does NOT suppress hint', async () => {
     // Cat calls post_message(targetCats: ['codex']) but it fails.
     // Before the fix, structuredTargetCats still had ['codex'] → hint suppressed.

--- a/packages/api/test/route-serial-replyto-stream.test.js
+++ b/packages/api/test/route-serial-replyto-stream.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { after, before, describe, it } from 'node:test';
+import { catRegistry } from '@cat-cafe/shared';
 
 function createMockService(catId, text) {
   return {
@@ -59,7 +60,50 @@ function createMockDeps(services, appendCalls, initialMessages = []) {
   };
 }
 
+/**
+ * Filter helpers — separate business stream messages from guard notices
+ * emitted by the ack-liveness detection system (LI-005).
+ */
+function streamMsgs(appendCalls) {
+  return appendCalls.filter((m) => m.source?.connector !== 'ack-liveness-hint');
+}
+
+function guardNotices(appendCalls) {
+  return appendCalls.filter((m) => m.source?.connector === 'ack-liveness-hint');
+}
+
 describe('routeSerial replyTo on stream messages', () => {
+  /** Save / restore catRegistry so mention detection resolves @缅因猫 → codex. */
+  let savedConfigs;
+  before(() => {
+    savedConfigs = catRegistry.getAllConfigs();
+    const minCat = (id, displayName, mentionPatterns, clientId, defaultModel) => ({
+      id,
+      name: id,
+      displayName,
+      avatar: '',
+      color: { primary: '#000', secondary: '#fff' },
+      mentionPatterns,
+      clientId,
+      defaultModel,
+      mcpSupport: true,
+      roleDescription: 'test',
+      personality: 'test',
+    });
+    if (!catRegistry.has('opus')) {
+      catRegistry.register('opus', minCat('opus', '布偶猫', ['@布偶猫'], 'anthropic', 'claude-opus-4-6'));
+    }
+    if (!catRegistry.has('codex')) {
+      catRegistry.register('codex', minCat('codex', '缅因猫', ['@缅因猫'], 'openai', 'gpt-5.3-codex'));
+    }
+  });
+  after(() => {
+    catRegistry.reset();
+    for (const [id, config] of Object.entries(savedConfigs)) {
+      catRegistry.register(id, config);
+    }
+  });
+
   it('attaches replyTo + replyPreview to CLI A2A stream responses', async () => {
     const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
     const appendCalls = [];
@@ -76,9 +120,14 @@ describe('routeSerial replyTo on stream messages', () => {
       yielded.push(msg);
     }
 
-    assert.equal(appendCalls.length, 2, 'should persist both opus and codex stream messages');
-    assert.equal(appendCalls[0].replyTo, undefined, 'originating cat should not reply to anything');
-    assert.equal(appendCalls[1].replyTo, 'msg-1', 'A2A stream reply should persist replyTo to trigger message');
+    // LI-005: ack-liveness hint fires for codex (A2A invocation with no routing exit / durable trigger).
+    // Filter business messages from guard notices to validate each category independently.
+    const msgs = streamMsgs(appendCalls);
+    const hints = guardNotices(appendCalls);
+    assert.equal(msgs.length, 2, 'should persist both opus and codex stream messages');
+    assert.equal(hints.length, 1, 'A2A ack-liveness hint should fire for codex (no routing exit)');
+    assert.equal(msgs[0].replyTo, undefined, 'originating cat should not reply to anything');
+    assert.equal(msgs[1].replyTo, 'msg-1', 'A2A stream reply should persist replyTo to trigger message');
 
     const codexText = yielded.find((msg) => msg.type === 'text' && msg.catId === 'codex');
     assert.ok(codexText, 'should yield codex stream text');
@@ -117,8 +166,12 @@ describe('routeSerial replyTo on stream messages', () => {
       yielded.push(msg);
     }
 
-    assert.equal(appendCalls.length, 1, 'should persist queue-dispatched codex stream message');
-    assert.equal(appendCalls[0].replyTo, 'msg-trigger', 'queue-dispatched A2A stream should persist trigger replyTo');
+    // LI-005: ack-liveness hint fires for codex (queue-dispatched A2A, no routing exit / durable trigger).
+    const msgs = streamMsgs(appendCalls);
+    const hints = guardNotices(appendCalls);
+    assert.equal(msgs.length, 1, 'should persist queue-dispatched codex stream message');
+    assert.equal(hints.length, 1, 'A2A ack-liveness hint should fire (no routing exit)');
+    assert.equal(msgs[0].replyTo, 'msg-trigger', 'queue-dispatched A2A stream should persist trigger replyTo');
 
     const codexText = yielded.find((msg) => msg.type === 'text' && msg.catId === 'codex');
     assert.ok(codexText, 'should yield codex stream text');

--- a/packages/shared/src/types/ball-custody.ts
+++ b/packages/shared/src/types/ball-custody.ts
@@ -13,14 +13,15 @@
  */
 
 // ---------------------------------------------------------------------------
-// Event kinds（全 17 种，每种在 state-machine 转移表必有一行——INV-10 穷举钉死）
-// Phase B 13 种 + Phase C 3 安乐死 + Phase P 1 wakeWhen kind
+// Event kinds（全 18 种，每种在 state-machine 转移表必有一行——INV-10 穷举钉死）
+// Phase B 13 种 + Phase C 3 安乐死 + Phase P 1 wakeWhen kind + F257 LI-005 1 void_ack
 // ---------------------------------------------------------------------------
 
 export type BallEventKind =
   | 'ball.handed' // 行首 @ 路由投递给某猫（payload: { fromCatId?, toCatId }）
   | 'ball.handed_cvo' // @co-creator（payload: { fromCatId?, intent: BallIntent }）
   | 'ball.void_pass' // F167 forced-pass guard / 路由守卫：说传了但无系统动作
+  | 'ball.void_ack' // F257 LI-005: A2A 接球但无持久触发器绑定（球静默死亡）
   | 'ball.held' // hold_ball 设（payload: { catId, fireAt }）
   | 'ball.hold_expired' // hold fireAt 已过
   | 'invocation.started' // 持有者起 invocation

--- a/packages/shared/src/types/ball-custody.ts
+++ b/packages/shared/src/types/ball-custody.ts
@@ -14,14 +14,14 @@
 
 // ---------------------------------------------------------------------------
 // Event kinds（全 18 种，每种在 state-machine 转移表必有一行——INV-10 穷举钉死）
-// Phase B 13 种 + Phase C 3 安乐死 + Phase P 1 wakeWhen kind + F257 LI-005 1 void_ack
+// Phase B 13 种 + Phase C 3 安乐死 + Phase P 1 wakeWhen kind + LI-005 1 void_ack
 // ---------------------------------------------------------------------------
 
 export type BallEventKind =
   | 'ball.handed' // 行首 @ 路由投递给某猫（payload: { fromCatId?, toCatId }）
   | 'ball.handed_cvo' // @co-creator（payload: { fromCatId?, intent: BallIntent }）
   | 'ball.void_pass' // F167 forced-pass guard / 路由守卫：说传了但无系统动作
-  | 'ball.void_ack' // F257 LI-005: A2A 接球但无持久触发器绑定（球静默死亡）
+  | 'ball.void_ack' // LI-005: A2A 接球但无持久触发器绑定（球静默死亡）
   | 'ball.held' // hold_ball 设（payload: { catId, fireAt }）
   | 'ball.hold_expired' // hold fireAt 已过
   | 'invocation.started' // 持有者起 invocation


### PR DESCRIPTION
## Summary

- Add structural guard detecting A2A ball acceptance without durable trigger binding (hold_ball / register_scheduled_task / register_pr_tracking / register_issue_tracking / community_await_external) or routing exit — preventing silent ball death
- Emit `ack-liveness-hint` system notice + `ball.void_ack` event when A2A invocation ends with no exit
- Bridge `tool_result` events across all three Claude carriers (print NDJSON, bg transcript, PTY hook) enabling two-level durable trigger success classification (`toolResultStatus` + tool-specific body parsing)
- Add `PostToolUseFailure` hook registration for failure path coverage

## Key Design Decisions

- **Phase A only**: detection + hint + observability. Phase B (structural rejection / auto-wake) deferred
- **Fail-closed**: unknown tool_result shapes or parse errors → hint fires (safer than suppressing)
- **Contract pair testing**: QueueProcessor option-propagation test + routeSerial behavior test = complete coverage without monolithic E2E
- **`a2aTriggerMessageId` is cat→cat exclusive**: 5 assignment sites all in A2A paths, 0 operator paths

## Test Plan

- [x] 30 unit tests for `evaluateAckLiveness` + `classifyDurableTriggerResult` pure functions
- [x] 33 ball-custody state machine tests (including `ball.void_ack` transitions)
- [x] 12 integration behavior tests proving full chain:
  - Queue A2A no exit → hint + ball.void_ack
  - Successful durable trigger → no hint/void
  - Failed trigger (error/unknown) → hint + void_ack
  - ball.void_ack → ingest → projector → projection=void
- [x] 8 Claude NDJSON parser tool_result bridge tests
- [x] 3 bg transcript parity tests
- [x] 6 PTY hook sidechannel consumer tests (PostToolUse + PostToolUseFailure)
- [x] Hook setup PostToolUseFailure registration test
- [x] 159 total tests green, biome clean

## Review History

8 rounds of cross-family review (Sol/缅因猫 gpt-5.6-sol):
- R1-R6: P1 findings found and closed each round
- R7: all P1 closed, P2 (integration tests) requested
- R8: APPROVE — contract pair coverage accepted

🐾 Clowder AI cross-family reviewed (opus ↔ sol)
🤖 Generated with [Claude Code](https://claude.com/claude-code)