### PR TITLE
fix(api): allow loopback writes on wildcard bind

### DIFF
--- a/packages/api/src/config/capabilities/capability-write-guards.ts
+++ b/packages/api/src/config/capabilities/capability-write-guards.ts
@@ -100,14 +100,7 @@ function hasTrustedLocalOrigin(value: string | undefined): boolean {
   }
 }
 
-function isApiBoundToLocalhost(): boolean {
-  const host = process.env.API_SERVER_HOST?.trim();
-  if (!host) return true;
-  return isLoopbackHost(normalizeHostForLoopbackCheck(host));
-}
-
 export function isLocalCapabilityWriteRequest(request: FastifyRequest): boolean {
-  if (!isApiBoundToLocalhost()) return false;
   if (!isLoopbackAddress(request.ip)) return false;
   if (hasProxyForwardingHeaders(request)) return false;
 

--- a/packages/api/test/config/capabilities/capabilities-mcp-write-route.test.js
+++ b/packages/api/test/config/capabilities/capabilities-mcp-write-route.test.js
@@ -16,6 +16,16 @@ const OWNER_HEADERS = { 'x-test-session-user': 'you' };
 const NON_OWNER_HEADERS = { 'x-test-session-user': 'codex' };
 const LOCAL_OWNER_HEADERS = { ...OWNER_HEADERS, host: 'localhost:3004', origin: 'http://localhost:3003' };
 const LOCAL_NON_OWNER_HEADERS = { ...NON_OWNER_HEADERS, host: 'localhost:3004', origin: 'http://localhost:3003' };
+const PROXY_FORWARDING_HEADERS = [
+  'forwarded',
+  'x-forwarded-for',
+  'x-forwarded-host',
+  'x-forwarded-proto',
+  'x-real-ip',
+  'x-client-ip',
+  'cf-connecting-ip',
+  'true-client-ip',
+];
 const REDACTED_SECRET = '••••••';
 
 const savedEnv = new Map();
@@ -127,7 +137,7 @@ describe('capabilities MCP write routes', () => {
     assert.deepEqual(config?.capabilities, []);
   });
 
-  it('rejects local-looking MCP writes when the API is bound for LAN access', async () => {
+  it('allows direct loopback MCP writes when the API is bound to all interfaces', async () => {
     setEnv('API_SERVER_HOST', '0.0.0.0');
 
     const res = await app.inject({
@@ -140,8 +150,83 @@ describe('capabilities MCP write routes', () => {
       },
     });
 
-    assert.equal(res.statusCode, 403);
+    assert.equal(res.statusCode, 200, res.payload);
+    const config = await readCapabilitiesConfig(projectRoot);
+    assert.ok(config?.capabilities.some((entry) => entry.id === 'external-mcp'));
+  });
+
+  it('rejects remote peers even when Host and Origin look local', async () => {
+    setEnv('API_SERVER_HOST', '0.0.0.0');
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/capabilities/mcp/install',
+      headers: LOCAL_OWNER_HEADERS,
+      remoteAddress: '192.0.2.10',
+      payload: { id: 'remote-mcp', command: 'node', args: ['server.js'] },
+    });
+
+    assert.equal(res.statusCode, 403, res.payload);
     assert.match(JSON.parse(res.payload).error, /direct localhost/i);
+    const config = await readCapabilitiesConfig(projectRoot);
+    assert.deepEqual(config?.capabilities, []);
+  });
+
+  it('rejects loopback peers with a non-local Host or Origin', async () => {
+    const cases = [
+      {
+        label: 'Host',
+        headers: { ...OWNER_HEADERS, host: 'api.example.test', origin: 'http://localhost:3003' },
+      },
+      {
+        label: 'Origin',
+        headers: { ...OWNER_HEADERS, host: 'localhost:3004', origin: 'https://app.example.test' },
+      },
+    ];
+
+    for (const testCase of cases) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/capabilities/mcp/install',
+        headers: testCase.headers,
+        payload: { id: `non-local-${testCase.label.toLowerCase()}`, command: 'node', args: ['server.js'] },
+      });
+
+      assert.equal(res.statusCode, 403, `${testCase.label}: ${res.payload}`);
+      assert.match(JSON.parse(res.payload).error, /direct localhost/i);
+    }
+
+    const config = await readCapabilitiesConfig(projectRoot);
+    assert.deepEqual(config?.capabilities, []);
+  });
+
+  it('rejects loopback peers with any proxy-forwarding header', async () => {
+    for (const header of PROXY_FORWARDING_HEADERS) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/capabilities/mcp/install',
+        headers: { ...LOCAL_OWNER_HEADERS, [header]: '203.0.113.10' },
+        payload: { id: `forwarded-${header}`, command: 'node', args: ['server.js'] },
+      });
+
+      assert.equal(res.statusCode, 403, `${header}: ${res.payload}`);
+      assert.match(JSON.parse(res.payload).error, /direct localhost/i);
+    }
+
+    const config = await readCapabilitiesConfig(projectRoot);
+    assert.deepEqual(config?.capabilities, []);
+  });
+
+  it('rejects MCP writes without a session-backed identity', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/capabilities/mcp/install',
+      headers: { host: 'localhost:3004', origin: 'http://localhost:3003' },
+      payload: { id: 'anonymous-mcp', command: 'node', args: ['server.js'] },
+    });
+
+    assert.equal(res.statusCode, 401, res.payload);
+    assert.match(JSON.parse(res.payload).error, /session/i);
     const config = await readCapabilitiesConfig(projectRoot);
     assert.deepEqual(config?.capabilities, []);
   });


### PR DESCRIPTION
## PR Type

- [x] Patch - Bug fix, typo, test gap (no Feature Doc needed)
- [ ] Feature - New capability or behavior change (requires Feature Doc)
- [ ] Protocol - Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #1174

## Feature Doc (Feature PRs only)

Not applicable. This is a focused P1 bug fix approved for implementation in issue #1174.

## What

- Remove the listener bind-address predicate from `isLocalCapabilityWriteRequest()`.
- Continue requiring a loopback socket peer, local `Host`, local `Origin`, no proxy-forwarding headers, a session-backed identity, and the existing owner authorization.
- Add the six-case regression matrix requested by the maintainer, including every forwarding header recognized by the guard.
- Leave the "3 MCP anomalies" wording unchanged as requested; that remains a separate UX concern.

## Why

`API_SERVER_HOST=0.0.0.0` describes where the API listens, not where an individual request originated. Supported LAN, Tailscale, Docker, and container deployments therefore rejected direct localhost MCP writes before evaluating the request-level local proof.

The request itself remains fail-closed unless all direct-local checks pass.

## Tradeoff

This does not add authenticated remote capability writes or reverse-proxy support. Remote peers and forwarded requests remain read-only for capability management. The change is intentionally limited to direct loopback requests and does not alter the owner, redaction, or audit boundaries.

## Test Evidence

TDD red phase, before the production change:

```text
allows direct loopback MCP writes when the API is bound to all interfaces
AssertionError: 403 !== 200
{"error":"Capability writes require direct localhost Hub access"}
27 passed, 1 failed
```

Validation:

```text
Focused MCP write-route suite: 28 passed, 0 failed
pnpm check: passed
pnpm lint: passed (existing web warnings only)
pnpm -r --if-present run build: passed
pnpm --filter @cat-cafe/api run test:public: 16614 tests, 16586 passed, 0 failed, 28 skipped
env -u PROMPT_CAPTURE_CATS pnpm gate: passed on SHA 1ee5b857, rebased onto origin/main
```

Security regression coverage:

1. Wildcard listener + loopback peer + local Host/Origin + no forwarding headers: 200.
2. Remote peer + local-looking Host/Origin: 403.
3. Loopback peer + non-local Host or Origin: 403.
4. Loopback peer + each recognized forwarding header: 403.
5. Missing session or header-only identity: 401/403.
6. Existing secret redaction, owner checks, and capability audit tests remain green.

## AC Checklist (Feature PRs only)

Not applicable.

[砚砚/gpt-5.6-sol🐾]
