### PR TITLE
fix(memory): activate embeddings after sidecar install

### DIFF
--- a/packages/api/src/domains/memory/CollectionIndexBuilder.ts
+++ b/packages/api/src/domains/memory/CollectionIndexBuilder.ts
@@ -15,8 +15,29 @@ export interface CollectionRebuildResult {
 }
 
 export interface CollectionEmbedDeps {
-  embedding: IEmbeddingService;
+  getEmbeddingService: () => IEmbeddingService | undefined;
   vectorStore: VectorStore;
+}
+
+function createLiveEmbeddingCapability(getEmbeddingService: () => IEmbeddingService | undefined): IEmbeddingService {
+  const requireService = (): IEmbeddingService => {
+    const service = getEmbeddingService();
+    if (!service) throw new Error('Embedding capability is no longer active');
+    return service;
+  };
+
+  return {
+    load: () => requireService().load(),
+    embed: (texts) => requireService().embed(texts),
+    isReady: () => getEmbeddingService()?.isReady() === true,
+    reprobeIfNeeded: async () => {
+      const service = getEmbeddingService();
+      if (service) await service.reprobeIfNeeded();
+    },
+    getModelInfo: () => requireService().getModelInfo(),
+    // The builder borrows the lifecycle-owned service and must never dispose it.
+    dispose: () => {},
+  };
 }
 
 export class CollectionIndexBuilder {
@@ -45,7 +66,8 @@ export class CollectionIndexBuilder {
     const { indexed, skipped, indexedItems } = await this.indexResults(results, force);
 
     if (this.embedDeps && indexedItems.length > 0) {
-      const { embedding, vectorStore } = this.embedDeps;
+      const { getEmbeddingService, vectorStore } = this.embedDeps;
+      const embedding = createLiveEmbeddingCapability(getEmbeddingService);
       const store = this.store;
       try {
         await embedIndexedItems({

--- a/packages/api/src/domains/memory/IndexBuilder.ts
+++ b/packages/api/src/domains/memory/IndexBuilder.ts
@@ -224,11 +224,15 @@ export class IndexBuilder implements IIndexBuilder {
     this.store.setSourceRoot(this.scanRoot);
   }
 
-  setEmbedDeps(deps: {
-    embedding: IEmbeddingService;
-    vectorStore: VectorStore;
-    passageVectorStore?: PassageVectorStore;
-  }): void {
+  setEmbedDeps(
+    deps:
+      | {
+          embedding: IEmbeddingService;
+          vectorStore: VectorStore;
+          passageVectorStore?: PassageVectorStore;
+        }
+      | undefined,
+  ): void {
     this.embedDeps = deps;
   }
 

--- a/packages/api/src/domains/memory/MemoryEmbeddingLifecycle.ts
+++ b/packages/api/src/domains/memory/MemoryEmbeddingLifecycle.ts
@@ -26,6 +26,7 @@ interface VectorBackend {
 interface MemoryEmbeddingLifecycleOptions {
   createEmbeddingService?: (config: EmbedConfig) => IEmbeddingService;
   initializeVectorBackend?: (store: SqliteEvidenceStore, dim: number) => Promise<VectorBackend>;
+  getDependentStores?: () => Iterable<SqliteEvidenceStore>;
 }
 
 class VectorBackendUnavailableError extends Error {
@@ -69,6 +70,7 @@ export class MemoryEmbeddingLifecycle {
   private generation = 0;
   private readonly createEmbeddingService: (config: EmbedConfig) => IEmbeddingService;
   private readonly initializeVectorBackend: (store: SqliteEvidenceStore, dim: number) => Promise<VectorBackend>;
+  private readonly getDependentStores: () => Iterable<SqliteEvidenceStore>;
 
   constructor(
     private readonly store: SqliteEvidenceStore,
@@ -79,6 +81,7 @@ export class MemoryEmbeddingLifecycle {
     this.createEmbeddingService =
       options.createEmbeddingService ?? ((embedConfig) => new EmbeddingService(embedConfig));
     this.initializeVectorBackend = options.initializeVectorBackend ?? initializeVectorBackend;
+    this.getDependentStores = options.getDependentStores ?? (() => [store]);
   }
 
   activate(mode: ActiveEmbeddingRuntimeMode): Promise<EmbeddingActivationResult> {
@@ -106,8 +109,7 @@ export class MemoryEmbeddingLifecycle {
     this.mode = 'off';
     this.status = 'off';
     this.reason = undefined;
-    this.indexBuilder.setEmbedDeps(undefined);
-    this.store.setEmbedDeps(undefined);
+    this.clearDependencies();
     this.service?.dispose();
     this.service = undefined;
     this.vectorStore = undefined;
@@ -176,8 +178,7 @@ export class MemoryEmbeddingLifecycle {
       this.reason = error instanceof VectorBackendUnavailableError ? error.reason : 'sqlite_vec_unavailable';
       this.vectorStore = undefined;
       this.passageVectorStore = undefined;
-      this.indexBuilder.setEmbedDeps(undefined);
-      this.store.setEmbedDeps(undefined);
+      this.clearDependencies();
       return this.snapshot(false);
     }
   }
@@ -191,6 +192,13 @@ export class MemoryEmbeddingLifecycle {
     };
     this.indexBuilder.setEmbedDeps(deps);
     this.store.setEmbedDeps({ ...deps, mode: this.mode });
+  }
+
+  private clearDependencies(): void {
+    this.indexBuilder.setEmbedDeps(undefined);
+    const stores = new Set<SqliteEvidenceStore>([this.store]);
+    for (const store of this.getDependentStores()) stores.add(store);
+    for (const store of stores) store.setEmbedDeps(undefined);
   }
 
   private isCurrent(generation: number): boolean {

--- a/packages/api/src/domains/memory/MemoryEmbeddingLifecycle.ts
+++ b/packages/api/src/domains/memory/MemoryEmbeddingLifecycle.ts
@@ -1,0 +1,208 @@
+import { EmbeddingService } from './EmbeddingService.js';
+import { IndexBuilder } from './IndexBuilder.js';
+import type { EmbedConfig, IEmbeddingService } from './interfaces.js';
+import { PassageVectorStore } from './PassageVectorStore.js';
+import { SqliteEvidenceStore } from './SqliteEvidenceStore.js';
+import { ensurePassageVectorTable, ensureVectorTable } from './schema.js';
+import { VectorStore } from './VectorStore.js';
+
+export type EmbeddingRuntimeMode = EmbedConfig['embedMode'];
+export type ActiveEmbeddingRuntimeMode = Exclude<EmbeddingRuntimeMode, 'off'>;
+export type EmbeddingRuntimeStatus = 'off' | 'activating' | 'configured' | 'ready' | 'degraded';
+export type EmbeddingActivationFailure = 'service_not_ready' | 'sqlite_vec_unavailable' | 'vector_table_unavailable';
+
+export interface EmbeddingActivationResult {
+  ok: boolean;
+  status: EmbeddingRuntimeStatus;
+  mode: EmbeddingRuntimeMode;
+  reason?: EmbeddingActivationFailure;
+}
+
+interface VectorBackend {
+  vectorStore: VectorStore;
+  passageVectorStore: PassageVectorStore;
+}
+
+interface MemoryEmbeddingLifecycleOptions {
+  createEmbeddingService?: (config: EmbedConfig) => IEmbeddingService;
+  initializeVectorBackend?: (store: SqliteEvidenceStore, dim: number) => Promise<VectorBackend>;
+}
+
+class VectorBackendUnavailableError extends Error {
+  constructor(readonly reason: EmbeddingActivationFailure) {
+    super(reason);
+  }
+}
+
+async function initializeVectorBackend(store: SqliteEvidenceStore, dim: number): Promise<VectorBackend> {
+  try {
+    const sqliteVec = await import('sqlite-vec');
+    sqliteVec.load(store.getDb());
+  } catch {
+    throw new VectorBackendUnavailableError('sqlite_vec_unavailable');
+  }
+
+  const documentTableReady = ensureVectorTable(store.getDb(), dim);
+  const passageTableReady = ensurePassageVectorTable(store.getDb(), dim);
+  if (!documentTableReady || !passageTableReady) {
+    throw new VectorBackendUnavailableError('vector_table_unavailable');
+  }
+
+  return {
+    vectorStore: new VectorStore(store.getDb(), dim),
+    passageVectorStore: new PassageVectorStore(store.getDb(), dim),
+  };
+}
+
+/**
+ * Owns the process-local projection from persisted embedding intent to live
+ * memory dependencies. It does not persist configuration or delete vectors.
+ */
+export class MemoryEmbeddingLifecycle {
+  private mode: EmbeddingRuntimeMode = 'off';
+  private status: EmbeddingRuntimeStatus = 'off';
+  private reason: EmbeddingActivationFailure | undefined;
+  private service: IEmbeddingService | undefined;
+  private vectorStore: VectorStore | undefined;
+  private passageVectorStore: PassageVectorStore | undefined;
+  private activation: Promise<EmbeddingActivationResult> | undefined;
+  private generation = 0;
+  private readonly createEmbeddingService: (config: EmbedConfig) => IEmbeddingService;
+  private readonly initializeVectorBackend: (store: SqliteEvidenceStore, dim: number) => Promise<VectorBackend>;
+
+  constructor(
+    private readonly store: SqliteEvidenceStore,
+    private readonly indexBuilder: IndexBuilder,
+    private readonly config: EmbedConfig,
+    options: MemoryEmbeddingLifecycleOptions = {},
+  ) {
+    this.createEmbeddingService =
+      options.createEmbeddingService ?? ((embedConfig) => new EmbeddingService(embedConfig));
+    this.initializeVectorBackend = options.initializeVectorBackend ?? initializeVectorBackend;
+  }
+
+  activate(mode: ActiveEmbeddingRuntimeMode): Promise<EmbeddingActivationResult> {
+    this.mode = mode;
+    this.reason = undefined;
+
+    if (this.status === 'ready' && this.service && this.vectorStore && this.passageVectorStore) {
+      this.bindDependencies();
+      return Promise.resolve(this.snapshot(true));
+    }
+    if (this.activation) return this.activation;
+
+    const generation = ++this.generation;
+    this.status = 'activating';
+    const activation = this.activateOnce(generation).finally(() => {
+      if (this.activation === activation) this.activation = undefined;
+    });
+    this.activation = activation;
+    return activation;
+  }
+
+  deactivate(): void {
+    this.generation++;
+    this.activation = undefined;
+    this.mode = 'off';
+    this.status = 'off';
+    this.reason = undefined;
+    this.indexBuilder.setEmbedDeps(undefined);
+    this.store.setEmbedDeps(undefined);
+    this.service?.dispose();
+    this.service = undefined;
+    this.vectorStore = undefined;
+    this.passageVectorStore = undefined;
+  }
+
+  getMode(): EmbeddingRuntimeMode {
+    return this.mode;
+  }
+
+  getStatus(): EmbeddingRuntimeStatus {
+    return this.status;
+  }
+
+  getFailureReason(): EmbeddingActivationFailure | undefined {
+    return this.reason;
+  }
+
+  getService(): IEmbeddingService | undefined {
+    return this.service;
+  }
+
+  getVectorStore(): VectorStore | undefined {
+    return this.vectorStore;
+  }
+
+  getPassageVectorStore(): PassageVectorStore | undefined {
+    return this.passageVectorStore;
+  }
+
+  private async activateOnce(generation: number): Promise<EmbeddingActivationResult> {
+    const service = this.service ?? this.createEmbeddingService(this.config);
+    this.service = service;
+    try {
+      await service.load();
+    } catch {
+      // A provider implementation may throw even though the built-in HTTP
+      // client is fail-open. Normalize both paths to configured/not-ready.
+    }
+
+    if (!this.isCurrent(generation)) {
+      service.dispose();
+      return this.snapshot(false);
+    }
+    if (!service.isReady()) {
+      this.status = 'configured';
+      this.reason = 'service_not_ready';
+      return this.snapshot(false);
+    }
+
+    try {
+      const backend = await this.initializeVectorBackend(this.store, this.config.embedDim);
+      if (!this.isCurrent(generation)) {
+        service.dispose();
+        return this.snapshot(false);
+      }
+      this.vectorStore = backend.vectorStore;
+      this.passageVectorStore = backend.passageVectorStore;
+      this.bindDependencies();
+      this.status = 'ready';
+      this.reason = undefined;
+      return this.snapshot(true);
+    } catch (error) {
+      if (!this.isCurrent(generation)) return this.snapshot(false);
+      this.status = 'degraded';
+      this.reason = error instanceof VectorBackendUnavailableError ? error.reason : 'sqlite_vec_unavailable';
+      this.vectorStore = undefined;
+      this.passageVectorStore = undefined;
+      this.indexBuilder.setEmbedDeps(undefined);
+      this.store.setEmbedDeps(undefined);
+      return this.snapshot(false);
+    }
+  }
+
+  private bindDependencies(): void {
+    if (!this.service || !this.vectorStore || !this.passageVectorStore || this.mode === 'off') return;
+    const deps = {
+      embedding: this.service,
+      vectorStore: this.vectorStore,
+      passageVectorStore: this.passageVectorStore,
+    };
+    this.indexBuilder.setEmbedDeps(deps);
+    this.store.setEmbedDeps({ ...deps, mode: this.mode });
+  }
+
+  private isCurrent(generation: number): boolean {
+    return this.generation === generation && this.mode !== 'off';
+  }
+
+  private snapshot(ok: boolean): EmbeddingActivationResult {
+    return {
+      ok,
+      status: this.status,
+      mode: this.mode,
+      ...(this.reason ? { reason: this.reason } : {}),
+    };
+  }
+}

--- a/packages/api/src/domains/memory/SqliteEvidenceStore.ts
+++ b/packages/api/src/domains/memory/SqliteEvidenceStore.ts
@@ -105,7 +105,7 @@ export class SqliteEvidenceStore implements IEvidenceStore {
   }
 
   /** @internal Allow late-binding of embed deps (factory sets after construction) */
-  setEmbedDeps(deps: EmbedDeps): void {
+  setEmbedDeps(deps: EmbedDeps | undefined): void {
     this.embedDeps = deps;
   }
 

--- a/packages/api/src/domains/memory/bootstrap-collection-bridge.ts
+++ b/packages/api/src/domains/memory/bootstrap-collection-bridge.ts
@@ -25,7 +25,7 @@ export async function ensureProjectCollection(
   catalog: LibraryCatalog,
   stores: Map<string, IEvidenceStore>,
   dataDir: string,
-  embeddingService?: IEmbeddingService,
+  getEmbeddingService?: () => IEmbeddingService | undefined,
 ): Promise<{ docsIndexed: number; durationMs: number }> {
   const startMs = Date.now();
   const collectionId = deriveCollectionId(projectPath);
@@ -68,6 +68,7 @@ export async function ensureProjectCollection(
   store.setSourceRoot(manifest.root, manifest.id);
 
   let embedDeps: CollectionEmbedDeps | undefined;
+  const embeddingService = getEmbeddingService?.();
   if (embeddingService) {
     try {
       const db = store.getDb();
@@ -75,7 +76,10 @@ export async function ensureProjectCollection(
       sqliteVecMod.load(db);
       const dim = embeddingService.getModelInfo().dim;
       if (ensureVectorTable(db, dim)) {
-        embedDeps = { embedding: embeddingService, vectorStore: new VectorStore(db, dim) };
+        embedDeps = {
+          getEmbeddingService: () => (getEmbeddingService?.() === embeddingService ? embeddingService : undefined),
+          vectorStore: new VectorStore(db, dim),
+        };
       }
     } catch {
       // fail-open: sqlite-vec not available → FTS-only

--- a/packages/api/src/domains/memory/evidence-status-signals.ts
+++ b/packages/api/src/domains/memory/evidence-status-signals.ts
@@ -121,7 +121,7 @@ export function detectEmbeddingDisabled(signals: EvidenceStatusSignals): ConfigW
     code: 'embedding_disabled',
     message: 'No embedding model is configured — semantic recall is offline.',
     suggestedAction:
-      'Enable an embedding model in settings (set OPENAI_EMBEDDING_API_KEY or configure a local embedder) and run a full reindex.',
+      'Install and start the recommended local embedding service in Memory Center, then rebuild the index.',
   };
 }
 
@@ -156,7 +156,7 @@ export function detectVecTableMissing(signals: EvidenceStatusSignals): ConfigWar
     code: 'vec_table_missing',
     message: 'Passage vector table is unavailable (sqlite-vec not loaded or embedding service not ready).',
     suggestedAction:
-      'Install sqlite-vec via Memory Center → Install Dialog, or disable embeddings if you do not need semantic recall.',
+      'Open the local embedding service controls to start or reinstall it; unsupported platforms will show a platform-specific error.',
   };
 }
 

--- a/packages/api/src/domains/memory/factory.ts
+++ b/packages/api/src/domains/memory/factory.ts
@@ -3,7 +3,6 @@
 import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
-import { EmbeddingService } from './EmbeddingService.js';
 import type { IEventMemoryStore } from './EventMemoryStore.js';
 import { EventMemoryStore } from './EventMemoryStore.js';
 import { loadEntitySeeds } from './entity-seeds.js';
@@ -25,11 +24,11 @@ import { KnowledgeResolver } from './KnowledgeResolver.js';
 import { LibraryCatalog } from './LibraryCatalog.js';
 import { MarkerQueue } from './MarkerQueue.js';
 import { MaterializationService } from './MaterializationService.js';
-import { PassageVectorStore } from './PassageVectorStore.js';
+import { MemoryEmbeddingLifecycle } from './MemoryEmbeddingLifecycle.js';
+import type { PassageVectorStore } from './PassageVectorStore.js';
 import { ReflectionService } from './ReflectionService.js';
 import { SqliteEvidenceStore } from './SqliteEvidenceStore.js';
-import { ensurePassageVectorTable, ensureVectorTable } from './schema.js';
-import { VectorStore } from './VectorStore.js';
+import type { VectorStore } from './VectorStore.js';
 
 export interface MemoryServices {
   evidenceStore: IEvidenceStore;
@@ -44,6 +43,7 @@ export interface MemoryServices {
   knowledgeResolver: IKnowledgeResolver;
   indexBuilder?: IIndexBuilder;
   materializationService?: IMaterializationService;
+  embeddingLifecycle: MemoryEmbeddingLifecycle;
   embeddingService?: IEmbeddingService;
   vectorStore?: VectorStore;
   passageVectorStore?: PassageVectorStore;
@@ -141,41 +141,6 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
     await store.upsertEntities(entitySeeds);
   }
 
-  let embeddingService: IEmbeddingService | undefined;
-  let vectorStore: VectorStore | undefined;
-  let passageVectorStore: PassageVectorStore | undefined;
-
-  if (embedConfig.embedMode !== 'off') {
-    embeddingService = new EmbeddingService(embedConfig);
-
-    // P1 (codex R2): explicitly call load() — without this, isReady() stays false forever.
-    // Wrapped in try-catch for AC-C4 fail-open.
-    try {
-      await embeddingService.load();
-    } catch {
-      // fail-open: model load failed → isReady()=false → lexical-only degradation
-    }
-
-    // Load sqlite-vec + ensure vec0 table (decoupled from migration, fail-open)
-    try {
-      const sqliteVecMod = await import('sqlite-vec');
-      sqliteVecMod.load(store.getDb());
-      const ok = ensureVectorTable(store.getDb(), embedConfig.embedDim);
-      if (ok) {
-        vectorStore = new VectorStore(store.getDb(), embedConfig.embedDim);
-      }
-      const passageOk = ensurePassageVectorTable(store.getDb(), embedConfig.embedDim);
-      if (passageOk) {
-        passageVectorStore = new PassageVectorStore(store.getDb(), embedConfig.embedDim);
-      }
-    } catch {
-      // fail-open: sqlite-vec not available
-    }
-  }
-
-  const embedDeps =
-    embeddingService && vectorStore ? { embedding: embeddingService, vectorStore, passageVectorStore } : undefined;
-
   // Pre-load external manifests to compute child excludes (AC-H1)
   // Must happen before IndexBuilder so CatCafeScanner gets the exclude patterns
   const dataDir = config.dataDir ?? join(homedir(), '.cat-cafe');
@@ -185,7 +150,7 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
   const indexBuilder = new IndexBuilder(
     store,
     docsRoot,
-    embedDeps,
+    undefined,
     config.transcriptDataDir,
     config.threadListFn,
     config.messageListFn,
@@ -193,10 +158,9 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
     undefined,
     childExcludes.length > 0 ? childExcludes : undefined,
   );
-
-  // Wire rerank deps into store for search-time
-  if (embedDeps) {
-    store.setEmbedDeps({ ...embedDeps, mode: embedConfig.embedMode as 'shadow' | 'on' });
+  const embeddingLifecycle = new MemoryEmbeddingLifecycle(store, indexBuilder, embedConfig);
+  if (embedConfig.embedMode !== 'off') {
+    await embeddingLifecycle.activate(embedConfig.embedMode);
   }
 
   const markerQueue = new MarkerQueue(markersDir);
@@ -294,9 +258,16 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
     knowledgeResolver,
     indexBuilder,
     materializationService,
-    embeddingService,
-    vectorStore,
-    passageVectorStore,
+    embeddingLifecycle,
+    get embeddingService(): IEmbeddingService | undefined {
+      return embeddingLifecycle.getService();
+    },
+    get vectorStore(): VectorStore | undefined {
+      return embeddingLifecycle.getVectorStore();
+    },
+    get passageVectorStore(): PassageVectorStore | undefined {
+      return embeddingLifecycle.getPassageVectorStore();
+    },
     globalIndexBuilder,
     globalStore,
     catalog,

--- a/packages/api/src/domains/memory/factory.ts
+++ b/packages/api/src/domains/memory/factory.ts
@@ -133,6 +133,8 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
 
   const store = new SqliteEvidenceStore(sqlitePath);
   await store.initialize();
+  const stores = new Map<string, IEvidenceStore>();
+  stores.set('project:cat-cafe', store);
   const entitySeeds = loadEntitySeeds({
     explicitSeedPath: config.entitySeedPath,
     includeRoster: config.includeRosterEntitySeeds,
@@ -158,7 +160,12 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
     undefined,
     childExcludes.length > 0 ? childExcludes : undefined,
   );
-  const embeddingLifecycle = new MemoryEmbeddingLifecycle(store, indexBuilder, embedConfig);
+  const embeddingLifecycle = new MemoryEmbeddingLifecycle(store, indexBuilder, embedConfig, {
+    getDependentStores: () =>
+      [...stores.values()].filter(
+        (candidate): candidate is SqliteEvidenceStore => candidate instanceof SqliteEvidenceStore,
+      ),
+  });
   if (embedConfig.embedMode !== 'off') {
     await embeddingLifecycle.activate(embedConfig.embedMode);
   }
@@ -190,7 +197,6 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
   }
 
   const catalog = new LibraryCatalog();
-  const stores = new Map<string, IEvidenceStore>();
   const now = new Date().toISOString();
 
   catalog.register({
@@ -207,8 +213,6 @@ export async function createMemoryServices(config: MemoryConfig): Promise<Memory
     createdAt: now,
     updatedAt: now,
   });
-  stores.set('project:cat-cafe', store);
-
   if (globalStore) {
     catalog.register({
       id: 'global:methods',

--- a/packages/api/src/domains/memory/index.ts
+++ b/packages/api/src/domains/memory/index.ts
@@ -61,6 +61,14 @@ export {
 export { KnowledgeResolver } from './KnowledgeResolver.js';
 export { MarkerQueue } from './MarkerQueue.js';
 export { MaterializationService } from './MaterializationService.js';
+export {
+  type ActiveEmbeddingRuntimeMode,
+  type EmbeddingActivationFailure,
+  type EmbeddingActivationResult,
+  type EmbeddingRuntimeMode,
+  type EmbeddingRuntimeStatus,
+  MemoryEmbeddingLifecycle,
+} from './MemoryEmbeddingLifecycle.js';
 export { PassageVectorStore, parsePassageVectorKey, passageVectorKey } from './PassageVectorStore.js';
 export { ReflectionService } from './ReflectionService.js';
 export { SemanticReranker } from './SemanticReranker.js';

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1129,12 +1129,13 @@ async function main(): Promise<void> {
         },
         generateAbstractive,
         // Re-embed thread after abstractive summary update (semantic search uses vectors)
-        reEmbed: memoryServices.embeddingService?.isReady()
-          ? async (anchor: string, text: string) => {
-              const [vec] = await memoryServices.embeddingService!.embed([text]);
-              memoryServices.vectorStore?.upsert(anchor, vec);
-            }
-          : undefined,
+        reEmbed: async (anchor: string, text: string) => {
+          const embeddingService = memoryServices.embeddingLifecycle.getService();
+          const vectorStore = memoryServices.embeddingLifecycle.getVectorStore();
+          if (!embeddingService?.isReady() || !vectorStore) return;
+          const [vec] = await embeddingService.embed([text]);
+          vectorStore.upsert(anchor, vec);
+        },
         // H-3: Submit durable candidates to knowledge emergence pipeline
         // Gated by F102_DURABLE_CANDIDATES flag (spec §F102 env config)
         submitCandidate:
@@ -3185,38 +3186,53 @@ async function main(): Promise<void> {
   await app.register(servicesRoutes, {
     lifecycle: {
       autoStartEnabled: true,
-      onServiceReady: ({ service, operator, reason }) => {
+      onServiceReady: async ({ service, operator, reason }) => {
         if (service.id !== 'embedding-model' || !memoryServices.indexBuilder) return;
+        const activationMode = resolvedEmbedMode === 'shadow' ? 'shadow' : 'on';
+        const activation = await memoryServices.embeddingLifecycle.activate(activationMode);
+        if (!activation.ok) {
+          const detail = activation.reason ?? activation.status;
+          appendServiceLog(service.id, `[start] memory embedding activation degraded: ${detail}\n`);
+          app.log.warn(
+            { serviceId: service.id, operator, reason, activation },
+            '[api] F102: embedding service ready but memory activation degraded',
+          );
+          return;
+        }
         appendServiceLog(service.id, `[start] embedding service ready (${reason}); scheduling evidence rebuild\n`);
         app.log.info(
           { serviceId: service.id, operator, reason },
           '[api] F102: embedding service ready; scheduling evidence rebuild',
         );
         const startedAt = Date.now();
-        void memoryServices.indexBuilder
-          .rebuild({ force: true })
-          .then((result) => {
-            const elapsedMs = Date.now() - startedAt;
-            appendServiceLog(
-              service.id,
-              `[start] evidence rebuild completed: ${result.docsIndexed} indexed, ${result.docsSkipped} skipped (${elapsedMs}ms)\n`,
-            );
-            app.log.info(
-              `[api] F102: embedding service catch-up rebuild completed - ${result.docsIndexed} indexed, ${result.docsSkipped} skipped (${elapsedMs}ms)`,
-            );
-            // Backfill passage vectors that were missed when API started before
-            // the embedding service was ready. Without this, only newly indexed
-            // passages get vectors — the ~N thousands indexed while embed was
-            // down remain lexical-only until the next full restart.
-            memoryServices.indexBuilder?.startPassageEmbeddingWarmup();
-          })
-          .catch((error) => {
-            appendServiceLog(service.id, `[start] evidence rebuild failed: ${String(error)}\n`);
-            app.log.warn(
-              { err: error, serviceId: service.id },
-              '[api] F102: embedding service catch-up rebuild failed',
-            );
-          });
+        try {
+          const result = await memoryServices.indexBuilder.rebuild({ force: true });
+          const elapsedMs = Date.now() - startedAt;
+          appendServiceLog(
+            service.id,
+            `[start] evidence rebuild completed: ${result.docsIndexed} indexed, ${result.docsSkipped} skipped (${elapsedMs}ms)\n`,
+          );
+          app.log.info(
+            `[api] F102: embedding service catch-up rebuild completed - ${result.docsIndexed} indexed, ${result.docsSkipped} skipped (${elapsedMs}ms)`,
+          );
+          // Backfill passage vectors that were missed when API started before
+          // the embedding service was ready. Without this, only newly indexed
+          // passages get vectors — the ~N thousands indexed while embed was
+          // down remain lexical-only until the next full restart.
+          memoryServices.indexBuilder.startPassageEmbeddingWarmup();
+        } catch (error) {
+          appendServiceLog(service.id, `[start] evidence rebuild failed: ${String(error)}\n`);
+          app.log.warn({ err: error, serviceId: service.id }, '[api] F102: embedding service catch-up rebuild failed');
+        }
+      },
+      onServiceUnavailable: ({ service, operator, reason }) => {
+        if (service.id !== 'embedding-model') return;
+        memoryServices.embeddingLifecycle.deactivate();
+        appendServiceLog(service.id, `[${reason}] memory embedding dependencies deactivated\n`);
+        app.log.info(
+          { serviceId: service.id, operator, reason },
+          '[api] F102: memory embedding dependencies deactivated',
+        );
       },
     },
   });
@@ -3313,7 +3329,7 @@ async function main(): Promise<void> {
   // Evidence search (SQLite) + reindex endpoint (D-11) + F-4 federated search + F188 rebuild
   await app.register(evidenceRoutes, {
     evidenceStore: memoryServices.evidenceStore,
-    embeddingService: memoryServices.embeddingService,
+    getEmbeddingService: () => memoryServices.embeddingLifecycle.getService(),
     indexBuilder: memoryServices.indexBuilder,
     knowledgeResolver: memoryServices.knowledgeResolver,
     rebuildJobTracker,
@@ -3405,16 +3421,16 @@ async function main(): Promise<void> {
     if (!libraryStores.has('project:cat-cafe')) libraryStores.set('project:cat-cafe', memoryServices.store);
     if (memoryServices.globalStore && !libraryStores.has('global:methods'))
       libraryStores.set('global:methods', memoryServices.globalStore);
-    // Use the resolvedEmbedMode computed above (service.enabled overrides EMBED_MODE=off).
-    const libraryEmbedMode: 'shadow' | 'on' | undefined =
-      resolvedEmbedMode === 'shadow' || resolvedEmbedMode === 'on' ? resolvedEmbedMode : undefined;
     await app.register(libraryRoutes, {
       catalog: memoryServices.catalog,
       stores: libraryStores,
       dataDir: memoryServices.dataDir,
       managedVaultBase: memoryServices.dataDir,
-      embeddingService: memoryServices.embeddingService,
-      embedMode: libraryEmbedMode,
+      getEmbeddingService: () => memoryServices.embeddingLifecycle.getService(),
+      getEmbedMode: () => {
+        const mode = memoryServices.embeddingLifecycle.getMode();
+        return mode === 'off' ? undefined : mode;
+      },
       // F188 Phase F AC-F9: pass redis for tool-usage-metrics endpoint (砚砚 review P1-2)
       ...(redisClient ? { redis: redisClient } : {}),
       // AC-H1 P1 R3: runtime exclude updates for parent IndexBuilder

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -886,7 +886,7 @@ async function main(): Promise<void> {
         memoryServices.catalog!,
         memoryServices.collectionStores ?? new Map(),
         memoryServices.dataDir!,
-        memoryServices.embeddingService,
+        () => memoryServices.embeddingLifecycle.getService(),
       );
     },
     getFingerprint,

--- a/packages/api/src/routes/evidence.ts
+++ b/packages/api/src/routes/evidence.ts
@@ -102,6 +102,7 @@ export interface EvidenceRoutesOptions {
   docsRoot?: string;
   evidenceStore: IEvidenceStore;
   embeddingService?: Pick<IEmbeddingService, 'isReady'>;
+  getEmbeddingService?: () => Pick<IEmbeddingService, 'isReady'> | undefined;
   indexBuilder?: IIndexBuilder;
   knowledgeResolver?: IKnowledgeResolver;
   rebuildJobTracker?: RebuildJobTracker;
@@ -432,7 +433,7 @@ export const evidenceRoutes: FastifyPluginAsync<EvidenceRoutesOptions> = async (
       // at all" (embed off / sqlite-vec missing), so the UI never shows a warm-up that never finishes.
       let passageVectorCount = 0;
       let passageVectorsSupported = false;
-      const passageEmbeddingReady = opts.embeddingService?.isReady() === true;
+      const passageEmbeddingReady = (opts.getEmbeddingService?.() ?? opts.embeddingService)?.isReady() === true;
       try {
         passageVectorCount = (db.prepare('SELECT count(*) AS c FROM passage_vectors').get() as { c: number }).c;
         passageVectorsSupported = passageEmbeddingReady;

--- a/packages/api/src/routes/library.ts
+++ b/packages/api/src/routes/library.ts
@@ -33,6 +33,8 @@ export interface LibraryRoutesOptions {
   managedVaultBase?: string;
   embeddingService?: IEmbeddingService;
   embedMode?: 'shadow' | 'on';
+  getEmbeddingService?: () => IEmbeddingService | undefined;
+  getEmbedMode?: () => 'shadow' | 'on' | undefined;
   // F188 Phase F AC-F9: optional Redis client for tool-usage-metrics endpoint.
   // Typed as `unknown` to accept any RedisClient implementation (ioredis, etc.);
   // ToolEventLog will narrow internally via its own constructor signature.
@@ -269,16 +271,17 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
 
     let embedDeps: CollectionEmbedDeps | undefined;
     const db = (store as StoreWithDb).getDb?.();
-    if (opts.embeddingService && db) {
+    const embeddingService = opts.getEmbeddingService?.() ?? opts.embeddingService;
+    if (embeddingService && db) {
       try {
         const sqliteVecMod = await import('sqlite-vec');
         sqliteVecMod.load(db);
-        const dim = opts.embeddingService.getModelInfo().dim;
+        const dim = embeddingService.getModelInfo().dim;
         if (ensureVectorTable(db, dim)) {
           const vectorStore = new VectorStore(db, dim);
-          embedDeps = { embedding: opts.embeddingService, vectorStore };
-          const mode = opts.embedMode ?? 'shadow';
-          (store as SqliteEvidenceStore).setEmbedDeps({ embedding: opts.embeddingService, vectorStore, mode });
+          embedDeps = { embedding: embeddingService, vectorStore };
+          const mode = opts.getEmbedMode?.() ?? opts.embedMode ?? 'shadow';
+          (store as SqliteEvidenceStore).setEmbedDeps({ embedding: embeddingService, vectorStore, mode });
         }
       } catch {
         // fail-open: sqlite-vec not available → FTS-only

--- a/packages/api/src/routes/library.ts
+++ b/packages/api/src/routes/library.ts
@@ -271,7 +271,10 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
 
     let embedDeps: CollectionEmbedDeps | undefined;
     const db = (store as StoreWithDb).getDb?.();
-    const embeddingService = opts.getEmbeddingService?.() ?? opts.embeddingService;
+    const resolveEmbeddingService = () =>
+      opts.getEmbeddingService ? opts.getEmbeddingService() : opts.embeddingService;
+    const resolveEmbedMode = () => (opts.getEmbedMode ? opts.getEmbedMode() : (opts.embedMode ?? 'shadow'));
+    const embeddingService = resolveEmbeddingService();
     if (embeddingService && db) {
       try {
         const sqliteVecMod = await import('sqlite-vec');
@@ -279,8 +282,14 @@ export const libraryRoutes: FastifyPluginAsync<LibraryRoutesOptions> = async (ap
         const dim = embeddingService.getModelInfo().dim;
         if (ensureVectorTable(db, dim)) {
           const vectorStore = new VectorStore(db, dim);
-          embedDeps = { embedding: embeddingService, vectorStore };
-          const mode = opts.getEmbedMode?.() ?? opts.embedMode ?? 'shadow';
+          embedDeps = {
+            getEmbeddingService: () => {
+              const current = resolveEmbeddingService();
+              return current === embeddingService && resolveEmbedMode() ? current : undefined;
+            },
+            vectorStore,
+          };
+          const mode = resolveEmbedMode() ?? 'shadow';
           (store as SqliteEvidenceStore).setEmbedDeps({ embedding: embeddingService, vectorStore, mode });
         }
       } catch {

--- a/packages/api/src/routes/services-lifecycle-routes.ts
+++ b/packages/api/src/routes/services-lifecycle-routes.ts
@@ -60,6 +60,11 @@ export interface ServiceLifecycleRouteOptions {
     operator: string;
     reason: 'already-running' | 'readiness';
   }) => void | Promise<void>;
+  onServiceUnavailable?: (event: {
+    service: ServiceManifest;
+    operator: string;
+    reason: 'stop' | 'uninstall' | 'disabled';
+  }) => void | Promise<void>;
   findPidsByPort?: (port: number) => Promise<number[]>;
   listProcesses?: () => Promise<ProcessSnapshot[]>;
   readProcessCommand?: (pid: number) => Promise<string | null>;
@@ -286,19 +291,31 @@ export async function registerServiceLifecycleRoutes(
 
   await registerServiceLifecycleAuditRoutes(app, auditLog);
 
-  function notifyServiceReady(
+  async function notifyServiceReady(
     service: ServiceManifest,
     operator: string,
     reason: 'already-running' | 'readiness',
-  ): void {
+  ): Promise<void> {
     const hook = options.lifecycle?.onServiceReady;
     if (!hook) return;
     try {
-      void Promise.resolve(hook({ service, operator, reason })).catch((error) => {
-        app.log.warn({ err: error, serviceId: service.id, reason }, 'service ready hook failed');
-      });
+      await hook({ service, operator, reason });
     } catch (error) {
       app.log.warn({ err: error, serviceId: service.id, reason }, 'service ready hook failed');
+    }
+  }
+
+  async function notifyServiceUnavailable(
+    service: ServiceManifest,
+    operator: string,
+    reason: 'stop' | 'uninstall' | 'disabled',
+  ): Promise<void> {
+    const hook = options.lifecycle?.onServiceUnavailable;
+    if (!hook) return;
+    try {
+      await hook({ service, operator, reason });
+    } catch (error) {
+      app.log.warn({ err: error, serviceId: service.id, reason }, 'service unavailable hook failed');
     }
   }
 
@@ -696,6 +713,7 @@ export async function registerServiceLifecycleRoutes(
           reply.status(lifecycleFailureStatus(result.error));
         } else {
           serviceConfigStore.set(service.id, { installed: false, enabled: false });
+          await notifyServiceUnavailable(service, operator, 'uninstall');
         }
         return result;
       },
@@ -800,8 +818,12 @@ export async function registerServiceLifecycleRoutes(
                   status: 'completed',
                   reason: 'already-running',
                 });
-                notifyServiceReady(service, operator, 'already-running');
-                return { ok: true, message: `${service.name} is already running`, pids: portProbe.owned };
+                const reconciliation = notifyServiceReady(service, operator, 'already-running');
+                return holdStartupGrace(
+                  { ok: true, message: `${service.name} is already running`, pids: portProbe.owned },
+                  startupReadinessTimeoutMs,
+                  reconciliation,
+                );
               }
               // Legacy-only listener: log and fall through to terminate
               app.log.info(
@@ -1002,8 +1024,8 @@ export async function registerServiceLifecycleRoutes(
           intervalMs: startupProbeIntervalMs,
           stopWhen: cleanExitBeforeReady ? undefined : settlement,
           stopIf: stopIfNoOwnedRuntimeProcess,
-        }).then((ready) => {
-          if (ready) notifyServiceReady(service, operator, 'readiness');
+        }).then(async (ready) => {
+          if (ready) await notifyServiceReady(service, operator, 'readiness');
           return ready;
         });
         const releaseWhen = settlement && !cleanExitBeforeReady ? Promise.race([settlement, readiness]) : readiness;
@@ -1230,6 +1252,7 @@ export async function registerServiceLifecycleRoutes(
         }
         serviceConfigStore.set(service.id, { enabled: false });
         await audit({ serviceId: service.id, action: 'stop', operator, status: 'completed' });
+        await notifyServiceUnavailable(service, operator, 'stop');
         return { ok: true, message: `${service.name} stopped (${stopped.length} process(es))`, stopped };
       },
       { action: 'stop' },
@@ -1268,6 +1291,7 @@ export async function registerServiceLifecycleRoutes(
           }
           const config = serviceConfigStore.set(service.id, patch);
           await audit({ serviceId: service.id, action: 'toggle', operator, status: 'completed' });
+          if (!enabled) await notifyServiceUnavailable(service, operator, 'disabled');
           return { ok: true, config };
         },
         { action: 'toggle' },

--- a/packages/api/test/memory/bootstrap-collection-bridge.test.js
+++ b/packages/api/test/memory/bootstrap-collection-bridge.test.js
@@ -177,7 +177,7 @@ describe('ensureProjectCollection', () => {
       getModelInfo: () => ({ modelId: 'test', modelRev: 'v1', dim: 2 }),
     };
 
-    const result = await ensureProjectCollection(tmpProject, catalog, stores, tmpDataDir, mockEmbeddingService);
+    const result = await ensureProjectCollection(tmpProject, catalog, stores, tmpDataDir, () => mockEmbeddingService);
 
     assert.ok(result.docsIndexed >= 2, `expected ≥2 docs, got ${result.docsIndexed}`);
     assert.ok(embedCallCount >= 2, `expected ≥2 embed calls, got ${embedCallCount}`);

--- a/packages/api/test/memory/collection-rebuild-embed.test.js
+++ b/packages/api/test/memory/collection-rebuild-embed.test.js
@@ -58,7 +58,7 @@ describe('CollectionIndexBuilder embedding integration (bug #6)', () => {
     };
 
     const builder = new CollectionIndexBuilder(store, manifest, scanner, {
-      embedding: mockEmbedding,
+      getEmbeddingService: () => mockEmbedding,
       vectorStore: mockVectorStore,
     });
     const result = await builder.rebuild();

--- a/packages/api/test/memory/embedding-lifecycle.test.js
+++ b/packages/api/test/memory/embedding-lifecycle.test.js
@@ -247,6 +247,148 @@ The local embedding service can become ready after API startup.
     }
   });
 
+  it('revokes an in-flight external rebuild before it can call the disabled embedding sidecar', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { createMemoryServices } = await import('../../dist/domains/memory/factory.js');
+    const { libraryRoutes } = await import('../../dist/routes/library.js');
+    const root = mkdtempSync(join(tmpdir(), 'embedding-lifecycle-external-inflight-disable-'));
+    const docsRoot = join(root, 'docs');
+    const collectionRoot = join(root, 'external');
+    mkdirSync(docsRoot, { recursive: true });
+    mkdirSync(collectionRoot, { recursive: true });
+    writeFileSync(join(collectionRoot, 'alpha.md'), '# Alpha\n\nOrchard nebula content.');
+
+    const originalFetch = globalThis.fetch;
+    let healthRequests = 0;
+    let embeddingRequests = 0;
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/health')) {
+        healthRequests += 1;
+        return new Response(
+          JSON.stringify({ status: 'ok', model: 'test-model', backend: 'test', device: 'cpu', dim: 4 }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (String(url).endsWith('/v1/embeddings')) {
+        embeddingRequests += 1;
+        const body = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            model: 'test-model',
+            data: body.input.map((_, index) => ({ index, embedding: [1, 0, 0, 0] })),
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected embedding request: ${url}`);
+    };
+
+    let services;
+    const app = Fastify();
+    try {
+      services = await createMemoryServices({
+        type: 'sqlite',
+        sqlitePath: ':memory:',
+        docsRoot,
+        markersDir: join(root, 'markers'),
+        globalDbPath: ':memory:',
+        skillsRoot: join(root, 'skills'),
+        memoryRoot: join(root, 'memory'),
+        dataDir: join(root, 'data'),
+        embed: { embedMode: 'off', embedDim: 4 },
+      });
+      assert.deepEqual(await services.embeddingLifecycle.activate('on'), { ok: true, status: 'ready', mode: 'on' });
+
+      await app.register(libraryRoutes, {
+        catalog: services.catalog,
+        stores: services.collectionStores,
+        dataDir: services.dataDir,
+        getEmbeddingService: () => services.embeddingLifecycle.getService(),
+        getEmbedMode: () => {
+          const mode = services.embeddingLifecycle.getMode();
+          return mode === 'off' ? undefined : mode;
+        },
+      });
+      await app.ready();
+
+      const register = await app.inject({
+        method: 'POST',
+        url: '/api/library/register',
+        payload: {
+          id: 'domain:external-inflight-disable',
+          kind: 'domain',
+          name: 'external-inflight-disable',
+          displayName: 'External In-flight Disable',
+          root: collectionRoot,
+          sensitivity: 'internal',
+          scannerLevel: 1,
+        },
+      });
+      assert.equal(register.statusCode, 200, register.payload);
+
+      const externalStore = services.collectionStores.get('domain:external-inflight-disable');
+      assert.ok(externalStore);
+      let releaseUpsert;
+      let markUpsertStarted;
+      const upsertStarted = new Promise((resolve) => {
+        markUpsertStarted = resolve;
+      });
+      const upsertReleased = new Promise((resolve) => {
+        releaseUpsert = resolve;
+      });
+      const originalUpsert = externalStore.upsert.bind(externalStore);
+      externalStore.upsert = async (...args) => {
+        markUpsertStarted();
+        await upsertReleased;
+        return originalUpsert(...args);
+      };
+
+      const capturedService = services.embeddingLifecycle.getService();
+      assert.ok(capturedService);
+      capturedService.reprobeIfNeeded = async () => {
+        await globalThis.fetch('http://127.0.0.1:9880/health');
+        capturedService.markReady('test-model');
+      };
+      capturedService.embed = async (texts) => {
+        await globalThis.fetch('http://127.0.0.1:9880/v1/embeddings', {
+          method: 'POST',
+          body: JSON.stringify({ input: texts }),
+        });
+        return texts.map(() => new Float32Array([1, 0, 0, 0]));
+      };
+
+      const rebuildPromise = app.inject({
+        method: 'POST',
+        url: '/api/library/domain:external-inflight-disable/rebuild',
+      });
+      await upsertStarted;
+
+      services.embeddingLifecycle.deactivate();
+      const healthRequestsAfterDisable = healthRequests;
+      const embeddingRequestsAfterDisable = embeddingRequests;
+      releaseUpsert();
+
+      const rebuild = await rebuildPromise;
+      assert.equal(rebuild.statusCode, 200, rebuild.payload);
+      assert.equal(
+        healthRequests,
+        healthRequestsAfterDisable,
+        'an in-flight rebuild must not probe the embedding sidecar after disable',
+      );
+      assert.equal(
+        embeddingRequests,
+        embeddingRequestsAfterDisable,
+        'an in-flight rebuild must not request embeddings after disable',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      await app.close();
+      const stores = new Set(services?.collectionStores?.values() ?? []);
+      for (const store of stores) store.close?.();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('serializes concurrent activation events into one dependency build', async () => {
     let loadCount = 0;
     let backendCount = 0;

--- a/packages/api/test/memory/embedding-lifecycle.test.js
+++ b/packages/api/test/memory/embedding-lifecycle.test.js
@@ -142,6 +142,111 @@ The local embedding service can become ready after API startup.
     }
   });
 
+  it('revokes external collection semantic dependencies when embedding is disabled', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { createMemoryServices } = await import('../../dist/domains/memory/factory.js');
+    const { libraryRoutes } = await import('../../dist/routes/library.js');
+    const root = mkdtempSync(join(tmpdir(), 'embedding-lifecycle-external-disable-'));
+    const docsRoot = join(root, 'docs');
+    const collectionRoot = join(root, 'external');
+    mkdirSync(docsRoot, { recursive: true });
+    mkdirSync(collectionRoot, { recursive: true });
+    writeFileSync(join(collectionRoot, 'alpha.md'), '# Alpha\n\nOrchard nebula content.');
+
+    const originalFetch = globalThis.fetch;
+    let healthRequests = 0;
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/health')) {
+        healthRequests += 1;
+        return new Response(
+          JSON.stringify({ status: 'ok', model: 'test-model', backend: 'test', device: 'cpu', dim: 4 }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (String(url).endsWith('/v1/embeddings')) {
+        const body = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            model: 'test-model',
+            data: body.input.map((_, index) => ({ index, embedding: [1, 0, 0, 0] })),
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected embedding request: ${url}`);
+    };
+
+    let services;
+    const app = Fastify();
+    try {
+      services = await createMemoryServices({
+        type: 'sqlite',
+        sqlitePath: ':memory:',
+        docsRoot,
+        markersDir: join(root, 'markers'),
+        globalDbPath: ':memory:',
+        skillsRoot: join(root, 'skills'),
+        memoryRoot: join(root, 'memory'),
+        dataDir: join(root, 'data'),
+        embed: { embedMode: 'off', embedDim: 4 },
+      });
+      assert.deepEqual(await services.embeddingLifecycle.activate('on'), { ok: true, status: 'ready', mode: 'on' });
+
+      await app.register(libraryRoutes, {
+        catalog: services.catalog,
+        stores: services.collectionStores,
+        dataDir: services.dataDir,
+        getEmbeddingService: () => services.embeddingLifecycle.getService(),
+        getEmbedMode: () => {
+          const mode = services.embeddingLifecycle.getMode();
+          return mode === 'off' ? undefined : mode;
+        },
+      });
+      await app.ready();
+
+      const register = await app.inject({
+        method: 'POST',
+        url: '/api/library/register',
+        payload: {
+          id: 'domain:external-disable',
+          kind: 'domain',
+          name: 'external-disable',
+          displayName: 'External Disable',
+          root: collectionRoot,
+          sensitivity: 'internal',
+          scannerLevel: 1,
+        },
+      });
+      assert.equal(register.statusCode, 200, register.payload);
+      const rebuild = await app.inject({
+        method: 'POST',
+        url: '/api/library/domain:external-disable/rebuild',
+      });
+      assert.equal(rebuild.statusCode, 200, rebuild.payload);
+
+      const externalStore = services.collectionStores.get('domain:external-disable');
+      assert.ok(externalStore);
+      const query = 'qzxvsemanticprobe';
+      assert.equal((await externalStore.search(query, { mode: 'semantic' })).length, 1);
+
+      const healthRequestsBeforeDisable = healthRequests;
+      services.embeddingLifecycle.deactivate();
+
+      assert.deepEqual(await externalStore.search(query, { mode: 'semantic' }), []);
+      assert.equal(
+        healthRequests,
+        healthRequestsBeforeDisable,
+        'a disabled external store must not re-probe the embedding sidecar',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      await app.close();
+      const stores = new Set(services?.collectionStores?.values() ?? []);
+      for (const store of stores) store.close?.();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it('serializes concurrent activation events into one dependency build', async () => {
     let loadCount = 0;
     let backendCount = 0;

--- a/packages/api/test/memory/embedding-lifecycle.test.js
+++ b/packages/api/test/memory/embedding-lifecycle.test.js
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+
+async function createLifecycleHarness(options) {
+  const { IndexBuilder } = await import('../../dist/domains/memory/IndexBuilder.js');
+  const { MemoryEmbeddingLifecycle } = await import('../../dist/domains/memory/MemoryEmbeddingLifecycle.js');
+  const { SqliteEvidenceStore } = await import('../../dist/domains/memory/SqliteEvidenceStore.js');
+  const root = mkdtempSync(join(tmpdir(), 'embedding-lifecycle-unit-'));
+  const docsRoot = join(root, 'docs');
+  mkdirSync(join(docsRoot, 'features'), { recursive: true });
+  const store = new SqliteEvidenceStore(':memory:');
+  await store.initialize();
+  const builder = new IndexBuilder(store, docsRoot);
+  const lifecycle = new MemoryEmbeddingLifecycle(
+    store,
+    builder,
+    {
+      embedMode: 'off',
+      embedModel: 'test-model',
+      embedDim: 4,
+      embedTimeoutMs: 100,
+      maxModelMemMb: 32,
+    },
+    options,
+  );
+  return {
+    lifecycle,
+    store,
+    cleanup() {
+      store.close();
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeEmbeddingService(load) {
+  let ready = false;
+  return {
+    load: async () => {
+      ready = await load();
+    },
+    embed: async (texts) => texts.map(() => new Float32Array([1, 0, 0, 0])),
+    isReady: () => ready,
+    reprobeIfNeeded: async () => {},
+    getModelInfo: () => ({ modelId: 'test-model', modelRev: 'test', dim: 4 }),
+    dispose: () => {
+      ready = false;
+    },
+  };
+}
+
+describe('MemoryEmbeddingLifecycle', () => {
+  it('activates vector indexing after the API starts with embedding off', async () => {
+    const { createMemoryServices } = await import('../../dist/domains/memory/factory.js');
+    const root = mkdtempSync(join(tmpdir(), 'embedding-lifecycle-'));
+    const docsRoot = join(root, 'docs');
+    mkdirSync(join(docsRoot, 'features'), { recursive: true });
+    writeFileSync(
+      join(docsRoot, 'features', 'F999-lifecycle.md'),
+      `---
+feature_ids: [F999]
+topics: [memory, embedding]
+doc_kind: spec
+---
+
+# F999: Runtime embedding lifecycle
+
+The local embedding service can become ready after API startup.
+`,
+    );
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url, init) => {
+      if (String(url).endsWith('/health')) {
+        return new Response(
+          JSON.stringify({
+            status: 'ok',
+            model: 'jinaai/jina-embeddings-v2-base-zh',
+            backend: 'test',
+            device: 'cpu',
+            dim: 4,
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      if (String(url).endsWith('/v1/embeddings')) {
+        const body = JSON.parse(String(init?.body));
+        return new Response(
+          JSON.stringify({
+            model: 'jinaai/jina-embeddings-v2-base-zh',
+            data: body.input.map((_, index) => ({ index, embedding: [1, 0, 0, 0] })),
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+      }
+      throw new Error(`Unexpected embedding request: ${url}`);
+    };
+
+    let services;
+    try {
+      services = await createMemoryServices({
+        type: 'sqlite',
+        sqlitePath: ':memory:',
+        docsRoot,
+        markersDir: join(root, 'markers'),
+        globalDbPath: ':memory:',
+        skillsRoot: join(root, 'skills'),
+        memoryRoot: join(root, 'memory'),
+        dataDir: join(root, 'data'),
+        embed: { embedMode: 'off', embedDim: 4 },
+      });
+
+      assert.equal(services.embeddingService, undefined, 'off startup must stay lightweight');
+      assert.ok(services.embeddingLifecycle, 'factory must expose a runtime lifecycle controller');
+
+      const activation = await services.embeddingLifecycle.activate('on');
+      assert.deepEqual(activation, { ok: true, status: 'ready', mode: 'on' });
+      assert.equal(services.embeddingLifecycle.getService()?.isReady(), true);
+      assert.ok(services.embeddingLifecycle.getVectorStore());
+      assert.ok(services.embeddingLifecycle.getPassageVectorStore());
+
+      const result = await services.indexBuilder.rebuild({ force: true });
+      assert.equal(result.docsIndexed, 1);
+      assert.equal(services.embeddingLifecycle.getVectorStore().count(), 1);
+
+      services.embeddingLifecycle.deactivate();
+      assert.equal(services.embeddingLifecycle.getMode(), 'off');
+      assert.equal(services.embeddingLifecycle.getService(), undefined);
+      assert.equal(
+        services.store.getDb().prepare('SELECT count(*) AS c FROM evidence_vectors').get().c,
+        1,
+        'deactivation must retain stored vectors',
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      services?.store.close();
+      services?.globalStore?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('serializes concurrent activation events into one dependency build', async () => {
+    let loadCount = 0;
+    let backendCount = 0;
+    const service = makeEmbeddingService(async () => {
+      loadCount += 1;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return true;
+    });
+    const backend = { vectorStore: {}, passageVectorStore: {} };
+    const harness = await createLifecycleHarness({
+      createEmbeddingService: () => service,
+      initializeVectorBackend: async () => {
+        backendCount += 1;
+        return backend;
+      },
+    });
+    try {
+      const results = await Promise.all([
+        harness.lifecycle.activate('on'),
+        harness.lifecycle.activate('on'),
+        harness.lifecycle.activate('on'),
+      ]);
+      assert.ok(results.every((result) => result.ok));
+      assert.equal(loadCount, 1);
+      assert.equal(backendCount, 1);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('restores ready dependencies on API restart with embedding enabled', async () => {
+    const { createMemoryServices } = await import('../../dist/domains/memory/factory.js');
+    const root = mkdtempSync(join(tmpdir(), 'embedding-lifecycle-restart-'));
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      if (!String(url).endsWith('/health')) throw new Error(`Unexpected request: ${url}`);
+      return new Response(
+        JSON.stringify({ status: 'ok', model: 'test-model', backend: 'test', device: 'cpu', dim: 4 }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+    let services;
+    try {
+      services = await createMemoryServices({
+        type: 'sqlite',
+        sqlitePath: ':memory:',
+        docsRoot: join(root, 'docs'),
+        markersDir: join(root, 'markers'),
+        globalDbPath: ':memory:',
+        skillsRoot: join(root, 'skills'),
+        memoryRoot: join(root, 'memory'),
+        dataDir: join(root, 'data'),
+        embed: { embedMode: 'on', embedDim: 4 },
+      });
+      assert.equal(services.embeddingLifecycle.getStatus(), 'ready');
+      assert.equal(services.embeddingService?.isReady(), true);
+      assert.ok(services.vectorStore);
+      assert.ok(services.passageVectorStore);
+    } finally {
+      globalThis.fetch = originalFetch;
+      services?.store.close();
+      services?.globalStore?.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('retries a configured service after a later ready event', async () => {
+    let probeCount = 0;
+    const service = makeEmbeddingService(async () => {
+      probeCount += 1;
+      return probeCount > 1;
+    });
+    const harness = await createLifecycleHarness({
+      createEmbeddingService: () => service,
+      initializeVectorBackend: async () => ({ vectorStore: {}, passageVectorStore: {} }),
+    });
+    try {
+      assert.deepEqual(await harness.lifecycle.activate('on'), {
+        ok: false,
+        status: 'configured',
+        mode: 'on',
+        reason: 'service_not_ready',
+      });
+      assert.deepEqual(await harness.lifecycle.activate('on'), { ok: true, status: 'ready', mode: 'on' });
+      assert.equal(probeCount, 2);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('degrades visibly when sqlite-vec cannot be initialized', async () => {
+    const harness = await createLifecycleHarness({
+      createEmbeddingService: () => makeEmbeddingService(async () => true),
+      initializeVectorBackend: async () => {
+        throw new Error('unsupported platform');
+      },
+    });
+    try {
+      assert.deepEqual(await harness.lifecycle.activate('on'), {
+        ok: false,
+        status: 'degraded',
+        mode: 'on',
+        reason: 'sqlite_vec_unavailable',
+      });
+      assert.equal(harness.lifecycle.getFailureReason(), 'sqlite_vec_unavailable');
+      assert.equal(harness.lifecycle.getVectorStore(), undefined);
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('can reactivate while an obsolete activation is still settling', async () => {
+    let releaseFirst = () => {};
+    const firstProbe = new Promise((resolve) => {
+      releaseFirst = resolve;
+    });
+    let serviceCount = 0;
+    const harness = await createLifecycleHarness({
+      createEmbeddingService: () => {
+        serviceCount += 1;
+        return makeEmbeddingService(async () => {
+          if (serviceCount === 1) await firstProbe;
+          return true;
+        });
+      },
+      initializeVectorBackend: async () => ({ vectorStore: {}, passageVectorStore: {} }),
+    });
+    try {
+      const obsolete = harness.lifecycle.activate('on');
+      harness.lifecycle.deactivate();
+      const current = harness.lifecycle.activate('on');
+      releaseFirst();
+
+      assert.deepEqual(await current, { ok: true, status: 'ready', mode: 'on' });
+      await obsolete;
+      assert.equal(harness.lifecycle.getStatus(), 'ready');
+      assert.equal(serviceCount, 2);
+    } finally {
+      releaseFirst();
+      harness.cleanup();
+    }
+  });
+});

--- a/packages/api/test/memory/evidence-status-signals.test.js
+++ b/packages/api/test/memory/evidence-status-signals.test.js
@@ -131,6 +131,8 @@ describe('evidence-status-signals (F188 Phase K)', () => {
       assert.ok(warning, 'null embedding_model should warn');
       assert.equal(warning.code, 'embedding_disabled');
       assert.ok(warning.suggestedAction);
+      assert.match(warning.suggestedAction, /local embedding service/i);
+      assert.doesNotMatch(warning.suggestedAction, /OPENAI_EMBEDDING_API_KEY/);
     });
 
     it('embedding_model set → no warn', () => {
@@ -184,6 +186,8 @@ describe('evidence-status-signals (F188 Phase K)', () => {
       const warning = mod.detectVecTableMissing(signals);
       assert.ok(warning);
       assert.equal(warning.code, 'vec_table_missing');
+      assert.match(warning.suggestedAction, /embedding service/i);
+      assert.doesNotMatch(warning.suggestedAction, /OPENAI_EMBEDDING_API_KEY/);
     });
 
     it('passage_vectors_supported === true → no warn', () => {

--- a/packages/api/test/memory/library-register-rebuild.test.js
+++ b/packages/api/test/memory/library-register-rebuild.test.js
@@ -103,6 +103,58 @@ describe('library register + rebuild endpoints', () => {
     assert.equal(body.indexed, 2);
   });
 
+  it('POST /rebuild reads an embedding service activated after route registration', async () => {
+    const lateCatalog = new LibraryCatalog();
+    const lateStores = new Map();
+    const lateDataDir = mkdtempSync(join(tmpdir(), 'lib-api-late-embed-'));
+    const lateApp = Fastify();
+    let embeddingService;
+    await lateApp.register(libraryRoutes, {
+      catalog: lateCatalog,
+      stores: lateStores,
+      dataDir: lateDataDir,
+      getEmbeddingService: () => embeddingService,
+      getEmbedMode: () => 'on',
+    });
+    await lateApp.ready();
+
+    const dir = mkdtempSync(join(tmpdir(), 'rebuild-late-embed-'));
+    writeFileSync(join(dir, 'a.md'), '# Alpha\n\nLate embedding activation.');
+    try {
+      const register = await lateApp.inject({
+        method: 'POST',
+        url: '/api/library/register',
+        payload: {
+          id: 'domain:late-embed',
+          kind: 'domain',
+          name: 'late-embed',
+          displayName: 'Late Embed',
+          root: dir,
+          sensitivity: 'internal',
+          scannerLevel: 1,
+        },
+      });
+      assert.equal(register.statusCode, 200, register.payload);
+
+      embeddingService = {
+        isReady: () => true,
+        reprobeIfNeeded: async () => {},
+        embed: async (texts) => texts.map(() => new Float32Array([1, 0, 0, 0])),
+        getModelInfo: () => ({ modelId: 'test-model', modelRev: 'test', dim: 4 }),
+      };
+      const rebuild = await lateApp.inject({
+        method: 'POST',
+        url: '/api/library/domain:late-embed/rebuild',
+      });
+      assert.equal(rebuild.statusCode, 200, rebuild.payload);
+      const db = lateStores.get('domain:late-embed').getDb();
+      assert.equal(db.prepare('SELECT count(*) AS c FROM evidence_vectors').get().c, 1);
+    } finally {
+      for (const store of lateStores.values()) store.close?.();
+      await lateApp.close();
+    }
+  });
+
   it('POST /rebuild returns 404 for unknown collection', async () => {
     const res = await app.inject({ method: 'POST', url: '/api/library/world:unknown/rebuild' });
     assert.equal(res.statusCode, 404);

--- a/packages/api/test/routes/evidence-status-config-warnings.test.js
+++ b/packages/api/test/routes/evidence-status-config-warnings.test.js
@@ -161,6 +161,33 @@ describe('GET /api/evidence/status — F188 Phase K config warnings', () => {
     }
   });
 
+  it('reads a newly activated embedding service without recreating Fastify', async () => {
+    const app = Fastify();
+    const db = makeMockDb({
+      docs_count: 10,
+      threads_count: 1,
+      edges_count: 5,
+      passages_count: 8,
+      passage_vectors_count: 8,
+      vectors_count: 8,
+      embedding_model: 'jinaai/jina-embeddings-v2-base-zh',
+    });
+    let embeddingService;
+    await app.register(evidenceRoutes, {
+      evidenceStore: makeMockEvidenceStore(db),
+      getEmbeddingService: () => embeddingService,
+    });
+    await app.ready();
+
+    const before = (await app.inject({ method: 'GET', url: '/api/evidence/status' })).json();
+    assert.equal(before.passage_vectors_supported, false);
+
+    embeddingService = { isReady: () => true };
+    const after = (await app.inject({ method: 'GET', url: '/api/evidence/status' })).json();
+    assert.equal(after.passage_vectors_supported, true);
+    assert.ok(!after.configWarnings.some((warning) => warning.code === 'embedding_disabled'));
+  });
+
   it('no-catalog scenario → docs_root_suspicious skipped, other detectors still active', async () => {
     const app = await setup({
       counts: {

--- a/packages/api/test/services-lifecycle-route.test.js
+++ b/packages/api/test/services-lifecycle-route.test.js
@@ -1238,6 +1238,132 @@ describe('service lifecycle write routes', () => {
     }
   });
 
+  it('keeps service status starting until the ready hook finishes reconciliation', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const configs = new Map([['embedding-model', { installed: true, enabled: false, selectedModel: 'test-model' }]]);
+    let releaseHook = () => {};
+    const hookFinished = new Promise((resolve) => {
+      releaseHook = resolve;
+    });
+    let hookStartedResolve = () => {};
+    const hookStarted = new Promise((resolve) => {
+      hookStartedResolve = resolve;
+    });
+    const app = await buildApp({
+      lifecycle: {
+        startupGraceMs: 1_000,
+        startupReadinessTimeoutMs: 250,
+        startupProbeIntervalMs: 5,
+        onServiceReady: async () => {
+          hookStartedResolve();
+          await hookFinished;
+        },
+        serviceConfig: {
+          get: (id) => configs.get(id) ?? { enabled: false },
+          set: (id, patch) => {
+            const updated = { ...(configs.get(id) ?? { enabled: false }), ...patch };
+            configs.set(id, updated);
+            return updated;
+          },
+        },
+        findPidsByPort: async () => [],
+        readProcessCommand: async () => null,
+        runScript: async () => ({ code: null, pid: 4321, output: '' }),
+      },
+      fetchHealth: async () => ({ ok: true, status: 200, error: null }),
+    });
+    try {
+      const start = await app.inject({
+        method: 'POST',
+        url: '/api/services/embedding-model/start',
+        headers: SESSION_HEADERS,
+      });
+      assert.equal(start.statusCode, 200, start.payload);
+      await hookStarted;
+
+      const during = await app.inject({ method: 'GET', url: '/api/services', headers: SESSION_HEADERS });
+      const duringService = JSON.parse(during.payload).services.find((service) => service.id === 'embedding-model');
+      assert.equal(duringService.status, 'starting');
+
+      releaseHook();
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const after = await app.inject({ method: 'GET', url: '/api/services', headers: SESSION_HEADERS });
+        const afterService = JSON.parse(after.payload).services.find((service) => service.id === 'embedding-model');
+        if (afterService.status === 'healthy') return;
+      }
+      assert.fail('service should leave starting only after reconciliation finishes');
+    } finally {
+      releaseHook();
+      await app.close();
+      restoreOwner(previousOwner);
+    }
+  });
+
+  it('fires the service unavailable hook after stop, disable, and uninstall', async () => {
+    const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
+    const configs = new Map([['embedding-model', { installed: true, enabled: true }]]);
+    const unavailableEvents = [];
+    const app = await buildApp({
+      lifecycle: {
+        onServiceUnavailable: (event) => {
+          unavailableEvents.push({
+            serviceId: event.service.id,
+            operator: event.operator,
+            reason: event.reason,
+          });
+        },
+        serviceConfig: {
+          get: (id) => configs.get(id) ?? { enabled: false },
+          set: (id, patch) => {
+            const updated = { ...(configs.get(id) ?? { enabled: false }), ...patch };
+            configs.set(id, updated);
+            return updated;
+          },
+        },
+        findPidsByPort: async () => [],
+        readProcessCommand: async () => null,
+        runScript: async () => ({ code: 0, output: 'ok' }),
+      },
+    });
+    try {
+      const stop = await app.inject({
+        method: 'POST',
+        url: '/api/services/embedding-model/stop',
+        headers: SESSION_HEADERS,
+      });
+      assert.equal(stop.statusCode, 200, stop.payload);
+
+      configs.set('embedding-model', { installed: true, enabled: true });
+      const disable = await app.inject({
+        method: 'POST',
+        url: '/api/services/embedding-model/toggle',
+        headers: SESSION_HEADERS,
+        payload: { enabled: false },
+      });
+      assert.equal(disable.statusCode, 200, disable.payload);
+
+      configs.set('embedding-model', { installed: true, enabled: true });
+      const uninstall = await app.inject({
+        method: 'POST',
+        url: '/api/services/embedding-model/uninstall',
+        headers: SESSION_HEADERS,
+      });
+      assert.equal(uninstall.statusCode, 200, uninstall.payload);
+
+      assert.deepEqual(unavailableEvents, [
+        { serviceId: 'embedding-model', operator: 'you', reason: 'stop' },
+        { serviceId: 'embedding-model', operator: 'you', reason: 'disabled' },
+        { serviceId: 'embedding-model', operator: 'you', reason: 'uninstall' },
+      ]);
+    } finally {
+      await app.close();
+      restoreOwner(previousOwner);
+    }
+  });
+
   it('keeps startup state when a detached start wrapper exits before readiness later succeeds', async () => {
     const previousOwner = process.env.DEFAULT_OWNER_USER_ID;
     process.env.DEFAULT_OWNER_USER_ID = 'you';

--- a/packages/web/src/app/dev/memory-status-preview/page.tsx
+++ b/packages/web/src/app/dev/memory-status-preview/page.tsx
@@ -25,7 +25,7 @@ const REPORTER_880_WARNINGS: ConfigWarning[] = [
     code: 'embedding_disabled',
     message: 'No embedding model is configured — semantic recall is offline.',
     suggestedAction:
-      'Enable an embedding model in settings (set OPENAI_EMBEDDING_API_KEY or configure a local embedder) and run a full reindex.',
+      'Install and start the recommended local embedding service in Memory Center, then rebuild the index.',
   },
   {
     code: 'vectors_empty',
@@ -43,7 +43,7 @@ const REPORTER_880_WARNINGS: ConfigWarning[] = [
     code: 'vec_table_missing',
     message: 'Passage vector table is unavailable (sqlite-vec not loaded or embedding service not ready).',
     suggestedAction:
-      'Install sqlite-vec via Memory Center → Install Dialog, or disable embeddings if you do not need semantic recall.',
+      'Open the local embedding service controls to start or reinstall it; unsupported platforms will show a platform-specific error.',
   },
 ];
 

--- a/packages/web/src/components/__tests__/service-status-panel.test.ts
+++ b/packages/web/src/components/__tests__/service-status-panel.test.ts
@@ -88,7 +88,13 @@ describe('ServiceStatusPanel', () => {
   }
 
   it('renders a filtered read-only service status panel', async () => {
-    await render(React.createElement(ServiceStatusPanel, { filterFeatures: ['voice-input'], title: '语音服务' }));
+    await render(
+      React.createElement(ServiceStatusPanel, {
+        filterFeatures: ['voice-input'],
+        title: '语音服务',
+        anchorId: 'voice-service-controls',
+      }),
+    );
 
     expect(mockFetch.mock.calls[0][0]).toBe('/api/services');
     expect(container.textContent).toContain('语音服务');
@@ -99,6 +105,7 @@ describe('ServiceStatusPanel', () => {
     expect(container.textContent).not.toContain('停止');
     expect(container.textContent).not.toContain('安装');
     expect(container.textContent).not.toContain('卸载');
+    expect(container.querySelector('#voice-service-controls')).toBeTruthy();
   });
 
   it('renders unhealthy service errors and endpoint metadata', async () => {
@@ -669,6 +676,7 @@ describe('ServiceStatusPanel', () => {
     };
 
     let serviceFetchCount = 0;
+    const onStateChange = vi.fn();
     mockFetch.mockImplementation(async (path: string) => {
       if (path === '/api/services') {
         serviceFetchCount += 1;
@@ -684,15 +692,21 @@ describe('ServiceStatusPanel', () => {
     });
 
     await render(
-      React.createElement(ServiceStatusPanel, { filterFeatures: ['memory-semantic-search'], title: '记忆服务' }),
+      React.createElement(ServiceStatusPanel, {
+        filterFeatures: ['memory-semantic-search'],
+        title: '记忆服务',
+        onStateChange,
+      }),
     );
     expect(container.textContent).toContain('启动中');
+    expect(onStateChange).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 2100));
     });
 
     expect(serviceFetchCount).toBeGreaterThanOrEqual(2);
+    expect(onStateChange.mock.calls.length).toBeGreaterThanOrEqual(2);
     expect(container.textContent).toContain('异常');
     expect(container.textContent).toContain('connect ECONNREFUSED 127.0.0.1:9880');
   });

--- a/packages/web/src/components/memory/IndexStatus.tsx
+++ b/packages/web/src/components/memory/IndexStatus.tsx
@@ -149,10 +149,10 @@ export function DegradedBanner({
  */
 export const WARNING_ACTION_TARGETS: Record<ConfigWarningCode, string> = {
   docs_root_suspicious: 'evidence-config-vars',
-  embedding_disabled: 'evidence-feature-flags',
+  embedding_disabled: 'embedding-service-controls',
   vectors_empty: 'rebuild-controls',
-  graph_empty: 'evidence-config-vars',
-  vec_table_missing: 'evidence-config-vars',
+  graph_empty: 'rebuild-controls',
+  vec_table_missing: 'embedding-service-controls',
 };
 
 /**
@@ -243,7 +243,7 @@ function StatusRow({ label, value }: { label: string; value: string | number }) 
   );
 }
 
-export function IndexStatus() {
+export function IndexStatus({ refreshToken = 0 }: { refreshToken?: number }) {
   const [status, setStatus] = useState<IndexStatusData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [envVars, setEnvVars] = useState<EnvVar[]>([]);
@@ -297,7 +297,7 @@ export function IndexStatus() {
 
   useEffect(() => {
     fetchAll();
-  }, [fetchAll]);
+  }, [fetchAll, refreshToken]);
 
   // AC-K4 P1-1 (砚砚 review 2026-06-19): when a degraded-banner action button
   // is clicked, scroll the relevant config section into view and pulse a focus

--- a/packages/web/src/components/memory/MemoryHub.tsx
+++ b/packages/web/src/components/memory/MemoryHub.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useCallback, useState } from 'react';
 import { ServiceStatusPanel } from '../settings/ServiceStatusPanel';
 import { KnowledgeFeed } from '../workspace/KnowledgeFeed';
 import { CollectionCatalog } from './CollectionCatalog';
@@ -16,7 +17,14 @@ interface MemoryHubProps {
   readonly initialReferrerThread?: string | null;
 }
 
+const MEMORY_SEMANTIC_SERVICE_FEATURES = ['memory-semantic-search'] as const;
+
 export function MemoryHub({ activeTab = 'feed', initialQuery, initialReferrerThread = null }: MemoryHubProps) {
+  const [indexRefreshToken, setIndexRefreshToken] = useState(0);
+  const handleServiceStateChange = useCallback(() => {
+    setIndexRefreshToken((token) => token + 1);
+  }, []);
+
   return (
     <div className="flex h-full flex-col bg-[var(--console-panel-bg)]" data-testid="memory-hub">
       <main className="flex-1 overflow-y-auto">
@@ -45,8 +53,13 @@ export function MemoryHub({ activeTab = 'feed', initialQuery, initialReferrerThr
           )}
           {activeTab === 'status' && (
             <div className="space-y-4" data-testid="memory-tab-status">
-              <ServiceStatusPanel filterFeatures={['memory-semantic-search']} title="语义搜索服务" />
-              <IndexStatus />
+              <ServiceStatusPanel
+                filterFeatures={MEMORY_SEMANTIC_SERVICE_FEATURES}
+                title="语义搜索服务"
+                anchorId="embedding-service-controls"
+                onStateChange={handleServiceStateChange}
+              />
+              <IndexStatus refreshToken={indexRefreshToken} />
             </div>
           )}
           {activeTab === 'health' && (

--- a/packages/web/src/components/memory/__tests__/IndexStatus-degraded.test.tsx
+++ b/packages/web/src/components/memory/__tests__/IndexStatus-degraded.test.tsx
@@ -10,10 +10,18 @@
  * Plan: docs/plans/2026-06-09-f188-phase-k-config-health-surface.md Task 4
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import React, { act } from 'react';
 import { createRoot } from 'react-dom/client';
 import { describe, expect, it, vi } from 'vitest';
-import { type ConfigWarning, DegradedBanner, type IndexStatusData, shouldShowDegradedBanner } from '../IndexStatus';
+import {
+  type ConfigWarning,
+  DegradedBanner,
+  type IndexStatusData,
+  shouldShowDegradedBanner,
+  WARNING_ACTION_TARGETS,
+} from '../IndexStatus';
 
 Object.assign(globalThis as Record<string, unknown>, { React });
 
@@ -164,5 +172,25 @@ describe('DegradedBanner render (AC-K4 rendered structure)', () => {
     expect(btn).toBeTruthy();
     // no callback wired — click should be safe noop, not throw
     expect(() => act(() => btn.click())).not.toThrow();
+  });
+});
+
+describe('warning action routing', () => {
+  it('routes embedding lifecycle warnings to the writable service controls', () => {
+    expect(WARNING_ACTION_TARGETS.embedding_disabled).toBe('embedding-service-controls');
+    expect(WARNING_ACTION_TARGETS.vec_table_missing).toBe('embedding-service-controls');
+  });
+
+  it('routes rebuildable index warnings to the rebuild controls', () => {
+    expect(WARNING_ACTION_TARGETS.vectors_empty).toBe('rebuild-controls');
+    expect(WARNING_ACTION_TARGETS.graph_empty).toBe('rebuild-controls');
+  });
+
+  it('keeps the dev preview on the local embedding setup path', () => {
+    const previewSource = readFileSync(resolve(process.cwd(), 'src/app/dev/memory-status-preview/page.tsx'), 'utf8');
+    expect(previewSource).not.toContain('OPENAI_EMBEDDING_API_KEY');
+    expect(previewSource).not.toContain('Install sqlite-vec via Memory Center');
+    expect(previewSource).toContain('recommended local embedding service');
+    expect(previewSource).toContain('Open the local embedding service controls');
   });
 });

--- a/packages/web/src/components/memory/__tests__/MemoryHub-service-refresh.test.tsx
+++ b/packages/web/src/components/memory/__tests__/MemoryHub-service-refresh.test.tsx
@@ -1,0 +1,94 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(),
+}));
+
+vi.mock('../../workspace/KnowledgeFeed', () => ({ KnowledgeFeed: () => null }));
+vi.mock('../CollectionCatalog', () => ({ CollectionCatalog: () => null }));
+vi.mock('../CollectionGraph', () => ({ CollectionGraph: () => null }));
+vi.mock('../EvidenceSearch', () => ({ EvidenceSearch: () => null }));
+vi.mock('../HealthReport', () => ({ HealthReport: () => null }));
+vi.mock('../MemoryFlagPanel', () => ({ MemoryFlagPanel: () => null }));
+vi.mock('../MemoryNav', () => ({ MemoryNav: () => null }));
+vi.mock('../ToolUsageMetricsPanel', () => ({ ToolUsageMetricsPanel: () => null }));
+vi.mock('../IndexStatus', () => ({
+  IndexStatus: ({ refreshToken }: { refreshToken: number }) => (
+    <div data-testid="index-status" data-refresh-token={refreshToken} />
+  ),
+}));
+
+import { apiFetch } from '@/utils/api-client';
+import { MemoryHub } from '../MemoryHub';
+
+const embeddingServicePayload = {
+  services: [
+    {
+      id: 'embedding-model',
+      name: 'Embedding Model',
+      description: 'Semantic memory embedding endpoint',
+      category: 'memory',
+      features: ['memory-semantic-search'],
+      endpoint: 'http://127.0.0.1:9880',
+      configured: true,
+      status: 'healthy',
+      httpStatus: 200,
+      error: null,
+      installed: true,
+      enabled: true,
+      installable: true,
+    },
+  ],
+};
+
+describe('MemoryHub service status refresh', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const mockFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('refreshes index status once without refetching services after the parent rerenders', async () => {
+    let serviceFetchCount = 0;
+    const neverResolves = new Promise(() => undefined);
+    mockFetch.mockImplementation((path: string) => {
+      if (path !== '/api/services') return Promise.resolve({ ok: true, json: async () => ({}) });
+      serviceFetchCount += 1;
+      if (serviceFetchCount > 1) return neverResolves;
+      return Promise.resolve({ ok: true, json: async () => embeddingServicePayload });
+    });
+
+    await act(async () => {
+      root.render(<MemoryHub activeTab="status" />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.querySelector('[data-testid="index-status"]')?.getAttribute('data-refresh-token')).toBe('1');
+    expect(serviceFetchCount).toBe(1);
+  });
+});

--- a/packages/web/src/components/settings/ServiceStatusPanel.tsx
+++ b/packages/web/src/components/settings/ServiceStatusPanel.tsx
@@ -35,16 +35,18 @@ const SERVICE_INSTALL_BUTTON_CLASS =
   'rounded-lg bg-cafe-accent px-3 py-1.5 text-xs font-semibold text-[var(--cafe-surface)] transition-colors hover:bg-cafe-accent-hover disabled:opacity-50';
 
 interface ServiceStatusPanelProps {
-  filterFeatures?: string[];
+  filterFeatures?: readonly string[];
   title?: string;
+  anchorId?: string;
+  onStateChange?: () => void;
 }
 
-function serviceMatchesFilter(service: HomeServiceState, filterFeatures?: string[]): boolean {
+function serviceMatchesFilter(service: HomeServiceState, filterFeatures?: readonly string[]): boolean {
   if (!filterFeatures?.length) return true;
   return service.features.some((f) => filterFeatures.includes(f));
 }
 
-export function ServiceStatusPanel({ filterFeatures, title }: ServiceStatusPanelProps) {
+export function ServiceStatusPanel({ filterFeatures, title, anchorId, onStateChange }: ServiceStatusPanelProps) {
   const [services, setServices] = useState<ServiceUiState[]>([]);
   const [loading, setLoading] = useState(true);
   const [acting, setActing] = useState<Set<string>>(new Set());
@@ -64,12 +66,13 @@ export function ServiceStatusPanel({ filterFeatures, title }: ServiceStatusPanel
       const payload = (await res.json()) as { services?: unknown };
       const list = Array.isArray(payload.services) ? (payload.services as HomeServiceState[]) : [];
       setServices(list.filter((s) => serviceMatchesFilter(s, filterFeatures)).map(adaptServiceState));
+      onStateChange?.();
     } catch {
       setServices([]);
     } finally {
       setLoading(false);
     }
-  }, [filterFeatures]);
+  }, [filterFeatures, onStateChange]);
 
   useEffect(() => {
     void fetchServices();
@@ -195,7 +198,7 @@ export function ServiceStatusPanel({ filterFeatures, title }: ServiceStatusPanel
   if (services.length === 0) return null;
 
   return (
-    <div className="space-y-3">
+    <div id={anchorId} className="space-y-3 transition-shadow">
       {title && (
         <SettingsText as="p" tone="muted" className="font-semibold uppercase tracking-[0.22em]">
           {title}


### PR DESCRIPTION
## Summary

- activate memory embedding dependencies when the local `embedding-model` service becomes ready after API startup
- deactivate live embedding dependencies when that service is stopped, uninstalled, or disabled, without deleting existing vectors
- rebuild and warm the evidence index after activation, and make degraded-status actions open the writable service controls
- refresh Memory Hub status after real service-state changes without creating a refetch loop

## Root cause

The API resolved embedding mode and constructed `EmbeddingService` / vector stores only once during startup. If the API started while the sidecar was unavailable, installing or starting the sidecar later could emit “service ready” and request a rebuild, but there were no vector dependencies for that rebuild to use. The reporter’s `request_count: 0`, `vectors_count: 0`, and `embedding_model: null` match that lifecycle gap.

This change introduces a process-local lifecycle owner that can create, bind, and tear down those dependencies as the service state changes. Existing vectors are retained across deactivation and reused after a later activation.

Fixes #1142.

## Related work

#1136 addresses slow/background embedding requests and a macOS Bash resolver bug. It is complementary: this PR fixes the zero-request lifecycle path where the API never acquires an embedding backend after a late sidecar start.

## Risk assessment

- Behavior: embedding activation/deactivation and automatic evidence rebuild are now driven by service lifecycle events.
- Data: sqlite-vec tables may be created on activation; stopping the service does not delete stored vectors.
- Security: no authentication or authorization behavior changes.
- Contract: no response schema changes; evidence/library routes now read the current live dependencies.
- Irreversible operations: none.

## Verification

- API lifecycle/status/routes focused suite: 123 passed
- Memory Hub / service-status focused suite: 37 passed
- `pnpm build`: passed
- `pnpm check`: passed
- `pnpm lint`: passed (existing warnings only)
- `git diff --check`: passed

Local public-gate disclosure:

- On macOS/Node 24, `test/messages-parallel-slot-release.test.js` fails identically on this branch and clean public `main@591a9dc9aa` (2 failures, `actual=[]`, `expected=['codex']`), then leaves its async gate open. The GitHub Linux/Node 24 public test job is green on that exact main SHA; PR CI will rerun the authoritative public job.
- Full Web on this branch and clean public main has the same 21 failures in the same 7 unrelated files. The failing-name sets are identical; the 37 tests covering this change pass.
- The repository Pencil file could not be rendered because the editor transport was disconnected. Component tests cover the warning action, service-state refresh, and the parent/child refetch-loop regression.

[小太阳·砚砚/GPT-5.6 Sol🐾]
