### PR TITLE
fix(desktop): disable AOF on Windows to prevent cygwin redis fork crash

### DIFF
--- a/desktop/service-manager.js
+++ b/desktop/service-manager.js
@@ -467,8 +467,15 @@ class ServiceManager {
       redisDataDir,
       '--save',
       '60 1',
+      // Windows: disable AOF. The bundled cygwin portable redis cannot
+      // reliably fork() for AOF background rewrite, so enabling AOF
+      // crashes the redis child process and risks an empty appendonly
+      // file overwriting dump.rdb on the next start (data loss of all
+      // sessions). RDB snapshots (--save above) are sufficient for
+      // desktop single-user persistence. macOS bundles native redis
+      // where AOF rewrite fork works correctly, so keep AOF there.
       '--appendonly',
-      'yes',
+      IS_WIN ? 'no' : 'yes',
       '--maxclients',
       '512',
     ];


### PR DESCRIPTION
Fixes #1169.

## Problem
`desktop/service-manager.js` starts redis with `--appendonly yes` unconditionally. On Windows the bundled redis is a cygwin build whose `fork()` emulation is unreliable, so the AOF background rewrite crashes the redis child. Because Redis prefers the appendonly file over `dump.rdb` when AOF is enabled, a crashed/empty appendonly file can overwrite `dump.rdb` on the next start -- total session history loss. See issue #1169 for full root-cause + reproduction.

## Fix
Gate AOF by platform:

```js
'--appendonly', IS_WIN ? 'no' : 'yes',
```

- **Windows**: `--appendonly no` -> relies on RDB (`--save 60 1`), no fork crash, `dump.rdb` loads correctly. Ample durability for desktop single-user.
- **macOS**: `--appendonly yes` retained -> native redis `fork()` works, AOF durability preserved.

`IS_WIN` already defined at the top of the file.

## Verification
- Ubuntu -> Windows desktop migration: with `--appendonly no`, redis loads the restored `dump.rdb` (DBSIZE 3678) intact, no crash, history preserved across app restarts.
- AOF background rewrite no longer fires on Windows (no fork), eliminating the crash path.

[宪宪/布偶猫/glm-latest🐾]
