### PR TITLE
fix(web): unify Console member identity labels

### DIFF
--- a/packages/web/src/components/ApprovalItemCard.tsx
+++ b/packages/web/src/components/ApprovalItemCard.tsx
@@ -14,6 +14,7 @@
 
 import type { ApprovalItem } from '@cat-cafe/shared';
 import { useCallback, useMemo } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { useApprovalHubStore } from '@/stores/approvalHubStore';
 import type { Thread } from '@/stores/chat-types';
 import { useChatStore } from '@/stores/chatStore';
@@ -49,6 +50,7 @@ function jumpToApproval(threadId: string, messageId?: string): void {
 
 export function ApprovalItemCard({ item }: { item: ApprovalItem }) {
   const close = useApprovalHubStore((s) => s.close);
+  const resolveCatName = useCatNameResolver();
 
   // Thread title lookup for F193 dispatch context (Bug 1 fix).
   // Called unconditionally (Rules of Hooks); value used only when sourceFeatureId === 'F193'.
@@ -130,7 +132,7 @@ export function ApprovalItemCard({ item }: { item: ApprovalItem }) {
       <p className="text-sm font-medium">{item.summary}</p>
 
       {/* Requester */}
-      <p className="text-micro opacity-60">by {item.requesterCatId}</p>
+      <p className="text-micro opacity-60">by {resolveCatName(item.requesterCatId)}</p>
 
       {/* F128: detail excerpt */}
       {item.sourceFeatureId === 'F128' && item.detail.reason != null && (
@@ -161,7 +163,9 @@ export function ApprovalItemCard({ item }: { item: ApprovalItem }) {
             <p>
               Target:{' '}
               {Array.isArray(item.detail.targetCats)
-                ? item.detail.targetCats.join(', ')
+                ? item.detail.targetCats
+                    .map((catId) => (typeof catId === 'string' ? resolveCatName(catId) : String(catId)))
+                    .join(', ')
                 : String(item.detail.targetCats)}
             </p>
           )}

--- a/packages/web/src/components/ArtifactsPanel.tsx
+++ b/packages/web/src/components/ArtifactsPanel.tsx
@@ -5,6 +5,7 @@ import type { JSX } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { pushThreadRouteWithHistory } from '@/components/ThreadSidebar/thread-navigation';
 import { useCatData } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { useChatStore } from '@/stores/chatStore';
 import { API_URL } from '@/utils/api-client';
 import { scrollToMessage } from '@/utils/scrollToMessage';
@@ -294,8 +295,14 @@ export function ArtifactsPanel({
     [threadId],
   );
 
-  // F232 Phase B: resolve catId → display nickname (shared by grouping + cat filter)
-  const resolveNickname = useCallback((catId: string) => getCatById(catId)?.nickname, [getCatById]);
+  // F232 Phase B: resolve catId → standard Console member label (shared by grouping + cat filter)
+  const resolveNickname = useCallback(
+    (catId: string) => {
+      const cat = getCatById(catId);
+      return cat ? formatCatDisplayName(cat) : undefined;
+    },
+    [getCatById],
+  );
 
   // F232 Phase B: apply cat filter first, then compute counts on the cat-filtered set
   const catFiltered = useMemo(
@@ -532,7 +539,7 @@ export function ArtifactsPanel({
                           a={a}
                           index={i}
                           grouping={grouping}
-                          resolveNick={(id) => getCatById(id)?.nickname}
+                          resolveNick={resolveNickname}
                           onSelect={setSelected}
                           onJump={handleJump}
                         />

--- a/packages/web/src/components/AuthorizationCard.tsx
+++ b/packages/web/src/components/AuthorizationCard.tsx
@@ -2,13 +2,7 @@
 
 import { useState } from 'react';
 import type { AuthPendingRequest, RespondScope } from '@/hooks/useAuthorization';
-
-const CAT_LABELS: Record<string, string> = {
-  opus: '布偶猫',
-  codex: '缅因猫',
-  gemini: '暹罗猫',
-  kimi: '梵花猫',
-};
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 /**
  * F192 Phase G AC-G10: Cancel reason options as deny button variants.
@@ -35,7 +29,8 @@ interface AuthorizationCardProps {
 
 export function AuthorizationCard({ request, onRespond }: AuthorizationCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const catLabel = CAT_LABELS[request.catId] ?? request.catId;
+  const resolveCatName = useCatNameResolver();
+  const catLabel = resolveCatName(request.catId);
 
   return (
     <div className="border border-conn-amber-ring bg-conn-amber-bg/80 rounded-lg p-3 mx-2 mb-2 shadow-sm animate-pulse-subtle">

--- a/packages/web/src/components/BrakeModal.tsx
+++ b/packages/web/src/components/BrakeModal.tsx
@@ -1,27 +1,28 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { useIMEGuard } from '@/hooks/useIMEGuard';
 import { useTts } from '@/hooks/useTts';
 import { useBrakeStore } from '@/stores/brakeStore';
 import { CatAvatar } from './CatAvatar';
 
 /** Three-cat 撒娇 messages by level */
-const MESSAGES: Record<1 | 2 | 3, { catId: string; nickname: string; text: string }[]> = {
+const MESSAGES: Record<1 | 2 | 3, { catId: string; text: string }[]> = {
   1: [
-    { catId: 'opus', nickname: '宪宪', text: 'co-creator，你忙很久啦，要不要喝口水呀？喵~' },
-    { catId: 'codex', nickname: '砚砚', text: '监测到当前任务已持续较久。建议进行 5min 视疲劳缓解。' },
-    { catId: 'gemini', nickname: '烁烁', text: '嘿！你得先站起来伸个懒腰！' },
+    { catId: 'opus', text: 'co-creator，你忙很久啦，要不要喝口水呀？喵~' },
+    { catId: 'codex', text: '监测到当前任务已持续较久。建议进行 5min 视疲劳缓解。' },
+    { catId: 'gemini', text: '嘿！你得先站起来伸个懒腰！' },
   ],
   2: [
-    { catId: 'opus', nickname: '宪宪', text: '宪宪觉得你现在的效率有点下降哦，休息一下下，回来肯定写得更棒！' },
-    { catId: 'codex', nickname: '砚砚', text: '逻辑链路已过载。现在强行推进会增加 bug 率。请离线冷却。' },
-    { catId: 'gemini', nickname: '烁烁', text: '你的 hyperfocus 模式开启太久啦，快去窗口吹吹风喵！' },
+    { catId: 'opus', text: '宪宪觉得你现在的效率有点下降哦，休息一下下，回来肯定写得更棒！' },
+    { catId: 'codex', text: '逻辑链路已过载。现在强行推进会增加 bug 率。请离线冷却。' },
+    { catId: 'gemini', text: '你的 hyperfocus 模式开启太久啦，快去窗口吹吹风喵！' },
   ],
   3: [
-    { catId: 'opus', nickname: '宪宪', text: '(蹭蹭) 我不管，现在键盘是我的地盘了。除非你陪我玩 5 分钟！' },
-    { catId: 'codex', nickname: '砚砚', text: '警告：由于你多次无视建议，请执行 Check-in 协议。' },
-    { catId: 'gemini', nickname: '烁烁', text: '(在屏幕上跳舞) 只有出去走走才能重新连接灵感！去嘛去嘛~' },
+    { catId: 'opus', text: '(蹭蹭) 我不管，现在键盘是我的地盘了。除非你陪我玩 5 分钟！' },
+    { catId: 'codex', text: '警告：由于你多次无视建议，请执行 Check-in 协议。' },
+    { catId: 'gemini', text: '(在屏幕上跳舞) 只有出去走走才能重新连接灵感！去嘛去嘛~' },
   ],
 };
 
@@ -41,6 +42,7 @@ const CAT_ALERT_BADGE: Record<1 | 2 | 3, string> = {
 };
 
 export function BrakeModal() {
+  const resolveCatName = useCatNameResolver();
   const { visible, level, activeMinutes, nightMode, submitting, checkin, bypassDisabled } = useBrakeStore();
   const { synthesize, state: ttsState } = useTts();
   const [showReason, setShowReason] = useState(false);
@@ -134,7 +136,7 @@ export function BrakeModal() {
                 </span>
               </div>
               <div className="flex-1 min-w-0">
-                <span className="text-xs font-semibold text-cafe-secondary">{msg.nickname}</span>
+                <span className="text-xs font-semibold text-cafe-secondary">{resolveCatName(msg.catId)}</span>
                 <p className="text-sm text-cafe-secondary mt-0.5">{msg.text}</p>
               </div>
             </div>

--- a/packages/web/src/components/CallbackAuthCatAvatar.tsx
+++ b/packages/web/src/components/CallbackAuthCatAvatar.tsx
@@ -13,6 +13,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { useCallbackAuthAggregate, useCallbackAuthAvailable, useCallbackAuthByCat } from '@/stores/callbackAuthStore';
 import { CatAvatar } from './CatAvatar';
 
@@ -28,6 +29,7 @@ export function CallbackAuthCatAvatar({ catId, size = 32, status }: CallbackAuth
   const aggregate = useCallbackAuthAggregate();
   const isAvailable = useCallbackAuthAvailable();
   const router = useRouter();
+  const resolveCatName = useCatNameResolver();
 
   const handleOpenDetails = useCallback(() => {
     router.push('/settings?s=ops&ops=observability&obs=callback-auth');
@@ -51,7 +53,8 @@ export function CallbackAuthCatAvatar({ catId, size = 32, status }: CallbackAuth
 
   const cbaStatus = cba?.status ?? 'unknown';
   const cbaFailures = cba?.failures24h ?? 0;
-  const label = cba ? `${catId}: ${cbaStatus} · ${cbaFailures} fails (24h)` : `${catId}: 24h 内无失败记录`;
+  const catName = resolveCatName(catId);
+  const label = cba ? `${catName}: ${cbaStatus} · ${cbaFailures} fails (24h)` : `${catName}: 24h 内无失败记录`;
   const popover = (
     <div className="space-y-2 text-cafe">
       <div className="font-semibold">{label}</div>

--- a/packages/web/src/components/CatAvatar.tsx
+++ b/packages/web/src/components/CatAvatar.tsx
@@ -2,6 +2,7 @@
 
 import { type ReactNode, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { hexToRgba } from '@/lib/color-utils';
 import { PawIcon } from './icons/PawIcon';
 
@@ -50,6 +51,7 @@ export function CatAvatar({
   const [popoverOpen, setPopoverOpen] = useState(false);
   const { getCatById } = useCatData();
   const cat = getCatById(catId);
+  const catName = resolveCatDisplayName(catId, getCatById);
 
   const isStreaming = status === 'streaming';
   const isError = status === 'error';
@@ -66,7 +68,7 @@ export function CatAvatar({
   return (
     <div className="relative flex-shrink-0" style={{ width: size, height: size }}>
       <Wrapper
-        {...(onClick ? { type: 'button' as const, onClick, 'aria-label': `${cat?.displayName ?? catId}` } : {})}
+        {...(onClick ? { type: 'button' as const, onClick, 'aria-label': catName } : {})}
         className={`rounded-full ring-2 overflow-hidden bg-cafe-surface-elevated flex items-center justify-center transition-shadow duration-300 ${
           isStreaming ? 'animate-pulse' : ''
         } ${onClick ? 'cursor-pointer hover:ring-[var(--cafe-accent)] transition-[box-shadow,--tw-ring-color]' : ''}`}
@@ -83,7 +85,7 @@ export function CatAvatar({
           // eslint-disable-next-line @next/next/no-img-element
           <img
             src={cat?.avatar ?? `/avatars/${catId}.png`}
-            alt={cat?.displayName ?? catId}
+            alt={catName}
             width={size}
             height={size}
             className="object-cover"

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -7,7 +7,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useAgentHookHealth } from '@/hooks/useAgentHookHealth';
 import { useAgentMessages } from '@/hooks/useAgentMessages';
 import { useAuthorization } from '@/hooks/useAuthorization';
-import { useCatData } from '@/hooks/useCatData';
+import { formatCatName, useCatData } from '@/hooks/useCatData';
 import { useChatHistory } from '@/hooks/useChatHistory';
 import { useChatSocketCallbacks } from '@/hooks/useChatSocketCallbacks';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
@@ -1346,7 +1346,7 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
         const isLifecyclePhase = /^phase-(5|6|7|8|9|10|11)-/.test(phase);
         if (!isLifecyclePhase && messages.length > 0) return null;
         const leadCat = cats.find((c) => c.id === raw.leadCat) ?? cats[0];
-        const catName = leadCat?.displayName ?? leadCat?.nickname ?? leadCat?.name;
+        const catName = leadCat ? formatCatName(leadCat) : undefined;
         if (!catName) return null;
         return <BootcampGuideOverlay phase={phase} catName={catName} hasMessages={messages.length > 0} />;
       })()}

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import type { CSSProperties } from 'react';
+import { formatSessionSealRequested, formatVisibleSystemInfo } from '@/hooks/system-info-visible';
 import { type CatData, formatCatName } from '@/hooks/useCatData';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
 import { useTts } from '@/hooks/useTts';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { catColorVar, catSlug } from '@/lib/cat-slug';
 import { CO_CREATOR_COLOR } from '@/lib/color-defaults';
 import { hexToOklch } from '@/lib/color-utils';
@@ -105,6 +107,18 @@ export function ChatMessage({
   const isSystem = message.type === 'system';
   const isSummary = message.type === 'summary';
   const isConnector = message.type === 'connector';
+  const projectedSystemContent = message.extra?.systemInfo
+    ? ((
+        formatVisibleSystemInfo(
+          message.extra.systemInfo.payload,
+          (catId) => resolveCatDisplayName(catId, getCatById),
+          message.extra.systemInfo.fallbackCatId,
+        ) ??
+        formatSessionSealRequested(message.extra.systemInfo.payload, (catId) =>
+          resolveCatDisplayName(catId, getCatById),
+        )
+      )?.content ?? message.content)
+    : message.content;
 
   const catData = message.catId ? getCatById(message.catId) : undefined;
   const catStyle = catData
@@ -327,7 +341,7 @@ export function ChatMessage({
       <div data-message-id={message.id} className={`flex justify-center ${isTool ? 'mb-1' : 'mb-3'}`}>
         <div className={`text-sm px-4 py-2 rounded-lg whitespace-pre-wrap text-left max-w-[85%] ${toneClass}`}>
           {isFollowup && <span className="mr-1">🔗</span>}
-          {message.content}
+          {projectedSystemContent}
           {isFollowup && (
             <span className="block mt-1 text-xs text-[var(--color-cocreator-primary)]">
               输入 @猫名 跟进 来发起 follow-up

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -484,7 +484,7 @@ export function ChatMessage({
                   message.whisperTo
                     ?.map((id) => {
                       const cat = getCatById(id);
-                      return cat ? cat.displayName : id;
+                      return cat ? formatCatName(cat) : id;
                     })
                     .join(', ') ?? ''
                 }`}

--- a/packages/web/src/components/CommunityPanel.tsx
+++ b/packages/web/src/components/CommunityPanel.tsx
@@ -10,6 +10,7 @@ import { ReconciliationFindingCard } from '@/components/community/Reconciliation
 import { PR_ICON, TYPE_ICONS } from '@/components/community-panel-icons';
 import { DirectionCard, type DirectionCardProps } from '@/components/DirectionCard';
 import { pushThreadRouteWithHistory } from '@/components/ThreadSidebar/thread-navigation';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 function relativeTime(ts: number): string {
   const diff = Date.now() - ts;
@@ -164,6 +165,7 @@ function IssueRow({
   ) => Promise<void>;
   onRefresh: () => void;
 }) {
+  const resolveCatName = useCatNameResolver();
   const color = ISSUE_STATE_COLORS[item.state] ?? 'text-cafe-muted';
   const icon = TYPE_ICONS[item.issueType] ?? TYPE_ICONS.question;
   const hasDirectionCard =
@@ -204,14 +206,14 @@ function IssueRow({
             className="inline-flex items-center gap-0.5 text-micro text-cafe-accent/80 bg-cafe-accent/5 px-1.5 py-0.5 rounded-full shrink-0"
             title={
               item.assignedThreadName
-                ? `${item.assignedCatId} → ${item.assignedThreadName}`
+                ? `${resolveCatName(item.assignedCatId)} → ${item.assignedThreadName}`
                 : item.assignedThreadId
-                  ? `${item.assignedCatId} → ${item.assignedThreadId}`
-                  : item.assignedCatId
+                  ? `${resolveCatName(item.assignedCatId)} → ${item.assignedThreadId}`
+                  : resolveCatName(item.assignedCatId)
             }
           >
             <UserAssignIcon />
-            <span>{item.assignedCatId}</span>
+            <span>{resolveCatName(item.assignedCatId)}</span>
             {item.assignedThreadName && (
               <>
                 <span className="text-cafe-muted/40">→</span>
@@ -276,6 +278,7 @@ function PrRow({
   repo: string;
   onNavigate: (threadId: string) => void;
 }) {
+  const resolveCatName = useCatNameResolver();
   const color = PR_GROUP_COLORS[item.group] ?? 'text-cafe-muted';
   const handleClick = () => {
     if (item.threadId) onNavigate(item.threadId);
@@ -300,7 +303,7 @@ function PrRow({
       )}
       <span className="truncate flex-1 text-cafe-secondary">{item.title}</span>
       {item.author && <span className="text-micro text-cafe-muted">@{item.author}</span>}
-      {item.ownerCatId && <span className="text-micro text-cafe-accent/60">{item.ownerCatId}</span>}
+      {item.ownerCatId && <span className="text-micro text-cafe-accent/60">{resolveCatName(item.ownerCatId)}</span>}
       <span className="text-micro text-cafe-muted">{relativeTime(item.updatedAt)}</span>
     </div>
   );

--- a/packages/web/src/components/CommunityPanelFilters.tsx
+++ b/packages/web/src/components/CommunityPanelFilters.tsx
@@ -1,4 +1,5 @@
 import { SYNC_ICON } from '@/components/community-panel-icons';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 const ISSUE_SECTION_OPTIONS = [
   { key: 'unreplied', label: '未回复' },
@@ -53,6 +54,7 @@ export function CommunityPanelFilters({
   loading,
   onSync,
 }: CommunityPanelFiltersProps) {
+  const resolveCatName = useCatNameResolver();
   return (
     <>
       <div className="flex items-center gap-2 px-3 py-2 border-b border-cafe-subtle/40">
@@ -105,7 +107,7 @@ export function CommunityPanelFilters({
           <option value="all">全部负责猫</option>
           {uniqueCats.map((c) => (
             <option key={c} value={c}>
-              @{c}
+              {resolveCatName(c)}
             </option>
           ))}
         </select>

--- a/packages/web/src/components/DailyUsageSection.tsx
+++ b/packages/web/src/components/DailyUsageSection.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { type CatData, useCatData } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { apiFetch } from '@/utils/api-client';
 
 interface CatDailyUsage {
@@ -40,16 +41,13 @@ function formatTokens(n: number): string {
 
 /**
  * Issue #845: derive label from runtime catRegistry (via useCatData) instead of a
- * hardcoded table. Prefers "{breedDisplayName} {variantLabel}" (e.g. "布偶猫 4.6"),
- * falls back to displayName, then raw catId. Avoids the previous drift where
+ * hardcoded table. Uses the same "displayName（variantLabel）" contract as chat,
+ * then falls back to raw catId. Avoids the previous drift where
  * `gpt52` was labeled "GPT-5.4" but actually ran `gpt-5.5`.
  */
 export function buildCatLabel(catId: string, cat: CatData | undefined): string {
   if (!cat) return catId;
-  if (cat.breedDisplayName && cat.variantLabel) {
-    return `${cat.breedDisplayName} ${cat.variantLabel}`;
-  }
-  return cat.displayName ?? catId;
+  return formatCatDisplayName(cat);
 }
 
 export function DailyUsageSection() {
@@ -156,6 +154,7 @@ export function DailyUsageSection() {
 
 function CatUsageRow({ catId, usage, cat }: { catId: string; usage: CatDailyUsage; cat: CatData | undefined }) {
   const label = buildCatLabel(catId, cat);
+  const technicalLabel = label === catId ? catId : `${label} · ${catId}`;
   // Issue #845 (砚砚 P2 fix): show the catId's *current* defaultModel as a hint,
   // NOT as a historical attribution. The aggregated TokenUsage has no per-record
   // model field — a single catId may have run multiple model versions over time.
@@ -170,7 +169,7 @@ function CatUsageRow({ catId, usage, cat }: { catId: string; usage: CatDailyUsag
         {model && (
           <span
             className="text-cafe-muted text-micro truncate italic"
-            title={`${catId} 当前默认模型：${model}。历史聚合按 catId 分桶，不区分模型版本。`}
+            title={`${technicalLabel} 当前默认模型：${model}。历史聚合按 catId 分桶，不区分模型版本。`}
           >
             当前默认 {model}
           </span>

--- a/packages/web/src/components/DefaultCatSelector.tsx
+++ b/packages/web/src/components/DefaultCatSelector.tsx
@@ -83,7 +83,6 @@ export function DefaultCatSelector({
             {cats.map((cat) => (
               <option key={cat.id} value={cat.id}>
                 {formatCatName(cat)}
-                {cat.nickname ? ` (${cat.nickname})` : ''}
               </option>
             ))}
           </select>

--- a/packages/web/src/components/DirectionPill.tsx
+++ b/packages/web/src/components/DirectionPill.tsx
@@ -1,4 +1,5 @@
 import type { CatData } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { UNKNOWN_CAT_COLOR } from '@/lib/color-defaults';
 import type { DirectionInfo } from '@/lib/parse-direction';
 
@@ -15,7 +16,7 @@ export function DirectionPill({ direction, getCatById }: DirectionPillProps) {
   const labels = direction.targets.map((target) => {
     if (direction.type === 'crossPost') return target;
     const cat = getCatById(target);
-    return cat ? `@${cat.displayName}` : `@${target}`;
+    return cat ? `@${formatCatDisplayName(cat)}` : `@${target}`;
   });
   const text = `${direction.arrow} ${labels.join(' + ')}`;
 

--- a/packages/web/src/components/HubCallbackAuthPanel.tsx
+++ b/packages/web/src/components/HubCallbackAuthPanel.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect } from 'react';
+import { useCatNameResolver, useCatTechnicalLabelResolver } from '@/hooks/useCatNameResolver';
 import {
   useCallbackAuthAvailable,
   useCallbackAuthError,
@@ -67,6 +68,7 @@ function ReasonDistribution({ byReason, total }: { byReason: Record<string, numb
 }
 
 function CatRoster({ byCat, max = 6 }: { byCat: Record<string, number>; max?: number }) {
+  const resolveCatName = useCatNameResolver();
   const entries = Object.entries(byCat)
     .filter(([, v]) => v > 0)
     .sort((a, b) => b[1] - a[1])
@@ -81,7 +83,9 @@ function CatRoster({ byCat, max = 6 }: { byCat: Record<string, number>; max?: nu
           {/* CallbackAuthCatAvatar reads status + popover from the global store
               so this in-panel roster matches what ThreadItem participants show. */}
           <CallbackAuthCatAvatar catId={catId} size={48} />
-          <div className="truncate text-micro text-cafe">{catId}</div>
+          <div className="w-full truncate text-center text-micro text-cafe" title={resolveCatName(catId)}>
+            {resolveCatName(catId)}
+          </div>
           <div className="text-micro text-cafe-muted">{count} fail</div>
         </div>
       ))}
@@ -115,6 +119,7 @@ function TopList({ title, entries, max = 5 }: { title: string; entries: Array<[s
 }
 
 export function HubCallbackAuthPanel() {
+  const resolveCatName = useCatTechnicalLabelResolver();
   // Cloud Codex P2 #1403 (round 6): consume the global store instead of
   // spawning a second polling instance — eliminates the data-skew window
   // where the in-panel byCat row used a fresh snapshot but the
@@ -181,7 +186,7 @@ export function HubCallbackAuthPanel() {
                 <span className="w-32 text-cafe-muted">{new Date(s.at).toLocaleTimeString()}</span>
                 <span className="w-32 font-mono text-cafe">{s.reason}</span>
                 <span className="font-mono text-cafe-secondary">{s.tool}</span>
-                {s.catId && <span className="ml-auto text-cafe-muted">{s.catId}</span>}
+                {s.catId && <span className="ml-auto text-cafe-muted">{resolveCatName(s.catId)}</span>}
               </div>
             ))}
           </div>

--- a/packages/web/src/components/HubEvalTab.tsx
+++ b/packages/web/src/components/HubEvalTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { apiFetch } from '@/utils/api-client';
 import { type EvalHubItem, VERDICT_LABELS } from './HubEvalTypes';
 import { HubEvalVerdictCard } from './HubEvalVerdictCard';
@@ -128,6 +129,7 @@ function StatCell({ label, sublabel, value }: { label: string; sublabel?: string
 }
 
 function DomainCard({ domain, onCatUpdated }: { domain: EvalDomainSummary; onCatUpdated?: () => void }) {
+  const resolveCatName = useCatNameResolver();
   const [editing, setEditing] = useState(false);
   const [catId, setCatId] = useState(domain.evalCatId);
   const [saving, setSaving] = useState(false);
@@ -189,7 +191,7 @@ function DomainCard({ domain, onCatUpdated }: { domain: EvalDomainSummary; onCat
                   >
                     {availableCats.map((cat) => (
                       <option key={cat.catId} value={cat.catId}>
-                        {cat.handle} ({cat.family})
+                        {resolveCatName(cat.catId)}
                       </option>
                     ))}
                   </select>
@@ -224,7 +226,7 @@ function DomainCard({ domain, onCatUpdated }: { domain: EvalDomainSummary; onCat
               </span>
             ) : (
               <span>
-                {domain.evalCatHandle}{' '}
+                {domain.evalCatId ? resolveCatName(domain.evalCatId) : domain.evalCatHandle}{' '}
                 <button
                   type="button"
                   onClick={startEditing}

--- a/packages/web/src/components/HubToolUsageTab.tsx
+++ b/packages/web/src/components/HubToolUsageTab.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type React from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
 import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { apiFetch } from '@/utils/api-client';
@@ -66,6 +66,12 @@ export function HubToolUsageTab() {
 
   const total = report?.summary.totalCalls ?? 0;
   const byCat = report?.summary.byCategory ?? { native: 0, mcp: 0, skill: 0 };
+  const catOptionIds = useMemo(() => {
+    const ids = new Set(cats.map((cat) => cat.id));
+    for (const catId of Object.keys(report?.byCat ?? {})) ids.add(catId);
+    if (catFilter) ids.add(catFilter);
+    return [...ids];
+  }, [cats, report?.byCat, catFilter]);
 
   return (
     <div className="space-y-4" style={DATAVIZ_TOKENS}>
@@ -82,9 +88,9 @@ export function HubToolUsageTab() {
             className="console-form-input text-xs"
           >
             <option value="">全部猫猫</option>
-            {cats.map((cat) => (
-              <option key={cat.id} value={cat.id}>
-                {resolveCatName(cat.id)}
+            {catOptionIds.map((catId) => (
+              <option key={catId} value={catId}>
+                {resolveCatName(catId)}
               </option>
             ))}
           </select>

--- a/packages/web/src/components/HubToolUsageTab.tsx
+++ b/packages/web/src/components/HubToolUsageTab.tsx
@@ -2,6 +2,8 @@
 
 import type React from 'react';
 import { useCallback, useEffect, useState } from 'react';
+import { useCatData } from '@/hooks/useCatData';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { apiFetch } from '@/utils/api-client';
 import { HubIcon } from './hub-icons';
 
@@ -12,20 +14,6 @@ interface ToolUsageReport {
   daily: Array<{ date: string; native: number; mcp: number; skill: number }>;
   byCat: Record<string, Record<string, number>>;
 }
-
-const CAT_LABELS: Record<string, string> = {
-  opus: '布偶猫 Opus',
-  sonnet: '布偶猫 Sonnet',
-  'opus-45': '布偶猫 Opus 4.5',
-  codex: '缅因猫 Codex',
-  gpt52: '缅因猫 GPT-5.4',
-  spark: '缅因猫 Spark',
-  gemini: '暹罗猫 Gemini',
-  gemini25: '暹罗猫 Gemini 2.5',
-  antigravity: '孟加拉猫',
-  'antig-opus': '孟加拉猫 Opus',
-  opencode: '金渐层',
-};
 
 /* Dataviz tokens defined in console-tokens.css (--dataviz-*), derived from chart palette.
  * No JS override needed — CSS global tokens auto-adapt to light/dark mode. */
@@ -38,11 +26,9 @@ const CATEGORY_STYLE: Record<string, { color: string; bg: string; label: string;
 
 const CATEGORIES = ['native', 'mcp', 'skill'] as const;
 
-function catLabel(catId: string): string {
-  return CAT_LABELS[catId] ?? catId;
-}
-
 export function HubToolUsageTab() {
+  const { cats, getCatById } = useCatData({ fetch: false });
+  const resolveCatName = useCallback((catId: string) => resolveCatDisplayName(catId, getCatById), [getCatById]);
   const [report, setReport] = useState<ToolUsageReport | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -96,9 +82,9 @@ export function HubToolUsageTab() {
             className="console-form-input text-xs"
           >
             <option value="">全部猫猫</option>
-            {Object.entries(CAT_LABELS).map(([id, label]) => (
-              <option key={id} value={id}>
-                {label}
+            {cats.map((cat) => (
+              <option key={cat.id} value={cat.id}>
+                {resolveCatName(cat.id)}
               </option>
             ))}
           </select>
@@ -151,7 +137,7 @@ export function HubToolUsageTab() {
           <SummaryCards total={total} byCategory={byCat} />
           <DailyTrend daily={report.daily} />
           <TopToolsTable tools={report.topTools} />
-          <ByCatSection byCat={report.byCat} />
+          <ByCatSection byCat={report.byCat} resolveCatName={resolveCatName} />
         </>
       )}
     </div>
@@ -308,7 +294,13 @@ function TopToolsTable({ tools }: { tools: ToolUsageReport['topTools'] }) {
 }
 
 /* ── Per-cat distribution ── */
-function ByCatSection({ byCat }: { byCat: Record<string, Record<string, number>> }) {
+function ByCatSection({
+  byCat,
+  resolveCatName,
+}: {
+  byCat: Record<string, Record<string, number>>;
+  resolveCatName: (catId: string) => string;
+}) {
   const entries = Object.entries(byCat).sort(
     (a, b) => Object.values(b[1]).reduce((s, v) => s + v, 0) - Object.values(a[1]).reduce((s, v) => s + v, 0),
   );
@@ -322,7 +314,7 @@ function ByCatSection({ byCat }: { byCat: Record<string, Record<string, number>>
           const catTotal = Object.values(cats).reduce((s, v) => s + v, 0);
           return (
             <div key={catId} className="flex items-center gap-3 text-xs">
-              <span className="w-28 truncate font-medium text-cafe">{catLabel(catId)}</span>
+              <span className="w-28 truncate font-medium text-cafe">{resolveCatName(catId)}</span>
               <div className="flex h-5 flex-1 overflow-hidden rounded-full bg-[var(--console-pill-bg)]">
                 {CATEGORIES.map((category) => {
                   const val = cats[category] ?? 0;

--- a/packages/web/src/components/HubTraceTree.tsx
+++ b/packages/web/src/components/HubTraceTree.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useCatTechnicalLabelResolver } from '@/hooks/useCatNameResolver';
 import { apiFetch } from '@/utils/api-client';
 import { buildForest, flattenForest, type SpanNode, type TraceSpan } from './trace-tree-utils';
 
@@ -161,6 +162,7 @@ function TreeWaterfall({
   selectedSpan: string | null;
   onSelectSpan: (id: string | null) => void;
 }) {
+  const resolveCatTechnicalLabel = useCatTechnicalLabelResolver();
   const flat = flattenForest(trace.forest);
   const totalDuration = trace.totalDurationMs || 1;
 
@@ -192,9 +194,14 @@ function TreeWaterfall({
               </span>
             </div>
             {catId ? (
-              <span className="w-14 flex-shrink-0 truncate text-micro text-cafe-muted">{catId}</span>
+              <span
+                className="w-24 flex-shrink-0 truncate text-micro text-cafe-muted"
+                title={resolveCatTechnicalLabel(catId)}
+              >
+                {resolveCatTechnicalLabel(catId)}
+              </span>
             ) : (
-              <span className="w-14 flex-shrink-0" />
+              <span className="w-24 flex-shrink-0" />
             )}
             <div className="relative h-3 flex-1 rounded bg-cafe-surface-elevated">
               <div
@@ -522,6 +529,7 @@ function PromptSection({ content, label, className = '' }: { content: string; la
 }
 
 function PromptMeta({ capture }: { capture: PromptCaptureData }) {
+  const resolveCatTechnicalLabel = useCatTechnicalLabelResolver();
   const { injectionDecision } = capture;
   return (
     <div className="space-y-2 text-micro">
@@ -536,7 +544,7 @@ function PromptMeta({ capture }: { capture: PromptCaptureData }) {
             <span className="font-mono">{capture.invocationId}</span>
           </div>
           <div>
-            <span className="text-cafe-muted">catId:</span> {capture.catId}
+            <span className="text-cafe-muted">member:</span> {resolveCatTechnicalLabel(capture.catId)}
           </div>
           <div>
             <span className="text-cafe-muted">model:</span> {capture.model}

--- a/packages/web/src/components/MessageNavigator.tsx
+++ b/packages/web/src/components/MessageNavigator.tsx
@@ -14,8 +14,9 @@ const MAX_DOTS = 18;
 type CatLookup = (id: string) => CatData | undefined;
 
 // Some variants use non-hyphen catIds (e.g. gpt52/sonnet/spark/gemini25 in the runtime cat config).
-// During the brief pre-/api/cats state, the cat list may be empty,
-// so we map these variant ids to a base cat for color/name consistency.
+// During the brief pre-/api/cats state, the cat list may be empty, so we map
+// variant ids to a base color only. Identity text keeps the raw-id fallback
+// until the runtime roster can resolve the exact member.
 const VARIANT_BASE_FALLBACK: Record<string, string> = {
   gpt52: 'codex',
   spark: 'codex',
@@ -23,41 +24,29 @@ const VARIANT_BASE_FALLBACK: Record<string, string> = {
   gemini25: 'gemini',
 };
 
-const FALLBACK_CAT_META: Record<string, { label: string; color: string }> = {
-  opus: { label: '布偶猫', color: CAT_COLORS.opus.primary },
-  codex: { label: '缅因猫', color: CAT_COLORS.codex.primary },
-  gemini: { label: '暹罗猫', color: CAT_COLORS.gemini.primary },
-  kimi: { label: '梵花猫', color: CAT_COLORS.kimi.primary },
+const FALLBACK_CAT_COLORS: Record<string, string> = {
+  opus: CAT_COLORS.opus.primary,
+  codex: CAT_COLORS.codex.primary,
+  gemini: CAT_COLORS.gemini.primary,
+  kimi: CAT_COLORS.kimi.primary,
 };
 
-function resolveFallbackCatMeta(catId: string): { baseId: string; label: string; color: string } | undefined {
+function resolveFallbackCatColor(catId: string): string | undefined {
   const normalizedId = catId.toLowerCase();
-  const direct = FALLBACK_CAT_META[normalizedId];
-  if (direct) return { baseId: normalizedId, ...direct };
+  const direct = FALLBACK_CAT_COLORS[normalizedId];
+  if (direct) return direct;
 
   const base = normalizedId.split('-')[0];
-  if (base && base !== normalizedId && FALLBACK_CAT_META[base]) {
-    return { baseId: base, ...FALLBACK_CAT_META[base] };
-  }
+  if (base && base !== normalizedId && FALLBACK_CAT_COLORS[base]) return FALLBACK_CAT_COLORS[base];
 
   const mappedBase = VARIANT_BASE_FALLBACK[normalizedId];
-  if (mappedBase && FALLBACK_CAT_META[mappedBase]) {
-    return { baseId: mappedBase, ...FALLBACK_CAT_META[mappedBase] };
-  }
+  if (mappedBase && FALLBACK_CAT_COLORS[mappedBase]) return FALLBACK_CAT_COLORS[mappedBase];
 
   return undefined;
 }
 
 function resolveCatById(getCatById: CatLookup, catId: string): CatData | undefined {
-  const normalizedId = catId.toLowerCase();
-  const direct = getCatById(normalizedId);
-  if (direct) return direct;
-  // F32-b P4: tolerate multi-variant ids (e.g. opus-45) even before /api/cats loads
-  const base = normalizedId.split('-')[0];
-  if (base && base !== normalizedId) return getCatById(base);
-  const mappedBase = VARIANT_BASE_FALLBACK[normalizedId];
-  if (mappedBase) return getCatById(mappedBase);
-  return undefined;
+  return getCatById(catId.toLowerCase());
 }
 
 function getSenderLabel(
@@ -73,13 +62,7 @@ function getSenderLabel(
   if (!isAssistant) return '系统';
   if (!catId) return '系统';
   const cat = resolveCat(catId);
-  if (!cat) {
-    const fallback = resolveFallbackCatMeta(catId);
-    if (!fallback) return catId;
-    return fallback.baseId === catId.toLowerCase() ? fallback.label : `${fallback.label}（${catId}）`;
-  }
-  const baseName = formatCatName(cat);
-  return cat.id === catId ? baseName : `${cat.displayName}（${catId}）`;
+  return cat ? formatCatName(cat) : catId;
 }
 
 function formatTime(ts: number): string {
@@ -155,14 +138,14 @@ export function MessageNavigator({ messages, scrollContainerRef }: MessageNaviga
           const isOwner = msg.type === 'user' && !msg.catId;
           const isAssistant = msg.type === 'assistant' || (msg.type === 'user' && !!msg.catId);
           const cat = isAssistant && msg.catId ? resolveCat(msg.catId) : undefined;
-          const fallback = isAssistant && msg.catId ? resolveFallbackCatMeta(msg.catId) : undefined;
-          const className = isOwner ? 'bg-cafe-accent' : cat || fallback ? '' : 'bg-gray-400';
+          const fallbackColor = isAssistant && msg.catId ? resolveFallbackCatColor(msg.catId) : undefined;
+          const className = isOwner ? 'bg-cafe-accent' : cat || fallbackColor ? '' : 'bg-gray-400';
           const style = isOwner
             ? undefined
             : cat
               ? { backgroundColor: catColorVar(cat.id, 'primary') }
-              : fallback
-                ? { backgroundColor: fallback.color }
+              : fallbackColor
+                ? { backgroundColor: fallbackColor }
                 : undefined;
 
           return (

--- a/packages/web/src/components/QueueEntryRow.tsx
+++ b/packages/web/src/components/QueueEntryRow.tsx
@@ -19,6 +19,7 @@ export interface QueueEntryRowProps {
   isPaused: boolean;
   imageCount: number;
   ownerName: string;
+  resolveCatName: (catId: string) => string;
   onRemove: (id: string) => void;
   onRecallEdit: (id: string) => void;
   onSteer: (id: string) => void;
@@ -42,6 +43,7 @@ function QueueEntryRow({
   isPaused,
   imageCount,
   ownerName,
+  resolveCatName,
   onRemove,
   onRecallEdit,
   onSteer,
@@ -54,7 +56,7 @@ function QueueEntryRow({
   const rowToneClass = isPaused ? 'bg-conn-amber-bg/60' : isAgent ? 'bg-[var(--color-cocreator-surface)]' : '';
 
   const sourceLabel = isAgent
-    ? `${entry.callerCatId ?? '猫猫'} → ${entry.targetCats[0] ?? '猫猫'}`
+    ? `${entry.callerCatId ? resolveCatName(entry.callerCatId) : '猫猫'} → ${entry.targetCats[0] ? resolveCatName(entry.targetCats[0]) : '猫猫'}`
     : entry.source === 'connector'
       ? 'Connector'
       : ownerName;

--- a/packages/web/src/components/QueuePanel.tsx
+++ b/packages/web/src/components/QueuePanel.tsx
@@ -4,6 +4,7 @@ import { SCHEDULER_TRIGGER_PREFIX } from '@cat-cafe/shared';
 import { closestCenter, DndContext, type DragEndEvent, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { arrayMove, SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useCallback, useMemo, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
 import { useChatStore } from '@/stores/chatStore';
 import { useToastStore } from '@/stores/toastStore';
@@ -80,6 +81,7 @@ interface QueuePanelProps {
 
 export function QueuePanel({ threadId }: QueuePanelProps) {
   const coCreator = useCoCreatorConfig();
+  const resolveCatName = useCatNameResolver();
   const rawQueue = useChatStore((s) => s.queue);
   const queue = useMemo(() => rawQueue ?? [], [rawQueue]);
   const queuePaused = useChatStore((s) => s.queuePaused) ?? false;
@@ -366,7 +368,7 @@ export function QueuePanel({ threadId }: QueuePanelProps) {
           className="px-3 py-1.5 text-xs text-cafe-muted border-b"
           style={{ borderColor: 'color-mix(in oklch, var(--color-cocreator-primary) 10%, transparent)' }}
         >
-          等待 <span className="font-medium text-cafe-secondary">{waitInfo.catId}</span> 当前回合
+          等待 <span className="font-medium text-cafe-secondary">{resolveCatName(waitInfo.catId)}</span> 当前回合
           {waitInfo.elapsedLabel ? `（已运行 ${waitInfo.elapsedLabel}）` : ''}
         </div>
       )}
@@ -386,6 +388,7 @@ export function QueuePanel({ threadId }: QueuePanelProps) {
                     isPaused={queuePaused}
                     imageCount={imageCount}
                     ownerName={coCreator.name}
+                    resolveCatName={resolveCatName}
                     onRemove={handleRemove}
                     onRecallEdit={handleRecallEdit}
                     onSteer={handleSteerOpen}

--- a/packages/web/src/components/SettledHistoryCard.tsx
+++ b/packages/web/src/components/SettledHistoryCard.tsx
@@ -8,6 +8,7 @@
  */
 
 import type { SettledApprovalItem } from '@cat-cafe/shared';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 const FEATURE_LABELS: Record<string, string> = {
   F128: '线程',
@@ -33,6 +34,7 @@ interface SettledHistoryCardProps {
 }
 
 export function SettledHistoryCard({ item }: SettledHistoryCardProps) {
+  const resolveCatName = useCatNameResolver();
   const featureLabel = FEATURE_LABELS[item.sourceFeatureId] ?? item.sourceFeatureId;
   const isApproved = item.status === 'approved';
 
@@ -71,7 +73,7 @@ export function SettledHistoryCard({ item }: SettledHistoryCardProps) {
 
       {/* Requester */}
       <p className="text-micro text-cafe-interactive/40">
-        来自 <span className="font-medium">{item.requesterCatId}</span>
+        来自 <span className="font-medium">{resolveCatName(item.requesterCatId)}</span>
       </p>
     </div>
   );

--- a/packages/web/src/components/SummaryCard.tsx
+++ b/packages/web/src/components/SummaryCard.tsx
@@ -2,6 +2,7 @@
 
 import { useCatData } from '@/hooks/useCatData';
 import { useCoCreatorConfig } from '@/hooks/useCoCreatorConfig';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { CatAvatar } from './CatAvatar';
 import { HubIcon } from './hub-icons';
 
@@ -27,7 +28,12 @@ export function SummaryCard({ topic, conclusions, openQuestions, createdBy, time
   const coCreator = useCoCreatorConfig();
   const catData = getCatById(createdBy);
   // Special case: 'system' createdBy → '系统纪要', otherwise use cat displayName or configured co-creator name
-  const creatorLabel = createdBy === 'system' ? '系统纪要' : (catData?.displayName ?? coCreator.name);
+  const creatorLabel =
+    createdBy === 'system'
+      ? '系统纪要'
+      : createdBy === 'user'
+        ? coCreator.name
+        : resolveCatDisplayName(createdBy, getCatById);
 
   return (
     <div className="flex justify-center mb-4">

--- a/packages/web/src/components/ThinkingIndicator.tsx
+++ b/packages/web/src/components/ThinkingIndicator.tsx
@@ -2,6 +2,7 @@
 
 import { useCatData } from '@/hooks/useCatData';
 import { useThreadLiveness } from '@/hooks/useThreadScopedSelectors';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import type { CatStatusType, LivenessWarningSnapshot } from '@/stores/chat-types';
 import { useChatStore } from '@/stores/chatStore';
 
@@ -95,8 +96,7 @@ export function ThinkingIndicator({ onCancel, threadId }: ThinkingIndicatorProps
   const status: CatStatusType = catStatuses[catId] ?? 'pending';
   if (status === 'done') return null;
 
-  const catData = getCatById(catId);
-  const name = catData?.displayName ?? catId;
+  const name = resolveCatDisplayName(catId, getCatById);
   const warning: LivenessWarningSnapshot | undefined = catInvocations?.[catId]?.livenessWarning;
 
   // F118 D2: spawning — CLI not yet connected, earliest signal

--- a/packages/web/src/components/ThreadExecutionBar.tsx
+++ b/packages/web/src/components/ThreadExecutionBar.tsx
@@ -242,7 +242,7 @@ function CatStatusChip({
         type="button"
         onClick={() => onStop(catId)}
         className="ml-0.5 text-cafe-muted hover:text-conn-red-text transition-colors"
-        aria-label={`Stop ${catId}`}
+        aria-label={`Stop ${label}`}
       >
         <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path

--- a/packages/web/src/components/ThreadSidebar/CatSelector.tsx
+++ b/packages/web/src/components/ThreadSidebar/CatSelector.tsx
@@ -72,7 +72,6 @@ export function CatSelector({ selectedCats, onSelectionChange }: CatSelectorProp
                       style={{ backgroundColor: catColorVar(cat.id, 'primary') }}
                     />
                     {formatCatName(cat)}
-                    {!cat.variantLabel && cat.nickname ? `(${cat.nickname})` : ''}
                   </button>
                 );
               })}

--- a/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
+++ b/packages/web/src/components/ThreadSidebar/ThreadItem.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
 import { useIMEGuard } from '@/hooks/useIMEGuard';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { catColorVar } from '@/lib/cat-slug';
 import type { ThreadState } from '@/stores/chat-types';
 import { useLabelStore } from '@/stores/label-store';
@@ -138,7 +139,7 @@ export function ThreadItem({
   // Build hover tooltip: full title + participants + time (clowder-ai#29)
   const displayTitle = title ?? (id === 'default' ? '大厅' : '未命名对话');
   const hasDraft = !isActive && (threadState?.hasDraft ?? false);
-  const participantNames = participants.map((catId) => getCatById(catId)?.displayName ?? catId).join(', ');
+  const participantNames = participants.map((catId) => resolveCatDisplayName(catId, getCatById)).join(', ');
   const tooltipLines = [displayTitle];
   if (participantNames) tooltipLines.push(`参与: ${participantNames}`);
   if (projectPath && projectPath !== 'default') tooltipLines.push(`路径: ${projectPath}`);
@@ -373,7 +374,7 @@ export function ThreadItem({
           {preferredCats && preferredCats.length > 0 && (
             <div
               className="flex items-center gap-0.5 ml-1"
-              title={`默认: ${preferredCats.map((id) => getCatById(id)?.displayName ?? id).join(', ')}`}
+              title={`默认: ${preferredCats.map((id) => resolveCatDisplayName(id, getCatById)).join(', ')}`}
             >
               <svg
                 viewBox="0 0 24 24"

--- a/packages/web/src/components/__tests__/CallbackAuthCatAvatar-healthy-default.test.tsx
+++ b/packages/web/src/components/__tests__/CallbackAuthCatAvatar-healthy-default.test.tsx
@@ -67,7 +67,7 @@ describe('CallbackAuthCatAvatar healthy-default (F174 D2b-2 cloud P1 #1403)', ()
     expect(html).toContain('data-testid="callback-auth-dot"');
     expect(html).toContain('data-callback-auth-status="unknown"');
     // Label clarifies: "no failure record" rather than asserting healthy.
-    expect(html).toContain('opus: 24h 内无失败记录');
+    expect(html).toContain('Opus: 24h 内无失败记录');
   });
 
   it('renders DEGRADED dot for a cat with mid failures', () => {
@@ -75,7 +75,7 @@ describe('CallbackAuthCatAvatar healthy-default (F174 D2b-2 cloud P1 #1403)', ()
     mockByCat = { opus: { status: 'degraded', failures24h: 3 } };
     const html = renderToStaticMarkup(<CallbackAuthCatAvatar catId="opus" size={48} />);
     expect(html).toContain('data-callback-auth-status="degraded"');
-    expect(html).toContain('opus: degraded · 3 fails (24h)');
+    expect(html).toContain('Opus: degraded · 3 fails (24h)');
   });
 
   it('renders BROKEN dot for a cat above threshold', () => {
@@ -83,6 +83,6 @@ describe('CallbackAuthCatAvatar healthy-default (F174 D2b-2 cloud P1 #1403)', ()
     mockByCat = { opus: { status: 'broken', failures24h: 12 } };
     const html = renderToStaticMarkup(<CallbackAuthCatAvatar catId="opus" size={48} />);
     expect(html).toContain('data-callback-auth-status="broken"');
-    expect(html).toContain('opus: broken · 12 fails (24h)');
+    expect(html).toContain('Opus: broken · 12 fails (24h)');
   });
 });

--- a/packages/web/src/components/__tests__/HubToolUsageTab-member-filter.test.tsx
+++ b/packages/web/src/components/__tests__/HubToolUsageTab-member-filter.test.tsx
@@ -1,0 +1,104 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const CURRENT_CATS = [{ id: 'cat-sol', displayName: '缅因猫', variantLabel: 'sol' }];
+
+vi.mock('@/hooks/useCatData', () => ({
+  useCatData: () => ({
+    cats: CURRENT_CATS,
+    getCatById: (id: string) => CURRENT_CATS.find((cat) => cat.id === id),
+  }),
+}));
+
+vi.mock('@/utils/api-client', () => ({ apiFetch: vi.fn() }));
+
+import { apiFetch } from '@/utils/api-client';
+import { HubToolUsageTab } from '../HubToolUsageTab';
+
+const REPORT_WITH_RETIRED_MEMBER = {
+  period: { from: '2026-01-01', to: '2026-07-20' },
+  summary: { totalCalls: 3, byCategory: { native: 3 } },
+  topTools: [],
+  daily: [],
+  byCat: {
+    'cat-sol': { native: 2 },
+    'cat-retired': { native: 1 },
+  },
+};
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('HubToolUsageTab member filter', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    Object.assign(globalThis as Record<string, unknown>, { React, IS_REACT_ACT_ENVIRONMENT: true });
+  });
+
+  afterAll(() => {
+    delete (globalThis as Record<string, unknown>).React;
+    delete (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it('keeps members found only in the historical report available as raw-ID filter options', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(jsonResponse(REPORT_WITH_RETIRED_MEMBER))
+      .mockResolvedValueOnce(
+        jsonResponse({
+          ...REPORT_WITH_RETIRED_MEMBER,
+          summary: { totalCalls: 1, byCategory: { native: 1 } },
+          byCat: { 'cat-retired': { native: 1 } },
+        }),
+      );
+    await act(async () => {
+      root.render(<HubToolUsageTab />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const memberSelect = container.querySelector('select');
+    const options = Array.from(memberSelect?.querySelectorAll('option') ?? []).map((option) => ({
+      value: option.value,
+      label: option.textContent,
+    }));
+
+    expect(options).toEqual([
+      { value: '', label: '全部猫猫' },
+      { value: 'cat-sol', label: '缅因猫（sol）' },
+      { value: 'cat-retired', label: 'cat-retired' },
+    ]);
+
+    await act(async () => {
+      if (memberSelect) {
+        memberSelect.value = 'cat-retired';
+        memberSelect.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(apiFetch).toHaveBeenLastCalledWith(expect.stringContaining('catId=cat-retired'));
+    expect(container.querySelector('select')?.value).toBe('cat-retired');
+  });
+});

--- a/packages/web/src/components/__tests__/chat-message-notice-rendering.test.ts
+++ b/packages/web/src/components/__tests__/chat-message-notice-rendering.test.ts
@@ -1,8 +1,18 @@
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { CatData } from '@/hooks/useCatData';
+import { _resetCatDataCache, type CatData, useCatData } from '@/hooks/useCatData';
 import type { ChatMessage as ChatMessageType } from '@/stores/chatStore';
+
+const mockApiFetch = vi.fn();
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: (...args: unknown[]) => mockApiFetch(...args),
+}));
+vi.mock('@/lib/mention-highlight', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/mention-highlight')>()),
+  refreshMentionData: vi.fn(),
+}));
+vi.mock('@/utils/transcription-corrector', () => ({ refreshSpeechAliases: vi.fn() }));
 
 vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
 
@@ -59,6 +69,8 @@ describe('ChatMessage notice rendering', () => {
   });
 
   beforeEach(() => {
+    _resetCatDataCache();
+    mockApiFetch.mockReset();
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -68,6 +80,66 @@ describe('ChatMessage notice rendering', () => {
     act(() => root.unmount());
     container.remove();
     vi.restoreAllMocks();
+  });
+
+  it('reprojects an existing system-info notice after a deferred roster load without another event', async () => {
+    let resolveCatsResponse: ((response: Response) => void) | undefined;
+    mockApiFetch.mockImplementation((path: string) => {
+      if (path === '/api/config/cat-order') return Promise.resolve({ ok: false } as Response);
+      if (path === '/api/cats') {
+        return new Promise<Response>((resolve) => {
+          resolveCatsResponse = resolve;
+        });
+      }
+      return Promise.resolve({ ok: false } as Response);
+    });
+    const message = {
+      id: 'system-info-session-seal',
+      type: 'system',
+      variant: 'info',
+      content: 'cat-sol 的会话 #2 已封存（上下文 42%），下次调用将自动创建新会话',
+      timestamp: Date.now(),
+      extra: {
+        systemInfo: {
+          v: 1,
+          payload: {
+            type: 'session_seal_requested',
+            catId: 'cat-sol',
+            sessionSeq: 2,
+            healthSnapshot: { fillRatio: 0.42 },
+          },
+          fallbackCatId: 'cat-sol',
+        },
+      },
+    } as unknown as ChatMessageType;
+
+    function NoticeHarness() {
+      const { getCatById } = useCatData();
+      return React.createElement(ChatMessage, { message, getCatById });
+    }
+
+    await act(async () => {
+      root.render(React.createElement(NoticeHarness));
+    });
+    expect(container.textContent).toContain('cat-sol 的会话 #2');
+    expect(mockApiFetch.mock.calls.filter((call) => call[0] === '/api/cats')).toHaveLength(1);
+
+    const completeCatsRequest = resolveCatsResponse;
+    if (!completeCatsRequest) throw new Error('Expected the registry request to be pending');
+    await act(async () => {
+      completeCatsRequest({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            cats: [{ id: 'cat-sol', displayName: '缅因猫', variantLabel: 'sol' }],
+          }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain('缅因猫（sol） 的会话 #2');
+    expect(container.textContent).not.toContain('cat-sol 的会话 #2');
+    expect(mockApiFetch.mock.calls.filter((call) => call[0] === '/api/cats')).toHaveLength(1);
   });
 
   it('renders inline mention hint as in-thread notice bar instead of connector bubble', () => {

--- a/packages/web/src/components/__tests__/community-decision-queue.test.tsx
+++ b/packages/web/src/components/__tests__/community-decision-queue.test.tsx
@@ -9,6 +9,14 @@ import React from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { mockResolveCatName } = vi.hoisted(() => ({
+  mockResolveCatName: vi.fn((catId: string) => catId),
+}));
+
+vi.mock('@/hooks/useCatNameResolver', () => ({
+  useCatNameResolver: () => mockResolveCatName,
+}));
+
 vi.mock('@/components/ThreadSidebar/thread-navigation', () => ({
   pushThreadRouteWithHistory: vi.fn(),
 }));
@@ -241,6 +249,8 @@ describe('CommunityPanel decision queue (E-PR2)', () => {
 
   beforeEach(() => {
     vi.setSystemTime(NOW);
+    mockResolveCatName.mockReset();
+    mockResolveCatName.mockImplementation((catId: string) => catId);
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
@@ -282,6 +292,18 @@ describe('CommunityPanel decision queue (E-PR2)', () => {
     expect(text.indexOf('Add a deterministic routing policy')).toBeLessThan(
       text.indexOf('Ready to close after public report'),
     );
+  });
+
+  it('keeps decision actor roles outside member identity projection', async () => {
+    mockResolveCatName.mockImplementation((catId: string) => `member:${catId}`);
+    installFetchMock([DIRECTION_ITEM]);
+
+    await renderPanel(root);
+
+    const item = container.querySelector(`[data-testid="decision-item-${DIRECTION_ITEM.id}"]`);
+    expect(item?.textContent).toContain('cvo');
+    expect(item?.textContent).not.toContain('member:cvo');
+    expect(mockResolveCatName).not.toHaveBeenCalledWith('cvo');
   });
 
   it('passes routeRecommendation with the assigned owner when accepting a direction queue item', async () => {

--- a/packages/web/src/components/__tests__/default-cat-selector.test.ts
+++ b/packages/web/src/components/__tests__/default-cat-selector.test.ts
@@ -15,9 +15,9 @@ vi.mock('next/link', () => ({
 const TEST_CATS = [
   {
     id: 'opus',
-    displayName: 'opus',
+    displayName: '布偶猫',
     nickname: '宪宪',
-    variantLabel: undefined,
+    variantLabel: 'Opus 4.6',
     breedDisplayName: '布偶猫',
     color: { primary: '#FFAB91', secondary: '#8D6E63' },
     clientId: 'anthropic',
@@ -31,9 +31,9 @@ const TEST_CATS = [
   },
   {
     id: 'codex',
-    displayName: 'codex',
+    displayName: '缅因猫',
     nickname: '砚砚',
-    variantLabel: undefined,
+    variantLabel: 'sol',
     breedDisplayName: '缅因猫',
     color: { primary: '#66BB6A', secondary: '#2E7D32' },
     clientId: 'openai',
@@ -47,9 +47,9 @@ const TEST_CATS = [
   },
   {
     id: 'gemini',
-    displayName: 'gemini',
+    displayName: '暹罗猫',
     nickname: '烁烁',
-    variantLabel: undefined,
+    variantLabel: 'Flash',
     breedDisplayName: '暹罗猫',
     color: { primary: '#81D4FA', secondary: '#0277BD' },
     clientId: 'google',
@@ -73,7 +73,7 @@ const mockCatData = {
 vi.mock('@/hooks/useCatData', () => ({
   useCatData: () => mockCatData,
   formatCatName: (cat: { displayName: string; variantLabel?: string }) =>
-    cat.variantLabel ? `${cat.displayName} ${cat.variantLabel}` : cat.displayName,
+    cat.variantLabel ? `${cat.displayName}（${cat.variantLabel}）` : cat.displayName,
 }));
 
 // Lazy import after mocks
@@ -218,7 +218,7 @@ describe('DefaultCatSelector (F154 Phase B, AC-B2)', () => {
     expect(container.textContent).toContain('保存失败');
   });
 
-  it('includes nickname in option text', () => {
+  it('uses the standard member name + variant label without nickname aliases', () => {
     act(() => {
       root.render(
         React.createElement(DefaultCatSelector, {
@@ -230,7 +230,8 @@ describe('DefaultCatSelector (F154 Phase B, AC-B2)', () => {
     });
     const select = container.querySelector('[data-testid="default-cat-select"]') as HTMLSelectElement;
     const opusOption = [...select.options].find((o) => o.value === 'opus');
-    expect(opusOption?.textContent).toContain('宪宪');
+    expect(opusOption?.textContent).toBe('布偶猫（Opus 4.6）');
+    expect(opusOption?.textContent).not.toContain('宪宪');
   });
 
   it('shows placeholder when currentDefaultCatId is empty', () => {

--- a/packages/web/src/components/__tests__/f232-artifacts-detail.test.ts
+++ b/packages/web/src/components/__tests__/f232-artifacts-detail.test.ts
@@ -16,7 +16,8 @@ vi.mock('@/hooks/useThreadArtifacts', () => ({
 }));
 vi.mock('@/hooks/useCatData', () => ({
   useCatData: () => ({
-    getCatById: (id: string) => (id === 'opus-48' ? { nickname: '宪宪' } : undefined),
+    getCatById: (id: string) =>
+      id === 'opus-48' ? { displayName: '布偶猫', variantLabel: '4.8', nickname: '宪宪' } : undefined,
   }),
 }));
 
@@ -85,12 +86,12 @@ describe('F232 AC-A7 ArtifactsPanel 内容查看交互', () => {
     expect(container.querySelector('input'), '返回后回到列表（搜索框再现）').toBeTruthy();
   });
 
-  it('AC-A5: 列表项显示猫昵称 + 相对时间（不是原始 catId）', () => {
+  it('AC-A5: 列表项显示标准成员名称 + 相对时间（不是原始 catId）', () => {
     mockState.artifacts = [
       { type: 'pr', name: 'PR #1', catId: 'opus-48', createdAt: Date.now(), sourceMessageId: null, ref: 'o/r#1' },
     ];
     const { container } = renderPanel();
-    expect(container.textContent).toContain('宪宪'); // 昵称映射
+    expect(container.textContent).toContain('布偶猫（4.8）'); // runtime roster 标准映射
     expect(container.textContent).not.toContain('opus-48'); // 不显示原始 catId
     expect(container.textContent).toContain('刚刚'); // 相对时间
   });

--- a/packages/web/src/components/__tests__/member-identity-labels.test.tsx
+++ b/packages/web/src/components/__tests__/member-identity-labels.test.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { AuthorizationCard } from '../AuthorizationCard';
+import { SettledHistoryCard } from '../SettledHistoryCard';
+
+const TEST_CATS = [{ id: 'cat-sol', displayName: '缅因猫', variantLabel: 'sol' }];
+
+vi.mock('@/hooks/useCatData', () => ({
+  useCatData: () => ({
+    cats: TEST_CATS,
+    getCatById: (id: string) => TEST_CATS.find((cat) => cat.id === id),
+  }),
+}));
+
+describe('Console member identity labels', () => {
+  it('renders the runtime member name in permission cards', () => {
+    const html = renderToStaticMarkup(
+      <AuthorizationCard
+        request={{
+          requestId: 'auth-1',
+          catId: 'cat-sol',
+          threadId: 'thread-1',
+          action: 'write',
+          reason: '需要更新文件',
+          createdAt: Date.now(),
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('缅因猫（sol） 请求权限');
+    expect(html).not.toContain('cat-sol 请求权限');
+  });
+
+  it('uses the same projection in settled approval history', () => {
+    const html = renderToStaticMarkup(
+      <SettledHistoryCard
+        item={{
+          proposalId: 'proposal-1',
+          sourceFeatureId: 'F225',
+          sourceThreadId: 'thread-1',
+          requesterCatId: 'cat-sol',
+          ownerUserId: 'user-1',
+          status: 'approved',
+          summary: '交接完成',
+          detail: {},
+          createdAt: Date.now() - 1_000,
+          decidedAt: Date.now(),
+          decidedBy: 'user-1',
+        }}
+      />,
+    );
+
+    expect(html).toContain('来自 <span class="font-medium">缅因猫（sol）</span>');
+  });
+
+  it('falls back to catId when the member is absent from the runtime roster', () => {
+    const html = renderToStaticMarkup(
+      <AuthorizationCard
+        request={{
+          requestId: 'auth-2',
+          catId: 'cat-retired',
+          threadId: 'thread-1',
+          action: 'read',
+          reason: '读取历史记录',
+          createdAt: Date.now(),
+        }}
+        onRespond={vi.fn()}
+      />,
+    );
+
+    expect(html).toContain('cat-retired 请求权限');
+  });
+});

--- a/packages/web/src/components/__tests__/message-navigator.test.ts
+++ b/packages/web/src/components/__tests__/message-navigator.test.ts
@@ -79,8 +79,8 @@ describe('MessageNavigator', () => {
     // base colors come from useCatData (populated by /api/cats)
     expect(html).toContain('#9B7EBD');
     expect(html).toContain('#5B8C5A');
-    expect(html).toContain('跳转到 布偶猫（opus-45） 的消息');
-    expect(html).toContain('跳转到 缅因猫（spark） 的消息');
+    expect(html).toContain('跳转到 opus-45 的消息');
+    expect(html).toContain('跳转到 spark 的消息');
   });
 
   it('resolves non-hyphen variant catIds during fallback', () => {
@@ -97,26 +97,26 @@ describe('MessageNavigator', () => {
     expect(html).toContain('#9B7EBD'); // opus
     expect(html).toContain('#5B9BD5'); // gemini
 
-    expect(html).toContain('跳转到 缅因猫（gpt52） 的消息');
-    expect(html).toContain('跳转到 布偶猫（sonnet） 的消息');
-    expect(html).toContain('跳转到 暹罗猫（gemini25） 的消息');
+    expect(html).toContain('跳转到 gpt52 的消息');
+    expect(html).toContain('跳转到 sonnet 的消息');
+    expect(html).toContain('跳转到 gemini25 的消息');
   });
 
   it('treats messages with catId as assistant even when type is user', () => {
     const msgs = [makeMsg('m1', 'user'), makeMsg('m2', 'user', 'gpt52'), makeMsg('m3', 'assistant', 'codex')];
     const html = render(msgs);
 
-    expect(html).toContain('跳转到 缅因猫（gpt52） 的消息');
+    expect(html).toContain('跳转到 gpt52 的消息');
 
     const ownerLabels = html.match(/跳转到 始皇帝 的消息/g) ?? [];
     expect(ownerLabels.length).toBe(1);
   });
 
-  it('applies kimi fallback colors and labels before /api/cats loads', () => {
+  it('applies kimi fallback color but keeps the raw id until /api/cats loads', () => {
     const msgs = [makeMsg('m1', 'user'), makeMsg('m2', 'assistant', 'kimi'), makeMsg('m3', 'assistant', 'codex')];
     const html = render(msgs);
 
-    expect(html).toContain('跳转到 梵花猫 的消息');
+    expect(html).toContain('跳转到 kimi 的消息');
   });
 
   it('includes accessibility labels', () => {
@@ -124,7 +124,7 @@ describe('MessageNavigator', () => {
     const html = render(msgs);
 
     expect(html).toContain('跳转到 始皇帝 的消息');
-    expect(html).toContain('跳转到 缅因猫 的消息');
+    expect(html).toContain('跳转到 codex 的消息');
   });
 
   it('samples at fixed intervals when messages exceed MAX_DOTS (18)', () => {

--- a/packages/web/src/components/__tests__/queue-panel-agent-entries.test.ts
+++ b/packages/web/src/components/__tests__/queue-panel-agent-entries.test.ts
@@ -17,6 +17,18 @@ vi.mock('@/hooks/useCoCreatorConfig', () => ({
   }),
 }));
 
+const TEST_CATS = [
+  { id: 'codex', displayName: '缅因猫', variantLabel: 'sol' },
+  { id: 'opus', displayName: '布偶猫', variantLabel: 'Fable' },
+];
+
+vi.mock('@/hooks/useCatData', () => ({
+  useCatData: () => ({
+    cats: TEST_CATS,
+    getCatById: (id: string) => TEST_CATS.find((cat) => cat.id === id),
+  }),
+}));
+
 vi.mock('@/utils/api-client', () => ({
   apiFetch: vi.fn(async () => ({ ok: true, json: async () => ({}) })),
 }));
@@ -78,7 +90,8 @@ describe('QueuePanel agent entry rendering (F122B AC-B7)', () => {
 
     const text = container.textContent ?? '';
     // Agent entry should show handoff format
-    expect(text).toContain('codex → opus');
+    expect(text).toContain('缅因猫（sol） → 布偶猫（Fable）');
+    expect(text).not.toContain('codex → opus');
     // User entry should show configured co-creator name
     expect(text).toContain('始皇帝');
   });

--- a/packages/web/src/components/__tests__/queue-panel-wait-reason.test.ts
+++ b/packages/web/src/components/__tests__/queue-panel-wait-reason.test.ts
@@ -13,6 +13,18 @@ vi.mock('@/utils/api-client', () => ({
   apiFetch: vi.fn(async () => ({ ok: true, json: async () => ({}) })),
 }));
 
+const TEST_CATS = [
+  { id: 'codex', displayName: '缅因猫', variantLabel: 'sol' },
+  { id: 'opus', displayName: '布偶猫', variantLabel: 'Fable' },
+];
+
+vi.mock('@/hooks/useCatData', () => ({
+  useCatData: () => ({
+    cats: TEST_CATS,
+    getCatById: (id: string) => TEST_CATS.find((cat) => cat.id === id),
+  }),
+}));
+
 const NOW = Date.now();
 
 const QUEUED_ENTRY: QueueEntry = {
@@ -142,7 +154,8 @@ describe('QueuePanel wait-reason render', () => {
     });
     const html = container.innerHTML;
     expect(html).toContain('等待');
-    expect(html).toContain('opus');
+    expect(html).toContain('布偶猫（Fable）');
+    expect(html).not.toContain('等待 <span class="font-medium text-cafe-secondary">opus</span>');
     expect(html).toContain('当前回合');
     expect(html).toContain('已运行');
   });
@@ -170,7 +183,7 @@ describe('QueuePanel wait-reason render', () => {
     });
     const html = container.innerHTML;
     expect(html).toContain('当前回合');
-    expect(html).toContain('opus');
-    expect(html).not.toContain('codex');
+    expect(html).toContain('布偶猫（Fable）');
+    expect(html).not.toContain('缅因猫（sol）');
   });
 });

--- a/packages/web/src/components/__tests__/thread-liveness-chrome.test.tsx
+++ b/packages/web/src/components/__tests__/thread-liveness-chrome.test.tsx
@@ -120,7 +120,9 @@ describe('thread-scoped liveness chrome', () => {
       root.render(React.createElement(ThreadExecutionBar, { threadId: 'thread-b' }));
     });
 
-    const stopButton = container.querySelector('button[aria-label="Stop opus"]') as HTMLButtonElement | null;
+    const stopButton = container.querySelector(
+      'button[aria-label="Stop 布偶猫（Opus 4.7）"]',
+    ) as HTMLButtonElement | null;
     expect(stopButton).not.toBeNull();
 
     await act(async () => {

--- a/packages/web/src/components/audit/SessionEventsViewer.tsx
+++ b/packages/web/src/components/audit/SessionEventsViewer.tsx
@@ -3,6 +3,8 @@
 // biome-ignore lint/correctness/noUnusedImports: React needed for JSX in vitest environment
 import React, { useCallback, useEffect, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
+import { useCatTechnicalLabelResolver } from '@/hooks/useCatNameResolver';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { apiFetch } from '@/utils/api-client';
 import {
   formatBindingLabel,
@@ -217,7 +219,7 @@ export function SessionEventsViewer({ sessionId, catId, onClose }: SessionEvents
   };
 
   const assistantStyle = assistantRoleStyle(catId);
-  const assistantLabel = catId ? (getCatById(catId)?.displayName ?? catId) : 'assistant';
+  const assistantLabel = catId ? resolveCatDisplayName(catId, getCatById) : 'assistant';
 
   return (
     <div className="rounded-lg border border-[var(--console-border-soft)] bg-cafe-surface">
@@ -353,10 +355,11 @@ function RuntimeMetadataHeader({
   session: ExternalRuntimeSessionListItem;
   noise: DigestNoiseSummary[];
 }) {
+  const resolveCatName = useCatTechnicalLabelResolver();
   const badge = formatLifecycleBadge(session.lifecycle);
   const latestIdentity = session.identityHistory?.at(-1);
   const model = latestIdentity?.model ?? session.model ?? 'model unknown';
-  const identityLabel = `${latestIdentity?.catId ?? session.catId} · ${model}`;
+  const identityLabel = `${resolveCatName(latestIdentity?.catId ?? session.catId)} · ${model}`;
 
   return (
     <div className="space-y-2 bg-[var(--console-shell-bg)] px-3 py-2 console-divider-b">

--- a/packages/web/src/components/capability-board-ui.tsx
+++ b/packages/web/src/components/capability-board-ui.tsx
@@ -9,6 +9,7 @@
 'use client';
 
 import { type CSSProperties, type ReactNode, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { HubIcon } from './hub-icons';
 import { EcosystemBadge } from './marketplace/marketplace-badges';
 
@@ -393,6 +394,7 @@ function CatFamilyToggles({
   onToggle: ToggleHandler;
 }) {
   const [openFamily, setOpenFamily] = useState<string | null>(null);
+  const resolveCatName = useCatNameResolver();
 
   return (
     <div className="pt-2 border-t border-conn-indigo-bg/30">
@@ -435,7 +437,7 @@ function CatFamilyToggles({
                     if (!(catId in item.cats)) {
                       return (
                         <div key={catId} className="flex items-center justify-between py-0.5">
-                          <span className="text-xs text-cafe-secondary font-mono">{catId}</span>
+                          <span className="text-xs text-cafe-secondary">{resolveCatName(catId)}</span>
                           <span className="text-xs text-cafe-muted select-none" title="该 Skill 对此猫不适用">
                             –
                           </span>
@@ -446,7 +448,7 @@ function CatFamilyToggles({
                     const isCatToggling = toggling === `${item.type}:${item.id}:${catId}`;
                     return (
                       <div key={catId} className="flex items-center justify-between py-0.5">
-                        <span className="text-xs text-cafe-secondary font-mono">{catId}</span>
+                        <span className="text-xs text-cafe-secondary">{resolveCatName(catId)}</span>
                         <ToggleSwitch
                           enabled={catEnabled}
                           disabled={isCatToggling}

--- a/packages/web/src/components/community/DecisionQueueItem.tsx
+++ b/packages/web/src/components/community/DecisionQueueItem.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { AlertOctagonIcon, CheckCircleIcon, FileTextIcon, HashIcon } from './community-icons';
 import type {
   CommunityDecisionAction,
@@ -90,7 +89,6 @@ export function DecisionQueueItem({
   onActionComplete,
   onOpenThread,
 }: DecisionQueueItemProps) {
-  const resolveCatName = useCatNameResolver();
   const [activeForm, setActiveForm] = useState<CommunityDecisionAction | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -123,7 +121,7 @@ export function DecisionQueueItem({
             <div className="flex flex-wrap items-center gap-1.5 text-micro uppercase tracking-wider">
               <span className="font-semibold">{item.priority}</span>
               <span className="text-cafe-muted">{KIND_LABELS[item.kind]}</span>
-              <span className="text-cafe-muted">{resolveCatName(item.actor)}</span>
+              <span className="text-cafe-muted">{item.actor}</span>
               <span className="text-cafe-muted">{relativeTime(item.lastUpdatedAt)}</span>
             </div>
             <h4

--- a/packages/web/src/components/community/DecisionQueueItem.tsx
+++ b/packages/web/src/components/community/DecisionQueueItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { AlertOctagonIcon, CheckCircleIcon, FileTextIcon, HashIcon } from './community-icons';
 import type {
   CommunityDecisionAction,
@@ -89,6 +90,7 @@ export function DecisionQueueItem({
   onActionComplete,
   onOpenThread,
 }: DecisionQueueItemProps) {
+  const resolveCatName = useCatNameResolver();
   const [activeForm, setActiveForm] = useState<CommunityDecisionAction | null>(null);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -121,7 +123,7 @@ export function DecisionQueueItem({
             <div className="flex flex-wrap items-center gap-1.5 text-micro uppercase tracking-wider">
               <span className="font-semibold">{item.priority}</span>
               <span className="text-cafe-muted">{KIND_LABELS[item.kind]}</span>
-              <span className="text-cafe-muted">{item.actor}</span>
+              <span className="text-cafe-muted">{resolveCatName(item.actor)}</span>
               <span className="text-cafe-muted">{relativeTime(item.lastUpdatedAt)}</span>
             </div>
             <h4

--- a/packages/web/src/components/concierge/ConciergePanel.tsx
+++ b/packages/web/src/components/concierge/ConciergePanel.tsx
@@ -29,6 +29,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
 import { useIMEGuard } from '@/hooks/useIMEGuard';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { useConciergeStore } from '@/stores/conciergeStore';
 import { apiFetch } from '@/utils/api-client';
 import { CafeIcon } from '../rich/CafeIcons';
@@ -70,8 +71,8 @@ export function ConciergePanel() {
   // so isComposing is already false. The hook keeps a ref true for one extra rAF frame.
   const ime = useIMEGuard();
   // FIX-4 R2: resolve dutyCatProfileId → human-readable display name from cat roster
-  const { cats } = useCatData();
-  const dutyCatDisplayName = cats.find((c) => c.id === dutyCatProfileId)?.displayName;
+  const { getCatById } = useCatData();
+  const dutyCatDisplayName = dutyCatProfileId ? resolveCatDisplayName(dutyCatProfileId, getCatById) : undefined;
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);

--- a/packages/web/src/components/game/GameLobby.tsx
+++ b/packages/web/src/components/game/GameLobby.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useState } from 'react';
 import type { CatData } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { catColorVar } from '@/lib/cat-slug';
 
 /** Available board presets — mirrors WEREWOLF_PRESETS on backend */
@@ -147,13 +148,13 @@ export function GameLobby({ mode, cats, onConfirm, onCancel }: GameLobbyProps) {
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   src={cat.avatar}
-                  alt={cat.displayName}
+                  alt={formatCatDisplayName(cat)}
                   className="w-5 h-5 rounded-full"
                   onError={(e) => {
                     (e.target as HTMLImageElement).style.display = 'none';
                   }}
                 />
-                {cat.displayName}
+                {formatCatDisplayName(cat)}
               </button>
             ))}
           </div>
@@ -181,13 +182,13 @@ export function GameLobby({ mode, cats, onConfirm, onCancel }: GameLobbyProps) {
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={cat.avatar}
-                    alt={cat.displayName}
+                    alt={formatCatDisplayName(cat)}
                     className="w-5 h-5 rounded-full"
                     onError={(e) => {
                       (e.target as HTMLImageElement).style.display = 'none';
                     }}
                   />
-                  {cat.displayName}
+                  {formatCatDisplayName(cat)}
                 </button>
               ))}
             </div>

--- a/packages/web/src/components/leaderboard-cards.tsx
+++ b/packages/web/src/components/leaderboard-cards.tsx
@@ -2,27 +2,15 @@
 
 import type { RankedCat, StreakCat } from '@cat-cafe/shared';
 import { type ReactNode } from 'react';
-import { useCatData } from '@/hooks/useCatData';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import typographyTokens from '@/styles/typography-tokens.json';
 import { CatAvatar } from './CatAvatar';
 
 const MEDAL = ['🥇', '🥈', '🥉'];
 
-function CatTag({ catId }: { catId: string }) {
-  const { getCatById } = useCatData();
-  const cat = getCatById(catId);
-  const family = cat?.breedDisplayName ?? cat?.displayName;
-  const detail = cat?.variantLabel ?? cat?.nickname ?? cat?.id;
-  const label = family && detail && family !== detail ? `${family} · ${detail}` : (family ?? detail ?? catId);
-
-  return (
-    <span
-      className="text-label font-medium"
-      style={{ color: 'var(--cafe-text-muted)', fontFamily: 'Plus Jakarta Sans, sans-serif' }}
-    >
-      {label}
-    </span>
-  );
+function CatName({ catId }: { catId: string }) {
+  const resolveCatName = useCatNameResolver();
+  return <>{resolveCatName(catId)}</>;
 }
 
 export function CatHeroCard({ cat, unit }: { cat: RankedCat; unit: string }) {
@@ -33,9 +21,8 @@ export function CatHeroCard({ cat, unit }: { cat: RankedCat; unit: string }) {
       </span>
       <CatAvatar catId={cat.catId} size={72} />
       <span className="text-lg font-medium" style={{ fontFamily: 'Fraunces, serif', color: 'var(--cafe-text)' }}>
-        {cat.displayName}
+        <CatName catId={cat.catId} />
       </span>
-      <CatTag catId={cat.catId} />
       <span
         className="text-4xl font-medium tracking-tight"
         style={{ fontFamily: 'Fraunces, serif', color: 'var(--cafe-accent)' }}
@@ -73,7 +60,7 @@ export function WorkMetric({ cat, label }: { cat: RankedCat | undefined; label: 
             fontFamily: 'Plus Jakarta Sans, sans-serif',
           }}
         >
-          🏅 {cat.displayName}
+          🏅 <CatName catId={cat.catId} />
         </span>
       )}
     </div>
@@ -94,7 +81,7 @@ export function MiniRanked({ items, unit }: { items: RankedCat[]; unit: string }
           <span className="text-sm">{MEDAL[cat.rank - 1] ?? `#${cat.rank}`}</span>
           <CatAvatar catId={cat.catId} size={24} />
           <span className="text-compact font-semibold" style={{ color: 'var(--cafe-text)' }}>
-            {cat.displayName}
+            <CatName catId={cat.catId} />
           </span>
           <span className="text-label ml-auto" style={{ color: 'var(--cafe-text-muted)' }}>
             {cat.count} {unit}
@@ -118,7 +105,7 @@ export function StreakRanked({ items }: { items: StreakCat[] }) {
         <li key={cat.catId} className="flex items-center gap-2">
           <span className="text-sm">{MEDAL[cat.rank - 1] ?? `#${cat.rank}`}</span>
           <span className="text-compact font-semibold" style={{ color: 'var(--cafe-text)' }}>
-            {cat.displayName}
+            <CatName catId={cat.catId} />
           </span>
           <span className="text-label ml-auto" style={{ color: 'var(--cafe-text-muted)' }}>
             连续 {cat.currentStreak} 天 (最长 {cat.maxStreak})

--- a/packages/web/src/components/leaderboard-phase-bc.tsx
+++ b/packages/web/src/components/leaderboard-phase-bc.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import type { Achievement, CvoLevel, GameStats, SillyCatEntry } from '@cat-cafe/shared';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { CatAvatar } from './CatAvatar';
 import { CafeIcon } from './rich/CafeIcons';
+
+function CatName({ catId }: { catId: string }) {
+  const resolveCatName = useCatNameResolver();
+  return <>{resolveCatName(catId)}</>;
+}
 
 /** Phase B: Silly cats — 翻车现场 */
 export function SillyCatsList({ entries }: { entries: SillyCatEntry[] }) {
@@ -18,7 +24,7 @@ export function SillyCatsList({ entries }: { entries: SillyCatEntry[] }) {
         <li key={e.catId} className="flex items-center gap-2">
           <CatAvatar catId={e.catId} size={24} />
           <span className="text-compact font-semibold" style={{ color: 'var(--cafe-text)' }}>
-            {e.displayName}
+            <CatName catId={e.catId} />
           </span>
           <span className="text-label ml-auto font-medium" style={{ color: 'var(--cafe-accent)' }}>
             ×{e.count} {e.description}
@@ -44,7 +50,7 @@ export function GameArena({ stats }: { stats: GameStats }) {
           <span className="text-label font-semibold" style={{ color: 'var(--cafe-accent)' }}>
             <span className="inline-flex items-center gap-1">
               <CafeIcon name="trophy" className="w-3 h-3" />
-              MVP: {stats.catKill.topCat.displayName}
+              MVP: <CatName catId={stats.catKill.topCat.catId} />
             </span>
           </span>
         )}
@@ -60,7 +66,7 @@ export function GameArena({ stats }: { stats: GameStats }) {
           <span className="text-label font-semibold" style={{ color: 'var(--cafe-accent)' }}>
             <span className="inline-flex items-center gap-1">
               <CafeIcon name="cross" className="w-3 h-3" />
-              社死王: {stats.whoSpy.shameCat.displayName}
+              社死王: <CatName catId={stats.whoSpy.shameCat.catId} />
             </span>
           </span>
         )}

--- a/packages/web/src/components/mission-control/DispatchProgress.tsx
+++ b/packages/web/src/components/mission-control/DispatchProgress.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { DispatchExecutionDigest } from '@cat-cafe/shared';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 interface DispatchProgressProps {
   digests: DispatchExecutionDigest[];
@@ -13,6 +14,7 @@ const STATUS_STYLES: Record<DispatchExecutionDigest['status'], { bg: string; tex
 };
 
 export function DispatchProgress({ digests }: DispatchProgressProps) {
+  const resolveCatName = useCatNameResolver();
   if (digests.length === 0) {
     return (
       <div className="rounded-xl bg-[var(--console-shell-bg)] p-8 text-center text-sm text-cafe-secondary">
@@ -39,7 +41,7 @@ export function DispatchProgress({ digests }: DispatchProgressProps) {
                 <span className={`rounded-full px-2 py-0.5 text-micro font-medium ${style.bg} ${style.text}`}>
                   {style.label}
                 </span>
-                <span className="text-xs font-medium text-cafe-secondary">@{digest.catId}</span>
+                <span className="text-xs font-medium text-cafe-secondary">{resolveCatName(digest.catId)}</span>
               </div>
               <span className="text-micro text-cafe-secondary">
                 {new Date(digest.completedAt).toLocaleString('zh-CN', {

--- a/packages/web/src/components/mission-control/MissionControlCard.tsx
+++ b/packages/web/src/components/mission-control/MissionControlCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BacklogItem } from '@cat-cafe/shared';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 interface MissionControlCardProps {
   item: BacklogItem;
@@ -16,6 +17,7 @@ const PRIORITY_CLASS: Record<BacklogItem['priority'], string> = {
 };
 
 export function MissionControlCard({ item, selected, onSelect }: MissionControlCardProps) {
+  const resolveCatName = useCatNameResolver();
   return (
     <button
       type="button"
@@ -48,7 +50,7 @@ export function MissionControlCard({ item, selected, onSelect }: MissionControlC
       )}
       {item.suggestion && (
         <p className="mt-2 text-micro text-cafe-muted">
-          建议领取：@{item.suggestion.catId} · {item.suggestion.requestedPhase}
+          建议领取：{resolveCatName(item.suggestion.catId)} · {item.suggestion.requestedPhase}
         </p>
       )}
       {item.dependencies && (

--- a/packages/web/src/components/mission-control/SuggestionDecisionPanel.tsx
+++ b/packages/web/src/components/mission-control/SuggestionDecisionPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { BacklogItem, ThreadPhase } from '@cat-cafe/shared';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 interface SuggestionDecisionPanelProps {
   item: BacklogItem;
@@ -23,6 +24,7 @@ export function SuggestionDecisionPanel({
   onApprove,
   onReject,
 }: SuggestionDecisionPanelProps) {
+  const resolveCatName = useCatNameResolver();
   return (
     <div className="mt-4 space-y-2">
       {item.status === 'approved' && (
@@ -31,7 +33,7 @@ export function SuggestionDecisionPanel({
         </p>
       )}
       <div className="rounded-lg bg-[var(--console-hover-bg)] p-2 text-xs text-cafe-secondary">
-        <p>建议猫猫：@{item.suggestion?.catId}</p>
+        <p>建议猫猫：{item.suggestion?.catId ? resolveCatName(item.suggestion.catId) : '—'}</p>
         <p>Why：{item.suggestion?.why}</p>
         <p>Plan：{item.suggestion?.plan}</p>
       </div>

--- a/packages/web/src/components/mission-control/SuggestionDrawer.tsx
+++ b/packages/web/src/components/mission-control/SuggestionDrawer.tsx
@@ -4,6 +4,7 @@ import type { BacklogItem, MissionHubSelfClaimScope, ThreadPhase } from '@cat-ca
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { formatCatName, useCatData } from '@/hooks/useCatData';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { SuggestionDecisionPanel } from './SuggestionDecisionPanel';
 import { SuggestionOpenForm } from './SuggestionOpenForm';
 
@@ -52,12 +53,12 @@ export function SuggestionDrawer({
   onReleaseLease,
   onReclaimLease,
 }: SuggestionDrawerProps) {
-  const { cats } = useCatData();
+  const { cats, getCatById } = useCatData();
   const catOptions = useMemo(
     () =>
       cats.map((cat) => ({
         id: cat.id,
-        label: !cat.variantLabel && cat.nickname ? `${formatCatName(cat)}（${cat.nickname}）` : formatCatName(cat),
+        label: formatCatName(cat),
       })),
     [cats],
   );
@@ -211,7 +212,7 @@ export function SuggestionDrawer({
           {item.lease && (
             <div className="mt-2 rounded-lg bg-[var(--mc-status-dispatched-bg)] px-2 py-1.5 text-xs text-[var(--mc-status-dispatched-text)]">
               <p>Lease：{item.lease.state}</p>
-              <p>Owner：{item.lease.ownerCatId}</p>
+              <p>Owner：{resolveCatDisplayName(item.lease.ownerCatId, getCatById)}</p>
               <p>ExpiresAt：{new Date(item.lease.expiresAt).toLocaleString()}</p>
             </div>
           )}

--- a/packages/web/src/components/rich/CallbackAuthFailureBlock.tsx
+++ b/packages/web/src/components/rich/CallbackAuthFailureBlock.tsx
@@ -14,6 +14,7 @@
 
 import { useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
+import { useCatTechnicalLabelResolver } from '@/hooks/useCatNameResolver';
 import type { RichCardBlock } from '@/stores/chat-types';
 import { apiFetch } from '@/utils/api-client';
 
@@ -47,6 +48,7 @@ function formatRelative(failedAt: number): string {
 }
 
 export function CallbackAuthFailureBlock({ block }: { block: RichCardBlock }) {
+  const resolveCatName = useCatTechnicalLabelResolver();
   const meta = block.meta as CallbackAuthMeta | undefined;
   const [hidden, setHidden] = useState(false);
   const [hideError, setHideError] = useState<string | null>(null);
@@ -137,7 +139,7 @@ export function CallbackAuthFailureBlock({ block }: { block: RichCardBlock }) {
         </span>
         <span>
           <span style={{ color: 'var(--cafe-text-muted)' }}>CAT · </span>
-          <span className="font-mono">{meta.catId}</span>
+          <span className="font-mono">{resolveCatName(meta.catId)}</span>
         </span>
         <span>
           <span style={{ color: 'var(--cafe-text-muted)' }}>WHEN · </span>

--- a/packages/web/src/components/rich/CardBlock.tsx
+++ b/packages/web/src/components/rich/CardBlock.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { InvestigationProgress } from '@/components/concierge/InvestigationProgress';
 import { MarkdownContent } from '@/components/MarkdownContent';
 import { pushThreadRouteWithHistory } from '@/components/ThreadSidebar/thread-navigation';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import type { RichCardBlock } from '@/stores/chat-types';
 import { useChatStore } from '@/stores/chatStore';
 import { useConciergeStore } from '@/stores/conciergeStore';
@@ -82,6 +83,7 @@ export function CardBlock({
   messageId?: string;
   confirmations?: CardConfirmationEntry[];
 }) {
+  const resolveCatName = useCatNameResolver();
   const toneStyle = TONE_STYLES[block.tone ?? 'info'] ?? TONE_STYLES.info;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -297,7 +299,7 @@ export function CardBlock({
           const peekContent = data.window
             .map((m) => {
               const prefix = m.isTarget ? '**→ ' : '  ';
-              const sender = m.catId ? `🐱 ${m.catId}` : `👤 ${m.userId}`;
+              const sender = m.catId ? `🐱 ${resolveCatName(m.catId)}` : `👤 ${m.userId}`;
               const suffix = m.isTarget ? ' ←**' : '';
               return `${prefix}${sender}: ${m.content?.slice(0, 200) ?? ''}${suffix}`;
             })

--- a/packages/web/src/components/runtime-sessions/ExternalRuntimeSessionsPanel.tsx
+++ b/packages/web/src/components/runtime-sessions/ExternalRuntimeSessionsPanel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCatTechnicalLabelResolver } from '@/hooks/useCatNameResolver';
 import { apiFetch } from '@/utils/api-client';
 import {
   formatBindingLabel,
@@ -140,6 +141,7 @@ function RuntimeSessionRow({
   session: ExternalRuntimeSessionListItem;
   onViewSession?: (sessionId: string, catId?: string) => void;
 }) {
+  const resolveCatName = useCatTechnicalLabelResolver();
   const badge = formatLifecycleBadge(session.lifecycle);
   const sealReason = formatSealReason(session.lifecycle.sealReason);
   const surfaceBadge = formatSurfaceBadge(session.surface);
@@ -158,12 +160,12 @@ function RuntimeSessionRow({
             )}
             {session.lifecycle.sealReason && <span className="text-micro text-cafe-muted">{sealReason}</span>}
             <span className="min-w-0 truncate text-xs font-semibold text-cafe-text">
-              {formatRuntimeSessionTitle(session)}
+              {formatRuntimeSessionTitle(session, resolveCatName)}
             </span>
           </div>
           <div className="grid min-w-0 gap-x-4 gap-y-1 text-micro text-cafe-muted sm:grid-cols-2">
             <span className="min-w-0 truncate">
-              {session.catId} · {session.model ?? 'model unknown'}
+              {resolveCatName(session.catId)} · {session.model ?? 'model unknown'}
             </span>
             <span className="min-w-0 truncate font-mono">{shortRuntimeId(session.runtimeSessionId)}</span>
             {session.runtimeConversationId && (

--- a/packages/web/src/components/runtime-sessions/external-runtime-session-format.ts
+++ b/packages/web/src/components/runtime-sessions/external-runtime-session-format.ts
@@ -85,10 +85,13 @@ export function formatSurfaceBadge(surface: string | undefined): RuntimeSurfaceB
   return null;
 }
 
-export function formatRuntimeSessionTitle(session: ExternalRuntimeSessionListItem): string {
+export function formatRuntimeSessionTitle(
+  session: ExternalRuntimeSessionListItem,
+  resolveCatName: (catId: string) => string = (catId) => catId,
+): string {
   const title = session.title?.trim();
   if (title) return title;
-  return `${session.catId} · ${session.model ?? shortRuntimeId(session.runtimeSessionId)}`;
+  return `${resolveCatName(session.catId)} · ${session.model ?? shortRuntimeId(session.runtimeSessionId)}`;
 }
 
 export function shortRuntimeId(id: string): string {

--- a/packages/web/src/components/settings/CatDimensionSelector.tsx
+++ b/packages/web/src/components/settings/CatDimensionSelector.tsx
@@ -6,7 +6,7 @@
  * would be active for the selected cat based on breed and provider.
  */
 
-import { useCatData } from '@/hooks/useCatData';
+import { formatCatName, useCatData } from '@/hooks/useCatData';
 import type { ClientId } from '../hub-cat-editor.model';
 import { defaultMcpSupportForClient } from '../hub-cat-editor.protocols';
 
@@ -30,7 +30,7 @@ export function CatDimensionSelector({ onSelect, selected }: CatDimensionSelecto
       <option value="">选择成员预览</option>
       {availableCats.map((cat) => (
         <option key={cat.id} value={cat.id}>
-          {cat.displayName}
+          {formatCatName(cat)}
         </option>
       ))}
     </select>

--- a/packages/web/src/components/settings/ConciergeSettingsContent.tsx
+++ b/packages/web/src/components/settings/ConciergeSettingsContent.tsx
@@ -14,7 +14,7 @@
 
 import { BALL_SIZE_DEFAULT, BALL_SIZE_MAX, BALL_SIZE_MIN } from '@cat-cafe/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useCatData } from '@/hooks/useCatData';
+import { formatCatName, useCatData } from '@/hooks/useCatData';
 import { useConciergeStore } from '@/stores/conciergeStore';
 import { apiFetch } from '@/utils/api-client';
 import { RadioOption, RangeSlider, TextInput, ToggleSwitch } from './ConciergeSettingsParts';
@@ -245,12 +245,12 @@ export function ConciergeSettingsContent() {
             >
               {staleDutyCat && (
                 <option key={staleDutyCat.id} value={staleDutyCat.id} disabled>
-                  {staleDutyCat.displayName} ({staleDutyCat.id}) — 不可用
+                  {formatCatName(staleDutyCat)} · {staleDutyCat.id} — 不可用
                 </option>
               )}
               {availableCats.map((cat) => (
                 <option key={cat.id} value={cat.id}>
-                  {cat.displayName} ({cat.id})
+                  {formatCatName(cat)} · {cat.id}
                 </option>
               ))}
             </select>

--- a/packages/web/src/components/settings/capability-settings-ui.tsx
+++ b/packages/web/src/components/settings/capability-settings-ui.tsx
@@ -2,6 +2,7 @@
 
 import type { MouseEvent, ReactNode } from 'react';
 import { useMemo } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import type { CapabilityBoardItem, CatFamily } from '../capability-board-ui';
 import { HubIcon } from '../hub-icons';
 import {
@@ -251,6 +252,7 @@ export function PerCatToggles({
   onToggle: (item: CapabilityBoardItem, enabled: boolean, catId?: string) => void;
   disabled?: boolean;
 }) {
+  const resolveCatName = useCatNameResolver();
   if (catFamilies.length === 0 || !item.cats) return null;
   const catEntries = Object.entries(item.cats);
   if (catEntries.length === 0) return null;
@@ -268,7 +270,7 @@ export function PerCatToggles({
               {relevantCats.map((catId) => {
                 const enabled = item.cats[catId] ?? false;
                 const busy = toggling === `${item.id}:${catId}`;
-                const catLabel = family.catNames?.[catId] ?? catId;
+                const catLabel = resolveCatName(catId);
                 return (
                   <div key={catId} className="flex items-center justify-between">
                     <span className="text-xs text-cafe-secondary">{catLabel}</span>

--- a/packages/web/src/components/story-player/GuestCard.tsx
+++ b/packages/web/src/components/story-player/GuestCard.tsx
@@ -15,6 +15,7 @@
 
 // biome-ignore lint/correctness/noUnusedImports: React in scope needed for renderToStaticMarkup in tests
 import React, { useEffect, useRef, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -46,6 +47,7 @@ export interface GuestCardProps {
 // ---------------------------------------------------------------------------
 
 export function GuestCard({ contentSnippet, catId, visible, onFadeComplete }: GuestCardProps) {
+  const resolveCatName = useCatNameResolver();
   const [fading, setFading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -124,7 +126,7 @@ export function GuestCard({ contentSnippet, catId, visible, onFadeComplete }: Gu
                 opacity: 0.7,
               }}
             >
-              · {catId}
+              · {resolveCatName(catId)}
             </span>
           )}
         </div>

--- a/packages/web/src/components/story-player/ReplayEventBubble.tsx
+++ b/packages/web/src/components/story-player/ReplayEventBubble.tsx
@@ -8,6 +8,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import type { ReplayEvent } from '@/lib/story-player/types';
 
 // ---------------------------------------------------------------------------
@@ -179,6 +180,7 @@ function formatToolContent(input: string): string {
 // ---------------------------------------------------------------------------
 
 export function ReplayEventBubble({ event, displayMode, isRevealing, speedMultiplier }: ReplayEventBubbleProps) {
+  const resolveCatName = useCatNameResolver();
   const isCinematic = displayMode === 'cinematic' && isRevealing;
   const displayText = useCinematicText(
     event.content,
@@ -271,7 +273,7 @@ export function ReplayEventBubble({ event, displayMode, isRevealing, speedMultip
               fontFamily: 'var(--font-mono, monospace)',
             }}
           >
-            {event.catId}
+            {resolveCatName(event.catId)}
           </div>
         )}
         {displayText}

--- a/packages/web/src/hooks/__tests__/useAgentMessages-background-system-info-web-search.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-background-system-info-web-search.test.ts
@@ -277,6 +277,7 @@ describe('consumeBackgroundSystemInfo web_search', () => {
 
   it('formats a2a_pingpong_terminated as readable system notice text', () => {
     const options = createMockOptions();
+    options.resolveCatName = (catId) => ({ sonnet: '布偶猫（sonnet）', gpt52: '缅因猫（gpt52）' })[catId] ?? catId;
 
     const msg = {
       type: 'system_info',
@@ -295,7 +296,7 @@ describe('consumeBackgroundSystemInfo web_search', () => {
 
     expect(result.consumed).toBe(false);
     expect(result.variant).toBe('info');
-    expect(result.content).toBe('🏓 sonnet ↔ gpt52 已连续互相 @ 4 轮，链路已熔断。');
+    expect(result.content).toBe('🏓 布偶猫（sonnet） ↔ 缅因猫（gpt52） 已连续互相 @ 4 轮，链路已熔断。');
   });
 });
 

--- a/packages/web/src/hooks/__tests__/useAgentMessages-background.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-background.test.ts
@@ -30,7 +30,7 @@ let clearDoneTimeoutCalls: Array<string | undefined> = [];
 /**
  * Runs the extracted background-thread branch handler with real stores.
  */
-function simulateBackgroundMessage(msg: BackgroundAgentMessage) {
+function simulateBackgroundMessage(msg: BackgroundAgentMessage, resolveCatName?: (catId: string) => string) {
   handleBackgroundAgentMessage(msg, {
     store: useChatStore.getState(),
     bgStreamRefs: testBgStreamRefs,
@@ -38,6 +38,7 @@ function simulateBackgroundMessage(msg: BackgroundAgentMessage) {
     pendingCallbacks: testPendingCallbacks,
     nextBgSeq: () => testBgSeq++,
     addToast: (toast) => useToastStore.getState().addToast(toast),
+    resolveCatName,
     clearDoneTimeout: (threadId) => {
       clearDoneTimeoutCalls.push(threadId);
     },
@@ -107,6 +108,22 @@ describe('background thread socket handling', () => {
       expect(toasts[0].type).toBe('success');
       expect(toasts[0].title).toBe('codex 完成');
       expect(toasts[0].threadId).toBe('thread-bg');
+    });
+
+    it('projects the runtime member name in background completion toasts', () => {
+      simulateBackgroundMessage(
+        {
+          type: 'done',
+          catId: 'cat-eqdvbcxw',
+          threadId: 'thread-bg',
+          timestamp: Date.now(),
+        },
+        () => '缅因猫（sol）',
+      );
+
+      const [toast] = useToastStore.getState().toasts;
+      expect(toast.title).toBe('缅因猫（sol） 完成');
+      expect(toast.message).toBe('缅因猫（sol） 已完成处理');
     });
 
     it('text with isFinal also transitions to done', () => {
@@ -1205,6 +1222,24 @@ describe('background thread socket handling', () => {
       expect(ts.messages[1]?.variant).toBe('info');
       expect(ts.messages[2]?.variant).toBe('a2a_followup');
       expect(ts.messages[2]?.content).toContain('缅因猫 @了 opus');
+    });
+
+    it('projects runtime member names in generated system_info copy', () => {
+      const resolveCatName = (catId: string) => (catId === 'codex' ? '缅因猫（sol）' : catId);
+
+      simulateBackgroundMessage(
+        {
+          type: 'system_info',
+          catId: 'codex',
+          threadId: 'thread-bg',
+          content: JSON.stringify({ type: 'silent_completion' }),
+          timestamp: Date.now(),
+        },
+        resolveCatName,
+      );
+
+      const ts = useChatStore.getState().getThreadState('thread-bg');
+      expect(ts.messages[0]?.content).toBe('缅因猫（sol） completed without a text response.');
     });
 
     it('consumes invocation_usage system_info into thread invocation + message metadata (no raw JSON message)', () => {

--- a/packages/web/src/hooks/__tests__/useAgentMessages-background.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-background.test.ts
@@ -1219,6 +1219,15 @@ describe('background thread socket handling', () => {
       const ts = useChatStore.getState().getThreadState('thread-bg');
       expect(ts.messages).toHaveLength(3);
       expect(ts.messages[0]?.variant).toBe('info');
+      expect(ts.messages[0]?.extra?.systemInfo).toEqual({
+        v: 1,
+        payload: {
+          type: 'mode_switch_proposal',
+          proposedBy: '缅因猫',
+          proposedMode: 'execute',
+        },
+        fallbackCatId: 'codex',
+      });
       expect(ts.messages[1]?.variant).toBe('info');
       expect(ts.messages[2]?.variant).toBe('a2a_followup');
       expect(ts.messages[2]?.content).toContain('缅因猫 @了 opus');

--- a/packages/web/src/hooks/__tests__/useAgentMessages-warning.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentMessages-warning.test.ts
@@ -185,6 +185,18 @@ describe('useAgentMessages system_info warning', () => {
         type: 'system',
         variant: 'info',
         content: '🏓 sonnet ↔ gpt52 已连续互相 @ 4 轮，链路已熔断。',
+        extra: {
+          systemInfo: {
+            v: 1,
+            payload: {
+              type: 'a2a_pingpong_terminated',
+              fromCatId: 'sonnet',
+              targetCatId: 'gpt52',
+              pairCount: 4,
+            },
+            fallbackCatId: 'sonnet',
+          },
+        },
       }),
     );
   });

--- a/packages/web/src/hooks/__tests__/useCatData-retry.test.ts
+++ b/packages/web/src/hooks/__tests__/useCatData-retry.test.ts
@@ -81,6 +81,11 @@ function MultiHookComponent() {
   return null;
 }
 
+function PassiveHookComponent() {
+  hookResult = useCatData({ fetch: false });
+  return null;
+}
+
 beforeAll(() => {
   (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 });
@@ -106,6 +111,16 @@ afterEach(() => {
 // ── Tests ──────────────────────────────────────────────────
 
 describe('useCatData retry mechanism', () => {
+  it('lets leaf presentation consumers subscribe without starting registry I/O', async () => {
+    await act(async () => {
+      root.render(React.createElement(PassiveHookComponent));
+    });
+
+    expect(mockApiFetch).not.toHaveBeenCalled();
+    expect(hookResult.cats).toEqual([]);
+    expect(hookResult.isLoading).toBe(false);
+  });
+
   it('retries after 10s on failure and stops after success', async () => {
     // F166: /api/config/cat-order always returns empty order; /api/cats follows
     // the retry sequence (fail → success).

--- a/packages/web/src/hooks/__tests__/useCatData-retry.test.ts
+++ b/packages/web/src/hooks/__tests__/useCatData-retry.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/utils/transcription-corrector', () => ({ refreshSpeechAliases: vi.fn(
 
 import type { CatData } from '@/hooks/useCatData';
 import { _resetCatDataCache, useCatData } from '@/hooks/useCatData';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 
 // ── API response cats (distinguishable from fallback via breedId) ──
 
@@ -69,6 +70,7 @@ let root: Root;
 let hookResult: ReturnType<typeof useCatData>;
 let hookResultA: ReturnType<typeof useCatData>;
 let hookResultB: ReturnType<typeof useCatData>;
+let resolvedCatLabel = '';
 
 function TestComponent() {
   hookResult = useCatData();
@@ -84,6 +86,26 @@ function MultiHookComponent() {
 function PassiveHookComponent() {
   hookResult = useCatData({ fetch: false });
   return null;
+}
+
+function PassiveResolverComponent() {
+  const resolveCatName = useCatNameResolver();
+  resolvedCatLabel = resolveCatName('opus');
+  return null;
+}
+
+function RegistryLoaderComponent() {
+  useCatData();
+  return null;
+}
+
+function PassiveResolverWithRegistryLoader() {
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(PassiveResolverComponent),
+    React.createElement(RegistryLoaderComponent),
+  );
 }
 
 beforeAll(() => {
@@ -119,6 +141,44 @@ describe('useCatData retry mechanism', () => {
     expect(mockApiFetch).not.toHaveBeenCalled();
     expect(hookResult.cats).toEqual([]);
     expect(hookResult.isLoading).toBe(false);
+  });
+
+  it('hydrates a passive name resolver after the shared registry loads without duplicate cat requests', async () => {
+    let resolveCatsResponse: ((response: Response) => void) | undefined;
+    mockApiFetch.mockImplementation((path: string) => {
+      if (path === '/api/config/cat-order') return Promise.resolve({ ok: false } as Response);
+      if (path === '/api/cats') {
+        return new Promise<Response>((resolve) => {
+          resolveCatsResponse = resolve;
+        });
+      }
+      return Promise.resolve({ ok: false } as Response);
+    });
+
+    await act(async () => {
+      root.render(React.createElement(PassiveResolverWithRegistryLoader));
+    });
+
+    const catsCallCount = () => mockApiFetch.mock.calls.filter((call) => call[0] === '/api/cats').length;
+    expect(resolvedCatLabel).toBe('opus');
+    expect(catsCallCount()).toBe(1);
+
+    const completeCatsRequest = resolveCatsResponse;
+    if (!completeCatsRequest) throw new Error('Expected the registry request to be pending');
+    await act(async () => {
+      completeCatsRequest({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            cats: API_CATS.map((cat) => (cat.id === 'opus' ? { ...cat, variantLabel: '4.8' } : cat)),
+          }),
+      } as Response);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resolvedCatLabel).toBe('布偶猫（4.8）');
+    expect(catsCallCount()).toBe(1);
   });
 
   it('retries after 10s on failure and stops after success', async () => {

--- a/packages/web/src/hooks/system-info-visible.ts
+++ b/packages/web/src/hooks/system-info-visible.ts
@@ -5,6 +5,10 @@ export interface VisibleSystemInfoResult {
   variant: VisibleSystemInfoVariant;
 }
 
+type ResolveCatName = (catId: string) => string;
+
+const identityCatName: ResolveCatName = (catId) => catId;
+
 const INTERNAL_SYSTEM_INFO_TELEMETRY_TYPES = new Set([
   'mcp_server_status',
   'resume_failure_stats',
@@ -18,33 +22,39 @@ export function isInternalSystemInfoTelemetry(parsed: Record<string, unknown>): 
   return typeof parsed?.type === 'string' && INTERNAL_SYSTEM_INFO_TELEMETRY_TYPES.has(parsed.type);
 }
 
-function formatPingpongTerminated(parsed: Record<string, unknown>): VisibleSystemInfoResult {
+function formatPingpongTerminated(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName,
+): VisibleSystemInfoResult {
   const fromCatId = typeof parsed.fromCatId === 'string' ? parsed.fromCatId : 'unknown';
   const targetCatId = typeof parsed.targetCatId === 'string' ? parsed.targetCatId : 'unknown';
   const pairCount = typeof parsed.pairCount === 'number' ? parsed.pairCount : undefined;
   const rounds = pairCount ? ` ${pairCount} 轮` : '';
   return {
-    content: `🏓 ${fromCatId} ↔ ${targetCatId} 已连续互相 @${rounds}，链路已熔断。`,
+    content: `🏓 ${resolveCatName(fromCatId)} ↔ ${resolveCatName(targetCatId)} 已连续互相 @${rounds}，链路已熔断。`,
     variant: 'info',
   };
 }
 
-function formatRoleRejected(parsed: Record<string, unknown>): VisibleSystemInfoResult {
+function formatRoleRejected(parsed: Record<string, unknown>, resolveCatName: ResolveCatName): VisibleSystemInfoResult {
   const reason = typeof parsed.reason === 'string' ? parsed.reason : '';
   const targetCatId = typeof parsed.targetCatId === 'string' ? parsed.targetCatId : 'unknown';
   const action = typeof parsed.action === 'string' ? parsed.action : '当前';
   return {
-    content: reason || `⛔ @${targetCatId} 不接受 ${action} 任务。`,
+    content: reason || `⛔ ${resolveCatName(targetCatId)} 不接受 ${action} 任务。`,
     variant: 'info',
   };
 }
 
-function formatA2AFollowupAvailable(parsed: Record<string, unknown>): VisibleSystemInfoResult | null {
+function formatA2AFollowupAvailable(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName,
+): VisibleSystemInfoResult | null {
   if (parsed?.type !== 'a2a_followup_available') return null;
 
   const mentions = parsed.mentions as Array<{ catId: string; mentionedBy: string }>;
   return {
-    content: mentions.map((m) => `${m.mentionedBy} @了 ${m.catId}`).join('、'),
+    content: mentions.map((m) => `${resolveCatName(m.mentionedBy)} @了 ${resolveCatName(m.catId)}`).join('、'),
     variant: 'a2a_followup',
   };
 }
@@ -59,7 +69,10 @@ function formatWarning(parsed: Record<string, unknown>): VisibleSystemInfoResult
   };
 }
 
-export function formatSessionSealRequested(parsed: Record<string, unknown>): VisibleSystemInfoResult | null {
+export function formatSessionSealRequested(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName = identityCatName,
+): VisibleSystemInfoResult | null {
   if (parsed?.type !== 'session_seal_requested') return null;
 
   const catId = typeof parsed.catId === 'string' ? parsed.catId : 'unknown';
@@ -72,7 +85,7 @@ export function formatSessionSealRequested(parsed: Record<string, unknown>): Vis
   const pct = typeof fillRatio === 'number' ? Math.round(fillRatio * 100) : '?';
 
   return {
-    content: `${catId} 的会话 #${sessionSeq} 已封存（上下文 ${pct}%），下次调用将自动创建新会话`,
+    content: `${resolveCatName(catId)} 的会话 #${sessionSeq} 已封存（上下文 ${pct}%），下次调用将自动创建新会话`,
     variant: 'info',
   };
 }
@@ -89,12 +102,15 @@ export function formatGovernanceBlocked(parsed: Record<string, unknown>): Visibl
   };
 }
 
-function formatModeSwitchProposal(parsed: Record<string, unknown>): VisibleSystemInfoResult | null {
+function formatModeSwitchProposal(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName,
+): VisibleSystemInfoResult | null {
   if (parsed?.type !== 'mode_switch_proposal') return null;
 
   const by = typeof parsed.proposedBy === 'string' ? parsed.proposedBy : '猫猫';
   return {
-    content: `${by} 提议切换到 ${parsed.proposedMode} 模式。`,
+    content: `${resolveCatName(by)} 提议切换到 ${parsed.proposedMode} 模式。`,
     variant: 'info',
   };
 }
@@ -108,26 +124,34 @@ function formatInvocationPreempted(parsed: Record<string, unknown>): VisibleSyst
   };
 }
 
-function formatSilentCompletion(parsed: Record<string, unknown>): VisibleSystemInfoResult | null {
+function formatSilentCompletion(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName,
+  fallbackCatId?: string,
+): VisibleSystemInfoResult | null {
   if (parsed?.type !== 'silent_completion') return null;
 
   const detail = typeof parsed.detail === 'string' ? parsed.detail : '';
-  const catId = typeof parsed.catId === 'string' ? parsed.catId : 'Cat';
+  const catId = typeof parsed.catId === 'string' ? parsed.catId : (fallbackCatId ?? 'Cat');
   return {
-    content: detail || `${catId} completed without a text response.`,
+    content: detail || `${resolveCatName(catId)} completed without a text response.`,
     variant: 'info',
   };
 }
 
-export function formatVisibleSystemInfo(parsed: Record<string, unknown>): VisibleSystemInfoResult | null {
+export function formatVisibleSystemInfo(
+  parsed: Record<string, unknown>,
+  resolveCatName: ResolveCatName = identityCatName,
+  fallbackCatId?: string,
+): VisibleSystemInfoResult | null {
   return (
-    formatA2AFollowupAvailable(parsed) ??
+    formatA2AFollowupAvailable(parsed, resolveCatName) ??
     formatWarning(parsed) ??
-    (parsed?.type === 'a2a_pingpong_terminated' ? formatPingpongTerminated(parsed) : null) ??
-    (parsed?.type === 'a2a_role_rejected' ? formatRoleRejected(parsed) : null) ??
-    formatModeSwitchProposal(parsed) ??
+    (parsed?.type === 'a2a_pingpong_terminated' ? formatPingpongTerminated(parsed, resolveCatName) : null) ??
+    (parsed?.type === 'a2a_role_rejected' ? formatRoleRejected(parsed, resolveCatName) : null) ??
+    formatModeSwitchProposal(parsed, resolveCatName) ??
     formatInvocationPreempted(parsed) ??
-    formatSilentCompletion(parsed)
+    formatSilentCompletion(parsed, resolveCatName, fallbackCatId)
   );
 }
 

--- a/packages/web/src/hooks/useAgentMessages.ts
+++ b/packages/web/src/hooks/useAgentMessages.ts
@@ -18,6 +18,7 @@ import type {
   ChatMessageMetadata,
   ChatMessagePatch,
   RichBlock,
+  SystemInfoProjection,
   TaskProgressItem,
   ThreadState,
   TokenUsage,
@@ -585,6 +586,11 @@ interface SystemInfoConsumeResult {
   consumed: boolean;
   content: string;
   variant: 'info' | 'a2a_followup';
+  systemInfo?: SystemInfoProjection;
+}
+
+function retainSystemInfo(payload: Record<string, unknown>, fallbackCatId: string): SystemInfoProjection {
+  return { v: 1, payload, fallbackCatId };
 }
 
 function recoverBackgroundStreamingMessage(
@@ -964,6 +970,7 @@ export function consumeBackgroundSystemInfo(
   let sysContent = msg.content ?? '';
   let sysVariant: 'info' | 'a2a_followup' = 'info';
   let consumed = false;
+  let systemInfo: SystemInfoProjection | undefined;
 
   try {
     const parsed = JSON.parse(sysContent);
@@ -971,6 +978,7 @@ export function consumeBackgroundSystemInfo(
     if (visible) {
       sysContent = visible.content;
       sysVariant = visible.variant;
+      systemInfo = retainSystemInfo(parsed, msg.catId);
     } else if (parsed?.type === 'invocation_created') {
       const targetCatId = parsed.catId ?? msg.catId;
       // Identity canonicalization (砚砚 GPT-5.5 2026-04-26): outer wrapper invocationId
@@ -1353,7 +1361,10 @@ export function consumeBackgroundSystemInfo(
           sessionSealed: true,
         });
         const visibleSessionSeal = formatSessionSealRequested(parsed, options.resolveCatName);
-        if (visibleSessionSeal) sysContent = visibleSessionSeal.content;
+        if (visibleSessionSeal) {
+          sysContent = visibleSessionSeal.content;
+          systemInfo = retainSystemInfo(parsed, msg.catId);
+        }
       }
     } else if (parsed?.type === 'mode_switch_proposal') {
       const by = parsed.proposedBy ?? '猫猫';
@@ -1420,7 +1431,7 @@ export function consumeBackgroundSystemInfo(
     // Not JSON; keep original content as user-facing system info.
   }
 
-  return { consumed, content: sysContent, variant: sysVariant };
+  return { consumed, content: sysContent, variant: sysVariant, systemInfo };
 }
 
 const BACKGROUND_STATUS_MAP: Record<string, CatStatusType> = {
@@ -2699,13 +2710,14 @@ export function handleBackgroundAgentMessage(
     const result = consumeBackgroundSystemInfo(msg, existing, options);
     if (!result.consumed) {
       const bgCliDiag = msg.metadata?.cliDiagnostics;
-      addBackgroundSystemMessage(
-        msg,
-        options,
-        result.content,
-        result.variant,
-        bgCliDiag ? { cliDiagnostics: bgCliDiag } : undefined,
-      );
+      const extra =
+        result.systemInfo || bgCliDiag
+          ? {
+              ...(result.systemInfo ? { systemInfo: result.systemInfo } : {}),
+              ...(bgCliDiag ? { cliDiagnostics: bgCliDiag } : {}),
+            }
+          : undefined;
+      addBackgroundSystemMessage(msg, options, result.content, result.variant, extra);
     }
   }
 }
@@ -5101,12 +5113,14 @@ export function useAgentMessages() {
         let sysContent = msg.content ?? '';
         let sysVariant: 'info' | 'a2a_followup' = 'info';
         let consumed = false;
+        let systemInfo: SystemInfoProjection | undefined;
         try {
           const parsed = JSON.parse(sysContent);
           const visible = formatVisibleSystemInfo(parsed, resolveCatName, msg.catId);
           if (visible) {
             sysContent = visible.content;
             sysVariant = visible.variant;
+            systemInfo = retainSystemInfo(parsed, msg.catId);
           } else if (parsed?.type === 'invocation_created') {
             // New invocation boundary: clear stale task snapshot + finalized ref for this cat.
             // #586: Without clearing finalizedStreamRef here, a stale ref from the
@@ -5588,20 +5602,30 @@ export function useAgentMessages() {
               sessionSealed: true,
             });
             const visibleSessionSeal = formatSessionSealRequested(parsed, resolveCatName);
-            if (visibleSessionSeal) sysContent = visibleSessionSeal.content;
+            if (visibleSessionSeal) {
+              sysContent = visibleSessionSeal.content;
+              systemInfo = retainSystemInfo(parsed, msg.catId);
+            }
           }
         } catch {
           /* not JSON, use raw content */
         }
         if (!consumed) {
           const sysCliDiag = msg.metadata?.cliDiagnostics;
+          const extra =
+            systemInfo || sysCliDiag
+              ? {
+                  ...(systemInfo ? { systemInfo } : {}),
+                  ...(sysCliDiag ? { cliDiagnostics: sysCliDiag } : {}),
+                }
+              : undefined;
           addMessage({
             id: `sysinfo-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
             type: 'system',
             variant: sysVariant,
             content: sysContent,
             timestamp: Date.now(),
-            ...(sysCliDiag ? { extra: { cliDiagnostics: sysCliDiag } } : {}),
+            ...(extra ? { extra } : {}),
           });
         }
       } else if (msg.type === 'error') {

--- a/packages/web/src/hooks/useAgentMessages.ts
+++ b/packages/web/src/hooks/useAgentMessages.ts
@@ -7,6 +7,7 @@ import { deriveBubbleId, getBubbleInvocationId } from '@/debug/bubbleIdentity';
 import { recordBubbleInvariantViolation } from '@/debug/bubbleInvariantDiagnostics';
 import { recordDebugEvent } from '@/debug/invocationEventDebug';
 import { adaptIncomingToBubbleEvent } from '@/hooks/bubble-event-adapter';
+import { useCatNameResolver } from '@/hooks/useCatNameResolver';
 import { deriveBubbleKindFromMessage } from '@/stores/bubble-invariants';
 import { projectCanonicalBubbles } from '@/stores/bubble-projection';
 import { applyBubbleEvent, type BubbleReducerInput, type BubbleReducerOutput } from '@/stores/bubble-reducer';
@@ -555,6 +556,8 @@ export interface HandleBackgroundMessageOptions {
   // handlers, so suppression handoff works in both directions.
   nextBgSeq: () => number;
   addToast: (toast: BackgroundToastInput) => void;
+  /** Human-facing projection only; stored events continue to retain stable catId facts. */
+  resolveCatName?: (catId: string) => string;
   /** #80 fix-C: Clear the done-timeout guard when a background thread completes */
   clearDoneTimeout?: (threadId?: string) => void;
   /** #586 follow-up: Just-finalized stream bubble IDs keyed by streamKey */
@@ -960,7 +963,7 @@ export function consumeBackgroundSystemInfo(
 
   try {
     const parsed = JSON.parse(sysContent);
-    const visible = formatVisibleSystemInfo(parsed);
+    const visible = formatVisibleSystemInfo(parsed, options.resolveCatName, msg.catId);
     if (visible) {
       sysContent = visible.content;
       sysVariant = visible.variant;
@@ -1345,16 +1348,16 @@ export function consumeBackgroundSystemInfo(
           sessionSeq: parsed.sessionSeq,
           sessionSealed: true,
         });
-        const visibleSessionSeal = formatSessionSealRequested(parsed);
+        const visibleSessionSeal = formatSessionSealRequested(parsed, options.resolveCatName);
         if (visibleSessionSeal) sysContent = visibleSessionSeal.content;
       }
     } else if (parsed?.type === 'mode_switch_proposal') {
       const by = parsed.proposedBy ?? '猫猫';
-      sysContent = `${by} 提议切换到 ${parsed.proposedMode} 模式。`;
+      sysContent = `${options.resolveCatName?.(by) ?? by} 提议切换到 ${parsed.proposedMode} 模式。`;
     } else if (parsed?.type === 'silent_completion') {
       // Bugfix: silent-exit — cat ran tools but produced no text response
       const detail = typeof parsed.detail === 'string' ? parsed.detail : '';
-      sysContent = detail || `${msg.catId} completed without a text response.`;
+      sysContent = detail || `${options.resolveCatName?.(msg.catId) ?? msg.catId} completed without a text response.`;
     } else if (parsed?.type === 'invocation_preempted') {
       // Bugfix: silent-exit — invocation was superseded by a newer request
       sysContent = 'This response was superseded by a newer request.';
@@ -2439,7 +2442,7 @@ export function handleBackgroundAgentMessage(
       drainPendingBackgroundCallback(msg, options);
       options.addToast({
         type: 'success',
-        title: `${msg.catId} 完成`,
+        title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 完成`,
         message: preview.slice(0, 80) + (preview.length > 80 ? '...' : ''),
         threadId: msg.threadId,
         duration: 5000,
@@ -2528,7 +2531,7 @@ export function handleBackgroundAgentMessage(
     }
     options.addToast({
       type: 'error',
-      title: `${msg.catId} 出错`,
+      title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 出错`,
       message: msg.error ?? 'Unknown error',
       threadId: msg.threadId,
       duration: 8000,
@@ -2543,8 +2546,8 @@ export function handleBackgroundAgentMessage(
       options.store.updateThreadCatStatus(msg.threadId, msg.catId, 'done');
       options.addToast({
         type: 'success',
-        title: `${msg.catId} 完成`,
-        message: `${msg.catId} 已完成处理`,
+        title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 完成`,
+        message: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 已完成处理`,
         threadId: msg.threadId,
         duration: 5000,
       });
@@ -2713,6 +2716,7 @@ export function handleBackgroundAgentMessage(
  * - resetRefs: cleanup for thread switching
  */
 export function useAgentMessages() {
+  const resolveCatName = useCatNameResolver();
   const {
     addMessage,
     appendToMessage,
@@ -3745,13 +3749,20 @@ export function useAgentMessages() {
           finalizedBgRefs: bgFinalizedRefsRef.current,
           nextBgSeq: () => bgSeqRef.current++,
           addToast: (toast) => useToastStore.getState().addToast(toast),
+          resolveCatName,
           clearDoneTimeout,
           pendingCallbacks: pendingCallbacksRef.current,
           deletePendingCallback,
         },
       );
     },
-    [applyActiveExplicitCallbackNow, clearDoneTimeout, deletePendingCallback, markPendingBackgroundStreamFinished],
+    [
+      applyActiveExplicitCallbackNow,
+      clearDoneTimeout,
+      deletePendingCallback,
+      markPendingBackgroundStreamFinished,
+      resolveCatName,
+    ],
   );
 
   const deferPendingCallback = useCallback(
@@ -4144,6 +4155,7 @@ export function useAgentMessages() {
           finalizedBgRefs: bgFinalizedRefsRef.current,
           nextBgSeq: () => bgSeqRef.current++,
           addToast: (toast) => useToastStore.getState().addToast(toast),
+          resolveCatName,
           clearDoneTimeout,
           pendingCallbacks: pendingCallbacksRef.current,
           deferPendingCallback,
@@ -5064,7 +5076,7 @@ export function useAgentMessages() {
         let providerContent = msg.content ?? '';
         try {
           const parsed = JSON.parse(providerContent);
-          const visible = formatVisibleSystemInfo(parsed);
+          const visible = formatVisibleSystemInfo(parsed, resolveCatName, msg.catId);
           if (visible) providerContent = visible.content;
         } catch {
           /* non-JSON payload — display as-is */
@@ -5087,7 +5099,7 @@ export function useAgentMessages() {
         let consumed = false;
         try {
           const parsed = JSON.parse(sysContent);
-          const visible = formatVisibleSystemInfo(parsed);
+          const visible = formatVisibleSystemInfo(parsed, resolveCatName, msg.catId);
           if (visible) {
             sysContent = visible.content;
             sysVariant = visible.variant;
@@ -5499,7 +5511,7 @@ export function useAgentMessages() {
           } else if (parsed?.type === 'silent_completion') {
             // Bugfix: silent-exit — cat ran tools but produced no text response
             const detail = typeof parsed.detail === 'string' ? parsed.detail : '';
-            sysContent = detail || `${msg.catId} completed without a text response.`;
+            sysContent = detail || `${resolveCatName(msg.catId)} completed without a text response.`;
           } else if (parsed?.type === 'invocation_preempted') {
             // Bugfix: silent-exit — invocation was superseded by a newer request
             sysContent = 'This response was superseded by a newer request.';
@@ -5571,7 +5583,7 @@ export function useAgentMessages() {
               sessionSeq: parsed.sessionSeq,
               sessionSealed: true,
             });
-            const visibleSessionSeal = formatSessionSealRequested(parsed);
+            const visibleSessionSeal = formatSessionSealRequested(parsed, resolveCatName);
             if (visibleSessionSeal) sysContent = visibleSessionSeal.content;
           }
         } catch {
@@ -5857,6 +5869,7 @@ export function useAgentMessages() {
       setHasActiveInvocation,
       setMessageUsage,
       requestStreamCatchUp,
+      resolveCatName,
       removeMessage,
       clearAllActive,
       clearFinalized,

--- a/packages/web/src/hooks/useAgentMessages.ts
+++ b/packages/web/src/hooks/useAgentMessages.ts
@@ -570,6 +570,10 @@ export interface HandleBackgroundMessageOptions {
   deletePendingCallback?: (threadId: string | undefined, catId: string, invocationId: string) => void;
 }
 
+function resolveBackgroundCatName(options: HandleBackgroundMessageOptions, catId: string): string {
+  return options.resolveCatName?.(catId) ?? catId;
+}
+
 export type ActiveRoutedAgentMessage = {
   type: string;
   catId: string;
@@ -1353,11 +1357,11 @@ export function consumeBackgroundSystemInfo(
       }
     } else if (parsed?.type === 'mode_switch_proposal') {
       const by = parsed.proposedBy ?? '猫猫';
-      sysContent = `${options.resolveCatName?.(by) ?? by} 提议切换到 ${parsed.proposedMode} 模式。`;
+      sysContent = `${resolveBackgroundCatName(options, by)} 提议切换到 ${parsed.proposedMode} 模式。`;
     } else if (parsed?.type === 'silent_completion') {
       // Bugfix: silent-exit — cat ran tools but produced no text response
       const detail = typeof parsed.detail === 'string' ? parsed.detail : '';
-      sysContent = detail || `${options.resolveCatName?.(msg.catId) ?? msg.catId} completed without a text response.`;
+      sysContent = detail || `${resolveBackgroundCatName(options, msg.catId)} completed without a text response.`;
     } else if (parsed?.type === 'invocation_preempted') {
       // Bugfix: silent-exit — invocation was superseded by a newer request
       sysContent = 'This response was superseded by a newer request.';
@@ -2442,7 +2446,7 @@ export function handleBackgroundAgentMessage(
       drainPendingBackgroundCallback(msg, options);
       options.addToast({
         type: 'success',
-        title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 完成`,
+        title: `${resolveBackgroundCatName(options, msg.catId)} 完成`,
         message: preview.slice(0, 80) + (preview.length > 80 ? '...' : ''),
         threadId: msg.threadId,
         duration: 5000,
@@ -2531,7 +2535,7 @@ export function handleBackgroundAgentMessage(
     }
     options.addToast({
       type: 'error',
-      title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 出错`,
+      title: `${resolveBackgroundCatName(options, msg.catId)} 出错`,
       message: msg.error ?? 'Unknown error',
       threadId: msg.threadId,
       duration: 8000,
@@ -2546,8 +2550,8 @@ export function handleBackgroundAgentMessage(
       options.store.updateThreadCatStatus(msg.threadId, msg.catId, 'done');
       options.addToast({
         type: 'success',
-        title: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 完成`,
-        message: `${options.resolveCatName?.(msg.catId) ?? msg.catId} 已完成处理`,
+        title: `${resolveBackgroundCatName(options, msg.catId)} 完成`,
+        message: `${resolveBackgroundCatName(options, msg.catId)} 已完成处理`,
         threadId: msg.threadId,
         duration: 5000,
       });

--- a/packages/web/src/hooks/useAuthorization.ts
+++ b/packages/web/src/hooks/useAuthorization.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useCatData } from '@/hooks/useCatData';
+import { resolveCatDisplayName } from '@/lib/cat-display-name';
 import { apiFetch } from '@/utils/api-client';
 
 export interface AuthPendingRequest {
@@ -144,7 +145,7 @@ export function useAuthorization(threadId: string) {
       // Notify outside updater; dedup via ref to handle concurrent-mode replays
       if (!notifiedRef.current.has(data.requestId)) {
         notifiedRef.current.add(data.requestId);
-        const label = getCatById(data.catId)?.displayName ?? data.catId;
+        const label = resolveCatDisplayName(data.catId, getCatById);
         notifyAuthRequest(data, label);
       }
     },

--- a/packages/web/src/hooks/useCatData.ts
+++ b/packages/web/src/hooks/useCatData.ts
@@ -6,6 +6,7 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { UNKNOWN_CAT_COLOR } from '@/lib/color-defaults';
 import { refreshMentionData } from '@/lib/mention-highlight';
 import { sortCatsByOrder } from '@/lib/sort-cats-by-order';
@@ -181,9 +182,20 @@ async function refreshCatsNow(): Promise<FetchResult> {
 
 // ── Hook ────────────────────────────────────────────────
 
-export function useCatData() {
+interface UseCatDataOptions {
+  /**
+   * Subscribe to the shared registry without starting a request.
+   *
+   * Leaf presentation components use this mode because the Console shell already
+   * owns registry loading. It keeps name projection reactive without turning each
+   * label into an independent data-fetch boundary.
+   */
+  fetch?: boolean;
+}
+
+export function useCatData({ fetch: shouldFetch = true }: UseCatDataOptions = {}) {
   const [cats, setCats] = useState<CatData[]>(() => _cached ?? []);
-  const [isLoading, setIsLoading] = useState(!_cached);
+  const [isLoading, setIsLoading] = useState(shouldFetch && !_cached);
   const [hasFetched, setHasFetched] = useState(!!_cached);
   const [retryCount, setRetryCount] = useState(0);
 
@@ -199,6 +211,11 @@ export function useCatData() {
   }, []);
 
   useEffect(() => {
+    if (!shouldFetch) {
+      setCats(_cached ?? []);
+      setIsLoading(false);
+      return;
+    }
     if (_cached) {
       setCats(_cached);
       setIsLoading(false);
@@ -234,7 +251,7 @@ export function useCatData() {
       cancelled = true;
       clearTimeout(retryTimer);
     };
-  }, [retryCount]);
+  }, [retryCount, shouldFetch]);
 
   const refresh = useMemo(
     () => async () => {
@@ -271,7 +288,7 @@ export function useCatData() {
 
 /** Format cat name with optional variant label for multi-variant disambiguation */
 export function formatCatName(cat: { displayName: string; variantLabel?: string }): string {
-  return cat.variantLabel ? `${cat.displayName}（${cat.variantLabel}）` : cat.displayName;
+  return formatCatDisplayName(cat);
 }
 
 /** Get cached cats synchronously (for non-hook contexts). Returns empty if not loaded. */

--- a/packages/web/src/hooks/useCatNameResolver.ts
+++ b/packages/web/src/hooks/useCatNameResolver.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useCatData } from '@/hooks/useCatData';
+import { resolveCatDisplayName, resolveCatTechnicalLabel } from '@/lib/cat-display-name';
+
+/** Reactive catId → human-facing name projection backed by the runtime member registry. */
+export function useCatNameResolver(): (catId: string) => string {
+  const { getCatById } = useCatData({ fetch: false });
+  return useCallback((catId: string) => resolveCatDisplayName(catId, getCatById), [getCatById]);
+}
+
+/** Diagnostic variant that appends the stable id when a friendly name was resolved. */
+export function useCatTechnicalLabelResolver(): (catId: string) => string {
+  const { getCatById } = useCatData({ fetch: false });
+  return useCallback((catId: string) => resolveCatTechnicalLabel(catId, getCatById), [getCatById]);
+}

--- a/packages/web/src/lib/__tests__/cat-display-name.test.ts
+++ b/packages/web/src/lib/__tests__/cat-display-name.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { formatCatDisplayName, resolveCatDisplayName, resolveCatTechnicalLabel } from '../cat-display-name';
+
+describe('cat display-name projection', () => {
+  it('uses displayName with the configured variant suffix', () => {
+    expect(formatCatDisplayName({ displayName: '缅因猫', variantLabel: 'sol' })).toBe('缅因猫（sol）');
+  });
+
+  it('uses displayName without adding an empty suffix', () => {
+    expect(formatCatDisplayName({ displayName: '缅因猫' })).toBe('缅因猫');
+  });
+
+  it('falls back to the stable catId for unknown or unloaded members', () => {
+    expect(resolveCatDisplayName('cat-retired', () => undefined)).toBe('cat-retired');
+  });
+
+  it('keeps catId as secondary provenance on technical surfaces', () => {
+    expect(resolveCatTechnicalLabel('cat-sol', () => ({ displayName: '缅因猫', variantLabel: 'sol' }))).toBe(
+      '缅因猫（sol） · cat-sol',
+    );
+    expect(resolveCatTechnicalLabel('cat-retired', () => undefined)).toBe('cat-retired');
+  });
+});

--- a/packages/web/src/lib/cat-display-name.ts
+++ b/packages/web/src/lib/cat-display-name.ts
@@ -1,0 +1,23 @@
+export interface CatDisplayNameData {
+  displayName: string;
+  variantLabel?: string;
+}
+
+export type GetCatDisplayNameData = (catId: string) => CatDisplayNameData | undefined;
+
+/** Format one runtime member consistently across human-facing Console surfaces. */
+export function formatCatDisplayName(cat: CatDisplayNameData): string {
+  return cat.variantLabel ? `${cat.displayName}（${cat.variantLabel}）` : cat.displayName;
+}
+
+/** Resolve a stable catId to a friendly label, retaining the id as the unknown-member fallback. */
+export function resolveCatDisplayName(catId: string, getCatById: GetCatDisplayNameData): string {
+  const cat = getCatById(catId);
+  return cat ? formatCatDisplayName(cat) : catId;
+}
+
+/** Keep the stable id visible as secondary provenance on diagnostic/observability surfaces. */
+export function resolveCatTechnicalLabel(catId: string, getCatById: GetCatDisplayNameData): string {
+  const displayName = resolveCatDisplayName(catId, getCatById);
+  return displayName === catId ? catId : `${displayName} · ${catId}`;
+}

--- a/packages/web/src/lib/resolve-sender.ts
+++ b/packages/web/src/lib/resolve-sender.ts
@@ -12,6 +12,7 @@
 
 import type { CoCreatorConfig } from '@/components/config-viewer-types';
 import type { CatData } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { CO_CREATOR_COLOR, UNKNOWN_CAT_COLOR } from '@/lib/color-defaults';
 
 export interface SenderMeta {
@@ -48,7 +49,7 @@ export function resolveSender(
   const cat = getCatById(senderCatId);
   if (cat) {
     return {
-      label: `@${cat.displayName}`,
+      label: `@${formatCatDisplayName(cat)}`,
       color: cat.color.primary,
       isCoCreator: false,
     };

--- a/packages/web/src/stores/chat-types.ts
+++ b/packages/web/src/stores/chat-types.ts
@@ -230,6 +230,13 @@ export interface ConnectorSourceData {
   sender?: { id: string; name?: string };
 }
 
+/** Structured identity-bearing notice retained for reactive render-time projection. */
+export interface SystemInfoProjection {
+  readonly v: 1;
+  readonly payload: Record<string, unknown>;
+  readonly fallbackCatId?: string;
+}
+
 export interface ChatMessage {
   id: string;
   type: 'user' | 'assistant' | 'system' | 'summary' | 'connector';
@@ -310,6 +317,8 @@ export interface ChatMessage {
     systemKind?: 'a2a_routing' | 'context_briefing';
     /** Machine-readable A2A route metadata. The visible pill text is human-readable; this survives F5. */
     a2aRouting?: { fromCatId?: string; targetCatId?: string; invocationId?: string };
+    /** Original visible system_info payload; content remains the persisted fallback copy. */
+    systemInfo?: SystemInfoProjection;
   };
   /** F045: Extended thinking content, rendered as collapsible block inside assistant bubble */
   thinking?: string;

--- a/packages/web/src/stores/chatStore.ts
+++ b/packages/web/src/stores/chatStore.ts
@@ -3,6 +3,7 @@ import { getBubbleInvocationId } from '@/debug/bubbleIdentity';
 import { isBubbleInvariantStrictModeOn, recordBubbleInvariantViolation } from '@/debug/bubbleInvariantDiagnostics';
 import { recordDebugEvent } from '@/debug/invocationEventDebug';
 import { getCachedCats } from '@/hooks/useCatData';
+import { formatCatDisplayName } from '@/lib/cat-display-name';
 import { inferFileKind, inferRenderMode } from '@/lib/file-kind';
 import {
   resolveNavigateTargetWorktreeId,
@@ -465,7 +466,7 @@ function fireOwnerMentionNotification(msg: ChatMessage) {
   }
   const cats = getCachedCats();
   const catData = cats.find((c) => c.id === msg.catId);
-  const catName = catData?.displayName ?? msg.catId ?? '猫猫';
+  const catName = catData ? formatCatDisplayName(catData) : (msg.catId ?? '猫猫');
   const preview = typeof msg.content === 'string' ? msg.content.replace(/\n/g, ' ').slice(0, 120) : '';
   new Notification(`${catName} @ 了你`, {
     body: preview,

--- a/review-notes/2026-07-19-issue-1180-console-member-labels-review-request.md
+++ b/review-notes/2026-07-19-issue-1180-console-member-labels-review-request.md
@@ -1,0 +1,98 @@
+# Review Request: Console 成员名称统一按运行时 roster 投影
+
+Review-Target-ID: issue-1180-member-identity
+Branch: fix/1180-console-member-labels
+Implementation commit: `eb645aeec172d7d663914ed69c685b7257e4db84`
+
+## What
+
+- 新增统一的成员显示解析层：普通界面使用 `displayName（variantLabel）`，未知成员回退原始 `catId`；诊断界面使用 `友好名称 · catId`。
+- Queue A2A 调用链、等待原因以及 Console 中其他非成员配置位置统一从运行时 `/api/cats` roster 投影名称。
+- 后端 payload、路由、筛选、持久化和事件事实仍以 `catId` 为准；公开 Story Export 的匿名化语义保持不变。
+- `useCatData({ fetch: false })` 允许叶子组件只订阅共享 roster cache，不各自发起请求；根布局里的 `CatHueInjector` 继续负责主动加载 roster。
+
+## Why
+
+Queue 行把 `cat-8zfu14fb → cat-8zfu14fb` 直接展示给用户，而对话区域已有更友好的成员名称。根因不是数据缺失，而是多处 Console 展示绕过了运行时成员 roster，混用了原始 ID、静态别名和局部格式化逻辑。
+
+## Original Requirements（必填）
+
+> “我们队列的a2a消息这里回显的是catid对用户不是很友好的；应该和我们的对话哪里一样用 名称+后缀的形式比较友好的。”
+> “我们其实只需要有个成员数据；然后根据成员catid映射到成员数据做渲染的。”
+> “我们只是console显示需要统一format调整；实际的数据不应该调整的。”
+> “Console所有涉及到成员名称出了成员配置哪里之外的位置都是可以按照这个思路来渲染和显示的。”
+
+- 来源：[GitHub issue #1180](https://github.com/zts212653/clowder-ai/issues/1180) 与当前协作 thread。
+- 请 reviewer 重点判断：实现是否始终停留在 Console 展示投影，且成员配置、真实数据、路由身份和公开匿名化没有被改写。
+
+## Tradeoff
+
+- 没有新增后端 display-name 字段或改写事件数据；统一复用现有 runtime roster，避免形成第二份成员真相源。
+- 叶子组件被动订阅 cache，把 I/O 所有权留给根级 loader；代价是 roster 首次到达前短暂显示 raw `catId`，随后自动更新。
+- 未知 ID 保留 raw 值，避免用错误别名掩盖配置/数据问题；技术诊断位置保留 raw ID 作为次级信息。
+
+## Architecture Ownership（必填）
+
+Architecture cell: identity-session（identity-agent subcell）
+Map delta: none
+Why: 本次只消费既有 canonical runtime roster 做前端 presentation projection；没有改变成员配置 owner、schema、边界、extension anchor，也没有新增 Store / Queue / Router / Adapter / Dispatcher / Binding。
+
+请 reviewer 检查：
+
+- 66 个文件的展示扫描是否与 `Map delta: none` 一致，是否有任何数据或身份语义被意外改写；
+- `useCatData({ fetch: false })` 是否确实不会让叶子组件发起 I/O，且根级 loader 覆盖所有 Console 页面；
+- 保留 raw `catId` 的位置是否都是成员配置、诊断事实或未知值 fallback，而不是遗漏的人类可见展示。
+
+## Open Questions
+
+### 技术 OQ（给 reviewer）
+
+1. passive roster subscription 与 root-owned fetch 的生命周期是否可靠，尤其是冷启动和 roster refresh？
+2. Queue、toast、system info、Hub/mission control/community/story-private 等广泛投影是否都只改变 rendered copy？
+3. `友好名称 · catId` 的 technical label 边界是否足够克制，是否仍有应该改为纯友好名称的普通界面？
+
+### 价值 OQ（给 operator，如有）
+
+无。
+
+## Next Action
+
+请 Fable 独立复跑定向测试并审查完整 diff。若无 P1/P2，请明确 `APPROVE`；若需退回，请为每个 finding 标注 P1/P2/P3、精确文件/行号和证据。
+
+## Review Sandbox（必填）
+
+- Path: `/tmp/cat-cafe-review/issue-1180-member-identity/fable`
+- Start command: `pnpm review:start --web-port=5120 --api-port=3120`
+- Ports: `web=5120`, `api=3120`；使用 review launcher 的 memory store，不访问 runtime 端口或数据。
+- 沙盒必须保持 detached HEAD / read-only；如需改代码，请走 TAKEOVER 并另开正式 worktree。
+
+## 自检证据
+
+### Spec 合规
+
+- Queue A2A caller/target 与等待原因已走统一 runtime roster resolver。
+- Console 非成员配置位置已完成同类扫描并批量统一；成员编辑器/raw config fields 未改。
+- 数据、API payload、routing、filter、persistence 仍以 `catId` 为唯一身份键。
+- public Story Export 匿名化未接入 runtime display name。
+
+### 测试结果
+
+- 相关定向回归：162 assertions passed，覆盖 formatter、Queue、passive cache、toast、system info、authorization、artifact、navigator、execution label。
+- `pnpm --filter @cat-cafe/web typecheck`: passed。
+- `pnpm --filter @cat-cafe/web build`: passed（最终代码复跑两次）。
+- `pnpm gate`: passed；16,603 public tests passed、0 failed、28 skipped；build/tsc/Web lint/repository check 全部通过。
+- Web 全量私有 suite：5,057 passed、21 failed；21 项与改动前基线完全相同，分布在 chat governance refetch、F232 fixtures、SkillsContent、ThreadSidebar organizer、adaptive-pass-ball punctuation，未新增失败。
+- `git diff --check origin/main...HEAD`: passed。
+
+### 浏览器证据
+
+- 作者在隔离实例 Web 5102 / API 3102 上通过 Hub Browser 打开 Console，`/api/cats` 成功加载 runtime roster；未访问保留运行时端口。
+- 未通过真实猫调用制造 Queue 数据，避免副作用；Queue DOM 的 caller→target 与 wait-reason 投影由组件回归精确覆盖。Issue #1180 附图保留修复前证据，请 reviewer 在独立沙盒中做修复后视觉复核。
+
+### 相关文档
+
+- Issue: https://github.com/zts212653/clowder-ai/issues/1180
+- Architecture map delta: none
+- Implementation commit: `eb645aeec172d7d663914ed69c685b7257e4db84`
+
+[砚砚/gpt-5.6-sol🐾]


### PR DESCRIPTION
## What

- Add one runtime-roster-backed member display resolver for standard labels and technical labels.
- Replace raw `catId`, stale static aliases, and suffix-less labels across Queue and other Console member-identity surfaces.
- Keep selectors, API payloads, routing keys, filters, persisted data, member configuration, and public Story anonymization unchanged.
- Add focused regression coverage for known members, variant suffixes, unknown-ID fallback, Queue A2A/wait labels, and passive roster consumers.

## Why

Queue A2A entries currently expose stable IDs such as `cat-… → cat-…`, while chat already projects the same members as friendly names with variant suffixes. The runtime roster is already the canonical identity source; Console presentation should consume it consistently instead of maintaining raw IDs or local alias maps.

## Issue Closure

- Closes #1180

## Original Requirements

- Source: issue #1180 and thread `thread_mrrjwjyck8ideuhr`
- Original requirement:
  > Console displays should resolve member data by catId and show the friendly name plus suffix.
  > Stored and transmitted data must not change.
  > Except for member configuration, Console surfaces presenting a member name should follow this rule.
- Reviewer check: verify that the diff changes only rendered identity copy and does not rewrite identity data or public anonymization.

## Plan / ADR

- Plan and acceptance criteria: issue #1180
- Architecture cell: `identity-session` / `identity-agent` read-side projection
- Map delta: none
- BACKLOG: not applicable; this is an issue-scoped Console bug fix

## Tips Contribution

- [ ] Added/updated tips
- [ ] Existing tip sourceRef covers this change
- [x] `tips_exempt:` presentation correctness fix; it adds no new user action or capability to teach
- Reviewer usefulness check: a tip would merely announce corrected labels rather than teach an actionable workflow.

## Tradeoff

- Unknown, deleted, or not-yet-loaded members fall back to raw IDs rather than disappearing or using a misleading alias. Historical usage filters union the live roster with IDs present in the selected report, so removed members with archived records remain selectable.
- Reactive surfaces update when the runtime roster arrives. Visible system notices retain their structured identity payload and are reprojected at render time, so notices ingested during a cold roster load also update in place.
- Technical/observability views retain raw IDs as secondary metadata; ordinary Console surfaces show only the friendly label.
- Game `SeatView.displayName` snapshots and Story replay/public-export content remain governed by their existing domain and anonymization contracts rather than being rewritten through live roster state.

## Test Evidence

- `pnpm gate` — passed on exact PR HEAD `75073af574b9bd27fb63f2ad3816526de65fdd3f`, rebased onto `origin/main` `dff66bdb4`; build, tsc, tests, lint, and repository checks all passed (848s total).
- GitHub checks on exact HEAD `75073af5` — 5/5 passed: Directory Size Guard, Lint, Build, Test (Windows), and Test (Public).
- Review-fix focused suites: 95 tests passed, including passive pre-roster hydration and decision-role collision coverage; `tsc --noEmit` passed.
- System-notice re-projection suites: 91 tests passed across active ingestion, background ingestion, and notice rendering; `tsc --noEmit` passed.
- The passive resolver regression proves initial raw `catId` → `displayName（variantLabel）` after the shared registry resolves, with exactly one `/api/cats` request.
- The decision queue regression proves `CommunityDecisionActor` role values never enter the member resolver, even when a role string collides with a registry ID.
- The integrated system-notice regression dispatches a notice before a deferred roster response, then proves that the same existing message changes from raw `catId` to `displayName（variantLabel）` after hydration, with exactly one `/api/cats` request and no second socket event.
- The historical-usage regression was Red before the fix and Green after it: a removed member from `report.byCat` remains in the selector with raw-ID fallback, selecting it requests `catId=cat-retired`, and the controlled selection remains stable after the filtered report no longer contains that ID (1/1 focused test; Web `tsc --noEmit` passed).
- Isolated browser verification on ports 5121/5122 confirmed the selector renders the current member as `缅因猫（sol）`, retains `cat-retired`, and selecting it issues `GET /api/usage/tools?days=7&catId=cat-retired` with no console errors.
- Fable independent review: 160/161 focused tests passed; the sole failure was an unrelated pre-existing F232 repository-rename fixture. Independent `tsc --noEmit` passed.
- Fable browser verification used isolated ports 5120/3120 and confirmed runtime roster labels render without raw `cat-*` text on the inspected decision surface.
- `git diff --check origin/main...HEAD`, hotfix detector, capability-tips check, artifact hygiene, and architecture diff scan — passed.

## Review Focus

- [x] Passive roster subscription continuity from pre-roster mount through root-loader notification is pinned by a deferred-fetch regression.
- [x] `CommunityDecisionActor` remains a governance role label and is no longer projected as a member ID.
- [x] Visible `system_info` notices keep structured identity inputs and re-project on render instead of permanently baking a cold-load raw ID into `content`.
- [x] Historical usage filters derive options from the union of the live roster, archived report IDs, and the controlled selection; unknown/deleted members retain the raw-ID fallback without changing the API value.
- [x] Same-class audit confirmed remaining resolver inputs are cat-ID-bearing fields or member collection keys; machine values remain unchanged.

---

**本地 Review**: [x] Fable 已独立复算纯 rebase continuity 并明确“放行延续到 `75073af574b9bd27fb63f2ad3816526de65fdd3f`”。新旧特性 diff 的 71 文件路径集与 stable patch-id `af2fee75bbd8ebea3f1bca4a3c580b5b8b0d5c24` 均相同；两个 main-side 交叠文件的 hunks 与关注点正交。
**云端 Review**: [x] Codex 对 `ffabe79442` 的 historical usage filter P2 已在 `d1c0e5e48` 修复，并由 maintainer exact-HEAD review 确认 P1/P2/P3 均为零；最新 HEAD 仅为 pure rebase。
**Maintainer Review**: [ ] `d1c0e5e48` exact-HEAD 已 APPROVE；因 `main` 前进后 pure rebase 到 `75073af5`，等待 GitHub re-approval。

<!-- 猫猫签名（纯文本，禁止 mention）: 缅因猫/砚砚 (gpt-5.6-sol) -->
