### PR TITLE
fix(acp): thread configured idle TTL + fix iterator lease leak (#1186)

### DIFF
--- a/docs/features/F089-hub-terminal-tmux.md
+++ b/docs/features/F089-hub-terminal-tmux.md
@@ -5,6 +5,7 @@ related_decisions: [012]
 topics: [terminal, tmux, workspace, xterm, pty, agent-observability]
 doc_kind: spec
 created: 2026-03-09
+tips_exempt: documentation-only gate repair — no new user-visible capability or interaction surface
 ---
 
 # F089 Hub Terminal & tmux Integration — 浏览器终端 + 猫猫可观测性
@@ -24,6 +25,21 @@ created: 2026-03-09
 
 > 终态是 tmux 管理所有 session，所以从 Day 1 底层就是 tmux。
 > "先做纯 PTY 再叠 tmux" = 脚手架（Phase 1 PTY 在 Phase 3 被推翻），违反 P1。
+
+## User Journey
+
+**Scope unit**：一个 workspace/worktree 及其对应的 tmux server。
+
+### 当前旅程（Phase 1–3a）
+
+1. Operator 在 Hub 的 Workspace Terminal 打开当前 workspace 的 shell，不需要切换到外部终端。
+2. 启用 tmux agent runtime 后，agent invocation 出现在同一 workspace 的 pane 列表中；operator 选择 pane，以只读方式观察 agent 正在执行的真实进程输出。
+3. Agent 异常退出时，`remain-on-exit` 保留 pane 现场，operator 可以回看最后输出并据此诊断，而不是只能重启后猜测原因。
+
+### 目标旅程（Phase 3 剩余项）
+
+1. Operator 从 watch 切换到 takeover，系统暂停机器侧 NDJSON 消费，避免人工输入与自动解析互相干扰。
+2. Operator 在同一 pane 中继续操作，并通过进程树查看、定位和管理 agent 启动的子进程。
 
 ## What
 

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -3104,243 +3104,256 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       // F089: Use abortableNext instead of `for await` so the invocation timeout
       // can break out even when the service generator is stuck on an unresolvable await.
       const serviceIter = service.invoke(effectivePrompt, options)[Symbol.asyncIterator]();
-      for (;;) {
-        const iterResult = await abortableNext(serviceIter, signal);
-        if (iterResult.done) break;
-        const msg = iterResult.value;
-        // F149: provider_signal / liveness_signal must NOT reset timeout — prevents "续命"
-        // F198 Phase C P2-1: status (daemon detail progress) also must NOT reset timeout —
-        // a daemon sending frequent status updates must not evade the 30-min kill deadline.
-        if (msg.type !== 'provider_signal' && msg.type !== 'liveness_signal' && msg.type !== 'status')
-          resetInvocationTimeout();
-        if (shouldTrackGeminiResumeFailures && options.sessionId && msg.type === 'error') {
-          const failureKind = classifyResumeFailure(msg.error);
-          if (failureKind) {
-            resumeFailureCounts[failureKind] = (resumeFailureCounts[failureKind] ?? 0) + 1;
-          }
-        }
-
-        if (
-          allowSessionRetry &&
-          msg.type === 'error' &&
-          (isMissingClaudeSessionError(msg.error) || isSessionNotFoundDiagnostic(msg.metadata))
-        ) {
-          suppressedMissingSessionError = msg;
-          continue;
-        }
-        if (
-          allowSessionRetry &&
-          !attemptHasContentOutput &&
-          msg.type === 'error' &&
-          isPromptTokenLimitExceededError(msg.error)
-        ) {
-          suppressedPromptLimitError = msg;
-          continue;
-        }
-        if (
-          allowSessionRetry &&
-          !attemptHasContentOutput &&
-          msg.type === 'error' &&
-          isContextWindowOverflowError(msg.error)
-        ) {
-          suppressedContextOverflowError = msg;
-          continue;
-        }
-        if (
-          allowTransientRetry &&
-          !attemptHasContentOutput &&
-          msg.type === 'error' &&
-          (isTransientCliExitCode1(msg.error) || isTransientAcpPromptFailure(msg.error))
-        ) {
-          suppressedTransientCliError = msg;
-          continue;
-        }
-        // #774 self-heal: CLI timeout during session resume with no substantive output
-        // → likely stale/unreachable session. Suppress and retry without session.
-        // Uses attemptHasSubstantiveOutput (not attemptHasContentOutput) because
-        // timeout_diagnostics (system_info) must NOT block the retry path.
-        if (
-          allowSessionRetry &&
-          options.sessionId &&
-          !attemptHasSubstantiveOutput &&
-          msg.type === 'error' &&
-          isCliTimeoutError(msg.error)
-        ) {
-          suppressedTimeoutError = msg;
-          continue;
-        }
-        // F215 AC-C1/C2: Suppress malformed tool-call error + preceding system_info signal
-        // → seal session + fresh-context retry (sessionId=undefined).
-        // Applies on all attempts (even without session) so a retried invocation that still
-        // produces malformed output also enters the fallback chain.
-        //
-        // BLOCKING 2 fix: malformed_toolcall_detected is emitted BEFORE the error, so we
-        // must suppress it unconditionally (not gated on suppressedMalformedError being set).
-        if (
-          msg.type === 'system_info' &&
-          (() => {
-            try {
-              return JSON.parse(msg.content ?? '{}').type === 'malformed_toolcall_detected';
-            } catch {
-              return false;
+      // #1186: Ensure service generator's finally block runs (lease.release()) on ALL exit paths.
+      // Manual .next() iteration does NOT auto-close the generator on break/throw — unlike
+      // `for await...of` which calls .return() on early exit. Without this try/finally,
+      // breaking from the loop (retry path, abort, error) leaves the generator suspended
+      // at its last yield, so AcpAgentService.invoke()'s finally { lease.release() } never
+      // executes → leaked lease → "Pool at capacity" after maxLiveProcesses invocations.
+      try {
+        for (;;) {
+          const iterResult = await abortableNext(serviceIter, signal);
+          if (iterResult.done) break;
+          const msg = iterResult.value;
+          // F149: provider_signal / liveness_signal must NOT reset timeout — prevents "续命"
+          // F198 Phase C P2-1: status (daemon detail progress) also must NOT reset timeout —
+          // a daemon sending frequent status updates must not evade the 30-min kill deadline.
+          if (msg.type !== 'provider_signal' && msg.type !== 'liveness_signal' && msg.type !== 'status')
+            resetInvocationTimeout();
+          if (shouldTrackGeminiResumeFailures && options.sessionId && msg.type === 'error') {
+            const failureKind = classifyResumeFailure(msg.error);
+            if (failureKind) {
+              resumeFailureCounts[failureKind] = (resumeFailureCounts[failureKind] ?? 0) + 1;
             }
-          })()
-        ) {
-          // Internal detection signal — always suppress; never reaches user.
-          continue;
-        }
-        // P1 7th fix: only suppress malformed error (and retry) when NO content was emitted yet.
-        // Other self-heal paths (prompt limit, context overflow) all guard on !attemptHasContentOutput.
-        // Without this guard, a multi-step run that used a tool then ended with a malformed turn
-        // would re-run the original prompt from scratch — duplicating tool actions.
-        if (msg.type === 'error' && isMalformedToolCallError(msg.error) && !attemptHasContentOutput) {
-          suppressedMalformedError = msg;
-          continue;
-        }
-        // F215 AC-B6 UX fix: when content was already emitted, the malformed error must NOT reach
-        // the user with "系统已触发恢复流程" (a lie — no retry fires when attemptHasContentOutput=true).
-        // Replace the raw error with an honest partial-output text notice.
-        if (msg.type === 'error' && isMalformedToolCallError(msg.error) && attemptHasContentOutput) {
-          log.warn(
-            { catId, error: msg.error },
-            '[F215] Malformed after content output — replacing misleading error with partial-output notice',
-          );
-          const notice: AgentMessage = {
-            type: 'text',
-            catId: catId as CatId,
-            content: `\n\n🐾 手抖了——最后一步没完成。上面的内容已经送到了，可以追问或让其他猫猫接着做。`,
-            timestamp: Date.now(),
-          };
-          for await (const out of streamProcessedOutputs(notice)) {
+          }
+
+          if (
+            allowSessionRetry &&
+            msg.type === 'error' &&
+            (isMissingClaudeSessionError(msg.error) || isSessionNotFoundDiagnostic(msg.metadata))
+          ) {
+            suppressedMissingSessionError = msg;
+            continue;
+          }
+          if (
+            allowSessionRetry &&
+            !attemptHasContentOutput &&
+            msg.type === 'error' &&
+            isPromptTokenLimitExceededError(msg.error)
+          ) {
+            suppressedPromptLimitError = msg;
+            continue;
+          }
+          if (
+            allowSessionRetry &&
+            !attemptHasContentOutput &&
+            msg.type === 'error' &&
+            isContextWindowOverflowError(msg.error)
+          ) {
+            suppressedContextOverflowError = msg;
+            continue;
+          }
+          if (
+            allowTransientRetry &&
+            !attemptHasContentOutput &&
+            msg.type === 'error' &&
+            (isTransientCliExitCode1(msg.error) || isTransientAcpPromptFailure(msg.error))
+          ) {
+            suppressedTransientCliError = msg;
+            continue;
+          }
+          // #774 self-heal: CLI timeout during session resume with no substantive output
+          // → likely stale/unreachable session. Suppress and retry without session.
+          // Uses attemptHasSubstantiveOutput (not attemptHasContentOutput) because
+          // timeout_diagnostics (system_info) must NOT block the retry path.
+          if (
+            allowSessionRetry &&
+            options.sessionId &&
+            !attemptHasSubstantiveOutput &&
+            msg.type === 'error' &&
+            isCliTimeoutError(msg.error)
+          ) {
+            suppressedTimeoutError = msg;
+            continue;
+          }
+          // F215 AC-C1/C2: Suppress malformed tool-call error + preceding system_info signal
+          // → seal session + fresh-context retry (sessionId=undefined).
+          // Applies on all attempts (even without session) so a retried invocation that still
+          // produces malformed output also enters the fallback chain.
+          //
+          // BLOCKING 2 fix: malformed_toolcall_detected is emitted BEFORE the error, so we
+          // must suppress it unconditionally (not gated on suppressedMalformedError being set).
+          if (
+            msg.type === 'system_info' &&
+            (() => {
+              try {
+                return JSON.parse(msg.content ?? '{}').type === 'malformed_toolcall_detected';
+              } catch {
+                return false;
+              }
+            })()
+          ) {
+            // Internal detection signal — always suppress; never reaches user.
+            continue;
+          }
+          // P1 7th fix: only suppress malformed error (and retry) when NO content was emitted yet.
+          // Other self-heal paths (prompt limit, context overflow) all guard on !attemptHasContentOutput.
+          // Without this guard, a multi-step run that used a tool then ended with a malformed turn
+          // would re-run the original prompt from scratch — duplicating tool actions.
+          if (msg.type === 'error' && isMalformedToolCallError(msg.error) && !attemptHasContentOutput) {
+            suppressedMalformedError = msg;
+            continue;
+          }
+          // F215 AC-B6 UX fix: when content was already emitted, the malformed error must NOT reach
+          // the user with "系统已触发恢复流程" (a lie — no retry fires when attemptHasContentOutput=true).
+          // Replace the raw error with an honest partial-output text notice.
+          if (msg.type === 'error' && isMalformedToolCallError(msg.error) && attemptHasContentOutput) {
+            log.warn(
+              { catId, error: msg.error },
+              '[F215] Malformed after content output — replacing misleading error with partial-output notice',
+            );
+            const notice: AgentMessage = {
+              type: 'text',
+              catId: catId as CatId,
+              content: `\n\n🐾 手抖了——最后一步没完成。上面的内容已经送到了，可以追问或让其他猫猫接着做。`,
+              timestamp: Date.now(),
+            };
+            for await (const out of streamProcessedOutputs(notice)) {
+              yield out;
+            }
+            continue;
+          }
+
+          if (
+            suppressedMissingSessionError ||
+            suppressedPromptLimitError ||
+            suppressedContextOverflowError ||
+            suppressedTransientCliError ||
+            suppressedTimeoutError ||
+            suppressedMalformedError
+          ) {
+            if (msg.type === 'done') {
+              // F215 AC-C1: Seal malformed session before fresh retry.
+              if (suppressedMalformedError && deps.sessionSealer && deps.sessionChainStore) {
+                try {
+                  const activeRec = await deps.sessionChainStore.getActive(catId as CatId, threadId);
+                  if (activeRec) {
+                    const sealResult = await deps.sessionSealer.requestSeal({
+                      sessionId: activeRec.id,
+                      reason: 'malformed_toolcall',
+                    });
+                    if (sealResult.accepted) {
+                      sessionManager.delete(userId, catId, threadId).catch(() => {});
+                      deps.sessionSealer.finalize({ sessionId: activeRec.id }).catch(() => {});
+                      log.info(
+                        { catId, threadId, invocationId, sessionId: activeRec.id },
+                        '[F215] Sealed malformed session for fresh-context retry',
+                      );
+                    }
+                  }
+                } catch {
+                  /* best-effort seal */
+                }
+              }
+              shouldRetryWithoutSession = Boolean(
+                suppressedMissingSessionError ||
+                  suppressedPromptLimitError ||
+                  suppressedContextOverflowError ||
+                  suppressedTimeoutError ||
+                  suppressedMalformedError,
+              );
+              shouldRetryOnTransientCliExit = Boolean(suppressedTransientCliError);
+              break;
+            }
+
+            if (suppressedMissingSessionError) {
+              for await (const out of streamProcessedOutputs(suppressedMissingSessionError)) {
+                yield out;
+              }
+              suppressedMissingSessionError = undefined;
+            }
+            if (suppressedPromptLimitError) {
+              for await (const out of streamProcessedOutputs(suppressedPromptLimitError)) {
+                yield out;
+              }
+              suppressedPromptLimitError = undefined;
+            }
+            if (suppressedContextOverflowError) {
+              for await (const out of streamProcessedOutputs(suppressedContextOverflowError)) {
+                yield out;
+              }
+              suppressedContextOverflowError = undefined;
+            }
+            if (suppressedTransientCliError) {
+              for await (const out of streamProcessedOutputs(suppressedTransientCliError)) {
+                yield out;
+              }
+              suppressedTransientCliError = undefined;
+            }
+            if (suppressedTimeoutError) {
+              for await (const out of streamProcessedOutputs(suppressedTimeoutError)) {
+                yield out;
+              }
+              suppressedTimeoutError = undefined;
+            }
+            // F215: Clear malformed error — will be re-evaluated on retry.
+            if (suppressedMalformedError) {
+              suppressedMalformedError = undefined;
+            }
+          }
+
+          // F149: Map provider_signal / liveness_signal → system_info for frontend delivery
+          const deliveryMsg =
+            msg.type === 'provider_signal' || msg.type === 'liveness_signal'
+              ? { ...msg, type: 'system_info' as const }
+              : msg;
+          for await (const out of streamProcessedOutputs(deliveryMsg)) {
             yield out;
           }
-          continue;
-        }
-
-        if (
-          suppressedMissingSessionError ||
-          suppressedPromptLimitError ||
-          suppressedContextOverflowError ||
-          suppressedTransientCliError ||
-          suppressedTimeoutError ||
-          suppressedMalformedError
-        ) {
-          if (msg.type === 'done') {
-            // F215 AC-C1: Seal malformed session before fresh retry.
-            if (suppressedMalformedError && deps.sessionSealer && deps.sessionChainStore) {
+          if (
+            msg.type !== 'error' &&
+            msg.type !== 'done' &&
+            msg.type !== 'session_init' &&
+            msg.type !== 'provider_signal' &&
+            msg.type !== 'liveness_signal' &&
+            msg.type !== 'status'
+          ) {
+            // F215 hotfix: attemptHasContentOutput must only be set by replay-sensitive types
+            // (text / tool_use / tool_result). system_info (rate_limit_event / agent_loop /
+            // timeout_diagnostics) and other metadata MUST NOT prevent malformed recovery —
+            // they carry no model output that would be duplicated on retry.
+            // Bug: system_info from rate_limit_event precedes malformed turn → sets
+            // attemptHasContentOutput=true → malformed suppress guard !attemptHasContentOutput
+            // fails → seal/fresh-retry/46接力 all skipped → bare malformed error leaks to user.
+            if (isUserVisibleSessionOutput(msg)) {
+              attemptHasContentOutput = true;
+            }
+            // Substantive = real model output, excludes system_info (e.g. timeout_diagnostics).
+            if (msg.type !== 'system_info') {
+              attemptHasSubstantiveOutput = true;
+            }
+            // F118 AC-C6: Reset consecutive restore failure counter on successful content
+            if (deps.sessionChainStore && !didResetRestoreFailures) {
+              didResetRestoreFailures = true; // only reset once per invocation
               try {
                 const activeRec = await deps.sessionChainStore.getActive(catId as CatId, threadId);
-                if (activeRec) {
-                  const sealResult = await deps.sessionSealer.requestSeal({
-                    sessionId: activeRec.id,
-                    reason: 'malformed_toolcall',
+                if (activeRec && (activeRec.consecutiveRestoreFailures ?? 0) > 0) {
+                  await deps.sessionChainStore.update(activeRec.id, {
+                    consecutiveRestoreFailures: 0,
+                    updatedAt: Date.now(),
                   });
-                  if (sealResult.accepted) {
-                    sessionManager.delete(userId, catId, threadId).catch(() => {});
-                    deps.sessionSealer.finalize({ sessionId: activeRec.id }).catch(() => {});
-                    log.info(
-                      { catId, threadId, invocationId, sessionId: activeRec.id },
-                      '[F215] Sealed malformed session for fresh-context retry',
-                    );
-                  }
                 }
               } catch {
-                /* best-effort seal */
+                /* best-effort reset */
               }
             }
-            shouldRetryWithoutSession = Boolean(
-              suppressedMissingSessionError ||
-                suppressedPromptLimitError ||
-                suppressedContextOverflowError ||
-                suppressedTimeoutError ||
-                suppressedMalformedError,
-            );
-            shouldRetryOnTransientCliExit = Boolean(suppressedTransientCliError);
-            break;
-          }
-
-          if (suppressedMissingSessionError) {
-            for await (const out of streamProcessedOutputs(suppressedMissingSessionError)) {
-              yield out;
-            }
-            suppressedMissingSessionError = undefined;
-          }
-          if (suppressedPromptLimitError) {
-            for await (const out of streamProcessedOutputs(suppressedPromptLimitError)) {
-              yield out;
-            }
-            suppressedPromptLimitError = undefined;
-          }
-          if (suppressedContextOverflowError) {
-            for await (const out of streamProcessedOutputs(suppressedContextOverflowError)) {
-              yield out;
-            }
-            suppressedContextOverflowError = undefined;
-          }
-          if (suppressedTransientCliError) {
-            for await (const out of streamProcessedOutputs(suppressedTransientCliError)) {
-              yield out;
-            }
-            suppressedTransientCliError = undefined;
-          }
-          if (suppressedTimeoutError) {
-            for await (const out of streamProcessedOutputs(suppressedTimeoutError)) {
-              yield out;
-            }
-            suppressedTimeoutError = undefined;
-          }
-          // F215: Clear malformed error — will be re-evaluated on retry.
-          if (suppressedMalformedError) {
-            suppressedMalformedError = undefined;
           }
         }
-
-        // F149: Map provider_signal / liveness_signal → system_info for frontend delivery
-        const deliveryMsg =
-          msg.type === 'provider_signal' || msg.type === 'liveness_signal'
-            ? { ...msg, type: 'system_info' as const }
-            : msg;
-        for await (const out of streamProcessedOutputs(deliveryMsg)) {
-          yield out;
-        }
-        if (
-          msg.type !== 'error' &&
-          msg.type !== 'done' &&
-          msg.type !== 'session_init' &&
-          msg.type !== 'provider_signal' &&
-          msg.type !== 'liveness_signal' &&
-          msg.type !== 'status'
-        ) {
-          // F215 hotfix: attemptHasContentOutput must only be set by replay-sensitive types
-          // (text / tool_use / tool_result). system_info (rate_limit_event / agent_loop /
-          // timeout_diagnostics) and other metadata MUST NOT prevent malformed recovery —
-          // they carry no model output that would be duplicated on retry.
-          // Bug: system_info from rate_limit_event precedes malformed turn → sets
-          // attemptHasContentOutput=true → malformed suppress guard !attemptHasContentOutput
-          // fails → seal/fresh-retry/46接力 all skipped → bare malformed error leaks to user.
-          if (isUserVisibleSessionOutput(msg)) {
-            attemptHasContentOutput = true;
-          }
-          // Substantive = real model output, excludes system_info (e.g. timeout_diagnostics).
-          if (msg.type !== 'system_info') {
-            attemptHasSubstantiveOutput = true;
-          }
-          // F118 AC-C6: Reset consecutive restore failure counter on successful content
-          if (deps.sessionChainStore && !didResetRestoreFailures) {
-            didResetRestoreFailures = true; // only reset once per invocation
-            try {
-              const activeRec = await deps.sessionChainStore.getActive(catId as CatId, threadId);
-              if (activeRec && (activeRec.consecutiveRestoreFailures ?? 0) > 0) {
-                await deps.sessionChainStore.update(activeRec.id, {
-                  consecutiveRestoreFailures: 0,
-                  updatedAt: Date.now(),
-                });
-              }
-            } catch {
-              /* best-effort reset */
-            }
-          }
-        }
+      } finally {
+        // #1186: Close the service generator so its finally block executes (lease.release()).
+        // This is the critical fix — without it, every manual-iteration break leaks a lease.
+        // Safe to call even if the generator already returned (no-op in 'completed' state).
+        await serviceIter.return?.();
       }
 
       if (shouldRetryWithoutSession && attempt + 1 < maxAttempts) {

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -3110,6 +3110,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       // breaking from the loop (retry path, abort, error) leaves the generator suspended
       // at its last yield, so AcpAgentService.invoke()'s finally { lease.release() } never
       // executes → leaked lease → "Pool at capacity" after maxLiveProcesses invocations.
+      let iterExitedNormally = false;
       try {
         for (;;) {
           const iterResult = await abortableNext(serviceIter, signal);
@@ -3349,11 +3350,26 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
             }
           }
         }
+        iterExitedNormally = true;
       } finally {
         // #1186: Close the service generator so its finally block executes (lease.release()).
         // This is the critical fix — without it, every manual-iteration break leaks a lease.
-        // Safe to call even if the generator already returned (no-op in 'completed' state).
-        await serviceIter.return?.();
+        //
+        // Two paths:
+        // 1. Normal/retry break: generator is suspended at a yield — .return() resolves
+        //    immediately (sync finally in AcpAgentService runs lease.release() inline).
+        //    MUST await so lease is released before any retry attempt acquires a new one.
+        // 2. Abort/error: abortableNext() rejected while .next() is still pending.
+        //    Async generator operations are serialized — .return() queues behind the
+        //    pending .next() and may block until cancelSession resolves the underlying
+        //    stream. Awaiting would reintroduce the stuck behavior abortableNext was
+        //    designed to prevent. Fire-and-forget; the lease releases asynchronously
+        //    when the cancel propagates.
+        if (iterExitedNormally) {
+          await serviceIter.return?.();
+        } else {
+          serviceIter.return?.()?.catch(() => {});
+        }
       }
 
       if (shouldRetryWithoutSession && attempt + 1 < maxAttempts) {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -60,6 +60,13 @@ export interface AcpAgentServiceConfig {
   sessionModel?: string;
   /** When false, disables ALL MCP servers (base + per-project) for this member. */
   mcpSupport?: boolean;
+  /**
+   * #1186: Configured ACP Idle TTL from member's pool config (ms).
+   * Used as the authoritative idle stall threshold for all "no events" termination
+   * paths in promptStream (both tool and non-tool idle). Previously, hardcoded
+   * constants (90s stall, 180s tool ceiling) overrode the user's configured value.
+   */
+  idleTtlMs?: number;
 }
 
 /** @deprecated Use AcpAgentServiceConfig. Kept for backward compat during transition. */
@@ -78,6 +85,8 @@ export class AcpAgentService implements AgentService {
   private readonly modelName: string;
   private readonly sessionModel?: string;
   private readonly mcpSupportEnabled: boolean;
+  /** #1186: Configured ACP idle TTL — authoritative threshold for all no-event termination. */
+  private readonly idleTtlMs: number | undefined;
 
   constructor(config: AcpAgentServiceConfig) {
     this.catId = config.catId;
@@ -90,6 +99,7 @@ export class AcpAgentService implements AgentService {
     this.modelName = config.modelName ?? config.sessionModel ?? 'acp';
     this.sessionModel = config.sessionModel?.trim() || undefined;
     this.mcpSupportEnabled = config.mcpSupport !== false;
+    this.idleTtlMs = config.idleTtlMs;
   }
 
   async *invoke(prompt: string, options?: AgentServiceOptions): AsyncIterable<AgentMessage> {
@@ -140,7 +150,11 @@ export class AcpAgentService implements AgentService {
       loadSession(sessionId: string, cwd: string, mcpServers?: AcpMcpServer[]): Promise<AcpNewSessionResult>;
       setSessionConfigOption(sessionId: string, configId: string, value: string): Promise<void>;
       cancelSession(sessionId: string): void;
-      promptStream(sessionId: string, text: string): AsyncGenerator<import('./types.js').AcpSessionUpdate>;
+      promptStream(
+        sessionId: string,
+        text: string,
+        options?: { timeoutMs?: number; idleWarningMs?: number; idleStallMs?: number },
+      ): AsyncGenerator<import('./types.js').AcpSessionUpdate>;
       onCapacity(fn: (signal: AcpCapacitySignal) => void): void;
       offCapacity(fn: (signal: AcpCapacitySignal) => void): void;
       readonly recentCapacitySignal: AcpCapacitySignal | null;
@@ -373,9 +387,12 @@ export class AcpAgentService implements AgentService {
       promptStreamStartedAt = Date.now();
       // Prompt digest: length + hash only (snippets gated by AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS)
       const promptDigest = createPromptDigest(effectivePrompt);
-      log.info({ ...ctx, sessionId, promptDigest }, 'ACP promptStream starting');
+      // #1186: Thread configured idle TTL to promptStream so the watchdog respects
+      // the member's ACP Idle TTL instead of using hardcoded 90s/180s defaults.
+      const promptStreamOpts = this.idleTtlMs ? { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs } : undefined;
+      log.info({ ...ctx, sessionId, promptDigest, idleTtlMs: this.idleTtlMs }, 'ACP promptStream starting');
       eventCount = 0;
-      for await (const event of client.promptStream(sessionId, effectivePrompt)) {
+      for await (const event of client.promptStream(sessionId, effectivePrompt, promptStreamOpts)) {
         // F149: Capacity signal injected by AcpClient.promptStream from stderr.
         // Breaks through zero-event stalls where the old listener-only path couldn't.
         if (event.update?.sessionUpdate === 'provider_capacity_signal') {
@@ -526,7 +543,7 @@ export class AcpAgentService implements AgentService {
           const retryState = createAcpSessionState();
           let retryEventCount = 0;
           log.info({ ...ctx, sessionId: freshSessionId }, '#1091: retry promptStream on fresh session');
-          for await (const event of client.promptStream(freshSessionId, retryPrompt)) {
+          for await (const event of client.promptStream(freshSessionId, retryPrompt, promptStreamOpts)) {
             // Skip synthetic events (capacity/idle/tool-wait warnings)
             if (event.update?.sessionUpdate === 'provider_capacity_signal') continue;
             if (event.update?.sessionUpdate === 'stream_idle_warning') continue;

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -22,7 +22,7 @@ import { readCapabilitiesConfig } from '../../../../../../config/capabilities/ca
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import { createPromptDigest } from '../../../context/prompt-digest.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata } from '../../../types.js';
-import { type AcpCapacitySignal, AcpProtocolError, AcpTimeoutError } from './AcpClient.js';
+import { type AcpCapacitySignal, AcpProtocolError, AcpStreamIdleError, AcpTimeoutError } from './AcpClient.js';
 import { type AcpLease, type AcpProcessPool, DEFAULT_ACP_IDLE_TTL_MS, type PoolKey } from './AcpProcessPool.js';
 import {
   bindSessionCredentialFile,
@@ -167,6 +167,15 @@ export class AcpAgentService implements AgentService {
     const cwd = options?.workingDirectory ?? this.projectRoot;
     let sessionId: string | undefined;
 
+    const sealUnquiescedSession = (activeSessionId: string) => {
+      const sessionIds = new Set([activeSessionId, options?.sessionId].filter((id): id is string => Boolean(id)));
+      for (const id of sessionIds) this.pool.sealSession?.(this.poolKey, id);
+    };
+    const cancelUnquiescedSession = (activeSessionId: string) => {
+      sealUnquiescedSession(activeSessionId);
+      client.cancelSession(activeSessionId);
+    };
+
     // Per-invoke capacity listener — covers the entire invoke lifecycle (newSession + prompt + grace).
     // This is intentionally invoke-level, not prompt-level: capacity is a provider-level property
     // (same process = same API key = same quota), so signals from any phase are relevant.
@@ -183,7 +192,7 @@ export class AcpAgentService implements AgentService {
       ? () => {
           log.info({ ...ctx, sessionId }, 'ACP session cancelled via abort signal');
           if (sessionId && client) {
-            client.cancelSession(sessionId);
+            cancelUnquiescedSession(sessionId);
           }
         }
       : undefined;
@@ -267,7 +276,13 @@ export class AcpAgentService implements AgentService {
       // Session reuse: if options.sessionId is provided (from session chain), try to
       // reuse the existing ACP session for multi-turn memory. The agent keeps conversation
       // history server-side, so reusing the session avoids "amnesia" across turns.
-      const resumeSessionId = options?.sessionId;
+      const resumeSessionId = lease.canResumeRequestedSession === false ? undefined : options?.sessionId;
+      if (options?.sessionId && !resumeSessionId) {
+        log.warn(
+          { ...ctx, sealedSessionId: options.sessionId },
+          'ACP cancelled session is sealed; creating a fresh replacement session',
+        );
+      }
       let isResumedSession = false;
       let resumeSessionLoadFailed = false;
 
@@ -347,7 +362,7 @@ export class AcpAgentService implements AgentService {
 
       // Window 2: abort may have fired during newSession
       if (options?.signal?.aborted) {
-        client.cancelSession(sessionId);
+        cancelUnquiescedSession(sessionId);
         yield {
           type: 'error',
           catId: this.catId,
@@ -371,7 +386,7 @@ export class AcpAgentService implements AgentService {
 
       // Window 3: consumer may abort during the yield above
       if (options?.signal?.aborted) {
-        client.cancelSession(sessionId);
+        cancelUnquiescedSession(sessionId);
         yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }
@@ -459,7 +474,7 @@ export class AcpAgentService implements AgentService {
               { ...ctx, sessionId, eventCount, scratchpadSuppressedEvents },
               'ACP compaction auto-continue loop detected — cancelling session',
             );
-            client.cancelSession(sessionId);
+            cancelUnquiescedSession(sessionId);
             throw new Error(
               `ACP compaction auto-continue loop cancelled after ${scratchpadSuppressedEvents} suppressed events`,
             );
@@ -504,7 +519,7 @@ export class AcpAgentService implements AgentService {
 
           // Abort may have fired during the fresh newSession (mirrors Window 2)
           if (options?.signal?.aborted) {
-            client.cancelSession(freshSessionId);
+            cancelUnquiescedSession(freshSessionId);
             yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
             return;
           }
@@ -534,7 +549,7 @@ export class AcpAgentService implements AgentService {
 
           // Consumer may abort during the yield above (mirrors Window 3)
           if (options?.signal?.aborted) {
-            client.cancelSession(freshSessionId);
+            cancelUnquiescedSession(freshSessionId);
             yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
             return;
           }
@@ -573,6 +588,9 @@ export class AcpAgentService implements AgentService {
           yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
           return; // Exit — retry path handled completion
         } catch (retryErr) {
+          if (sessionId && (retryErr instanceof AcpTimeoutError || retryErr instanceof AcpStreamIdleError)) {
+            sealUnquiescedSession(sessionId);
+          }
           const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
           log.error({ ...ctx, sessionId, err: retryErrMsg }, '#1091: retry with fresh session also failed');
           yield {
@@ -596,6 +614,9 @@ export class AcpAgentService implements AgentService {
 
       yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
     } catch (err) {
+      if (sessionId && (err instanceof AcpTimeoutError || err instanceof AcpStreamIdleError)) {
+        sealUnquiescedSession(sessionId);
+      }
       const waitedMs = promptStreamStartedAt ? Date.now() - promptStreamStartedAt : 0;
       // P1: stderr may arrive after timeout — give a grace window for late capacity signals
       if (!capacitySignal && err instanceof AcpTimeoutError) {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -38,6 +38,14 @@ import type { AcpMcpServer, AcpNewSessionResult } from './types.js';
 
 const log = createModuleLogger('acp-agent');
 
+type ResumeDisposition = 'fresh_without_resume' | 'resume_requested' | 'resumed' | 'load_failed_fresh' | 'sealed_fresh';
+
+type PromptPhase =
+  | 'not_started'
+  | 'active_unacknowledged'
+  | 'provider_acknowledged'
+  | 'locally_terminated_unacknowledged';
+
 export interface AcpAgentServiceConfig {
   catId: CatId;
   pool: AcpProcessPool;
@@ -166,14 +174,22 @@ export class AcpAgentService implements AgentService {
     };
     const cwd = options?.workingDirectory ?? this.projectRoot;
     let sessionId: string | undefined;
+    let promptPhase: PromptPhase = 'not_started';
 
-    const sealUnquiescedSession = (activeSessionId: string) => {
+    const sealActivePromptSession = (activeSessionId: string): boolean => {
+      if (promptPhase !== 'active_unacknowledged') return false;
+      promptPhase = 'locally_terminated_unacknowledged';
       const sessionIds = new Set([activeSessionId, options?.sessionId].filter((id): id is string => Boolean(id)));
       for (const id of sessionIds) this.pool.sealSession?.(this.poolKey, id);
+      return true;
     };
-    const cancelUnquiescedSession = (activeSessionId: string) => {
-      sealUnquiescedSession(activeSessionId);
+    const cancelActivePromptSession = (activeSessionId: string): boolean => {
+      if (!sealActivePromptSession(activeSessionId)) return false;
       client.cancelSession(activeSessionId);
+      return true;
+    };
+    const markPromptAcknowledged = () => {
+      if (promptPhase === 'active_unacknowledged') promptPhase = 'provider_acknowledged';
     };
 
     // Per-invoke capacity listener — covers the entire invoke lifecycle (newSession + prompt + grace).
@@ -190,10 +206,9 @@ export class AcpAgentService implements AgentService {
     // Abort handler: cancels the specific session, not the shared client
     const onAbort = options?.signal
       ? () => {
-          log.info({ ...ctx, sessionId }, 'ACP session cancelled via abort signal');
-          if (sessionId && client) {
-            cancelUnquiescedSession(sessionId);
-          }
+          const phaseAtAbort = promptPhase;
+          const cancelledActivePrompt = sessionId ? cancelActivePromptSession(sessionId) : false;
+          log.info({ ...ctx, sessionId, phaseAtAbort, cancelledActivePrompt }, 'ACP invocation abort signal observed');
         }
       : undefined;
     if (onAbort && options?.signal) {
@@ -276,15 +291,18 @@ export class AcpAgentService implements AgentService {
       // Session reuse: if options.sessionId is provided (from session chain), try to
       // reuse the existing ACP session for multi-turn memory. The agent keeps conversation
       // history server-side, so reusing the session avoids "amnesia" across turns.
-      const resumeSessionId = lease.canResumeRequestedSession === false ? undefined : options?.sessionId;
-      if (options?.sessionId && !resumeSessionId) {
+      let resumeDisposition: ResumeDisposition = options?.sessionId
+        ? lease.canResumeRequestedSession === false
+          ? 'sealed_fresh'
+          : 'resume_requested'
+        : 'fresh_without_resume';
+      const resumeSessionId = resumeDisposition === 'resume_requested' ? options?.sessionId : undefined;
+      if (resumeDisposition === 'sealed_fresh') {
         log.warn(
-          { ...ctx, sealedSessionId: options.sessionId },
+          { ...ctx, sealedSessionId: options?.sessionId },
           'ACP cancelled session is sealed; creating a fresh replacement session',
         );
       }
-      let isResumedSession = false;
-      let resumeSessionLoadFailed = false;
 
       if (resumeSessionId) {
         const resumeCreds = resolveSessionCredentialFile(options?.callbackEnv, resumeSessionId);
@@ -312,10 +330,10 @@ export class AcpAgentService implements AgentService {
           sessionMcpServers = resumeConfig.mcpServers;
           envDiag = resumeConfig.envDiag;
           metadata.sessionId = sessionId;
-          isResumedSession = true;
+          resumeDisposition = 'resumed';
           log.info({ ...ctx, sessionId, requestedSessionId: resumeSessionId }, 'ACP session resume completed');
         } catch (err) {
-          resumeSessionLoadFailed = true;
+          resumeDisposition = 'load_failed_fresh';
           const errorMsg = err instanceof Error ? err.message : String(err);
           log.warn(
             { ...ctx, sessionId: resumeSessionId, cwd, err: errorMsg },
@@ -324,7 +342,7 @@ export class AcpAgentService implements AgentService {
         }
       }
 
-      if (!isResumedSession) {
+      if (resumeDisposition !== 'resumed') {
         const freshCreds = prepareSessionCredentialFile(options?.callbackEnv);
         const freshConfig = buildSessionConfig(freshCreds);
         sessionMcpServers = freshConfig.mcpServers;
@@ -362,7 +380,6 @@ export class AcpAgentService implements AgentService {
 
       // Window 2: abort may have fired during newSession
       if (options?.signal?.aborted) {
-        cancelUnquiescedSession(sessionId);
         yield {
           type: 'error',
           catId: this.catId,
@@ -386,16 +403,16 @@ export class AcpAgentService implements AgentService {
 
       // Window 3: consumer may abort during the yield above
       if (options?.signal?.aborted) {
-        cancelUnquiescedSession(sessionId);
         yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
         return;
       }
 
       // Prepend system prompt (ACP agents have no system prompt flag).
-      // If a resume load failed, the outer invocation skipped identity because it
-      // expected session memory; the fresh fallback session must receive it once.
+      // Any resumed turn that had to create a fresh session lost the identity it
+      // expected session memory to carry, so restore the fallback exactly once.
+      const restoresResumeIdentity = resumeDisposition === 'load_failed_fresh' || resumeDisposition === 'sealed_fresh';
       const fallbackSystemPrompt =
-        resumeSessionLoadFailed && options?.resumeFallbackSystemPrompt ? options.resumeFallbackSystemPrompt : undefined;
+        restoresResumeIdentity && options?.resumeFallbackSystemPrompt ? options.resumeFallbackSystemPrompt : undefined;
       const effectivePrompt = options?.systemPrompt
         ? `${options.systemPrompt}\n\n${prompt}`
         : fallbackSystemPrompt
@@ -413,6 +430,7 @@ export class AcpAgentService implements AgentService {
       const promptStreamOpts = { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs + 60_000 };
       log.info({ ...ctx, sessionId, promptDigest, idleTtlMs: this.idleTtlMs }, 'ACP promptStream starting');
       eventCount = 0;
+      promptPhase = 'active_unacknowledged';
       for await (const event of client.promptStream(sessionId, effectivePrompt, promptStreamOpts)) {
         // F149: Capacity signal injected by AcpClient.promptStream from stderr.
         // Breaks through zero-event stalls where the old listener-only path couldn't.
@@ -474,7 +492,7 @@ export class AcpAgentService implements AgentService {
               { ...ctx, sessionId, eventCount, scratchpadSuppressedEvents },
               'ACP compaction auto-continue loop detected — cancelling session',
             );
-            cancelUnquiescedSession(sessionId);
+            cancelActivePromptSession(sessionId);
             throw new Error(
               `ACP compaction auto-continue loop cancelled after ${scratchpadSuppressedEvents} suppressed events`,
             );
@@ -488,6 +506,7 @@ export class AcpAgentService implements AgentService {
           yield result;
         }
       }
+      markPromptAcknowledged();
       log.info({ ...ctx, sessionId, eventCount }, 'ACP promptStream completed');
 
       // #1091: Zero-event resume detection. Some ACP providers (e.g. kimi) return
@@ -496,12 +515,13 @@ export class AcpAgentService implements AgentService {
       // Detect this and retry with a fresh session so the cat isn't silently dead.
       const promptElapsedMs = Date.now() - promptStreamStartedAt;
       const RESUME_EMPTY_THRESHOLD_MS = 3_000;
-      if (isResumedSession && eventCount === 0 && promptElapsedMs < RESUME_EMPTY_THRESHOLD_MS) {
+      if (resumeDisposition === 'resumed' && eventCount === 0 && promptElapsedMs < RESUME_EMPTY_THRESHOLD_MS) {
         log.warn(
           { ...ctx, sessionId, promptElapsedMs },
           '#1091: ACP resumed session produced zero events in <3s — retrying with fresh session',
         );
         // Create fresh session and retry promptStream once (not recursive — single retry)
+        promptPhase = 'not_started';
         try {
           const retryCreds = prepareSessionCredentialFile(options?.callbackEnv);
           const retryConfig = buildSessionConfig(retryCreds);
@@ -519,7 +539,6 @@ export class AcpAgentService implements AgentService {
 
           // Abort may have fired during the fresh newSession (mirrors Window 2)
           if (options?.signal?.aborted) {
-            cancelUnquiescedSession(freshSessionId);
             yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
             return;
           }
@@ -549,7 +568,6 @@ export class AcpAgentService implements AgentService {
 
           // Consumer may abort during the yield above (mirrors Window 3)
           if (options?.signal?.aborted) {
-            cancelUnquiescedSession(freshSessionId);
             yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
             return;
           }
@@ -564,6 +582,7 @@ export class AcpAgentService implements AgentService {
           const retryState = createAcpSessionState();
           let retryEventCount = 0;
           log.info({ ...ctx, sessionId: freshSessionId }, '#1091: retry promptStream on fresh session');
+          promptPhase = 'active_unacknowledged';
           for await (const event of client.promptStream(freshSessionId, retryPrompt, promptStreamOpts)) {
             // Skip synthetic events (capacity/idle/tool-wait warnings)
             if (event.update?.sessionUpdate === 'provider_capacity_signal') continue;
@@ -579,6 +598,7 @@ export class AcpAgentService implements AgentService {
               yield result;
             }
           }
+          markPromptAcknowledged();
           log.info({ ...ctx, sessionId: freshSessionId, retryEventCount }, '#1091: retry promptStream completed');
 
           // Flush trailing thinking from retry
@@ -589,7 +609,7 @@ export class AcpAgentService implements AgentService {
           return; // Exit — retry path handled completion
         } catch (retryErr) {
           if (sessionId && (retryErr instanceof AcpTimeoutError || retryErr instanceof AcpStreamIdleError)) {
-            sealUnquiescedSession(sessionId);
+            sealActivePromptSession(sessionId);
           }
           const retryErrMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
           log.error({ ...ctx, sessionId, err: retryErrMsg }, '#1091: retry with fresh session also failed');
@@ -615,7 +635,7 @@ export class AcpAgentService implements AgentService {
       yield { type: 'done', catId: this.catId, metadata, timestamp: Date.now() };
     } catch (err) {
       if (sessionId && (err instanceof AcpTimeoutError || err instanceof AcpStreamIdleError)) {
-        sealUnquiescedSession(sessionId);
+        sealActivePromptSession(sessionId);
       }
       const waitedMs = promptStreamStartedAt ? Date.now() - promptStreamStartedAt : 0;
       // P1: stderr may arrive after timeout — give a grace window for late capacity signals

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -393,7 +393,9 @@ export class AcpAgentService implements AgentService {
       const promptDigest = createPromptDigest(effectivePrompt);
       // #1186: Thread resolved idle TTL to promptStream so the watchdog respects
       // the member's ACP Idle TTL (or 30m default) instead of hardcoded 90s/180s.
-      const promptStreamOpts = { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs };
+      // Turn budget (timeoutMs) must exceed idle stall so AcpStreamIdleError fires
+      // first with configuredIdleStallMs. Add 60s margin to avoid timer races.
+      const promptStreamOpts = { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs + 60_000 };
       log.info({ ...ctx, sessionId, promptDigest, idleTtlMs: this.idleTtlMs }, 'ACP promptStream starting');
       eventCount = 0;
       for await (const event of client.promptStream(sessionId, effectivePrompt, promptStreamOpts)) {
@@ -788,8 +790,13 @@ function toUserFacingError(providerName: string, errorCode: string, errorMsg: st
       return `${base}\n⚠️ ${label} 服务端容量不足（服务器繁忙），非 Clowder AI 系统故障。`;
     case 'stream_idle_stall':
       return `${base}\n⚠️ ${label} 服务端响应中断（服务器可能繁忙或不稳定），非 Clowder AI 系统故障。`;
-    case 'turn_budget_exceeded':
-      return `${base}\n⚠️ 本轮对话时间预算用完（${Math.round(900 / 60)}分钟），agent 可能在执行复杂工具链。非故障，可重试。`;
+    case 'turn_budget_exceeded': {
+      // #1186: Derive actual timeout from error message instead of hardcoding 15m.
+      // AcpTimeoutError format: "...did not respond within ${ms}ms"
+      const budgetMatch = errorMsg.match(/within (\d+)ms/);
+      const budgetMinutes = budgetMatch ? Math.round(Number(budgetMatch[1]) / 60_000) : '?';
+      return `${base}\n⚠️ 本轮对话时间预算用完（${budgetMinutes}分钟），agent 可能在执行复杂工具链。非故障，可重试。`;
+    }
     case 'mcp_pollution':
       return `${base}\n⚠️ ${label} 工具调用异常（MCP 服务端错误）。`;
     case 'init_failure':

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -23,7 +23,7 @@ import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import { createPromptDigest } from '../../../context/prompt-digest.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata } from '../../../types.js';
 import { type AcpCapacitySignal, AcpProtocolError, AcpTimeoutError } from './AcpClient.js';
-import type { AcpLease, AcpProcessPool, PoolKey } from './AcpProcessPool.js';
+import { type AcpLease, type AcpProcessPool, DEFAULT_ACP_IDLE_TTL_MS, type PoolKey } from './AcpProcessPool.js';
 import {
   bindSessionCredentialFile,
   type PreparedCredentialEnv,
@@ -85,8 +85,12 @@ export class AcpAgentService implements AgentService {
   private readonly modelName: string;
   private readonly sessionModel?: string;
   private readonly mcpSupportEnabled: boolean;
-  /** #1186: Configured ACP idle TTL — authoritative threshold for all no-event termination. */
-  private readonly idleTtlMs: number | undefined;
+  /**
+   * #1186: Resolved ACP idle TTL — authoritative threshold for all no-event termination.
+   * Always concrete: defaults to DEFAULT_ACP_IDLE_TTL_MS (30m) when config omits it,
+   * so promptStream never falls back to the client's hardcoded 90s/15m defaults.
+   */
+  private readonly idleTtlMs: number;
 
   constructor(config: AcpAgentServiceConfig) {
     this.catId = config.catId;
@@ -99,7 +103,7 @@ export class AcpAgentService implements AgentService {
     this.modelName = config.modelName ?? config.sessionModel ?? 'acp';
     this.sessionModel = config.sessionModel?.trim() || undefined;
     this.mcpSupportEnabled = config.mcpSupport !== false;
-    this.idleTtlMs = config.idleTtlMs;
+    this.idleTtlMs = config.idleTtlMs ?? DEFAULT_ACP_IDLE_TTL_MS;
   }
 
   async *invoke(prompt: string, options?: AgentServiceOptions): AsyncIterable<AgentMessage> {
@@ -387,9 +391,9 @@ export class AcpAgentService implements AgentService {
       promptStreamStartedAt = Date.now();
       // Prompt digest: length + hash only (snippets gated by AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS)
       const promptDigest = createPromptDigest(effectivePrompt);
-      // #1186: Thread configured idle TTL to promptStream so the watchdog respects
-      // the member's ACP Idle TTL instead of using hardcoded 90s/180s defaults.
-      const promptStreamOpts = this.idleTtlMs ? { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs } : undefined;
+      // #1186: Thread resolved idle TTL to promptStream so the watchdog respects
+      // the member's ACP Idle TTL (or 30m default) instead of hardcoded 90s/180s.
+      const promptStreamOpts = { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs };
       log.info({ ...ctx, sessionId, promptDigest, idleTtlMs: this.idleTtlMs }, 'ACP promptStream starting');
       eventCount = 0;
       for await (const event of client.promptStream(sessionId, effectivePrompt, promptStreamOpts)) {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -22,7 +22,13 @@ import { readCapabilitiesConfig } from '../../../../../../config/capabilities/ca
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import { createPromptDigest } from '../../../context/prompt-digest.js';
 import type { AgentMessage, AgentService, AgentServiceOptions, MessageMetadata } from '../../../types.js';
-import { type AcpCapacitySignal, AcpProtocolError, AcpStreamIdleError, AcpTimeoutError } from './AcpClient.js';
+import {
+  ACP_PROMPT_TIMEOUT_MARGIN_MS,
+  type AcpCapacitySignal,
+  AcpProtocolError,
+  AcpStreamIdleError,
+  AcpTimeoutError,
+} from './AcpClient.js';
 import { type AcpLease, type AcpProcessPool, DEFAULT_ACP_IDLE_TTL_MS, type PoolKey } from './AcpProcessPool.js';
 import {
   bindSessionCredentialFile,
@@ -427,7 +433,10 @@ export class AcpAgentService implements AgentService {
       // the member's ACP Idle TTL (or 30m default) instead of hardcoded 90s/180s.
       // Turn budget (timeoutMs) must exceed idle stall so AcpStreamIdleError fires
       // first with configuredIdleStallMs. Add 60s margin to avoid timer races.
-      const promptStreamOpts = { idleStallMs: this.idleTtlMs, timeoutMs: this.idleTtlMs + 60_000 };
+      const promptStreamOpts = {
+        idleStallMs: this.idleTtlMs,
+        timeoutMs: this.idleTtlMs + ACP_PROMPT_TIMEOUT_MARGIN_MS,
+      };
       log.info({ ...ctx, sessionId, promptDigest, idleTtlMs: this.idleTtlMs }, 'ACP promptStream starting');
       eventCount = 0;
       promptPhase = 'active_unacknowledged';

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -678,6 +678,11 @@ export class AcpClient {
         stopReason = result.stopReason;
       })
       .catch((err: Error) => {
+        // Local termination (idle watchdog, activity budget, or explicit cancel)
+        // rejects the pending protocol request as cleanup. Preserve the terminal
+        // cause that already settled the stream instead of replacing it with the
+        // generic cancellation rejection while queued events are still draining.
+        if (done && promptError) return;
         if (err instanceof AcpTimeoutError) this.unquiescedSessionIds.add(sessionId);
         promptError = err;
       })

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -112,8 +112,13 @@ export class AcpStreamIdleError extends Error {
     public readonly sessionId: string,
     public readonly idleSinceMs: number,
     public readonly eventCount: number,
+    /** #1186: The configured threshold that triggered termination (ms). */
+    public readonly configuredIdleStallMs?: number,
   ) {
-    super(`Stream idle: no events for ${idleSinceMs}ms after ${eventCount} events received`);
+    super(
+      `Stream idle: no events for ${idleSinceMs}ms after ${eventCount} events received` +
+        (configuredIdleStallMs != null ? ` (configured threshold: ${configuredIdleStallMs}ms)` : ''),
+    );
     this.name = 'AcpStreamIdleError';
   }
 }
@@ -478,7 +483,7 @@ export class AcpClient {
               'Stream idle watchdog: tool execution exceeded configured idle TTL — terminating',
             );
             this.cancelSession(sessionId);
-            promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
+            promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount, idleStallMs);
             done = true;
             if (waitResolve) {
               const r = waitResolve;
@@ -496,7 +501,7 @@ export class AcpClient {
           // Stall — terminate the stream and cancel the upstream session
           log.error({ sessionId, idleSinceMs, eventCount }, 'Stream idle watchdog: stall — terminating');
           this.cancelSession(sessionId); // P1-fix: actually cancel the upstream session
-          promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
+          promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount, idleStallMs);
           done = true;
           if (waitResolve) {
             const r = waitResolve;

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -452,7 +452,11 @@ export class AcpClient {
       }
     };
 
-    /** Schedule the next idle check. Only active after first real event. */
+    /** Schedule the next idle check. Active from prompt start — covers zero-first-event.
+     *  #1186: Previously only started after the first real event, so zero-event stalls
+     *  could only be caught by the budget timer (at idleTtlMs + 60s) with AcpTimeoutError.
+     *  Now the idle watchdog owns the terminal transition for all silence, including
+     *  zero-first-event, producing AcpStreamIdleError at the configured TTL. */
     const scheduleIdleCheck = () => {
       if (idleTimer) clearTimeout(idleTimer);
       if (done) return;
@@ -460,7 +464,7 @@ export class AcpClient {
       // With warning at 20s and stall at 45s, the stall timer fires 25s after warning.
       const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : idleWarningMs;
       idleTimer = setTimeout(() => {
-        if (done || eventCount === 0) return;
+        if (done) return;
         // Clamp to at least the threshold that triggered this timer — a threshold
         // event must never report a duration smaller than its own trigger point.
         const rawIdle = Date.now() - lastEventAt;
@@ -599,8 +603,17 @@ export class AcpClient {
     };
     this.sessionCancelCallbacks.set(sessionId, cancelCb);
 
+    // #1186: Initialize lastEventAt so idle watchdog measures from prompt start for
+    // zero-first-event case. When real events arrive, lastEventAt is updated in the listener.
+    lastEventAt = Date.now();
+
     // Start activity-based budget timer — resets on each event from listener
     resetBudget();
+
+    // #1186: Start idle watchdog at prompt start — covers zero-first-event path.
+    // Previously only started from the listener (on first real event), leaving zero-event
+    // stalls uncovered until the budget timer fired at idleTtlMs + 60s.
+    scheduleIdleCheck();
 
     // Fire prompt request — don't await, we'll drain the queue concurrently.
     // sendRequest uses hard ceiling (1h); actual budget is managed by resetBudget().

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -142,6 +142,14 @@ export class AcpClient {
   private closed = false;
   private exited = false;
   private readonly capacityListeners = new Set<(signal: AcpCapacitySignal) => void>();
+  /**
+   * #1186 P1: Per-session cancel callbacks — when cancelSession() is called,
+   * invoke the registered callback to settle the local prompt stream immediately.
+   * Without this, cancel only sends a JSONRPC notification; the pending .next()
+   * blocks until the provider cooperates or the idle watchdog fires, leaving
+   * the lease pinned for the full TTL.
+   */
+  private readonly sessionCancelCallbacks = new Map<string, () => void>();
   /** Client-level capacity signal — always captured regardless of listeners.
    *  Fallback for delayed stderr arriving after invoke listener is removed. */
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
@@ -569,6 +577,28 @@ export class AcpClient {
     };
     this.capacityListeners.add(capacityInjector);
 
+    // #1186 P1: Register cancel callback so cancelSession() settles this stream
+    // immediately instead of waiting for the provider or idle watchdog.
+    const cancelCb = () => {
+      if (done) return;
+      log.info({ sessionId, eventCount }, 'Session cancel settled local prompt stream');
+      promptError = new AcpStreamIdleError(
+        sessionId,
+        Date.now() - (lastEventAt || Date.now()),
+        eventCount,
+        idleStallMs,
+      );
+      done = true;
+      if (idleTimer) clearTimeout(idleTimer);
+      if (budgetTimer) clearTimeout(budgetTimer);
+      if (waitResolve) {
+        const r = waitResolve;
+        waitResolve = null;
+        r();
+      }
+    };
+    this.sessionCancelCallbacks.set(sessionId, cancelCb);
+
     // Start activity-based budget timer — resets on each event from listener
     resetBudget();
 
@@ -611,6 +641,7 @@ export class AcpClient {
     } finally {
       if (idleTimer) clearTimeout(idleTimer);
       if (budgetTimer) clearTimeout(budgetTimer);
+      this.sessionCancelCallbacks.delete(sessionId);
       this.capacityListeners.delete(capacityInjector);
       const idx = this.notificationListeners.indexOf(listener);
       if (idx >= 0) this.notificationListeners.splice(idx, 1);
@@ -620,12 +651,20 @@ export class AcpClient {
   /**
    * Send session/cancel notification (fire-and-forget, no response expected).
    * Does NOT close the shared AcpClient — safe for concurrent sessions.
+   *
+   * #1186 P1: Also settles the local prompt stream via the registered cancel
+   * callback so the pending .next() resolves immediately. Without this, the
+   * generator stays suspended until the provider cooperates or the idle watchdog
+   * fires — leaving the lease pinned for the full TTL.
    */
   cancelSession(sessionId: string): void {
     if (!this.child?.stdin?.writable) return;
     const msg = { jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } };
     this.child.stdin.write(`${JSON.stringify(msg)}\n`);
     log.info('Sent session/cancel for %s', sessionId);
+    // Settle the local prompt stream immediately
+    const cb = this.sessionCancelCallbacks.get(sessionId);
+    if (cb) cb();
   }
 
   async close(): Promise<void> {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -38,6 +38,27 @@ const log = createModuleLogger('acp-client');
 
 const IS_WINDOWS = process.platform === 'win32';
 const KILL_GRACE_MS = 3_000;
+export const ACP_PROMPT_TIMEOUT_MARGIN_MS = 60_000;
+const MIN_ACP_PROMPT_REQUEST_CEILING_MS = 3_600_000;
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
+/**
+ * Keep the absolute protocol request ceiling strictly above the resettable
+ * activity budget without exceeding Node's representable timer range.
+ */
+export function resolveAcpPromptRequestCeilingMs(activityBudgetMs: number): number {
+  if (!Number.isSafeInteger(activityBudgetMs) || activityBudgetMs <= 0) {
+    throw new RangeError(`ACP prompt activity budget must be a positive safe integer, got ${activityBudgetMs}`);
+  }
+  const requestCeilingMs = Math.max(MIN_ACP_PROMPT_REQUEST_CEILING_MS, activityBudgetMs + ACP_PROMPT_TIMEOUT_MARGIN_MS);
+  if (requestCeilingMs > MAX_TIMER_DELAY_MS) {
+    throw new RangeError(
+      `ACP prompt timeout policy exceeds Node timer range: activityBudgetMs=${activityBudgetMs}, ` +
+        `max=${MAX_TIMER_DELAY_MS - ACP_PROMPT_TIMEOUT_MARGIN_MS}`,
+    );
+  }
+  return requestCeilingMs;
+}
 
 // ─── Config ──────────────────────────────────────────────���─────
 
@@ -412,13 +433,15 @@ export class AcpClient {
     // If agent produces events continuously, budget never fires. Only triggers
     // after timeoutMs of SILENCE (no events). Idle stall (90s) catches true hangs
     // faster; this is the wider safety net for slow-but-alive sessions.
-    // sendRequest gets a hard ceiling (1h) as absolute last-resort guard.
+    // sendRequest gets a wider absolute ceiling as a last-resort guard. The
+    // ceiling is derived from timeoutMs so a configured idle policy over one
+    // hour is never preempted by the legacy fixed request timer.
     const timeoutMs = options?.timeoutMs ?? 900_000;
     const idleWarningMs = options?.idleWarningMs ?? 20_000;
     // Idle stall catches true hangs. Gemini CLI doesn't emit tool_call for MCP
     // tools, so pendingTool never activates. 90s covers most MCP calls (10-30s).
     const idleStallMs = options?.idleStallMs ?? 90_000;
-    const HARD_CEILING_MS = 3_600_000; // 1h — absolute last-resort for sendRequest promise
+    const requestCeilingMs = resolveAcpPromptRequestCeilingMs(timeoutMs);
     const queue: AcpSessionUpdate[] = [];
     let waitResolve: (() => void) | null = null;
     let done = false;
@@ -639,7 +662,7 @@ export class AcpClient {
     this.sendRequest(
       ACP_METHODS.sessionPrompt,
       { sessionId, prompt: [{ type: 'text', text }] },
-      HARD_CEILING_MS,
+      requestCeilingMs,
       promptRequestId,
     )
       .then((resp) => {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -469,14 +469,13 @@ export class AcpClient {
           }
           scheduleIdleCheck(); // Schedule stall check (remaining time)
         } else if (pendingTool) {
-          // Tool still executing — allow extra time, but cap at TOOL_EXECUTION_CEILING_MS.
-          // Before this fix, pendingTool suppressed stall indefinitely without rescheduling,
-          // causing sessions (esp. kimi-acp) to block for up to 15min turn budget on hung tools.
-          const TOOL_EXECUTION_CEILING_MS = 180_000; // 3 minutes max for a single tool call
-          if (idleSinceMs >= TOOL_EXECUTION_CEILING_MS) {
+          // #1186: Tool execution ceiling follows the configured idleStallMs (from member's
+          // ACP Idle TTL), not a hardcoded constant. Previously TOOL_EXECUTION_CEILING_MS=180s
+          // killed tools that legitimately needed more time, ignoring user-configured idle TTL.
+          if (idleSinceMs >= idleStallMs) {
             log.error(
-              { sessionId, idleSinceMs, eventCount, pendingTool },
-              'Stream idle watchdog: tool execution exceeded ceiling — terminating',
+              { sessionId, idleSinceMs, eventCount, pendingTool, idleStallMs },
+              'Stream idle watchdog: tool execution exceeded configured idle TTL — terminating',
             );
             this.cancelSession(sessionId);
             promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
@@ -488,7 +487,7 @@ export class AcpClient {
             }
           } else {
             log.info(
-              { sessionId, idleSinceMs, eventCount, pendingTool },
+              { sessionId, idleSinceMs, eventCount, pendingTool, idleStallMs },
               'Stream idle watchdog: tool still pending, scheduling follow-up check',
             );
             scheduleIdleCheck(); // Reschedule — don't dead-end

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -141,8 +141,8 @@ export class AcpClient {
   private initResult: AcpInitializeResult | null = null;
   private closed = false;
   private exited = false;
-  /** False once an upstream prompt was cancelled without a completion acknowledgement. */
-  private singleFlightReusable = true;
+  /** Sessions whose local prompt ended before provider completion was acknowledged. */
+  private readonly unquiescedSessionIds = new Set<string>();
   private readonly capacityListeners = new Set<(signal: AcpCapacitySignal) => void>();
   /**
    * #1186 P1: Per-session cancel callbacks — when cancelSession() is called,
@@ -598,7 +598,7 @@ export class AcpClient {
       if (done) return;
       // The local stream can settle before the provider acknowledges prompt
       // termination. The pool uses this only for single-flight retirement.
-      this.singleFlightReusable = false;
+      this.unquiescedSessionIds.add(sessionId);
       log.info({ sessionId, eventCount }, 'Session cancel settled local prompt stream');
       promptError = new AcpStreamIdleError(
         sessionId,
@@ -647,6 +647,7 @@ export class AcpClient {
         stopReason = result.stopReason;
       })
       .catch((err: Error) => {
+        if (err instanceof AcpTimeoutError) this.unquiescedSessionIds.add(sessionId);
         promptError = err;
       })
       .finally(() => {
@@ -758,7 +759,11 @@ export class AcpClient {
   }
 
   get isSafeForSingleFlightReuse(): boolean {
-    return this.singleFlightReusable;
+    return this.unquiescedSessionIds.size === 0;
+  }
+
+  isSessionSafeForReuse(sessionId: string): boolean {
+    return !this.unquiescedSessionIds.has(sessionId);
   }
 
   /** Register a capacity-signal listener scoped to a prompt's lifetime. */

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -150,6 +150,14 @@ export class AcpClient {
    * the lease pinned for the full TTL.
    */
   private readonly sessionCancelCallbacks = new Map<string, () => void>();
+  /**
+   * #1186 P1: Track the pending request ID for each session's prompt so that
+   * cancelSession() can settle (reject) the underlying sendRequest promise.
+   * Without this, the promise + its 1h timer stay alive after the generator
+   * exits, leaving a stale entry in `pending` — a non-multiplexed process
+   * could be reused while the old request is unresolved.
+   */
+  private readonly sessionPromptPendingIds = new Map<string, string>();
   /** Client-level capacity signal — always captured regardless of listeners.
    *  Fallback for delayed stderr arriving after invoke listener is removed. */
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
@@ -618,7 +626,17 @@ export class AcpClient {
 
     // Fire prompt request — don't await, we'll drain the queue concurrently.
     // sendRequest uses hard ceiling (1h); actual budget is managed by resetBudget().
-    this.sendRequest(ACP_METHODS.sessionPrompt, { sessionId, prompt: [{ type: 'text', text }] }, HARD_CEILING_MS)
+    // #1186 P1: Pre-generate the request ID so cancelSession() can settle the pending
+    // entry. Without this, the sendRequest promise stays alive after generator exit,
+    // leaving a stale entry in `pending` that blocks safe non-multiplexed reuse.
+    const promptRequestId = randomUUID();
+    this.sessionPromptPendingIds.set(sessionId, promptRequestId);
+    this.sendRequest(
+      ACP_METHODS.sessionPrompt,
+      { sessionId, prompt: [{ type: 'text', text }] },
+      HARD_CEILING_MS,
+      promptRequestId,
+    )
       .then((resp) => {
         const result = resp.result as unknown as AcpPromptResult;
         stopReason = result.stopReason;
@@ -656,6 +674,7 @@ export class AcpClient {
       if (idleTimer) clearTimeout(idleTimer);
       if (budgetTimer) clearTimeout(budgetTimer);
       this.sessionCancelCallbacks.delete(sessionId);
+      this.sessionPromptPendingIds.delete(sessionId);
       this.capacityListeners.delete(capacityInjector);
       const idx = this.notificationListeners.indexOf(listener);
       if (idx >= 0) this.notificationListeners.splice(idx, 1);
@@ -679,6 +698,23 @@ export class AcpClient {
     // Settle the local prompt stream immediately
     const cb = this.sessionCancelCallbacks.get(sessionId);
     if (cb) cb();
+    // #1186 P1: Settle the pending sendRequest promise for this session's prompt.
+    // The cancel callback above exits the generator, which releases the lease.
+    // But without settling the underlying request, the sendRequest promise stays
+    // alive with its 1h timer, leaving a stale entry in `pending`. For a non-
+    // multiplexed process that gets reused after lease release, the stale entry
+    // means the old prompt response (if it ever arrives) would be misrouted.
+    // Rejecting here clears the timer and removes the entry, making the process
+    // safe for immediate reuse.
+    const promptReqId = this.sessionPromptPendingIds.get(sessionId);
+    if (promptReqId) {
+      const entry = this.pending.get(promptReqId);
+      if (entry) {
+        this.pending.delete(promptReqId);
+        entry.reject(new Error(`Session ${sessionId} cancelled — prompt request settled`));
+      }
+      this.sessionPromptPendingIds.delete(sessionId);
+    }
   }
 
   async close(): Promise<void> {
@@ -721,6 +757,12 @@ export class AcpClient {
   /** Unregister a capacity-signal listener. */
   offCapacity(fn: (signal: AcpCapacitySignal) => void): void {
     this.capacityListeners.delete(fn);
+  }
+
+  /** Number of pending (unresolved) sendRequest entries. Used by tests to verify
+   *  cancel settles the underlying prompt request and doesn't leave stale entries. */
+  get pendingRequestCount(): number {
+    return this.pending.size;
   }
 
   /** Most recent capacity signal observed on this client (provider-level, not per-invoke). */
@@ -827,12 +869,18 @@ export class AcpClient {
     });
   }
 
-  private sendRequest(method: string, params: Record<string, unknown>, timeoutMs = 60_000): Promise<AcpResponse> {
+  private sendRequest(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs = 60_000,
+    /** Pre-generated request ID — used by promptStream to enable cancel-time settlement. */
+    preGeneratedId?: string,
+  ): Promise<AcpResponse> {
     if (!this.child?.stdin?.writable) {
       return Promise.reject(new Error('ACP process stdin not writable'));
     }
 
-    const id = randomUUID();
+    const id = preGeneratedId ?? randomUUID();
     const msg = { jsonrpc: '2.0', method, id, params };
     const payload = JSON.stringify(msg);
     log.info(

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -141,6 +141,8 @@ export class AcpClient {
   private initResult: AcpInitializeResult | null = null;
   private closed = false;
   private exited = false;
+  /** False once an upstream prompt was cancelled without a completion acknowledgement. */
+  private singleFlightReusable = true;
   private readonly capacityListeners = new Set<(signal: AcpCapacitySignal) => void>();
   /**
    * #1186 P1: Per-session cancel callbacks — when cancelSession() is called,
@@ -594,6 +596,9 @@ export class AcpClient {
     // immediately instead of waiting for the provider or idle watchdog.
     const cancelCb = () => {
       if (done) return;
+      // The local stream can settle before the provider acknowledges prompt
+      // termination. The pool uses this only for single-flight retirement.
+      this.singleFlightReusable = false;
       log.info({ sessionId, eventCount }, 'Session cancel settled local prompt stream');
       promptError = new AcpStreamIdleError(
         sessionId,
@@ -683,30 +688,33 @@ export class AcpClient {
 
   /**
    * Send session/cancel notification (fire-and-forget, no response expected).
-   * Does NOT close the shared AcpClient — safe for concurrent sessions.
    *
    * #1186 P1: Also settles the local prompt stream via the registered cancel
    * callback so the pending .next() resolves immediately. Without this, the
    * generator stays suspended until the provider cooperates or the idle watchdog
-   * fires — leaving the lease pinned for the full TTL.
+   * fires — leaving the lease pinned for the full TTL. The callback also marks
+   * the carrier unsafe for single-flight reuse; the pool retires non-multiplexed
+   * clients while leaving multiplexed clients available to unrelated sessions.
    */
   cancelSession(sessionId: string): void {
-    if (!this.child?.stdin?.writable) return;
-    const msg = { jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } };
-    this.child.stdin.write(`${JSON.stringify(msg)}\n`);
-    log.info('Sent session/cancel for %s', sessionId);
-    // Settle the local prompt stream immediately
+    const promptReqId = this.sessionPromptPendingIds.get(sessionId);
     const cb = this.sessionCancelCallbacks.get(sessionId);
+
+    if (this.child?.stdin?.writable) {
+      const msg = { jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } };
+      this.child.stdin.write(`${JSON.stringify(msg)}\n`);
+      log.info('Sent session/cancel for %s', sessionId);
+    }
+    // Settle the local prompt stream immediately
     if (cb) cb();
     // #1186 P1: Settle the pending sendRequest promise for this session's prompt.
     // The cancel callback above exits the generator, which releases the lease.
     // But without settling the underlying request, the sendRequest promise stays
     // alive with its 1h timer, leaving a stale entry in `pending`. For a non-
-    // multiplexed process that gets reused after lease release, the stale entry
-    // means the old prompt response (if it ever arrives) would be misrouted.
-    // Rejecting here clears the timer and removes the entry, making the process
-    // safe for immediate reuse.
-    const promptReqId = this.sessionPromptPendingIds.get(sessionId);
+    // multiplexed process that remains alive after lease release, the stale entry
+    // would retain its timer and could consume a late response. Rejecting here
+    // clears local bookkeeping; the pool separately retires non-multiplexed
+    // carriers because local cleanup does not prove upstream quiescence.
     if (promptReqId) {
       const entry = this.pending.get(promptReqId);
       if (entry) {
@@ -747,6 +755,10 @@ export class AcpClient {
 
   get isAlive(): boolean {
     return this.child !== null && !this.child.killed && !this.closed && !this.exited;
+  }
+
+  get isSafeForSingleFlightReuse(): boolean {
+    return this.singleFlightReusable;
   }
 
   /** Register a capacity-signal listener scoped to a prompt's lifetime. */

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -462,7 +462,8 @@ export class AcpClient {
       if (done) return;
       // P1-fix: stall delay is relative to lastEventAt, not relative to warning.
       // With warning at 20s and stall at 45s, the stall timer fires 25s after warning.
-      const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : idleWarningMs;
+      // Cap initial delay at idleStallMs so short TTLs (< idleWarningMs) still fire on time.
+      const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : Math.min(idleWarningMs, idleStallMs);
       idleTimer = setTimeout(() => {
         if (done) return;
         // Clamp to at least the threshold that triggered this timer — a threshold

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -43,8 +43,8 @@ const MIN_ACP_PROMPT_REQUEST_CEILING_MS = 3_600_000;
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
 
 /**
- * Keep the absolute protocol request ceiling strictly above the resettable
- * activity budget without exceeding Node's representable timer range.
+ * Keep the protocol request inactivity window strictly above the activity
+ * budget without exceeding Node's representable timer range.
  */
 export function resolveAcpPromptRequestCeilingMs(activityBudgetMs: number): number {
   if (!Number.isSafeInteger(activityBudgetMs) || activityBudgetMs <= 0) {
@@ -154,10 +154,16 @@ export interface AcpCapacitySignal {
 
 const CAPACITY_RE = /MODEL_CAPACITY_EXHAUSTED|No capacity available|status 429.*Retrying/i;
 
+interface PendingAcpRequest {
+  resolve: (response: AcpResponse) => void;
+  reject: (error: Error) => void;
+  refreshTimeout: () => void;
+}
+
 export class AcpClient {
   private child: ChildProcess | null = null;
   private rl: ReadlineInterface | null = null;
-  private readonly pending = new Map<string, { resolve: (v: AcpResponse) => void; reject: (e: Error) => void }>();
+  private readonly pending = new Map<string, PendingAcpRequest>();
   private readonly notificationListeners: Array<(n: AcpNotification) => void> = [];
   private initResult: AcpInitializeResult | null = null;
   private closed = false;
@@ -176,7 +182,7 @@ export class AcpClient {
   /**
    * #1186 P1: Track the pending request ID for each session's prompt so that
    * cancelSession() can settle (reject) the underlying sendRequest promise.
-   * Without this, the promise + its 1h timer stay alive after the generator
+   * Without this, the promise + its request timer stay alive after the generator
    * exits, leaving a stale entry in `pending` — a non-multiplexed process
    * could be reused while the old request is unresolved.
    */
@@ -433,9 +439,9 @@ export class AcpClient {
     // If agent produces events continuously, budget never fires. Only triggers
     // after timeoutMs of SILENCE (no events). Idle stall (90s) catches true hangs
     // faster; this is the wider safety net for slow-but-alive sessions.
-    // sendRequest gets a wider absolute ceiling as a last-resort guard. The
-    // ceiling is derived from timeoutMs so a configured idle policy over one
-    // hour is never preempted by the legacy fixed request timer.
+    // sendRequest gets a wider inactivity window as a last-resort guard. The
+    // window is derived from timeoutMs and resets on real prompt activity, so it
+    // cannot preempt either the configured idle policy or its sliding budget.
     const timeoutMs = options?.timeoutMs ?? 900_000;
     const idleWarningMs = options?.idleWarningMs ?? 20_000;
     // Idle stall catches true hangs. Gemini CLI doesn't emit tool_call for MCP
@@ -455,6 +461,7 @@ export class AcpClient {
     let idleTimer: ReturnType<typeof setTimeout> | null = null;
     let pendingTool = false; // true while Gemini is waiting for MCP tool result
     let budgetTimer: ReturnType<typeof setTimeout> | null = null;
+    const promptRequestId = randomUUID();
 
     /** Reset (or start) the activity-based turn budget timer.
      *  Called once at prompt start and again on every incoming event. */
@@ -595,6 +602,7 @@ export class AcpClient {
       }
       scheduleIdleCheck();
       resetBudget(); // Activity-based: any event resets the turn budget
+      this.pending.get(promptRequestId)?.refreshTimeout();
       if (waitResolve) {
         const r = waitResolve;
         waitResolve = null;
@@ -653,11 +661,11 @@ export class AcpClient {
     scheduleIdleCheck();
 
     // Fire prompt request — don't await, we'll drain the queue concurrently.
-    // sendRequest uses hard ceiling (1h); actual budget is managed by resetBudget().
+    // The request timeout is a last-resort inactivity window that is wider than
+    // the activity budget and rearmed by the listener on every real event.
     // #1186 P1: Pre-generate the request ID so cancelSession() can settle the pending
     // entry. Without this, the sendRequest promise stays alive after generator exit,
     // leaving a stale entry in `pending` that blocks safe non-multiplexed reuse.
-    const promptRequestId = randomUUID();
     this.sessionPromptPendingIds.set(sessionId, promptRequestId);
     this.sendRequest(
       ACP_METHODS.sessionPrompt,
@@ -734,7 +742,7 @@ export class AcpClient {
     // #1186 P1: Settle the pending sendRequest promise for this session's prompt.
     // The cancel callback above exits the generator, which releases the lease.
     // But without settling the underlying request, the sendRequest promise stays
-    // alive with its 1h timer, leaving a stale entry in `pending`. For a non-
+    // alive with its request timer, leaving a stale entry in `pending`. For a non-
     // multiplexed process that remains alive after lease release, the stale entry
     // would retain its timer and could consume a late response. Rejecting here
     // clears local bookkeeping; the pool separately retires non-multiplexed
@@ -916,7 +924,9 @@ export class AcpClient {
     /** Pre-generated request ID — used by promptStream to enable cancel-time settlement. */
     preGeneratedId?: string,
   ): Promise<AcpResponse> {
-    if (!this.child?.stdin?.writable) {
+    const child = this.child;
+    const stdin = child?.stdin;
+    if (!child || !stdin?.writable) {
       return Promise.reject(new Error('ACP process stdin not writable'));
     }
 
@@ -924,29 +934,42 @@ export class AcpClient {
     const msg = { jsonrpc: '2.0', method, id, params };
     const payload = JSON.stringify(msg);
     log.info(
-      { method, id, timeoutMs, pid: this.child?.pid, payloadBytes: payload.length },
+      { method, id, timeoutMs, pid: child.pid, payloadBytes: payload.length },
       'ACP sendRequest: writing to stdin',
     );
-    this.child.stdin.write(payload + '\n');
 
     return new Promise<AcpResponse>((resolve, reject) => {
       const sentAt = Date.now();
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        log.error(
-          { method, id, timeoutMs, pid: this.child?.pid, elapsedMs: Date.now() - sentAt, exited: this.exited },
-          'ACP sendRequest: TIMEOUT — no response from agent process',
-        );
-        // For prompt timeouts, send session/cancel to stop the agent's internal retry loop
-        if (method === ACP_METHODS.sessionPrompt && params.sessionId) {
-          this.cancelSession(params.sessionId as string);
-        }
-        reject(new AcpTimeoutError(method, timeoutMs));
-      }, timeoutMs);
+      let timeoutStartedAt = sentAt;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+      const armTimeout = () => {
+        if (timer) clearTimeout(timer);
+        timeoutStartedAt = Date.now();
+        timer = setTimeout(() => {
+          this.pending.delete(id);
+          log.error(
+            {
+              method,
+              id,
+              timeoutMs,
+              pid: child.pid,
+              elapsedMs: Date.now() - sentAt,
+              inactiveMs: Date.now() - timeoutStartedAt,
+              exited: this.exited,
+            },
+            'ACP sendRequest: TIMEOUT — no response from agent process',
+          );
+          // For prompt timeouts, send session/cancel to stop the agent's internal retry loop
+          if (method === ACP_METHODS.sessionPrompt && params.sessionId) {
+            this.cancelSession(params.sessionId as string);
+          }
+          reject(new AcpTimeoutError(method, timeoutMs));
+        }, timeoutMs);
+      };
 
-      this.pending.set(id, {
+      const pendingRequest: PendingAcpRequest = {
         resolve: (resp) => {
-          clearTimeout(timer);
+          if (timer) clearTimeout(timer);
           log.info(
             { method, id, durationMs: Date.now() - sentAt, hasError: !!resp.error },
             'ACP sendRequest: response received',
@@ -958,11 +981,15 @@ export class AcpClient {
           }
         },
         reject: (err) => {
-          clearTimeout(timer);
+          if (timer) clearTimeout(timer);
           log.error({ method, id, durationMs: Date.now() - sentAt, error: err.message }, 'ACP sendRequest: rejected');
           reject(err);
         },
-      });
+        refreshTimeout: armTimeout,
+      };
+      this.pending.set(id, pendingRequest);
+      armTimeout();
+      stdin.write(`${payload}\n`);
     });
   }
 

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -78,8 +78,8 @@ export class AcpHttpStreamClient {
   private child: ChildProcess | null = null;
   private closed = false;
   private exited = false;
-  /** False once an upstream prompt was cancelled without a completion acknowledgement. */
-  private singleFlightReusable = true;
+  /** Sessions whose local prompt ended before provider completion was acknowledged. */
+  private readonly unquiescedSessionIds = new Set<string>();
   private port: number | null = null;
   private baseUrl = '';
   private initResult: AcpInitializeResult | null = null;
@@ -371,7 +371,7 @@ export class AcpHttpStreamClient {
       if (done) return;
       // Aborting the local HTTP stream does not prove the provider stopped the
       // prompt. The pool uses this only for single-flight retirement.
-      this.singleFlightReusable = false;
+      this.unquiescedSessionIds.add(sessionId);
       log.info({ sessionId, eventCount }, 'HTTP cancel settled local prompt stream');
       promptError = new AcpStreamIdleError(
         sessionId,
@@ -577,7 +577,10 @@ export class AcpHttpStreamClient {
     return this.child !== null && !this.child.killed && !this.closed && !this.exited;
   }
   get isSafeForSingleFlightReuse(): boolean {
-    return this.singleFlightReusable;
+    return this.unquiescedSessionIds.size === 0;
+  }
+  isSessionSafeForReuse(sessionId: string): boolean {
+    return !this.unquiescedSessionIds.has(sessionId);
   }
 
   onCapacity(fn: (signal: AcpCapacitySignal) => void): void {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -322,7 +322,8 @@ export class AcpHttpStreamClient {
     const scheduleIdleCheck = () => {
       if (idleTimer) clearTimeout(idleTimer);
       if (done) return;
-      const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : idleWarningMs;
+      // Cap initial delay at idleStallMs so short TTLs (< idleWarningMs) fire on time
+      const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : Math.min(idleWarningMs, idleStallMs);
       idleTimer = setTimeout(() => {
         if (done) return;
         const rawIdle = Date.now() - lastEventAt;

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -336,6 +336,23 @@ export class AcpHttpStreamClient {
           promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
           done = true;
           wakeConsumer();
+        } else {
+          // #1186: pendingTool — tool execution ceiling follows configured idleStallMs
+          // (parity with stdio AcpClient). Previously pendingTool suppressed stall
+          // indefinitely, causing sessions to block until the turn budget fired.
+          if (idleSinceMs >= idleStallMs) {
+            log.error(
+              { sessionId, idleSinceMs, eventCount, pendingTool: true, idleStallMs },
+              'HTTP stream idle watchdog: tool execution exceeded configured idle TTL — terminating',
+            );
+            this.cancelSession(sessionId);
+            controller.abort();
+            promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
+            done = true;
+            wakeConsumer();
+          } else {
+            scheduleIdleCheck(); // Reschedule follow-up check
+          }
         }
       }, nextMs);
     };

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -78,6 +78,8 @@ export class AcpHttpStreamClient {
   private child: ChildProcess | null = null;
   private closed = false;
   private exited = false;
+  /** False once an upstream prompt was cancelled without a completion acknowledgement. */
+  private singleFlightReusable = true;
   private port: number | null = null;
   private baseUrl = '';
   private initResult: AcpInitializeResult | null = null;
@@ -367,6 +369,9 @@ export class AcpHttpStreamClient {
     // #1186 P1: Register cancel callback so cancelSession() settles this stream
     const cancelCb = () => {
       if (done) return;
+      // Aborting the local HTTP stream does not prove the provider stopped the
+      // prompt. The pool uses this only for single-flight retirement.
+      this.singleFlightReusable = false;
       log.info({ sessionId, eventCount }, 'HTTP cancel settled local prompt stream');
       promptError = new AcpStreamIdleError(
         sessionId,
@@ -529,17 +534,20 @@ export class AcpHttpStreamClient {
 
   /**
    * #1186 P1: Cancel also settles the local prompt stream so the pending .next()
-   * resolves immediately and the lease is released without waiting for the provider.
+   * resolves immediately. The callback marks the carrier unsafe for single-flight
+   * reuse so the pool retires non-multiplexed clients after lease release.
    */
   cancelSession(sessionId: string): void {
-    if (!this.port || this.closed || this.exited) return;
-    const body = JSON.stringify({ jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } });
-    fetch(this.baseUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }).catch((err) => {
-      log.warn({ sessionId, err: err instanceof Error ? err.message : String(err) }, 'ACP HTTP cancel failed');
-    });
-    log.info('Sent HTTP session/cancel for %s', sessionId);
-    // Settle the local prompt stream immediately
     const cb = this.sessionCancelCallbacks.get(sessionId);
+
+    if (this.port && !this.closed && !this.exited) {
+      const body = JSON.stringify({ jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } });
+      fetch(this.baseUrl, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body }).catch((err) => {
+        log.warn({ sessionId, err: err instanceof Error ? err.message : String(err) }, 'ACP HTTP cancel failed');
+      });
+      log.info('Sent HTTP session/cancel for %s', sessionId);
+    }
+    // Settle the local prompt stream immediately
     if (cb) cb();
   }
 
@@ -567,6 +575,9 @@ export class AcpHttpStreamClient {
   }
   get isAlive(): boolean {
     return this.child !== null && !this.child.killed && !this.closed && !this.exited;
+  }
+  get isSafeForSingleFlightReuse(): boolean {
+    return this.singleFlightReusable;
   }
 
   onCapacity(fn: (signal: AcpCapacitySignal) => void): void {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -82,6 +82,8 @@ export class AcpHttpStreamClient {
   private baseUrl = '';
   private initResult: AcpInitializeResult | null = null;
   private readonly capacityListeners = new Set<(signal: AcpCapacitySignal) => void>();
+  /** #1186 P1: Per-session cancel callbacks — settles the local prompt stream on cancel. */
+  private readonly sessionCancelCallbacks = new Map<string, () => void>();
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
 
   constructor(private readonly config: AcpHttpStreamClientConfig) {}
@@ -359,6 +361,25 @@ export class AcpHttpStreamClient {
 
     // Start HTTP streaming request
     this.capacityListeners.add(capacityInjector);
+
+    // #1186 P1: Register cancel callback so cancelSession() settles this stream
+    const cancelCb = () => {
+      if (done) return;
+      log.info({ sessionId, eventCount }, 'HTTP cancel settled local prompt stream');
+      promptError = new AcpStreamIdleError(
+        sessionId,
+        Date.now() - (lastEventAt || Date.now()),
+        eventCount,
+        idleStallMs,
+      );
+      done = true;
+      if (idleTimer) clearTimeout(idleTimer);
+      if (budgetTimer) clearTimeout(budgetTimer);
+      controller.abort();
+      wakeConsumer();
+    };
+    this.sessionCancelCallbacks.set(sessionId, cancelCb);
+
     resetBudget();
 
     const streamPromise = (async () => {
@@ -493,10 +514,15 @@ export class AcpHttpStreamClient {
     } finally {
       if (idleTimer) clearTimeout(idleTimer);
       if (budgetTimer) clearTimeout(budgetTimer);
+      this.sessionCancelCallbacks.delete(sessionId);
       this.capacityListeners.delete(capacityInjector);
     }
   }
 
+  /**
+   * #1186 P1: Cancel also settles the local prompt stream so the pending .next()
+   * resolves immediately and the lease is released without waiting for the provider.
+   */
   cancelSession(sessionId: string): void {
     if (!this.port || this.closed || this.exited) return;
     const body = JSON.stringify({ jsonrpc: '2.0', method: ACP_METHODS.sessionCancel, params: { sessionId } });
@@ -504,6 +530,9 @@ export class AcpHttpStreamClient {
       log.warn({ sessionId, err: err instanceof Error ? err.message : String(err) }, 'ACP HTTP cancel failed');
     });
     log.info('Sent HTTP session/cancel for %s', sessionId);
+    // Settle the local prompt stream immediately
+    const cb = this.sessionCancelCallbacks.get(sessionId);
+    if (cb) cb();
   }
 
   async close(): Promise<void> {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -333,7 +333,7 @@ export class AcpHttpStreamClient {
           log.error({ sessionId, idleSinceMs, eventCount }, 'HTTP stream idle stall — terminating');
           this.cancelSession(sessionId);
           controller.abort();
-          promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
+          promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount, idleStallMs);
           done = true;
           wakeConsumer();
         } else {
@@ -347,7 +347,7 @@ export class AcpHttpStreamClient {
             );
             this.cancelSession(sessionId);
             controller.abort();
-            promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount);
+            promptError = new AcpStreamIdleError(sessionId, idleSinceMs, eventCount, idleStallMs);
             done = true;
             wakeConsumer();
           } else {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -318,12 +318,13 @@ export class AcpHttpStreamClient {
     const isAgentRequest = (method: string | undefined, msgId: string | undefined) =>
       !!method && (!!msgId || method === ACP_METHODS.requestPermission);
 
+    /** #1186: Active from prompt start — covers zero-first-event. */
     const scheduleIdleCheck = () => {
       if (idleTimer) clearTimeout(idleTimer);
       if (done) return;
       const nextMs = idleWarningFired ? Math.max(0, idleStallMs - idleWarningMs) : idleWarningMs;
       idleTimer = setTimeout(() => {
-        if (done || eventCount === 0) return;
+        if (done) return;
         const rawIdle = Date.now() - lastEventAt;
         const idleSinceMs = Math.max(rawIdle, idleWarningFired ? idleStallMs : idleWarningMs);
         if (!idleWarningFired) {
@@ -380,7 +381,13 @@ export class AcpHttpStreamClient {
     };
     this.sessionCancelCallbacks.set(sessionId, cancelCb);
 
+    // #1186: Initialize lastEventAt for zero-first-event idle watchdog
+    lastEventAt = Date.now();
+
     resetBudget();
+
+    // #1186: Start idle watchdog at prompt start — covers zero-first-event
+    scheduleIdleCheck();
 
     const streamPromise = (async () => {
       try {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
@@ -52,6 +52,12 @@ export interface AcpAcquireOptions {
 /** Minimal AcpClient interface needed by the pool. */
 export interface AcpPoolClient {
   readonly isAlive: boolean;
+  /**
+   * False after a cancelled prompt may still be running upstream. The pool only
+   * acts on this for non-multiplexed carriers; multiplexed clients can keep
+   * serving unrelated sessions.
+   */
+  readonly isSafeForSingleFlightReuse?: boolean;
   initialize(): Promise<unknown>;
   close(): Promise<void>;
 }
@@ -143,25 +149,29 @@ export class AcpProcessPool {
       const sessionKey = serializeSessionKey(poolKey, sessionId);
       const owner = this.sessionOwners.get(sessionKey);
       if (owner && owner.state === 'ready' && owner.client.isAlive) {
-        if (this.supportsMultiplexing || owner.leaseCount === 0) {
+        if (!this.supportsMultiplexing && owner.client.isSafeForSingleFlightReuse === false) {
+          this.retireEntry(owner, poolKey, 'cancelled prompt still unquiesced');
+        } else {
+          if (this.supportsMultiplexing || owner.leaseCount === 0) {
+            return this.leaseReadyEntry(owner, poolKey);
+          }
+          // #992: Stale lease recovery — the previous lease holder is a zombie (e.g. Windows
+          // console disconnect where the async generator finally block never ran). Since the
+          // caller is re-acquiring the SAME sessionId, the previous consumer is necessarily
+          // gone. Force-release the orphaned lease so the process can be reused.
+          log.warn(
+            { poolKey, sessionId, staleLeaseCount: owner.leaseCount },
+            'ACP stale lease detected — force-releasing zombie lease for session re-acquire',
+          );
+          this._metrics.activeLeaseCount -= owner.leaseCount;
+          owner.leaseCount = 0;
+          // Transition to idle so leaseReadyEntry's idleProcessCount-- is balanced.
+          this._metrics.idleProcessCount++;
+          // Bump generation so any late-arriving release() from the old lease becomes a
+          // no-op (the old closure captured the previous generation value).
+          owner.leaseGeneration++;
           return this.leaseReadyEntry(owner, poolKey);
         }
-        // #992: Stale lease recovery — the previous lease holder is a zombie (e.g. Windows
-        // console disconnect where the async generator finally block never ran). Since the
-        // caller is re-acquiring the SAME sessionId, the previous consumer is necessarily
-        // gone. Force-release the orphaned lease so the process can be reused.
-        log.warn(
-          { poolKey, sessionId, staleLeaseCount: owner.leaseCount },
-          'ACP stale lease detected — force-releasing zombie lease for session re-acquire',
-        );
-        this._metrics.activeLeaseCount -= owner.leaseCount;
-        owner.leaseCount = 0;
-        // Transition to idle so leaseReadyEntry's idleProcessCount-- is balanced.
-        this._metrics.idleProcessCount++;
-        // Bump generation so any late-arriving release() from the old lease becomes a
-        // no-op (the old closure captured the previous generation value).
-        owner.leaseGeneration++;
-        return this.leaseReadyEntry(owner, poolKey);
       }
       if (owner) this.sessionOwners.delete(sessionKey);
     }
@@ -298,6 +308,14 @@ export class AcpProcessPool {
         // Stale lease guard: generation mismatch means this lease was force-released
         // and a new lease has been issued on the same entry. The old release is a no-op.
         if (entry.leaseGeneration !== creationGeneration) return;
+        // A local cancel can settle the JavaScript iterator before the provider
+        // actually stops the upstream prompt. Reusing that same non-multiplexed
+        // process would overlap two prompts on a single-flight carrier. Retire it
+        // while the lease is still counted active, then let the next acquire spawn.
+        if (!this.supportsMultiplexing && entry.client.isSafeForSingleFlightReuse === false) {
+          this.retireEntry(entry, poolKey, 'cancelled prompt still unquiesced');
+          return;
+        }
         entry.leaseCount--;
         this._metrics.activeLeaseCount--;
         if (entry.leaseCount <= 0) {
@@ -307,6 +325,33 @@ export class AcpProcessPool {
         }
       },
     };
+  }
+
+  private retireEntry(entry: PoolEntry, poolKey: PoolKey, reason: string): void {
+    const key = serializeKey(poolKey);
+    const entries = this.entries.get(key);
+    const idx = entries?.indexOf(entry) ?? -1;
+    if (!entries || idx < 0 || entry.state === 'closing') return;
+
+    this.clearIdleTimer(entry);
+    this.forgetSessionsForEntry(entry);
+    entry.state = 'closing';
+
+    if (entry.leaseCount > 0) {
+      this._metrics.activeLeaseCount -= entry.leaseCount;
+      entry.leaseCount = 0;
+      // Any late release from an already-retired lease must not touch metrics.
+      entry.leaseGeneration++;
+    } else {
+      this._metrics.idleProcessCount--;
+    }
+
+    entries.splice(idx, 1);
+    if (entries.length === 0) this.entries.delete(key);
+    this._metrics.liveProcessCount--;
+    this._metrics.evictionCount++;
+    entry.client.close().catch(() => {});
+    log.warn({ poolKey, reason }, 'Retired unsafe ACP process');
   }
 
   private async spawnEntry(poolKey: PoolKey): Promise<PoolEntry> {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
@@ -41,6 +41,8 @@ export interface AcpPoolMetrics {
 export interface AcpLease {
   readonly client: AcpPoolClient;
   readonly poolKey: PoolKey;
+  /** False when the requested persisted session was sealed and must be replaced with session/new. */
+  readonly canResumeRequestedSession?: boolean;
   release(): void;
 }
 
@@ -58,6 +60,8 @@ export interface AcpPoolClient {
    * serving unrelated sessions.
    */
   readonly isSafeForSingleFlightReuse?: boolean;
+  /** Session-scoped counterpart used to seal only the cancelled logical session on multiplexed carriers. */
+  isSessionSafeForReuse?(sessionId: string): boolean;
   initialize(): Promise<unknown>;
   close(): Promise<void>;
 }
@@ -103,6 +107,8 @@ export class AcpProcessPool {
   private readonly supportsMultiplexing: boolean;
   private readonly entries = new Map<string, PoolEntry[]>();
   private readonly sessionOwners = new Map<string, PoolEntry>();
+  /** Persisted session ids that must never be loaded again after unacknowledged local termination. */
+  private readonly sealedSessions = new Set<string>();
   private readonly clientFactory: AcpClientFactory;
   private readonly pendingSpawns = new Map<string, Promise<PoolEntry>>();
   private healthTimer: ReturnType<typeof setInterval> | null = null;
@@ -144,36 +150,45 @@ export class AcpProcessPool {
     const key = serializeKey(poolKey);
     const entries = this.entries.get(key) ?? [];
     const sessionId = options.sessionId?.trim();
+    let canResumeRequestedSession = true;
 
     if (sessionId) {
       const sessionKey = serializeSessionKey(poolKey, sessionId);
-      const owner = this.sessionOwners.get(sessionKey);
-      if (owner && owner.state === 'ready' && owner.client.isAlive) {
-        if (!this.supportsMultiplexing && owner.client.isSafeForSingleFlightReuse === false) {
-          this.retireEntry(owner, poolKey, 'cancelled prompt still unquiesced');
-        } else {
-          if (this.supportsMultiplexing || owner.leaseCount === 0) {
-            return this.leaseReadyEntry(owner, poolKey);
+      if (this.sealedSessions.has(sessionKey)) {
+        canResumeRequestedSession = false;
+        this.sessionOwners.delete(sessionKey);
+        log.warn({ poolKey, sessionId }, 'ACP session is sealed; acquiring carrier for a fresh replacement session');
+      } else {
+        const owner = this.sessionOwners.get(sessionKey);
+        if (owner && owner.state === 'ready' && owner.client.isAlive) {
+          if (!this.supportsMultiplexing && owner.client.isSafeForSingleFlightReuse === false) {
+            this.sealSession(poolKey, sessionId);
+            canResumeRequestedSession = false;
+            this.retireEntry(owner, poolKey, 'cancelled prompt still unquiesced');
+          } else {
+            if (this.supportsMultiplexing || owner.leaseCount === 0) {
+              return this.leaseReadyEntry(owner, poolKey, canResumeRequestedSession);
+            }
+            // #992: Stale lease recovery — the previous lease holder is a zombie (e.g. Windows
+            // console disconnect where the async generator finally block never ran). Since the
+            // caller is re-acquiring the SAME sessionId, the previous consumer is necessarily
+            // gone. Force-release the orphaned lease so the process can be reused.
+            log.warn(
+              { poolKey, sessionId, staleLeaseCount: owner.leaseCount },
+              'ACP stale lease detected — force-releasing zombie lease for session re-acquire',
+            );
+            this._metrics.activeLeaseCount -= owner.leaseCount;
+            owner.leaseCount = 0;
+            // Transition to idle so leaseReadyEntry's idleProcessCount-- is balanced.
+            this._metrics.idleProcessCount++;
+            // Bump generation so any late-arriving release() from the old lease becomes a
+            // no-op (the old closure captured the previous generation value).
+            owner.leaseGeneration++;
+            return this.leaseReadyEntry(owner, poolKey, canResumeRequestedSession);
           }
-          // #992: Stale lease recovery — the previous lease holder is a zombie (e.g. Windows
-          // console disconnect where the async generator finally block never ran). Since the
-          // caller is re-acquiring the SAME sessionId, the previous consumer is necessarily
-          // gone. Force-release the orphaned lease so the process can be reused.
-          log.warn(
-            { poolKey, sessionId, staleLeaseCount: owner.leaseCount },
-            'ACP stale lease detected — force-releasing zombie lease for session re-acquire',
-          );
-          this._metrics.activeLeaseCount -= owner.leaseCount;
-          owner.leaseCount = 0;
-          // Transition to idle so leaseReadyEntry's idleProcessCount-- is balanced.
-          this._metrics.idleProcessCount++;
-          // Bump generation so any late-arriving release() from the old lease becomes a
-          // no-op (the old closure captured the previous generation value).
-          owner.leaseGeneration++;
-          return this.leaseReadyEntry(owner, poolKey);
         }
+        if (owner) this.sessionOwners.delete(sessionKey);
       }
-      if (owner) this.sessionOwners.delete(sessionKey);
     }
 
     // 1. Try warm reuse. Single-flight carriers may reuse only idle processes.
@@ -181,7 +196,7 @@ export class AcpProcessPool {
       (e) => e.state === 'ready' && e.client.isAlive && (this.supportsMultiplexing || e.leaseCount === 0),
     );
     if (warm) {
-      return this.leaseReadyEntry(warm, poolKey);
+      return this.leaseReadyEntry(warm, poolKey, canResumeRequestedSession);
     }
 
     // 2. Coalesce in-flight spawns only for carriers that permit concurrent prompts.
@@ -193,7 +208,7 @@ export class AcpProcessPool {
         entry.lastUsedAt = Date.now();
         this._metrics.activeLeaseCount++;
         this._metrics.warmHitCount++;
-        return this.createLease(entry, poolKey);
+        return this.createLease(entry, poolKey, canResumeRequestedSession);
       }
     }
 
@@ -213,12 +228,27 @@ export class AcpProcessPool {
     const entry = await spawnPromise;
     entry.leaseCount++;
     this._metrics.activeLeaseCount++;
-    return this.createLease(entry, poolKey);
+    return this.createLease(entry, poolKey, canResumeRequestedSession);
+  }
+
+  /** Seal a logical session after local termination without provider quiescence. */
+  sealSession(poolKey: PoolKey, sessionId: string): void {
+    const trimmedSessionId = sessionId.trim();
+    if (!trimmedSessionId) return;
+    const sessionKey = serializeSessionKey(poolKey, trimmedSessionId);
+    this.sealedSessions.add(sessionKey);
+    this.sessionOwners.delete(sessionKey);
   }
 
   rememberSession(poolKey: PoolKey, sessionId: string, lease: AcpLease): void {
     const trimmedSessionId = sessionId.trim();
     if (!trimmedSessionId) return;
+
+    const sessionKey = serializeSessionKey(poolKey, trimmedSessionId);
+    if (this.sealedSessions.has(sessionKey)) {
+      log.warn({ poolKey, sessionId: trimmedSessionId }, 'ACP session affinity skipped for sealed session');
+      return;
+    }
 
     const key = serializeKey(poolKey);
     const entry = this.entries.get(key)?.find((candidate) => candidate.client === lease.client);
@@ -227,7 +257,7 @@ export class AcpProcessPool {
       return;
     }
 
-    this.sessionOwners.set(serializeSessionKey(poolKey, trimmedSessionId), entry);
+    this.sessionOwners.set(sessionKey, entry);
   }
 
   private async doSpawn(poolKey: PoolKey, key: string, pendingKey?: string): Promise<PoolEntry> {
@@ -274,6 +304,7 @@ export class AcpProcessPool {
     }
     this.entries.clear();
     this.sessionOwners.clear();
+    this.sealedSessions.clear();
     this._metrics.liveProcessCount = 0;
     this._metrics.activeLeaseCount = 0;
     this._metrics.idleProcessCount = 0;
@@ -281,7 +312,7 @@ export class AcpProcessPool {
 
   // ── Internal ────────────────────────────────────────────────
 
-  private leaseReadyEntry(entry: PoolEntry, poolKey: PoolKey): AcpLease {
+  private leaseReadyEntry(entry: PoolEntry, poolKey: PoolKey, canResumeRequestedSession = true): AcpLease {
     if (entry.leaseCount === 0) {
       this._metrics.idleProcessCount--;
     }
@@ -290,10 +321,10 @@ export class AcpProcessPool {
     entry.lastUsedAt = Date.now();
     this._metrics.activeLeaseCount++;
     this._metrics.warmHitCount++;
-    return this.createLease(entry, poolKey);
+    return this.createLease(entry, poolKey, canResumeRequestedSession);
   }
 
-  private createLease(entry: PoolEntry, poolKey: PoolKey): AcpLease {
+  private createLease(entry: PoolEntry, poolKey: PoolKey, canResumeRequestedSession = true): AcpLease {
     let released = false;
     // Capture the generation at lease creation time. If a stale-lease force-release
     // bumps the generation before this closure runs, the release becomes a no-op —
@@ -302,12 +333,16 @@ export class AcpProcessPool {
     return {
       client: entry.client,
       poolKey,
+      canResumeRequestedSession,
       release: () => {
         if (released) return;
         released = true;
         // Stale lease guard: generation mismatch means this lease was force-released
         // and a new lease has been issued on the same entry. The old release is a no-op.
         if (entry.leaseGeneration !== creationGeneration) return;
+        // Persist session-scoped poison before either returning a multiplexed
+        // carrier to the pool or retiring a single-flight carrier.
+        this.sealUnsafeSessionsForEntry(entry, poolKey);
         // A local cancel can settle the JavaScript iterator before the provider
         // actually stops the upstream prompt. Reusing that same non-multiplexed
         // process would overlap two prompts on a single-flight carrier. Retire it
@@ -334,6 +369,7 @@ export class AcpProcessPool {
     if (!entries || idx < 0 || entry.state === 'closing') return;
 
     this.clearIdleTimer(entry);
+    this.sealUnsafeSessionsForEntry(entry, poolKey);
     this.forgetSessionsForEntry(entry);
     entry.state = 'closing';
 
@@ -352,6 +388,18 @@ export class AcpProcessPool {
     this._metrics.evictionCount++;
     entry.client.close().catch(() => {});
     log.warn({ poolKey, reason }, 'Retired unsafe ACP process');
+  }
+
+  /** Persist session poison before owner affinity is removed or the carrier is retired. */
+  private sealUnsafeSessionsForEntry(entry: PoolEntry, poolKey: PoolKey): void {
+    const prefix = `${serializeKey(poolKey)}::`;
+    for (const [sessionKey, owner] of this.sessionOwners) {
+      if (owner !== entry || !sessionKey.startsWith(prefix)) continue;
+      const sessionId = sessionKey.slice(prefix.length);
+      if (entry.client.isSessionSafeForReuse?.(sessionId) === false) {
+        this.sealedSessions.add(sessionKey);
+      }
+    }
   }
 
   private async spawnEntry(poolKey: PoolKey): Promise<PoolEntry> {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpServiceFactory.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpServiceFactory.ts
@@ -265,5 +265,8 @@ export async function createAcpServiceForConfig(
     modelName: spawn.sessionModel ?? config.defaultModel ?? 'acp',
     sessionModel: spawn.sessionModel,
     mcpSupport: config.mcpSupport,
+    // #1186: Thread the member's configured idle TTL to AcpAgentService so
+    // promptStream uses it as the authoritative no-event termination threshold.
+    idleTtlMs: acpConfig.pool?.idleTtlMs ?? DEFAULT_ACP_IDLE_TTL_MS,
   });
 }

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -954,6 +954,11 @@ describe('AcpClient', () => {
     // Should throw AcpStreamIdleError (from cancel callback)
     assert.ok(thrownError, 'Should throw after cancel');
     assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(
+      client.isSafeForSingleFlightReuse,
+      false,
+      'cancelled stdio prompt must mark a single-flight carrier unsafe for warm reuse',
+    );
 
     // Should settle promptly — not wait for idle stall (5000ms) or budget (10000ms)
     assert.ok(elapsed < 2000, `Cancel should settle within 2s, took ${elapsed}ms`);

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -1744,4 +1744,83 @@ describe('AcpClient', () => {
       'the legacy one-hour request ceiling must not precede a valid two-hour idle policy',
     );
   });
+
+  it('#1186: stdio request ceiling resets after real prompt activity', async (t) => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+    let promptRequestId = null;
+    let resolvePromptSeen;
+    const promptSeen = new Promise((resolve) => {
+      resolvePromptSeen = resolve;
+    });
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'sliding-ceiling-sess' });
+        } else if (msg.method === 'session/prompt') {
+          promptRequestId = msg.id;
+          resolvePromptSeen();
+          // Keep the provider request pending until the test has crossed the
+          // original-start request ceiling.
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const idleStallMs = 2 * 60 * 60 * 1000;
+    const activityBudgetMs = idleStallMs + 60_000;
+    const requestCeilingMs = activityBudgetMs + 60_000;
+    const eventAtMs = 90 * 60 * 1000;
+    t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 });
+    t.after(() => t.mock.timers.reset());
+
+    const iterator = client.promptStream('sliding-ceiling-sess', 'hello', {
+      idleStallMs,
+      timeoutMs: activityBudgetMs,
+    });
+    const firstEventPromise = iterator.next();
+    await promptSeen;
+
+    t.mock.timers.tick(eventAtMs);
+    agentNotify(agentStdout, 'session/update', {
+      sessionId: 'sliding-ceiling-sess',
+      update: { sessionUpdate: 'agent_thought_chunk', content: { type: 'text', text: 'still working' } },
+    });
+    const warningEvent = await firstEventPromise;
+    const activityEvent = await iterator.next();
+
+    t.mock.timers.tick(requestCeilingMs - eventAtMs + 1);
+    await Promise.resolve();
+    await Promise.resolve();
+    const pendingAtOriginalCeiling = client.pendingRequestCount;
+
+    agentRespond(agentStdout, promptRequestId, { stopReason: 'end_turn' });
+    await new Promise((resolve) => setImmediate(resolve));
+    const terminal = await (async () => {
+      try {
+        while (true) {
+          const next = await iterator.next();
+          if (next.done) return { value: next };
+        }
+      } catch (error) {
+        return { error };
+      }
+    })();
+
+    assert.equal(warningEvent.value?.update?.sessionUpdate, 'stream_idle_warning');
+    assert.equal(activityEvent.value?.update?.sessionUpdate, 'agent_thought_chunk');
+    assert.equal(
+      pendingAtOriginalCeiling,
+      1,
+      'real activity must rearm the request ceiling beyond its original-start deadline',
+    );
+    assert.equal(terminal.error, undefined);
+    assert.equal(terminal.value?.done, true);
+  });
 });

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -846,7 +846,9 @@ describe('AcpClient', () => {
     assert.match(thrownError.message, /[Ss]tream idle|STREAM_IDLE/);
   });
 
-  it('F149: idle watchdog does NOT fire before first event (eventCount=0)', async () => {
+  // #1186: Zero-first-event now produces AcpStreamIdleError at the configured TTL,
+  // not AcpTimeoutError at the later budget. The idle watchdog starts at prompt start.
+  it('#1186: zero-first-event produces AcpStreamIdleError at configured idleStallMs', async () => {
     const { child, clientStdin, agentStdout } = createMockChild();
 
     clientStdin.on('data', (chunk) => {
@@ -857,14 +859,8 @@ describe('AcpClient', () => {
         } else if (msg.method === 'session/new') {
           agentRespond(agentStdout, msg.id, { sessionId: 'zero-sess' });
         } else if (msg.method === 'session/prompt') {
-          // Delay first event longer than idle thresholds — but watchdog should NOT fire
-          setTimeout(() => {
-            agentNotify(agentStdout, 'session/update', {
-              sessionId: 'zero-sess',
-              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hello' } },
-            });
-            agentRespond(agentStdout, msg.id, { stopReason: 'end_turn' });
-          }, 200);
+          // Never send any events — zero-first-event scenario
+          // promptResponse stays pending — idle stall should terminate
         }
       }
     });
@@ -874,22 +870,93 @@ describe('AcpClient', () => {
     await client.newSession();
 
     const events = [];
-    for await (const event of client.promptStream('zero-sess', 'hello', {
-      idleWarningMs: 50,
-      idleStallMs: 100,
-    })) {
-      events.push(event);
+    let thrownError = null;
+    try {
+      for await (const event of client.promptStream('zero-sess', 'hello', {
+        idleWarningMs: 30,
+        idleStallMs: 100,
+        timeoutMs: 5000, // Budget much higher — must NOT fire first
+      })) {
+        events.push(event);
+      }
+    } catch (err) {
+      thrownError = err;
     }
 
-    // No idle events should fire — eventCount was 0 when the threshold passed
-    const idleEvents = events.filter(
-      (e) => e.update?.sessionUpdate === 'stream_idle_warning' || e.update?.sessionUpdate === 'stream_idle_stall',
-    );
-    assert.equal(idleEvents.length, 0, `Expected 0 idle events (eventCount=0), got ${idleEvents.length}`);
+    // Idle warning should fire even with zero events
+    const warningEvents = events.filter((e) => e.update?.sessionUpdate === 'stream_idle_warning');
+    assert.ok(warningEvents.length >= 1, `Expected at least 1 idle warning, got ${warningEvents.length}`);
 
-    // The real event should be present
-    const realEvents = events.filter((e) => e.update?.sessionUpdate === 'agent_message_chunk');
-    assert.equal(realEvents.length, 1, 'Should have 1 real event');
+    // Should throw AcpStreamIdleError, NOT AcpTimeoutError
+    assert.ok(thrownError, 'Should throw an error on zero-event stall');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(thrownError.configuredIdleStallMs, 100, 'Should carry configured idleStallMs');
+  });
+
+  it('#1186: cancel settles prompt stream via sessionCancelCallbacks (real transport)', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'cancel-cb-sess' });
+        } else if (msg.method === 'session/prompt') {
+          // Send one event, then go silent — provider never responds to cancel
+          setImmediate(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'cancel-cb-sess',
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start' } },
+            });
+          });
+          // Deliberately never complete — cancel must break us out
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const events = [];
+    let thrownError = null;
+    const startMs = Date.now();
+
+    // Start streaming
+    const iter = client.promptStream('cancel-cb-sess', 'hello', {
+      idleWarningMs: 500,
+      idleStallMs: 5000, // Very high — cancel must fire before this
+      timeoutMs: 10000,
+    });
+
+    try {
+      // Get the first real event
+      const first = await iter.next();
+      if (!first.done) events.push(first.value);
+
+      // Cancel the session — this should settle promptStream immediately
+      client.cancelSession('cancel-cb-sess');
+
+      // The next .next() should resolve promptly (not wait for idle/budget)
+      for (;;) {
+        const result = await iter.next();
+        if (result.done) break;
+        events.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+
+    const elapsed = Date.now() - startMs;
+
+    // Should throw AcpStreamIdleError (from cancel callback)
+    assert.ok(thrownError, 'Should throw after cancel');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+
+    // Should settle promptly — not wait for idle stall (5000ms) or budget (10000ms)
+    assert.ok(elapsed < 2000, `Cancel should settle within 2s, took ${elapsed}ms`);
   });
 
   // ─── pendingTool: suppress stall during MCP tool execution ──

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -959,6 +959,115 @@ describe('AcpClient', () => {
     assert.ok(elapsed < 2000, `Cancel should settle within 2s, took ${elapsed}ms`);
   });
 
+  it('#1186: short TTL regression — idleStallMs < idleWarningMs terminates at stall threshold (stdio)', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'short-ttl-sess' });
+        } else if (msg.method === 'session/prompt') {
+          // Never send events — zero-first-event with short TTL
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const startMs = Date.now();
+    let thrownError = null;
+    try {
+      // idleStallMs (100ms) < idleWarningMs (20_000ms default).
+      // Without Math.min fix, initial check schedules at 20_000ms — way too late.
+      // With fix, initial check schedules at Math.min(20_000, 100) = 100ms.
+      for await (const _event of client.promptStream('short-ttl-sess', 'hello', {
+        idleStallMs: 100,
+        // idleWarningMs defaults to 20_000
+        timeoutMs: 30_000,
+      })) {
+        // Should not receive any events
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+    const elapsed = Date.now() - startMs;
+
+    assert.ok(thrownError, 'Should throw on short-TTL zero-event stall');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(thrownError.configuredIdleStallMs, 100, 'Error should carry configured 100ms threshold');
+    // Must terminate near 100ms, not at 20_000ms (the warning interval)
+    assert.ok(elapsed < 2000, `Should terminate near 100ms, took ${elapsed}ms`);
+  });
+
+  it('#1186: cancel settles pending sendRequest — no stale entries in pending map (stdio)', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'pending-check-sess' });
+        } else if (msg.method === 'session/prompt') {
+          // Emit one event, then go silent — never resolve prompt
+          setImmediate(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'pending-check-sess',
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'hello' } },
+            });
+          });
+          // Provider ignores cancel, never resolves prompt
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const iter = client.promptStream('pending-check-sess', 'test', {
+      idleWarningMs: 500,
+      idleStallMs: 5000,
+      timeoutMs: 10000,
+    });
+
+    // Get the first event
+    const first = await iter.next();
+    assert.ok(!first.done, 'Should receive first event');
+
+    // Before cancel: there should be a pending prompt request
+    assert.ok(
+      client.pendingRequestCount >= 1,
+      `Should have pending request before cancel, got ${client.pendingRequestCount}`,
+    );
+
+    // Cancel — should settle both the generator AND the pending request
+    client.cancelSession('pending-check-sess');
+
+    // Drain the iterator
+    try {
+      for (;;) {
+        const result = await iter.next();
+        if (result.done) break;
+      }
+    } catch (_err) {
+      // Expected — cancel throws AcpStreamIdleError
+    }
+
+    // After cancel: no stale entries should remain
+    assert.equal(
+      client.pendingRequestCount,
+      0,
+      `No pending requests should remain after cancel, got ${client.pendingRequestCount}`,
+    );
+  });
+
   // ─── pendingTool: suppress stall during MCP tool execution ──
 
   it('pendingTool: tool_call suppresses stall, resumes watchdog on non-tool event', async () => {

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -846,6 +846,66 @@ describe('AcpClient', () => {
     assert.match(thrownError.message, /[Ss]tream idle|STREAM_IDLE/);
   });
 
+  it('#1186: delayed warning drain preserves the watchdog idle error', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'delayed-drain-sess' });
+        } else if (msg.method === 'session/prompt') {
+          setImmediate(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'delayed-drain-sess',
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start' } },
+            });
+          });
+          // Leave the prompt pending so the watchdog owns termination.
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const iter = client.promptStream('delayed-drain-sess', 'hello', {
+      idleWarningMs: 30,
+      idleStallMs: 100,
+      timeoutMs: 5000,
+    });
+    const first = await iter.next();
+    assert.equal(first.value?.update?.sessionUpdate, 'agent_message_chunk');
+
+    // Let both warning and stall fire while the async generator is paused at the
+    // first yield. The pending request rejection must not replace the watchdog's
+    // structured terminal error before the consumer drains the queued warning.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const remainingEvents = [];
+    let thrownError = null;
+    try {
+      for (;;) {
+        const result = await iter.next();
+        if (result.done) break;
+        remainingEvents.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+
+    assert.ok(
+      remainingEvents.some((event) => event.update?.sessionUpdate === 'stream_idle_warning'),
+      'queued idle warning should still be delivered',
+    );
+    assert.ok(thrownError, 'watchdog stall should terminate the stream');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL');
+    assert.equal(thrownError.configuredIdleStallMs, 100);
+  });
+
   // #1186: Zero-first-event now produces AcpStreamIdleError at the configured TTL,
   // not AcpTimeoutError at the later budget. The idle watchdog starts at prompt start.
   it('#1186: zero-first-event produces AcpStreamIdleError at configured idleStallMs', async () => {

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -1692,4 +1692,56 @@ describe('AcpClient', () => {
     const textEvents = events.filter((e) => e.update?.sessionUpdate === 'agent_message_chunk');
     assert.equal(textEvents.length, 1, 'Should have 1 text event after tool completes');
   });
+
+  it('#1186: stdio request ceiling stays above a configured activity budget over one hour', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'long-ttl-sess' });
+        } else if (msg.method === 'session/prompt') {
+          agentRespond(agentStdout, msg.id, { stopReason: 'end_turn' });
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const idleStallMs = 2 * 60 * 60 * 1000;
+    const activityBudgetMs = idleStallMs + 60_000;
+    const expectedRequestCeilingMs = activityBudgetMs + 60_000;
+    const scheduledDelays = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    const setTimeoutMock = mock.method(globalThis, 'setTimeout', (callback, delay, ...args) => {
+      scheduledDelays.push(delay);
+      return originalSetTimeout(callback, delay, ...args);
+    });
+
+    try {
+      for await (const _event of client.promptStream('long-ttl-sess', 'hello', {
+        idleStallMs,
+        timeoutMs: activityBudgetMs,
+      })) {
+        // No updates expected; the provider acknowledges immediately.
+      }
+    } finally {
+      setTimeoutMock.mock.restore();
+    }
+
+    assert.ok(
+      scheduledDelays.includes(expectedRequestCeilingMs),
+      `session/prompt request ceiling must be ${expectedRequestCeilingMs}ms, got ${scheduledDelays.join(', ')}`,
+    );
+    assert.equal(
+      scheduledDelays.includes(3_600_000),
+      false,
+      'the legacy one-hour request ceiling must not precede a valid two-hour idle policy',
+    );
+  });
 });

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -1303,6 +1303,7 @@ describe('AcpClient', () => {
     await client.initialize();
     await client.newSession();
 
+    let thrownError = null;
     try {
       for await (const _ of client.promptStream('cancel-sess', 'hello', {
         idleWarningMs: 30,
@@ -1311,14 +1312,17 @@ describe('AcpClient', () => {
       })) {
         // drain
       }
-    } catch {
-      // expected AcpStreamIdleError
+    } catch (err) {
+      thrownError = err;
     }
 
     // P1: session/cancel MUST be sent when idle stall fires
     const cancelMsgs = capturedMessages.filter((m) => m.method === 'session/cancel');
     assert.equal(cancelMsgs.length, 1, `Expected 1 session/cancel, got ${cancelMsgs.length}`);
     assert.equal(cancelMsgs[0].params.sessionId, 'cancel-sess');
+    // #1186 P2: structured error carries configured threshold
+    assert.ok(thrownError, 'Should throw AcpStreamIdleError');
+    assert.equal(thrownError.configuredIdleStallMs, 80, 'Ordinary silence error carries configured threshold');
   });
 
   it('F149-P1: stall fires at ~idleStallMs total idle (not warning + stall)', async () => {
@@ -1435,6 +1439,9 @@ describe('AcpClient', () => {
       /[Ss]tream idle|STREAM_IDLE/,
       `Expected AcpStreamIdleError, got: ${thrownError.message}`,
     );
+    // #1186 P2: structured error must include configured threshold
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL');
+    assert.equal(thrownError.configuredIdleStallMs, 150, 'Error must carry the configured idleStallMs');
 
     // Should have tool_wait_warning before stall
     const toolWaits = events.filter((e) => e.update?.sessionUpdate === 'stream_tool_wait_warning');

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -959,6 +959,8 @@ describe('AcpClient', () => {
       false,
       'cancelled stdio prompt must mark a single-flight carrier unsafe for warm reuse',
     );
+    assert.equal(client.isSessionSafeForReuse('cancel-cb-sess'), false);
+    assert.equal(client.isSessionSafeForReuse('unrelated-sess'), true);
 
     // Should settle promptly — not wait for idle stall (5000ms) or budget (10000ms)
     assert.ok(elapsed < 2000, `Cancel should settle within 2s, took ${elapsed}ms`);

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -937,7 +937,7 @@ describe('AcpClient', () => {
     try {
       for await (const event of client.promptStream('tool-sess', 'hello', {
         idleWarningMs: 30,
-        idleStallMs: 100,
+        idleStallMs: 500, // #1186: must exceed tool execution time (250ms) since ceiling now follows idleStallMs
         timeoutMs: 5000,
       })) {
         events.push(event);
@@ -1010,7 +1010,7 @@ describe('AcpClient', () => {
     try {
       for await (const event of client.promptStream('flat-sess', 'hello', {
         idleWarningMs: 30,
-        idleStallMs: 100,
+        idleStallMs: 500, // #1186: must exceed tool execution time (250ms) since ceiling now follows idleStallMs
         timeoutMs: 5000,
       })) {
         events.push(event);
@@ -1181,7 +1181,7 @@ describe('AcpClient', () => {
     try {
       for await (const event of client.promptStream('perm-stall-sess', 'hello', {
         idleWarningMs: 60,
-        idleStallMs: 200,
+        idleStallMs: 500, // #1186: must exceed tool execution time (250ms) since ceiling now follows idleStallMs
         timeoutMs: 5000,
       })) {
         events.push(event);
@@ -1247,7 +1247,7 @@ describe('AcpClient', () => {
     try {
       for await (const event of client.promptStream('thought-tool-sess', 'hello', {
         idleWarningMs: 30,
-        idleStallMs: 100,
+        idleStallMs: 500, // #1186: must exceed tool execution time (250ms) since ceiling now follows idleStallMs
         timeoutMs: 5000,
       })) {
         events.push(event);
@@ -1380,5 +1380,126 @@ describe('AcpClient', () => {
       [50, 70],
       `Idle watchdog should schedule warning then remaining stall delay, got ${scheduledDelays.join(', ')}`,
     );
+  });
+
+  // ─── #1186: Tool execution ceiling follows configured idleStallMs ───
+
+  it('#1186: pendingTool terminates at configured idleStallMs, not hardcoded 180s', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+    const capturedMessages = [];
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        capturedMessages.push(msg);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'tool-ceil-sess' });
+        } else if (msg.method === 'session/prompt') {
+          // Send tool_call event, then go silent — never complete
+          setImmediate(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'tool-ceil-sess',
+              update: { sessionUpdate: 'tool_call', content: { type: 'text', text: 'slow_tool' } },
+            });
+          });
+          // Never send response — tool stays pending forever
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const events = [];
+    let thrownError = null;
+    try {
+      for await (const event of client.promptStream('tool-ceil-sess', 'hello', {
+        idleWarningMs: 20,
+        idleStallMs: 150, // Configured idle TTL — tool ceiling must follow this
+        timeoutMs: 5000, // High outer timeout — should NOT fire first
+      })) {
+        events.push(event);
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+
+    // With fix: should throw AcpStreamIdleError at ~150ms (configured idleStallMs)
+    // Without fix: TOOL_EXECUTION_CEILING_MS=180_000 would never fire; timeoutMs would fire instead
+    assert.ok(thrownError, 'Should throw an error on tool execution exceeding idleStallMs');
+    assert.match(
+      thrownError.message,
+      /[Ss]tream idle|STREAM_IDLE/,
+      `Expected AcpStreamIdleError, got: ${thrownError.message}`,
+    );
+
+    // Should have tool_wait_warning before stall
+    const toolWaits = events.filter((e) => e.update?.sessionUpdate === 'stream_tool_wait_warning');
+    assert.ok(toolWaits.length >= 1, 'Should emit tool_wait_warning before termination');
+
+    // Should have sent session/cancel
+    const cancelMsgs = capturedMessages.filter((m) => m.method === 'session/cancel');
+    assert.equal(cancelMsgs.length, 1, 'Should send session/cancel when tool ceiling exceeded');
+  });
+
+  it('#1186: pendingTool does NOT terminate before configured idleStallMs', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        } else if (msg.method === 'session/new') {
+          agentRespond(agentStdout, msg.id, { sessionId: 'tool-safe-sess' });
+        } else if (msg.method === 'session/prompt') {
+          // Send tool_call, wait a while, then complete successfully
+          setImmediate(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'tool-safe-sess',
+              update: { sessionUpdate: 'tool_call', content: { type: 'text', text: 'slow_tool' } },
+            });
+          });
+          // Complete AFTER warning but BEFORE idleStallMs
+          setTimeout(() => {
+            agentNotify(agentStdout, 'session/update', {
+              sessionId: 'tool-safe-sess',
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'result' } },
+            });
+            agentRespond(agentStdout, msg.id, { stopReason: 'end_turn' });
+          }, 200); // 200ms: past warning (50ms) but before idleStallMs (400ms)
+        }
+      }
+    });
+
+    client = new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    await client.initialize();
+    await client.newSession();
+
+    const events = [];
+    let thrownError = null;
+    try {
+      for await (const event of client.promptStream('tool-safe-sess', 'hello', {
+        idleWarningMs: 50,
+        idleStallMs: 400, // Configured idle TTL — tool should survive within this
+        timeoutMs: 5000,
+      })) {
+        events.push(event);
+      }
+    } catch (err) {
+      thrownError = err;
+    }
+
+    // Tool completed within idleStallMs — should NOT throw
+    assert.equal(thrownError, null, `Should not terminate tool within idleStallMs, got: ${thrownError?.message}`);
+
+    // Should have real events
+    const toolEvents = events.filter((e) => e.update?.sessionUpdate === 'tool_call');
+    assert.equal(toolEvents.length, 1, 'Should have 1 tool_call event');
+    const textEvents = events.filter((e) => e.update?.sessionUpdate === 'agent_message_chunk');
+    assert.equal(textEvents.length, 1, 'Should have 1 text event after tool completes');
   });
 });

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -643,4 +643,115 @@ describe('AcpHttpStreamClient', () => {
     assert.equal(final.done, true);
     assert.equal(final.value, 'end_turn');
   });
+
+  // ─── #1186: Tool execution ceiling parity with stdio client ───
+
+  it('#1186: pendingTool terminates at configured idleStallMs (parity with stdio)', async () => {
+    let promptResponse = null;
+    let resolvePromptSeen;
+    const promptSeen = new Promise((resolve) => {
+      resolvePromptSeen = resolve;
+    });
+
+    server = await startJsonRpcServer((message, res) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      if (message.method === 'session/new') {
+        return { jsonrpc: '2.0', id: message.id, result: { sessionId: 'http-tool-ceil' } };
+      }
+      if (message.method === 'session/prompt') {
+        promptResponse = res;
+        res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+        res.flushHeaders();
+        resolvePromptSeen();
+        return undefined;
+      }
+      if (message.method === 'session/cancel') {
+        // End the prompt stream when cancel arrives — simulates agent reacting to cancel
+        if (promptResponse && !promptResponse.writableEnded) {
+          promptResponse.end();
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        return undefined;
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd: '/tmp',
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+    const session = await client.newSession();
+
+    const events = [];
+    let thrownError = null;
+
+    const iterator = client.promptStream(session.sessionId, 'hello', {
+      idleWarningMs: 20,
+      idleStallMs: 150, // Configured idle TTL — tool ceiling must follow this
+      timeoutMs: 5000, // High outer timeout — should NOT fire first
+    });
+
+    // Start the generator (sends HTTP request) and capture first result promise
+    const firstResult = iterator.next();
+
+    // Wait for prompt request to reach mock server
+    await promptSeen;
+
+    // Send tool_call event, then go silent — never complete
+    promptResponse.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'http-tool-ceil',
+          update: { sessionUpdate: 'tool_call', content: { type: 'text', text: 'slow_tool' } },
+        },
+      })}\n`,
+    );
+
+    try {
+      // Consume first result and continue draining
+      const first = await withTimeout(firstResult, 3000, 'HTTP first event did not arrive');
+      if (!first.done) events.push(first.value);
+
+      while (!first.done) {
+        const result = await withTimeout(iterator.next(), 3000, 'HTTP promptStream did not terminate');
+        if (result.done) break;
+        events.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    } finally {
+      // Ensure prompt response is always closed to prevent test hanging
+      if (promptResponse && !promptResponse.writableEnded) {
+        promptResponse.end();
+      }
+    }
+
+    // With fix: should throw AcpStreamIdleError at ~150ms (configured idleStallMs)
+    // Without fix: pendingTool suppresses stall indefinitely → timeoutMs fires at 5000ms
+    assert.ok(thrownError, 'Should throw an error on tool execution exceeding idleStallMs');
+    assert.match(
+      thrownError.message,
+      /[Ss]tream idle|STREAM_IDLE/,
+      `Expected AcpStreamIdleError, got: ${thrownError.message}`,
+    );
+
+    // Should have tool_wait_warning before stall
+    const toolWaits = events.filter((e) => e.update?.sessionUpdate === 'stream_tool_wait_warning');
+    assert.ok(toolWaits.length >= 1, 'Should emit tool_wait_warning before termination');
+  });
 });

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -846,4 +846,184 @@ describe('AcpHttpStreamClient', () => {
     assert.equal(thrownError.code, 'STREAM_IDLE_STALL');
     assert.equal(thrownError.configuredIdleStallMs, 100, 'HTTP ordinary silence error carries configured threshold');
   });
+
+  it('#1186: zero-first-event produces AcpStreamIdleError at configured idleStallMs (HTTP)', async () => {
+    let promptResponse = null;
+    let resolvePromptSeen;
+    const promptSeen = new Promise((resolve) => {
+      resolvePromptSeen = resolve;
+    });
+
+    server = await startJsonRpcServer((message, res) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      if (message.method === 'session/new') {
+        return { jsonrpc: '2.0', id: message.id, result: { sessionId: 'http-zero-evt' } };
+      }
+      if (message.method === 'session/prompt') {
+        promptResponse = res;
+        res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+        res.flushHeaders();
+        resolvePromptSeen();
+        // Never send any events — zero-first-event scenario
+        return undefined;
+      }
+      if (message.method === 'session/cancel') {
+        if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        return undefined;
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd: '/tmp',
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+    const session = await client.newSession();
+
+    let thrownError = null;
+    const events = [];
+    const iterator = client.promptStream(session.sessionId, 'hello', {
+      idleWarningMs: 30,
+      idleStallMs: 100, // Should fire at ~100ms
+      timeoutMs: 5000, // Budget much higher — must NOT fire first
+    });
+
+    const firstResult = iterator.next();
+    await promptSeen;
+
+    // No events sent — zero-first-event
+    try {
+      const first = await withTimeout(firstResult, 3000, 'HTTP zero-event did not start');
+      if (!first.done) events.push(first.value);
+      while (!first.done) {
+        const result = await withTimeout(iterator.next(), 3000, 'HTTP zero-event did not terminate');
+        if (result.done) break;
+        events.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    } finally {
+      if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+    }
+
+    // Should throw AcpStreamIdleError (not AcpTimeoutError)
+    assert.ok(thrownError, 'Zero-first-event should throw AcpStreamIdleError');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(thrownError.configuredIdleStallMs, 100, 'HTTP zero-event error carries configured threshold');
+  });
+
+  it('#1186: cancel settles HTTP prompt stream via sessionCancelCallbacks', async () => {
+    let promptResponse = null;
+    let resolvePromptSeen;
+    const promptSeen = new Promise((resolve) => {
+      resolvePromptSeen = resolve;
+    });
+
+    server = await startJsonRpcServer((message, res) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      if (message.method === 'session/new') {
+        return { jsonrpc: '2.0', id: message.id, result: { sessionId: 'http-cancel-cb' } };
+      }
+      if (message.method === 'session/prompt') {
+        promptResponse = res;
+        res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+        res.flushHeaders();
+        // Send one event, then go silent — provider never responds to cancel
+        setImmediate(() => {
+          res.write(
+            `${JSON.stringify({
+              jsonrpc: '2.0',
+              method: 'session/update',
+              params: {
+                sessionId: 'http-cancel-cb',
+                update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start' } },
+              },
+            })}\n`,
+          );
+        });
+        resolvePromptSeen();
+        return undefined;
+      }
+      if (message.method === 'session/cancel') {
+        // Provider acknowledges cancel but does NOT end the prompt stream
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        return undefined;
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd: '/tmp',
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+    const session = await client.newSession();
+
+    const events = [];
+    let thrownError = null;
+    const startMs = Date.now();
+    const iterator = client.promptStream(session.sessionId, 'hello', {
+      idleWarningMs: 500,
+      idleStallMs: 5000, // Very high — cancel must fire before this
+      timeoutMs: 10000,
+    });
+
+    const firstResult = iterator.next();
+    await promptSeen;
+
+    try {
+      // Get the first real event
+      const first = await withTimeout(firstResult, 3000, 'HTTP cancel-cb first event');
+      if (!first.done) events.push(first.value);
+
+      // Cancel the session — should settle promptStream immediately via callback
+      client.cancelSession(session.sessionId);
+
+      // The next .next() should resolve promptly
+      while (true) {
+        const result = await withTimeout(iterator.next(), 3000, 'HTTP cancel-cb did not settle');
+        if (result.done) break;
+        events.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    } finally {
+      if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+    }
+
+    const elapsed = Date.now() - startMs;
+
+    // Should throw AcpStreamIdleError (from cancel callback)
+    assert.ok(thrownError, 'HTTP cancel should throw');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+
+    // Should settle promptly — not wait for idle stall (5s) or budget (10s)
+    assert.ok(elapsed < 2000, `HTTP cancel should settle within 2s, took ${elapsed}ms`);
+  });
 });

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -749,9 +749,101 @@ describe('AcpHttpStreamClient', () => {
       /[Ss]tream idle|STREAM_IDLE/,
       `Expected AcpStreamIdleError, got: ${thrownError.message}`,
     );
+    // #1186 P2: structured error includes configured threshold
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL');
+    assert.equal(thrownError.configuredIdleStallMs, 150, 'HTTP error must carry configured idleStallMs');
 
     // Should have tool_wait_warning before stall
     const toolWaits = events.filter((e) => e.update?.sessionUpdate === 'stream_tool_wait_warning');
     assert.ok(toolWaits.length >= 1, 'Should emit tool_wait_warning before termination');
+  });
+
+  it('#1186: ordinary silence (no pendingTool) terminates at configured idleStallMs', async () => {
+    let promptResponse = null;
+    let resolvePromptSeen;
+    const promptSeen = new Promise((resolve) => {
+      resolvePromptSeen = resolve;
+    });
+
+    server = await startJsonRpcServer((message, res) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      if (message.method === 'session/new') {
+        return { jsonrpc: '2.0', id: message.id, result: { sessionId: 'http-silence-sess' } };
+      }
+      if (message.method === 'session/prompt') {
+        promptResponse = res;
+        res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+        res.flushHeaders();
+        resolvePromptSeen();
+        return undefined;
+      }
+      if (message.method === 'session/cancel') {
+        if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+        return undefined;
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd: '/tmp',
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+    const session = await client.newSession();
+
+    let thrownError = null;
+    const events = [];
+    const iterator = client.promptStream(session.sessionId, 'hello', {
+      idleWarningMs: 20,
+      idleStallMs: 100,
+      timeoutMs: 5000,
+    });
+
+    // Start generator (sends HTTP request)
+    const firstResult = iterator.next();
+    await promptSeen;
+
+    // Send ONE text event, then go silent (ordinary silence, no tool_call)
+    promptResponse.write(
+      `${JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'session/update',
+        params: {
+          sessionId: 'http-silence-sess',
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'partial' } },
+        },
+      })}\n`,
+    );
+
+    try {
+      const first = await withTimeout(firstResult, 3000, 'HTTP first event did not arrive');
+      if (!first.done) events.push(first.value);
+      while (!first.done) {
+        const result = await withTimeout(iterator.next(), 3000, 'HTTP ordinary silence did not terminate');
+        if (result.done) break;
+        events.push(result.value);
+      }
+    } catch (err) {
+      thrownError = err;
+    } finally {
+      if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+    }
+
+    assert.ok(thrownError, 'Ordinary silence should throw AcpStreamIdleError');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL');
+    assert.equal(thrownError.configuredIdleStallMs, 100, 'HTTP ordinary silence error carries configured threshold');
   });
 });

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -1026,4 +1026,66 @@ describe('AcpHttpStreamClient', () => {
     // Should settle promptly — not wait for idle stall (5s) or budget (10s)
     assert.ok(elapsed < 2000, `HTTP cancel should settle within 2s, took ${elapsed}ms`);
   });
+
+  it('#1186: short TTL regression — idleStallMs < idleWarningMs terminates at stall threshold (HTTP)', async () => {
+    let promptResponse = null;
+
+    server = await startJsonRpcServer((message, res) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      if (message.method === 'session/new') {
+        return { jsonrpc: '2.0', id: message.id, result: { sessionId: 'http-short-ttl' } };
+      }
+      if (message.method === 'session/prompt') {
+        promptResponse = res;
+        res.writeHead(200, { 'Content-Type': 'application/x-ndjson' });
+        res.flushHeaders();
+        // Never send any events — zero-first-event with short TTL
+        return undefined;
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd: '/tmp',
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+    const session = await client.newSession();
+
+    const startMs = Date.now();
+    let thrownError = null;
+    try {
+      // idleStallMs (100ms) < idleWarningMs (20_000ms default).
+      // Without Math.min fix, initial check schedules at 20_000ms — way too late.
+      for await (const _event of client.promptStream(session.sessionId, 'hello', {
+        idleStallMs: 100,
+        // idleWarningMs defaults to 20_000
+        timeoutMs: 30_000,
+      })) {
+        // Should not receive any events
+      }
+    } catch (err) {
+      thrownError = err;
+    } finally {
+      if (promptResponse && !promptResponse.writableEnded) promptResponse.end();
+    }
+    const elapsed = Date.now() - startMs;
+
+    assert.ok(thrownError, 'Should throw on short-TTL zero-event stall (HTTP)');
+    assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(thrownError.configuredIdleStallMs, 100, 'Error should carry configured 100ms threshold');
+    // Must terminate near 100ms, not at 20_000ms (the warning interval)
+    assert.ok(elapsed < 2000, `Should terminate near 100ms, took ${elapsed}ms`);
+  });
 });

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -1022,6 +1022,11 @@ describe('AcpHttpStreamClient', () => {
     // Should throw AcpStreamIdleError (from cancel callback)
     assert.ok(thrownError, 'HTTP cancel should throw');
     assert.equal(thrownError.code, 'STREAM_IDLE_STALL', `Expected STREAM_IDLE_STALL, got ${thrownError.code}`);
+    assert.equal(
+      client.isSafeForSingleFlightReuse,
+      false,
+      'cancelled HTTP prompt must mark a single-flight carrier unsafe for warm reuse',
+    );
 
     // Should settle promptly — not wait for idle stall (5s) or budget (10s)
     assert.ok(elapsed < 2000, `HTTP cancel should settle within 2s, took ${elapsed}ms`);

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -1027,6 +1027,8 @@ describe('AcpHttpStreamClient', () => {
       false,
       'cancelled HTTP prompt must mark a single-flight carrier unsafe for warm reuse',
     );
+    assert.equal(client.isSessionSafeForReuse('http-cancel-cb'), false);
+    assert.equal(client.isSessionSafeForReuse('unrelated-sess'), true);
 
     // Should settle promptly — not wait for idle stall (5s) or budget (10s)
     assert.ok(elapsed < 2000, `HTTP cancel should settle within 2s, took ${elapsed}ms`);

--- a/packages/api/test/acp/acp-process-pool.test.js
+++ b/packages/api/test/acp/acp-process-pool.test.js
@@ -18,14 +18,17 @@ function createMockClient() {
   const id = ++clientIdCounter;
   let alive = false;
   let closed = false;
-  let safeForSingleFlightReuse = true;
+  const unsafeSessionIds = new Set();
   return {
     id,
     get isAlive() {
       return alive && !closed;
     },
     get isSafeForSingleFlightReuse() {
-      return safeForSingleFlightReuse;
+      return unsafeSessionIds.size === 0;
+    },
+    isSessionSafeForReuse(sessionId) {
+      return !unsafeSessionIds.has('*') && !unsafeSessionIds.has(sessionId);
     },
     async initialize() {
       alive = true;
@@ -46,8 +49,8 @@ function createMockClient() {
     _isClosed() {
       return closed;
     },
-    _markUnsafeForSingleFlightReuse() {
-      safeForSingleFlightReuse = false;
+    _markUnsafeForSingleFlightReuse(sessionId = '*') {
+      unsafeSessionIds.add(sessionId);
     },
   };
 }
@@ -225,21 +228,57 @@ describe('AcpProcessPool', () => {
       lease2.release();
     });
 
-    test('multiplexed carrier is not retired when one cancelled session is unsafe', async () => {
+    test('multiplexed carrier keeps unrelated session affinity after another session is cancelled', async () => {
       const { AcpProcessPool } = await import(
         '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
       );
       pool = new AcpProcessPool(defaultPoolConfig, defaultVariantConfig, createMockClient);
 
-      const lease1 = await pool.acquire(key1);
-      const sharedClient = lease1.client;
-      sharedClient._markUnsafeForSingleFlightReuse();
-      lease1.release();
+      const cancelledLease = await pool.acquire(key1);
+      const sharedClient = cancelledLease.client;
+      pool.rememberSession(key1, 'cancelled-sess', cancelledLease);
+      const unrelatedLease = await pool.acquire(key1);
+      pool.rememberSession(key1, 'unrelated-sess', unrelatedLease);
+      sharedClient._markUnsafeForSingleFlightReuse('cancelled-sess');
+      cancelledLease.release();
+      unrelatedLease.release();
 
       assert.equal(sharedClient._isClosed(), false, 'one cancelled session must not close a multiplexed carrier');
-      const lease2 = await pool.acquire(key1);
-      assert.strictEqual(lease2.client, sharedClient, 'multiplexed carrier remains available to unrelated sessions');
-      lease2.release();
+      const resumedUnrelated = await pool.acquire(key1, { sessionId: 'unrelated-sess' });
+      assert.strictEqual(
+        resumedUnrelated.client,
+        sharedClient,
+        'multiplexed carrier remains available to unrelated sessions',
+      );
+      assert.notEqual(resumedUnrelated.canResumeRequestedSession, false);
+      resumedUnrelated.release();
+    });
+
+    test('multiplexed carrier seals an unquiesced cancelled session instead of resuming it', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(defaultPoolConfig, defaultVariantConfig, createMockClient);
+
+      const cancelledLease = await pool.acquire(key1);
+      const sharedClient = cancelledLease.client;
+      pool.rememberSession(key1, 'cancelled-sess', cancelledLease);
+      sharedClient._markUnsafeForSingleFlightReuse('cancelled-sess');
+      cancelledLease.release();
+
+      const replacementLease = await pool.acquire(key1, { sessionId: 'cancelled-sess' });
+      assert.equal(
+        replacementLease.canResumeRequestedSession,
+        false,
+        'same logical session must be remapped instead of resumed while its prior prompt is unresolved',
+      );
+      assert.strictEqual(
+        replacementLease.client,
+        sharedClient,
+        'the multiplexed carrier may host the replacement as a distinct fresh session',
+      );
+      assert.equal(sharedClient._isClosed(), false);
+      replacementLease.release();
     });
 
     test('unsafe session owner is retired instead of stale-lease force reuse', async () => {
@@ -255,6 +294,11 @@ describe('AcpProcessPool', () => {
 
       const lease2 = await pool.acquire(key1, { sessionId: 'cancelled-sess' });
       assert.notStrictEqual(lease2.client, unsafeClient, 'resume must not reuse an unquiesced session owner');
+      assert.equal(
+        lease2.canResumeRequestedSession,
+        false,
+        'replacement process must create a fresh session rather than load the still-running logical session',
+      );
       assert.equal(unsafeClient._isClosed(), true);
       assert.equal(pool.getMetrics().activeLeaseCount, 1, 'only replacement lease should remain active');
 

--- a/packages/api/test/acp/acp-process-pool.test.js
+++ b/packages/api/test/acp/acp-process-pool.test.js
@@ -18,10 +18,14 @@ function createMockClient() {
   const id = ++clientIdCounter;
   let alive = false;
   let closed = false;
+  let safeForSingleFlightReuse = true;
   return {
     id,
     get isAlive() {
       return alive && !closed;
+    },
+    get isSafeForSingleFlightReuse() {
+      return safeForSingleFlightReuse;
     },
     async initialize() {
       alive = true;
@@ -41,6 +45,9 @@ function createMockClient() {
     }, // simulate process death
     _isClosed() {
       return closed;
+    },
+    _markUnsafeForSingleFlightReuse() {
+      safeForSingleFlightReuse = false;
     },
   };
 }
@@ -188,6 +195,72 @@ describe('AcpProcessPool', () => {
       const lease2 = await pool.acquire(key1);
       assert.strictEqual(lease2.client, client);
       assert.strictEqual(pool.getMetrics().liveProcessCount, 1);
+      lease2.release();
+    });
+
+    test('non-multiplexed carrier is retired after a cancelled prompt may still be running', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(defaultPoolConfig, nonMultiplexedVariantConfig, createMockClient);
+
+      const lease1 = await pool.acquire(key1);
+      const unsafeClient = lease1.client;
+      unsafeClient._markUnsafeForSingleFlightReuse();
+      lease1.release();
+
+      assert.equal(unsafeClient._isClosed(), true, 'unsafe single-flight client must be closed');
+      assert.deepEqual(pool.getMetrics(), {
+        liveProcessCount: 0,
+        activeLeaseCount: 0,
+        idleProcessCount: 0,
+        warmHitCount: 0,
+        coldStartCount: 1,
+        evictionCount: 1,
+        zombieCleanupCount: 0,
+      });
+
+      const lease2 = await pool.acquire(key1);
+      assert.notStrictEqual(lease2.client, unsafeClient, 'next acquire must cold-start a fresh client');
+      lease2.release();
+    });
+
+    test('multiplexed carrier is not retired when one cancelled session is unsafe', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(defaultPoolConfig, defaultVariantConfig, createMockClient);
+
+      const lease1 = await pool.acquire(key1);
+      const sharedClient = lease1.client;
+      sharedClient._markUnsafeForSingleFlightReuse();
+      lease1.release();
+
+      assert.equal(sharedClient._isClosed(), false, 'one cancelled session must not close a multiplexed carrier');
+      const lease2 = await pool.acquire(key1);
+      assert.strictEqual(lease2.client, sharedClient, 'multiplexed carrier remains available to unrelated sessions');
+      lease2.release();
+    });
+
+    test('unsafe session owner is retired instead of stale-lease force reuse', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(defaultPoolConfig, nonMultiplexedVariantConfig, createMockClient);
+
+      const lease1 = await pool.acquire(key1);
+      const unsafeClient = lease1.client;
+      pool.rememberSession(key1, 'cancelled-sess', lease1);
+      unsafeClient._markUnsafeForSingleFlightReuse();
+
+      const lease2 = await pool.acquire(key1, { sessionId: 'cancelled-sess' });
+      assert.notStrictEqual(lease2.client, unsafeClient, 'resume must not reuse an unquiesced session owner');
+      assert.equal(unsafeClient._isClosed(), true);
+      assert.equal(pool.getMetrics().activeLeaseCount, 1, 'only replacement lease should remain active');
+
+      // The retired lease was generation-invalidated; its late release is a no-op.
+      lease1.release();
+      assert.equal(pool.getMetrics().activeLeaseCount, 1);
       lease2.release();
     });
 

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -3014,75 +3014,94 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
 // Real transport-level cancel tests exercising sessionCancelCallbacks are in:
 //   - acp-client.test.js: '#1186: cancel settles prompt stream via sessionCancelCallbacks (real transport)'
 //   - acp-httpstream-client.test.js: '#1186: cancel settles HTTP prompt stream via sessionCancelCallbacks'
-// This test verifies the service-level lease lifecycle: cancel → release → reacquire.
+// This test verifies the SERVICE-LEVEL lifecycle: cancel during active promptStream →
+// cancel callback → stream settles → catch → finally { lease.release() } → second invoke succeeds.
 describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
-  it('cancel releases lease so next invoke succeeds on constrained pool', async () => {
-    let releaseCalls = 0;
-    // Track cancel callbacks the same way the real clients do
+  it('cancel DURING active promptStream releases lease for next invoke', async () => {
+    const { AcpStreamIdleError } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
+    const timeline = []; // ordered event log for lifecycle assertions
     const cancelCallbacks = new Map();
 
-    const makeFakeClient = () => ({
+    const makeFakeClient = (clientLabel) => ({
       recentCapacitySignal: null,
       onCapacity() {},
       offCapacity() {},
+      clearRecentCapacitySignal() {},
       async newSession() {
-        return { sessionId: `sess-${Date.now()}` };
+        return { sessionId: `sess-cancel-${clientLabel}` };
       },
       cancelSession(sessionId) {
-        // Invoke the cancel callback — same as real AcpClient/AcpHttpStreamClient
+        timeline.push(`cancel:${clientLabel}`);
         const cb = cancelCallbacks.get(sessionId);
         if (cb) cb();
       },
       async *promptStream(sessionId, text, options) {
-        // Register cancel callback (mirrors real transport implementation)
+        // Register cancel callback (mirrors real transport)
         let settledByCancel = false;
-        const cancelCb = () => {
+        cancelCallbacks.set(sessionId, () => {
           settledByCancel = true;
-        };
-        cancelCallbacks.set(sessionId, cancelCb);
+        });
+        timeline.push(`promptStream:start:${clientLabel}`);
         try {
+          // Yield a real content event — test MUST receive this before aborting.
+          // This proves promptStream is running and the cancel callback is registered.
           yield {
             sessionId,
-            update: { sessionUpdate: 'session_init', agentInfo: { name: 'test' } },
+            update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'working...' } },
           };
-          // Block until cancel settles us
+          // Block until cancel settles us (provider never cooperates)
           while (!settledByCancel) {
-            await new Promise((r) => setTimeout(r, 10));
+            await new Promise((r) => setTimeout(r, 5));
           }
-          // Cancel callback was invoked — throw like the real implementation
-          const { AcpStreamIdleError } = await import(
-            '../../dist/domains/cats/services/agents/providers/acp/AcpClient.js'
-          );
-          throw new AcpStreamIdleError(sessionId, 0, 0, options?.idleStallMs ?? 1000);
+          // Cancel callback was invoked — throw like the real transport
+          throw new AcpStreamIdleError(sessionId, 0, 1, options?.idleStallMs ?? 1000);
         } finally {
           cancelCallbacks.delete(sessionId);
+          timeline.push(`promptStream:finally:${clientLabel}`);
         }
       },
     });
 
-    const release1 = () => {
-      releaseCalls++;
-    };
+    let releaseCalls = 0;
     let acquireCount = 0;
     const mockPool = {
       acquire: async () => {
         acquireCount++;
+        const label = acquireCount === 1 ? 'first' : 'second';
+        timeline.push(`acquire:${label}`);
         if (acquireCount > 1) {
-          // Second acquire — lease must have been released
+          // Second acquire — lease must have been released.
+          // This client completes normally (no cancel-blocking).
           return {
             client: {
-              ...makeFakeClient(),
-              async *promptStream() {
+              recentCapacitySignal: null,
+              onCapacity() {},
+              offCapacity() {},
+              clearRecentCapacitySignal() {},
+              async newSession() {
+                return { sessionId: 'sess-cancel-second' };
+              },
+              cancelSession() {},
+              async *promptStream(sessionId) {
+                timeline.push('promptStream:start:second');
                 yield {
-                  sessionId: 'second-sess',
+                  sessionId,
                   update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ok' } },
                 };
               },
             },
-            release: () => {},
+            release: () => {
+              timeline.push('release:second');
+            },
           };
         }
-        return { client: makeFakeClient(), release: release1 };
+        return {
+          client: makeFakeClient('first'),
+          release: () => {
+            releaseCalls++;
+            timeline.push('release:first');
+          },
+        };
       },
       rememberSession() {},
       closeAll: async () => {},
@@ -3096,15 +3115,22 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
       idleTtlMs: 60_000,
     });
 
-    // First invoke with abort
+    // --- First invoke with abort ---
     const ac = new AbortController();
     const iter1 = adapter.invoke('hello', { signal: ac.signal })[Symbol.asyncIterator]();
 
-    // Get first event (session_init)
-    const first = await iter1.next();
-    assert.ok(!first.done, 'Should get first event');
+    // Event 1: service-level session_init (before promptStream starts)
+    const e1 = await iter1.next();
+    assert.ok(!e1.done);
+    assert.equal(e1.value.type, 'session_init', 'First event must be session_init');
 
-    // Abort — this triggers cancelSession which invokes cancel callback
+    // Event 2: real content from promptStream — proves promptStream is active
+    // and cancel callback IS registered in cancelCallbacks map
+    const e2 = await iter1.next();
+    assert.ok(!e2.done);
+    assert.equal(e2.value.type, 'text', `Second event must be text from promptStream, got ${e2.value.type}`);
+
+    // NOW abort — promptStream is running, cancel callback is registered
     ac.abort();
 
     // Drain remaining events (error + done)
@@ -3115,16 +3141,134 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
       if (r.done) break;
     }
 
-    // The lease should have been released
+    // --- Assertions on first invoke ---
     assert.equal(releaseCalls, 1, 'Lease must be released after cancel');
+    assert.ok(
+      timeline.includes('promptStream:start:first'),
+      'promptStream must have started (not Window 3 early return)',
+    );
+    assert.ok(timeline.includes('cancel:first'), 'cancelSession must have been called');
 
-    // Second invoke should succeed (pool not at capacity)
+    // Ordering: release:first must come AFTER promptStream:finally:first
+    const finallyIdx = timeline.indexOf('promptStream:finally:first');
+    const releaseIdx = timeline.indexOf('release:first');
+    assert.ok(finallyIdx >= 0, 'promptStream finally must run');
+    assert.ok(releaseIdx >= 0, 'release must run');
+
+    // --- Second invoke must succeed (lease was released) ---
     const msgs2 = [];
     for await (const msg of adapter.invoke('world')) {
       msgs2.push(msg);
     }
     assert.ok(msgs2.length > 0, 'Second invoke must succeed after first lease released');
     assert.equal(acquireCount, 2, 'Pool must have been acquired twice');
+
+    // Ordering: release:first must come before acquire:second
+    const releaseFirstIdx = timeline.indexOf('release:first');
+    const acquireSecondIdx = timeline.indexOf('acquire:second');
+    assert.ok(
+      releaseFirstIdx < acquireSecondIdx,
+      `release:first (${releaseFirstIdx}) must precede acquire:second (${acquireSecondIdx}). Timeline: ${timeline.join(' → ')}`,
+    );
+  });
+});
+
+// #1186: Error-driven lease cleanup — promptStream throws an error, finally releases lease.
+// Proves that when promptStream fails (e.g., idle stall), the generator's finally block
+// releases the lease WITHOUT manual .return() — the production path for #1186.
+describe('#1186: error-driven lease cleanup (finally releases without manual .return())', () => {
+  it('promptStream error → catch → finally { lease.release() } → second invoke succeeds', async () => {
+    const { AcpStreamIdleError } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
+    const timeline = [];
+
+    let releaseCalls = 0;
+    let acquireCount = 0;
+    const mockPool = {
+      acquire: async () => {
+        acquireCount++;
+        const label = acquireCount === 1 ? 'first' : 'second';
+        timeline.push(`acquire:${label}`);
+        const fakeClient = {
+          recentCapacitySignal: null,
+          onCapacity() {},
+          offCapacity() {},
+          clearRecentCapacitySignal() {},
+          async newSession() {
+            return { sessionId: `sess-err-${label}` };
+          },
+          cancelSession() {},
+          async *promptStream(sessionId, text, options) {
+            timeline.push(`promptStream:start:${label}`);
+            // First invoke: yield one event then throw (simulating idle stall)
+            // Second invoke: complete normally
+            if (label === 'first') {
+              yield {
+                sessionId,
+                update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'partial' } },
+              };
+              // Simulate idle stall error — the exact production failure path
+              throw new AcpStreamIdleError(sessionId, 100, 1, options?.idleStallMs ?? 100);
+            }
+            yield {
+              sessionId,
+              update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'recovered' } },
+            };
+          },
+        };
+        return {
+          client: fakeClient,
+          release: () => {
+            releaseCalls++;
+            timeline.push(`release:${label}`);
+          },
+        };
+      },
+      rememberSession() {},
+      closeAll: async () => {},
+    };
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      idleTtlMs: 200,
+    });
+
+    // First invoke: promptStream throws AcpStreamIdleError
+    // The generator's catch block yields error+done, finally releases lease
+    // NO manual .return() — this is the production path
+    const msgs1 = [];
+    for await (const msg of adapter.invoke('first')) {
+      msgs1.push(msg);
+    }
+
+    // First invoke should have yielded error (stream_idle_stall)
+    const errorMsg = msgs1.find((m) => m.type === 'error');
+    assert.ok(errorMsg, 'First invoke should yield error');
+    assert.equal(errorMsg.errorCode, 'stream_idle_stall', 'Error should be stream_idle_stall');
+
+    // Lease must have been released by finally block
+    assert.equal(releaseCalls, 1, 'First lease released via finally (no manual .return())');
+
+    // Second invoke: should succeed because lease was released
+    const msgs2 = [];
+    for await (const msg of adapter.invoke('second')) {
+      msgs2.push(msg);
+    }
+    assert.ok(
+      msgs2.some((m) => m.type === 'text'),
+      'Second invoke must succeed (lease released)',
+    );
+    assert.equal(releaseCalls, 2, 'Both leases released');
+
+    // Ordering: release:first before acquire:second
+    const releaseFirstIdx = timeline.indexOf('release:first');
+    const acquireSecondIdx = timeline.indexOf('acquire:second');
+    assert.ok(
+      releaseFirstIdx < acquireSecondIdx,
+      `release:first (${releaseFirstIdx}) must precede acquire:second (${acquireSecondIdx}). Timeline: ${timeline.join(' → ')}`,
+    );
   });
 });
 

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -2896,3 +2896,100 @@ describe('#1186: iterator lease cleanup (Pool at capacity regression)', () => {
     );
   });
 });
+
+// #1186: TTL propagation — AcpAgentService threads idleTtlMs to promptStream
+describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () => {
+  it('passes configured idleTtlMs as idleStallMs + timeoutMs to promptStream', async () => {
+    let capturedPromptStreamOpts = null;
+    const fakeClient = {
+      recentCapacitySignal: null,
+      async newSession() {
+        return { sessionId: 'ttl-prop-sess' };
+      },
+      async loadSession(sessionId) {
+        return { sessionId };
+      },
+      async setSessionConfigOption() {},
+      cancelSession() {},
+      async *promptStream(sessionId, text, options) {
+        capturedPromptStreamOpts = options;
+        yield {
+          sessionId,
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ok' } },
+        };
+      },
+      onCapacity() {},
+      offCapacity() {},
+      clearRecentCapacitySignal() {},
+    };
+
+    const mockPool = {
+      acquire: async () => ({ client: fakeClient, release: () => {} }),
+      rememberSession() {},
+      closeAll: async () => {},
+    };
+
+    // With explicit idleTtlMs
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      idleTtlMs: 1_800_000, // 30 minutes
+    });
+
+    for await (const _ of adapter.invoke('hello')) {
+      /* drain */
+    }
+
+    assert.ok(capturedPromptStreamOpts, 'promptStream must receive options');
+    assert.equal(capturedPromptStreamOpts.idleStallMs, 1_800_000, 'idleStallMs = configured idleTtlMs');
+    assert.equal(capturedPromptStreamOpts.timeoutMs, 1_800_000, 'timeoutMs = configured idleTtlMs');
+  });
+
+  it('omits promptStream options when idleTtlMs is not configured (uses client defaults)', async () => {
+    let capturedPromptStreamOpts = 'NOT_CALLED';
+    const fakeClient = {
+      recentCapacitySignal: null,
+      async newSession() {
+        return { sessionId: 'no-ttl-sess' };
+      },
+      async loadSession(sessionId) {
+        return { sessionId };
+      },
+      async setSessionConfigOption() {},
+      cancelSession() {},
+      async *promptStream(sessionId, text, options) {
+        capturedPromptStreamOpts = options;
+        yield {
+          sessionId,
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ok' } },
+        };
+      },
+      onCapacity() {},
+      offCapacity() {},
+      clearRecentCapacitySignal() {},
+    };
+
+    const mockPool = {
+      acquire: async () => ({ client: fakeClient, release: () => {} }),
+      rememberSession() {},
+      closeAll: async () => {},
+    };
+
+    // Without idleTtlMs — should NOT pass options to promptStream
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      // no idleTtlMs
+    });
+
+    for await (const _ of adapter.invoke('hello')) {
+      /* drain */
+    }
+
+    assert.equal(capturedPromptStreamOpts, undefined, 'promptStream receives undefined options when no idleTtlMs');
+  });
+});

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -346,6 +346,116 @@ describe('GeminiAcpAdapter', () => {
     assert.ok(messages.some((m) => m.type === 'text' && m.content === 'resumed via owner'));
   });
 
+  it('creates and publishes a fresh session when the pool seals a cancelled resume target', async () => {
+    const client = {
+      loadSessionCalls: [],
+      newSessionCalls: 0,
+      promptedSessionIds: [],
+      recentCapacitySignal: null,
+      async newSession() {
+        client.newSessionCalls++;
+        return { sessionId: 'fresh-after-cancel' };
+      },
+      async loadSession(sessionId) {
+        client.loadSessionCalls.push(sessionId);
+        return { sessionId };
+      },
+      async setSessionConfigOption() {},
+      cancelSession() {},
+      async *promptStream(sessionId) {
+        client.promptedSessionIds.push(sessionId);
+        yield {
+          sessionId,
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'fresh result' } },
+        };
+      },
+      onCapacity() {},
+      offCapacity() {},
+      clearRecentCapacitySignal() {},
+    };
+    const rememberedSessions = [];
+    const fakePool = {
+      async acquire(poolKey) {
+        return {
+          client,
+          poolKey,
+          canResumeRequestedSession: false,
+          release() {},
+        };
+      },
+      rememberSession(_poolKey, sessionId) {
+        rememberedSessions.push(sessionId);
+      },
+    };
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: fakePool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      providerName: 'google',
+      modelName: 'gemini-acp',
+    });
+
+    const messages = [];
+    for await (const msg of adapter.invoke('continue safely', { sessionId: 'cancelled-sess' })) {
+      messages.push(msg);
+    }
+
+    assert.deepEqual(client.loadSessionCalls, [], 'sealed session must never reach loadSession');
+    assert.equal(client.newSessionCalls, 1);
+    assert.deepEqual(client.promptedSessionIds, ['fresh-after-cancel']);
+    assert.deepEqual(rememberedSessions, ['fresh-after-cancel']);
+    assert.ok(messages.some((msg) => msg.type === 'session_init' && msg.sessionId === 'fresh-after-cancel'));
+  });
+
+  it('seals both persisted and runtime session ids when a resumed prompt terminates locally', async () => {
+    const { AcpStreamIdleError } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
+    const sealedSessions = [];
+    const client = {
+      recentCapacitySignal: null,
+      async newSession() {
+        throw new Error('must not create before resume');
+      },
+      async loadSession() {
+        return { sessionId: 'runtime-session-alias' };
+      },
+      async setSessionConfigOption() {},
+      cancelSession() {},
+      async *promptStream(sessionId) {
+        throw new AcpStreamIdleError(sessionId, 100, 0, 100);
+      },
+      onCapacity() {},
+      offCapacity() {},
+      clearRecentCapacitySignal() {},
+    };
+    const fakePool = {
+      async acquire(poolKey) {
+        return { client, poolKey, release() {} };
+      },
+      rememberSession() {},
+      sealSession(_poolKey, sessionId) {
+        sealedSessions.push(sessionId);
+      },
+    };
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: fakePool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      idleTtlMs: 100,
+    });
+
+    for await (const _msg of adapter.invoke('resume then stall', { sessionId: 'persisted-session' })) {
+      // Drain terminal messages.
+    }
+
+    assert.deepEqual(
+      new Set(sealedSessions),
+      new Set(['persisted-session', 'runtime-session-alias']),
+      'all aliases of the unquiesced logical session must be sealed',
+    );
+  });
+
   it('falls back to session/new when resumed ACP session cannot be loaded', async () => {
     const { child, clientStdin, agentStdout } = createMockChild();
     const captured = [];
@@ -3489,5 +3599,108 @@ describe('#1186: cancel retires an unquiesced non-multiplexed carrier', () => {
     assert.notEqual(promptB.pid, promptA.pid, "Prompt B must not reach A's still-busy single-flight process");
     assert.equal(children.length, 2, 'Pool should spawn one replacement process');
     assert.equal(children[0].killed, true, 'The unquiesced first process must be retired');
+  });
+});
+
+describe('#1186: multiplexed cancel seals only the affected logical session', () => {
+  let pool = null;
+
+  afterEach(async () => {
+    if (pool) {
+      await pool.closeAll();
+      pool = null;
+    }
+  });
+
+  it('remaps the cancelled session on the same live carrier without calling session/load', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild(22_222);
+    let sessionCounter = 0;
+    const loads = [];
+    const prompts = [];
+    let unsafeSameSessionOverlap = false;
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          setImmediate(() =>
+            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: INIT_RESULT }) + '\n'),
+          );
+        } else if (msg.method === 'session/new') {
+          sessionCounter++;
+          const sessionId = `mux-sess-${sessionCounter}`;
+          setImmediate(() =>
+            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { sessionId } }) + '\n'),
+          );
+        } else if (msg.method === 'session/load') {
+          loads.push(msg.params.sessionId);
+          setImmediate(() =>
+            agentStdout.write(
+              JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { sessionId: msg.params.sessionId } }) + '\n',
+            ),
+          );
+        } else if (msg.method === 'session/prompt') {
+          const sessionId = msg.params.sessionId;
+          prompts.push({ sessionId, pid: child.pid });
+          if (sessionId === 'mux-sess-1' && prompts.filter((entry) => entry.sessionId === sessionId).length > 1) {
+            unsafeSameSessionOverlap = true;
+          }
+          setImmediate(() => {
+            agentStdout.write(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                method: 'session/update',
+                params: {
+                  sessionId,
+                  update: {
+                    sessionUpdate: 'agent_message_chunk',
+                    content: { type: 'text', text: sessionId === 'mux-sess-1' ? 'start-A' : 'result-B' },
+                  },
+                },
+              }) + '\n',
+            );
+            if (sessionId !== 'mux-sess-1' || unsafeSameSessionOverlap) {
+              agentStdout.write(
+                JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } }) + '\n',
+              );
+            }
+          });
+        }
+        // session/cancel is deliberately ignored; prompt A remains unresolved.
+      }
+    });
+
+    pool = new AcpProcessPool(
+      { maxLiveProcesses: 1, idleTtlMs: 999_999, healthCheckIntervalMs: 999_999 },
+      { supportsMultiplexing: true },
+      () => new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child }),
+    );
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+    });
+
+    const abortController = new AbortController();
+    for await (const msg of adapter.invoke('task-A', { signal: abortController.signal })) {
+      if (msg.type === 'text') abortController.abort();
+    }
+
+    const secondMessages = [];
+    for await (const msg of adapter.invoke('task-B', { sessionId: 'mux-sess-1' })) {
+      secondMessages.push(msg);
+    }
+
+    assert.deepEqual(loads, [], 'sealed multiplexed session must not call session/load');
+    assert.equal(unsafeSameSessionOverlap, false);
+    assert.deepEqual(
+      prompts.map((entry) => entry.sessionId),
+      ['mux-sess-1', 'mux-sess-2'],
+      'replacement prompt must use a fresh logical session',
+    );
+    assert.ok(secondMessages.some((msg) => msg.type === 'session_init' && msg.sessionId === 'mux-sess-2'));
+    assert.equal(child.killed, false, 'unrelated sessions keep the multiplexed carrier alive');
+    assert.deepEqual(pool.getActivePids(), [22_222]);
   });
 });

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -22,14 +22,14 @@ const { AcpClient } = await import('../../dist/domains/cats/services/agents/prov
 const TEST_POOL_KEY = { projectPath: '/tmp', providerProfile: 'test' };
 
 /** Create a minimal mock child process */
-function createMockChild() {
+function createMockChild(pid = 12345) {
   const clientStdin = new PassThrough();
   const agentStdout = new PassThrough();
   const agentStderr = new PassThrough();
 
   const ee = new EventEmitter();
   const child = {
-    pid: 12345,
+    pid,
     stdin: clientStdin,
     stdout: agentStdout,
     stderr: agentStderr,
@@ -146,10 +146,10 @@ function createPoolWithAutoRespond() {
 /**
  * Create a pool backed by a custom spawn function.
  */
-function createPoolWithSpawn(spawnFn) {
+function createPoolWithSpawn(spawnFn, variantConfig = {}) {
   return new AcpProcessPool(
     { maxLiveProcesses: 5, idleTtlMs: 999_999, healthCheckIntervalMs: 999_999 },
-    {},
+    variantConfig,
     () => new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn }),
   );
 }
@@ -1018,7 +1018,10 @@ describe('GeminiAcpAdapter integration', () => {
       }
     });
 
-    pool = createPoolWithSpawn(() => child);
+    // This fixture intentionally runs two concurrent sessions on one process;
+    // declare the carrier multiplexed so cancelling sess-1 must not retire it
+    // while sess-2 remains live.
+    pool = createPoolWithSpawn(() => child, { supportsMultiplexing: true });
     const adapter = new GeminiAcpAdapter({
       catId: 'gemini',
       pool,
@@ -3342,10 +3345,10 @@ describe('#1186: idle stall fires before turn budget (P2)', () => {
   });
 });
 
-// #1186 P1: Cancel must settle the pending prompt sendRequest so a non-multiplexed
-// process can be safely reused. Without the fix, the sendRequest promise stays alive
-// with a 1h timer after the generator exits, leaving a stale entry in `pending`.
-describe('#1186: cancel settles pending prompt request for safe non-multiplexed reuse', () => {
+// #1186 P1: Releasing a local lease does not prove that an ignored upstream
+// session/cancel stopped the prompt. A single-flight carrier with an unresolved
+// cancelled prompt must be retired rather than returned to warm reuse.
+describe('#1186: cancel retires an unquiesced non-multiplexed carrier', () => {
   let pool = null;
 
   afterEach(async () => {
@@ -3355,79 +3358,86 @@ describe('#1186: cancel settles pending prompt request for safe non-multiplexed 
     }
   });
 
-  it('second prompt succeeds on same single-flight process after cancelled prompt is settled', async () => {
-    const { child, clientStdin, agentStdout, ee } = createMockChild();
+  it('runs the next prompt on a fresh process when the provider ignores cancel', async () => {
     let sessionCounter = 0;
     const capturedCancels = [];
-    const promptsBySession = new Map();
+    const prompts = [];
+    const children = [];
 
-    clientStdin.on('data', (chunk) => {
-      for (const line of chunk.toString().trim().split('\n')) {
-        const msg = JSON.parse(line);
-        if (msg.method === 'initialize') {
-          setImmediate(() =>
-            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: INIT_RESULT }) + '\n'),
-          );
-        } else if (msg.method === 'session/new') {
-          sessionCounter++;
-          const sid = `sess-${sessionCounter}`;
-          setImmediate(() =>
-            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { sessionId: sid } }) + '\n'),
-          );
-        } else if (msg.method === 'session/prompt') {
-          const sid = msg.params.sessionId;
-          promptsBySession.set(sid, msg.id);
+    const createClient = () => {
+      const pid = 12_345 + children.length;
+      const { child, clientStdin, agentStdout } = createMockChild(pid);
+      children.push(child);
 
-          if (sid === 'sess-1') {
-            // Emit one event then go silent — never resolve prompt A.
-            // Provider ignores session/cancel — the worst case.
-            setImmediate(() => {
-              agentStdout.write(
-                JSON.stringify({
-                  jsonrpc: '2.0',
-                  method: 'session/update',
-                  params: {
-                    sessionId: sid,
-                    update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start-A' } },
-                  },
-                }) + '\n',
-              );
-            });
-            // Deliberately NEVER send the prompt response for sess-1
-          } else if (sid === 'sess-2') {
-            // Second prompt — respond normally
-            setImmediate(() => {
-              agentStdout.write(
-                JSON.stringify({
-                  jsonrpc: '2.0',
-                  method: 'session/update',
-                  params: {
-                    sessionId: sid,
-                    update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'result-B' } },
-                  },
-                }) + '\n',
-              );
-              setTimeout(
-                () =>
-                  agentStdout.write(
-                    JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } }) + '\n',
-                  ),
-                10,
-              );
-            });
+      clientStdin.on('data', (chunk) => {
+        for (const line of chunk.toString().trim().split('\n')) {
+          const msg = JSON.parse(line);
+          if (msg.method === 'initialize') {
+            setImmediate(() =>
+              agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: INIT_RESULT }) + '\n'),
+            );
+          } else if (msg.method === 'session/new') {
+            sessionCounter++;
+            const sid = `sess-${sessionCounter}`;
+            setImmediate(() =>
+              agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { sessionId: sid } }) + '\n'),
+            );
+          } else if (msg.method === 'session/prompt') {
+            const sid = msg.params.sessionId;
+            prompts.push({ sessionId: sid, pid });
+
+            if (sid === 'sess-1') {
+              // Emit one event then remain unresolved forever. The provider also
+              // ignores session/cancel below, so this process is not quiescent.
+              setImmediate(() => {
+                agentStdout.write(
+                  JSON.stringify({
+                    jsonrpc: '2.0',
+                    method: 'session/update',
+                    params: {
+                      sessionId: sid,
+                      update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start-A' } },
+                    },
+                  }) + '\n',
+                );
+              });
+            } else if (sid === 'sess-2') {
+              setImmediate(() => {
+                agentStdout.write(
+                  JSON.stringify({
+                    jsonrpc: '2.0',
+                    method: 'session/update',
+                    params: {
+                      sessionId: sid,
+                      update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'result-B' } },
+                    },
+                  }) + '\n',
+                );
+                setTimeout(
+                  () =>
+                    agentStdout.write(
+                      JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } }) + '\n',
+                    ),
+                  10,
+                );
+              });
+            }
+          } else if (msg.method === 'session/cancel') {
+            capturedCancels.push({ sessionId: msg.params?.sessionId, pid });
+            // Deliberately ignore cancel and never resolve prompt A.
           }
-        } else if (msg.method === 'session/cancel') {
-          capturedCancels.push(msg.params?.sessionId);
-          // Provider IGNORES cancel — does NOT resolve the pending prompt
         }
-      }
-    });
+      });
 
-    // Non-multiplexed pool with maxLiveProcesses=1 — forces process reuse
+      return new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child });
+    };
+
+    // maxLiveProcesses=1: retiring A must synchronously free the logical slot so
+    // B can cold-start a replacement instead of overlapping on A's process.
     pool = new AcpProcessPool(
       { maxLiveProcesses: 1, idleTtlMs: 999_999, healthCheckIntervalMs: 999_999 },
       {},
-      () => new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child }),
+      createClient,
     );
     const adapter = new GeminiAcpAdapter({
       catId: 'gemini',
@@ -3453,13 +3463,16 @@ describe('#1186: cancel settles pending prompt request for safe non-multiplexed 
     await invoke1;
 
     // Verify cancel was sent
-    assert.ok(capturedCancels.includes('sess-1'), `Should cancel sess-1, got: ${JSON.stringify(capturedCancels)}`);
+    assert.ok(
+      capturedCancels.some((entry) => entry.sessionId === 'sess-1'),
+      `Should cancel sess-1, got: ${JSON.stringify(capturedCancels)}`,
+    );
 
-    // After cancel + lease release, the pending prompt request must be settled.
+    // After cancel + retirement, no lease may remain pinned to the old carrier.
     const metrics = pool.getMetrics();
     assert.equal(metrics.activeLeaseCount, 0, 'All leases should be released after cancel');
 
-    // --- Invocation B: should reuse the same process and succeed ---
+    // --- Invocation B: must cold-start a fresh process and succeed ---
     const msgs2 = [];
     for await (const msg of adapter.invoke('task-B')) {
       msgs2.push(msg);
@@ -3469,10 +3482,12 @@ describe('#1186: cancel settles pending prompt request for safe non-multiplexed 
     assert.ok(types2.includes('text'), `Invocation B should have text, got: ${JSON.stringify(types2)}`);
     assert.ok(types2.includes('done'), `Invocation B should have done, got: ${JSON.stringify(types2)}`);
 
-    // The critical assertion: invocation B got sess-2, proving the process was
-    // reused (not stuck) and the second prompt was sent cleanly without the
-    // first prompt's stale pending entry interfering.
-    assert.equal(promptsBySession.size, 2, 'Both prompts should have been received by the provider');
-    assert.ok(promptsBySession.has('sess-2'), 'Provider should have received prompt for sess-2');
+    const promptA = prompts.find((entry) => entry.sessionId === 'sess-1');
+    const promptB = prompts.find((entry) => entry.sessionId === 'sess-2');
+    assert.ok(promptA, 'Provider should have received prompt A');
+    assert.ok(promptB, 'Provider should have received prompt B');
+    assert.notEqual(promptB.pid, promptA.pid, "Prompt B must not reach A's still-busy single-flight process");
+    assert.equal(children.length, 2, 'Pool should spawn one replacement process');
+    assert.equal(children[0].killed, true, 'The unquiesced first process must be retired');
   });
 });

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -3010,32 +3010,55 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
   });
 });
 
-// #1186 P1: Cancel + constrained pool — lease released promptly after cancel
+// #1186 P1: Cancel + constrained pool — lease released promptly after cancel.
+// Real transport-level cancel tests exercising sessionCancelCallbacks are in:
+//   - acp-client.test.js: '#1186: cancel settles prompt stream via sessionCancelCallbacks (real transport)'
+//   - acp-httpstream-client.test.js: '#1186: cancel settles HTTP prompt stream via sessionCancelCallbacks'
+// This test verifies the service-level lease lifecycle: cancel → release → reacquire.
 describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
   it('cancel releases lease so next invoke succeeds on constrained pool', async () => {
-    const cancelFn = null;
     let releaseCalls = 0;
-    const fakeClient = {
+    // Track cancel callbacks the same way the real clients do
+    const cancelCallbacks = new Map();
+
+    const makeFakeClient = () => ({
       recentCapacitySignal: null,
       onCapacity() {},
       offCapacity() {},
       async newSession() {
-        return { sessionId: 'cancel-lease-sess' };
+        return { sessionId: `sess-${Date.now()}` };
       },
       cancelSession(sessionId) {
-        // This should now settle the prompt stream via cancel callback
-        cancelFn?.(sessionId);
+        // Invoke the cancel callback — same as real AcpClient/AcpHttpStreamClient
+        const cb = cancelCallbacks.get(sessionId);
+        if (cb) cb();
       },
       async *promptStream(sessionId, text, options) {
-        // Simulate a stream that never produces events — waits forever
-        yield {
-          sessionId,
-          update: { sessionUpdate: 'session_init', agentInfo: { name: 'test' } },
+        // Register cancel callback (mirrors real transport implementation)
+        let settledByCancel = false;
+        const cancelCb = () => {
+          settledByCancel = true;
         };
-        // Block forever — cancel must break us out
-        await new Promise(() => {});
+        cancelCallbacks.set(sessionId, cancelCb);
+        try {
+          yield {
+            sessionId,
+            update: { sessionUpdate: 'session_init', agentInfo: { name: 'test' } },
+          };
+          // Block until cancel settles us
+          while (!settledByCancel) {
+            await new Promise((r) => setTimeout(r, 10));
+          }
+          // Cancel callback was invoked — throw like the real implementation
+          const { AcpStreamIdleError } = await import(
+            '../../dist/domains/cats/services/agents/providers/acp/AcpClient.js'
+          );
+          throw new AcpStreamIdleError(sessionId, 0, 0, options?.idleStallMs ?? 1000);
+        } finally {
+          cancelCallbacks.delete(sessionId);
+        }
       },
-    };
+    });
 
     const release1 = () => {
       releaseCalls++;
@@ -3048,7 +3071,7 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
           // Second acquire — lease must have been released
           return {
             client: {
-              ...fakeClient,
+              ...makeFakeClient(),
               async *promptStream() {
                 yield {
                   sessionId: 'second-sess',
@@ -3059,7 +3082,7 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
             release: () => {},
           };
         }
-        return { client: fakeClient, release: release1 };
+        return { client: makeFakeClient(), release: release1 };
       },
       rememberSession() {},
       closeAll: async () => {},
@@ -3081,7 +3104,7 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
     const first = await iter1.next();
     assert.ok(!first.done, 'Should get first event');
 
-    // Abort — this triggers cancelSession which should settle promptStream
+    // Abort — this triggers cancelSession which invokes cancel callback
     ac.abort();
 
     // Drain remaining events (error + done)
@@ -3105,10 +3128,17 @@ describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
   });
 });
 
-// #1186 P2: idle stall fires before turn budget when thresholds differ
+// #1186 P2: idle stall fires before turn budget when thresholds differ.
+// Real transport-level timer race tests are in:
+//   - acp-client.test.js: '#1186: zero-first-event produces AcpStreamIdleError at configured idleStallMs'
+//   - acp-httpstream-client.test.js: '#1186: zero-first-event produces AcpStreamIdleError at configured idleStallMs (HTTP)'
+//   - acp-client.test.js: 'F149: idle watchdog injects stream_idle_stall and terminates stream'
+// This test verifies the service-level wiring: idleTtlMs + 60s stagger and error mapping.
 describe('#1186: idle stall fires before turn budget (P2)', () => {
-  it('produces AcpStreamIdleError (not AcpTimeoutError) when idle exceeds configured TTL', async () => {
+  it('service passes timeoutMs > idleStallMs and maps idle stall to stream_idle_stall error', async () => {
+    let capturedOpts = null;
     const { AcpStreamIdleError } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
+
     const adapter = new GeminiAcpAdapter({
       catId: 'gemini',
       pool: {
@@ -3118,27 +3148,23 @@ describe('#1186: idle stall fires before turn budget (P2)', () => {
             onCapacity() {},
             offCapacity() {},
             async newSession() {
-              return { sessionId: 'idle-race-sess' };
+              return { sessionId: 'race-opts-sess' };
             },
             cancelSession() {},
             async *promptStream(sessionId, text, options) {
-              // Verify budget > stall
+              capturedOpts = options;
+              // Verify the stagger invariant
               assert.ok(
                 options.timeoutMs > options.idleStallMs,
                 `timeoutMs (${options.timeoutMs}) must exceed idleStallMs (${options.idleStallMs})`,
               );
-              // Emit one event then go silent — idle stall should fire first
+              assert.equal(options.timeoutMs - options.idleStallMs, 60_000, 'Stagger must be exactly 60s');
+              // Simulate idle stall (what the real transport would do)
               yield {
                 sessionId,
                 update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start' } },
               };
-              // Wait for idle stall to terminate us
-              await new Promise((_, reject) => {
-                setTimeout(
-                  () => reject(new AcpStreamIdleError(sessionId, options.idleStallMs, 1, options.idleStallMs)),
-                  options.idleStallMs + 50,
-                );
-              });
+              throw new AcpStreamIdleError(sessionId, options.idleStallMs, 1, options.idleStallMs);
             },
           },
           release: () => {},
@@ -3156,9 +3182,14 @@ describe('#1186: idle stall fires before turn budget (P2)', () => {
       msgs.push(msg);
     }
 
+    // Verify opts passed correctly
+    assert.ok(capturedOpts, 'promptStream must receive options');
+    assert.equal(capturedOpts.idleStallMs, 200, 'idleStallMs = idleTtlMs');
+    assert.equal(capturedOpts.timeoutMs, 60_200, 'timeoutMs = idleTtlMs + 60_000');
+
+    // Error should map to stream_idle_stall (not turn_budget_exceeded)
     const errorMsg = msgs.find((m) => m.type === 'error');
     assert.ok(errorMsg, 'Should yield error');
-    // The error should be stream_idle_stall, NOT turn_budget_exceeded
     assert.equal(
       errorMsg.errorCode,
       'stream_idle_stall',

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -351,6 +351,7 @@ describe('GeminiAcpAdapter', () => {
       loadSessionCalls: [],
       newSessionCalls: 0,
       promptedSessionIds: [],
+      promptedTexts: [],
       recentCapacitySignal: null,
       async newSession() {
         client.newSessionCalls++;
@@ -362,8 +363,9 @@ describe('GeminiAcpAdapter', () => {
       },
       async setSessionConfigOption() {},
       cancelSession() {},
-      async *promptStream(sessionId) {
+      async *promptStream(sessionId, text) {
         client.promptedSessionIds.push(sessionId);
+        client.promptedTexts.push(text);
         yield {
           sessionId,
           update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'fresh result' } },
@@ -397,13 +399,21 @@ describe('GeminiAcpAdapter', () => {
     });
 
     const messages = [];
-    for await (const msg of adapter.invoke('continue safely', { sessionId: 'cancelled-sess' })) {
+    for await (const msg of adapter.invoke('continue safely', {
+      sessionId: 'cancelled-sess',
+      resumeFallbackSystemPrompt: 'Static identity prompt',
+    })) {
       messages.push(msg);
     }
 
     assert.deepEqual(client.loadSessionCalls, [], 'sealed session must never reach loadSession');
     assert.equal(client.newSessionCalls, 1);
     assert.deepEqual(client.promptedSessionIds, ['fresh-after-cancel']);
+    assert.deepEqual(
+      client.promptedTexts,
+      ['Static identity prompt\n\ncontinue safely'],
+      'sealed resume replacement must restore the omitted static identity exactly once',
+    );
     assert.deepEqual(rememberedSessions, ['fresh-after-cancel']);
     assert.ok(messages.some((msg) => msg.type === 'session_init' && msg.sessionId === 'fresh-after-cancel'));
   });
@@ -454,6 +464,154 @@ describe('GeminiAcpAdapter', () => {
       new Set(['persisted-session', 'runtime-session-alias']),
       'all aliases of the unquiesced logical session must be sealed',
     );
+  });
+
+  describe('session sealing follows the prompt acknowledgement boundary', () => {
+    function createBoundaryHarness({ loadSession, promptStream, onCancel }) {
+      const sealedSessions = [];
+      const cancelCalls = [];
+      const client = {
+        recentCapacitySignal: null,
+        async newSession() {
+          throw new Error('boundary harness must resume the requested session');
+        },
+        loadSession,
+        async setSessionConfigOption() {},
+        cancelSession(sessionId) {
+          cancelCalls.push(sessionId);
+          onCancel?.(sessionId);
+        },
+        promptStream,
+        onCapacity() {},
+        offCapacity() {},
+        clearRecentCapacitySignal() {},
+      };
+      const pool = {
+        async acquire(poolKey) {
+          return { client, poolKey, release() {} };
+        },
+        rememberSession() {},
+        sealSession(_poolKey, sessionId) {
+          sealedSessions.push(sessionId);
+        },
+      };
+      return {
+        adapter: new GeminiAcpAdapter({
+          catId: 'gemini',
+          pool,
+          poolKey: TEST_POOL_KEY,
+          projectRoot: '/tmp',
+        }),
+        cancelCalls,
+        sealedSessions,
+      };
+    }
+
+    it('does not seal when abort fires during resumed-session setup', async () => {
+      const controller = new AbortController();
+      const harness = createBoundaryHarness({
+        async loadSession(sessionId) {
+          controller.abort();
+          return { sessionId };
+        },
+        async *promptStream() {
+          assert.fail('promptStream must not start after setup abort');
+        },
+      });
+
+      for await (const _msg of harness.adapter.invoke('stop during setup', {
+        sessionId: 'safe-setup-session',
+        signal: controller.signal,
+      })) {
+        // Drain terminal messages.
+      }
+
+      assert.deepEqual(harness.sealedSessions, []);
+      assert.deepEqual(harness.cancelCalls, []);
+    });
+
+    it('does not seal when abort fires while session_init is yielded', async () => {
+      const controller = new AbortController();
+      const harness = createBoundaryHarness({
+        async loadSession(sessionId) {
+          return { sessionId };
+        },
+        async *promptStream() {
+          assert.fail('promptStream must not start after session_init abort');
+        },
+      });
+
+      for await (const msg of harness.adapter.invoke('stop at session init', {
+        sessionId: 'safe-session-init',
+        signal: controller.signal,
+      })) {
+        if (msg.type === 'session_init') controller.abort();
+      }
+
+      assert.deepEqual(harness.sealedSessions, []);
+      assert.deepEqual(harness.cancelCalls, []);
+    });
+
+    it('seals persisted and runtime aliases when abort terminates an active prompt', async () => {
+      const controller = new AbortController();
+      let settlePrompt;
+      const promptSettled = new Promise((resolve) => {
+        settlePrompt = resolve;
+      });
+      const harness = createBoundaryHarness({
+        async loadSession() {
+          return { sessionId: 'runtime-active-session' };
+        },
+        async *promptStream(sessionId) {
+          yield {
+            sessionId,
+            update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'active' } },
+          };
+          await promptSettled;
+        },
+        onCancel() {
+          settlePrompt();
+        },
+      });
+
+      for await (const msg of harness.adapter.invoke('stop active prompt', {
+        sessionId: 'persisted-active-session',
+        signal: controller.signal,
+      })) {
+        if (msg.type === 'text') controller.abort();
+      }
+
+      assert.deepEqual(
+        new Set(harness.sealedSessions),
+        new Set(['persisted-active-session', 'runtime-active-session']),
+      );
+      assert.deepEqual(harness.cancelCalls, ['runtime-active-session']);
+    });
+
+    it('does not seal when abort fires after provider acknowledgement', async () => {
+      const controller = new AbortController();
+      const harness = createBoundaryHarness({
+        async loadSession(sessionId) {
+          return { sessionId };
+        },
+        async *promptStream(sessionId) {
+          yield {
+            sessionId,
+            update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'complete' } },
+          };
+        },
+      });
+
+      for await (const msg of harness.adapter.invoke('finish safely', {
+        sessionId: 'safe-completed-session',
+        signal: controller.signal,
+      })) {
+        if (msg.type === 'done') controller.abort();
+      }
+
+      assert.deepEqual(harness.sealedSessions, []);
+      assert.deepEqual(harness.cancelCalls, []);
+    });
   });
 
   it('falls back to session/new when resumed ACP session cannot be loaded', async () => {

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -14,7 +14,9 @@ import { afterEach, describe, it, mock } from 'node:test';
 const { AcpAgentService: GeminiAcpAdapter } = await import(
   '../../dist/domains/cats/services/agents/providers/acp/AcpAgentService.js'
 );
-const { AcpProcessPool } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js');
+const { AcpProcessPool, DEFAULT_ACP_IDLE_TTL_MS } = await import(
+  '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+);
 const { AcpClient } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
 
 const TEST_POOL_KEY = { projectPath: '/tmp', providerProfile: 'test' };
@@ -2947,7 +2949,7 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
     assert.equal(capturedPromptStreamOpts.timeoutMs, 1_800_000, 'timeoutMs = configured idleTtlMs');
   });
 
-  it('omits promptStream options when idleTtlMs is not configured (uses client defaults)', async () => {
+  it('resolves DEFAULT_ACP_IDLE_TTL_MS (30m) when idleTtlMs is omitted from config', async () => {
     let capturedPromptStreamOpts = 'NOT_CALLED';
     const fakeClient = {
       recentCapacitySignal: null,
@@ -2977,19 +2979,29 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
       closeAll: async () => {},
     };
 
-    // Without idleTtlMs — should NOT pass options to promptStream
+    // Without idleTtlMs — service resolves to DEFAULT_ACP_IDLE_TTL_MS (30m)
     const adapter = new GeminiAcpAdapter({
       catId: 'gemini',
       pool: mockPool,
       poolKey: TEST_POOL_KEY,
       projectRoot: '/tmp',
-      // no idleTtlMs
+      // no idleTtlMs — should resolve to 30m default
     });
 
     for await (const _ of adapter.invoke('hello')) {
       /* drain */
     }
 
-    assert.equal(capturedPromptStreamOpts, undefined, 'promptStream receives undefined options when no idleTtlMs');
+    assert.ok(capturedPromptStreamOpts, 'promptStream must receive options even without explicit idleTtlMs');
+    assert.equal(
+      capturedPromptStreamOpts.idleStallMs,
+      DEFAULT_ACP_IDLE_TTL_MS,
+      `idleStallMs should be DEFAULT_ACP_IDLE_TTL_MS (${DEFAULT_ACP_IDLE_TTL_MS}), got ${capturedPromptStreamOpts.idleStallMs}`,
+    );
+    assert.equal(
+      capturedPromptStreamOpts.timeoutMs,
+      DEFAULT_ACP_IDLE_TTL_MS,
+      `timeoutMs should be DEFAULT_ACP_IDLE_TTL_MS (${DEFAULT_ACP_IDLE_TTL_MS}), got ${capturedPromptStreamOpts.timeoutMs}`,
+    );
   });
 });

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -2735,3 +2735,164 @@ describe('GeminiAcpAdapter callbackEnv passthrough', () => {
     }
   });
 });
+
+// #1186: Iterator lifecycle / lease cleanup tests
+// Root cause: invoke-single-cat.ts uses manual .next() iteration (abortableNext)
+// instead of `for await...of`. When the loop breaks, .return() is never called,
+// so AcpAgentService.invoke()'s finally { lease.release() } never executes.
+// This leaks leases and eventually causes "Pool at capacity" errors.
+describe('#1186: iterator lease cleanup (Pool at capacity regression)', () => {
+  /**
+   * Helper: create a mock client whose promptStream yields one text chunk + done,
+   * and a constrained pool (maxLiveProcesses=1) that tracks lease release.
+   */
+  function createConstrainedPoolSetup() {
+    let releaseCallCount = 0;
+    const fakeClient = {
+      recentCapacitySignal: null,
+      async newSession() {
+        return { sessionId: 'sess-constrained' };
+      },
+      async loadSession(sessionId) {
+        return { sessionId };
+      },
+      async setSessionConfigOption() {},
+      cancelSession() {},
+      async *promptStream(sessionId) {
+        yield {
+          sessionId,
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'reply' },
+          },
+        };
+        // Generator returns here — done
+      },
+      onCapacity() {},
+      offCapacity() {},
+      clearRecentCapacitySignal() {},
+    };
+
+    // Constrained pool: maxLiveProcesses=1, tracks release calls
+    let activeLease = false;
+    const mockPool = {
+      async acquire() {
+        if (activeLease) throw new Error('Pool at capacity — all processes have active leases');
+        activeLease = true;
+        return {
+          client: fakeClient,
+          release() {
+            releaseCallCount++;
+            activeLease = false;
+          },
+        };
+      },
+      rememberSession() {},
+      closeAll: async () => {
+        activeLease = false;
+      },
+    };
+
+    return { mockPool, getReleaseCount: () => releaseCallCount };
+  }
+
+  it('#1186: manual .next() iteration + .return() releases lease for next invocation', async () => {
+    const { mockPool, getReleaseCount } = createConstrainedPoolSetup();
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+    });
+
+    // First invocation: manual iteration (simulating invoke-single-cat's abortableNext pattern)
+    const iter = adapter.invoke('first prompt')[Symbol.asyncIterator]();
+    const collected = [];
+    for (;;) {
+      const result = await iter.next();
+      if (result.done) break;
+      collected.push(result.value);
+      // Simulate invoke-single-cat: break when 'done' message received
+      if (result.value.type === 'done') break;
+    }
+    // Key: call .return() after breaking (the fix)
+    await iter.return();
+    assert.ok(collected.length > 0, 'Should have received messages');
+    assert.equal(getReleaseCount(), 1, 'Lease must be released after .return()');
+
+    // Second invocation: should succeed because lease was released
+    const secondMessages = [];
+    for await (const msg of adapter.invoke('second prompt')) {
+      secondMessages.push(msg);
+    }
+    assert.ok(
+      secondMessages.some((m) => m.type === 'text'),
+      'Second invocation should succeed when lease was properly released',
+    );
+    assert.equal(getReleaseCount(), 2, 'Second lease also released');
+  });
+
+  it('#1186: `for await...of` auto-closes generator and releases lease', async () => {
+    const { mockPool, getReleaseCount } = createConstrainedPoolSetup();
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+    });
+
+    // Normal `for await` — auto-calls .return() on break/completion
+    for await (const _ of adapter.invoke('first prompt')) {
+      /* drain */
+    }
+    assert.equal(getReleaseCount(), 1, 'Lease released after for-await completes');
+
+    // Second invoke should succeed
+    const secondMessages = [];
+    for await (const msg of adapter.invoke('second prompt')) {
+      secondMessages.push(msg);
+    }
+    assert.ok(
+      secondMessages.some((m) => m.type === 'text'),
+      'Second invoke succeeds with for-await (baseline)',
+    );
+    assert.equal(getReleaseCount(), 2);
+  });
+
+  it('#1186: constrained pool rejects when lease leaked by missing .return()', async () => {
+    const { mockPool, getReleaseCount } = createConstrainedPoolSetup();
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+    });
+
+    // First invocation: manual iteration WITHOUT .return() — the bug
+    const iter = adapter.invoke('first prompt')[Symbol.asyncIterator]();
+    for (;;) {
+      const result = await iter.next();
+      if (result.done) break;
+      if (result.value.type === 'done') break; // early break, no .return()
+    }
+    // Intentionally NOT calling iter.return() — this is the bug scenario
+
+    // When the done message was yielded but we broke without .return(),
+    // the generator's finally block hasn't run yet.
+    // The lease should still be active (not released).
+    assert.equal(getReleaseCount(), 0, 'Lease NOT released without .return() — bug confirmed');
+
+    // Second invocation should fail because the lease is still held
+    const secondIter = adapter.invoke('second prompt')[Symbol.asyncIterator]();
+    const firstResult = await secondIter.next();
+    // The error surfaces as an init_failure error message
+    assert.equal(firstResult.value.type, 'error', 'Should get error from constrained pool');
+    assert.ok(
+      firstResult.value.error.includes('Pool at capacity'),
+      `Error should mention pool capacity, got: ${firstResult.value.error}`,
+    );
+  });
+});

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -2901,7 +2901,7 @@ describe('#1186: iterator lease cleanup (Pool at capacity regression)', () => {
 
 // #1186: TTL propagation — AcpAgentService threads idleTtlMs to promptStream
 describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () => {
-  it('passes configured idleTtlMs as idleStallMs + timeoutMs to promptStream', async () => {
+  it('passes configured idleTtlMs as idleStallMs, timeoutMs = idleTtlMs + 60s to promptStream', async () => {
     let capturedPromptStreamOpts = null;
     const fakeClient = {
       recentCapacitySignal: null,
@@ -2946,7 +2946,11 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
 
     assert.ok(capturedPromptStreamOpts, 'promptStream must receive options');
     assert.equal(capturedPromptStreamOpts.idleStallMs, 1_800_000, 'idleStallMs = configured idleTtlMs');
-    assert.equal(capturedPromptStreamOpts.timeoutMs, 1_800_000, 'timeoutMs = configured idleTtlMs');
+    assert.equal(
+      capturedPromptStreamOpts.timeoutMs,
+      1_800_000 + 60_000,
+      'timeoutMs = idleTtlMs + 60s margin (budget must exceed stall)',
+    );
   });
 
   it('resolves DEFAULT_ACP_IDLE_TTL_MS (30m) when idleTtlMs is omitted from config', async () => {
@@ -3000,8 +3004,165 @@ describe('#1186: idleTtlMs propagation (AcpAgentService → promptStream)', () =
     );
     assert.equal(
       capturedPromptStreamOpts.timeoutMs,
-      DEFAULT_ACP_IDLE_TTL_MS,
-      `timeoutMs should be DEFAULT_ACP_IDLE_TTL_MS (${DEFAULT_ACP_IDLE_TTL_MS}), got ${capturedPromptStreamOpts.timeoutMs}`,
+      DEFAULT_ACP_IDLE_TTL_MS + 60_000,
+      `timeoutMs should be DEFAULT_ACP_IDLE_TTL_MS + 60s (${DEFAULT_ACP_IDLE_TTL_MS + 60_000}), got ${capturedPromptStreamOpts.timeoutMs}`,
+    );
+  });
+});
+
+// #1186 P1: Cancel + constrained pool — lease released promptly after cancel
+describe('#1186: cancel settles prompt stream and releases lease (P1)', () => {
+  it('cancel releases lease so next invoke succeeds on constrained pool', async () => {
+    const cancelFn = null;
+    let releaseCalls = 0;
+    const fakeClient = {
+      recentCapacitySignal: null,
+      onCapacity() {},
+      offCapacity() {},
+      async newSession() {
+        return { sessionId: 'cancel-lease-sess' };
+      },
+      cancelSession(sessionId) {
+        // This should now settle the prompt stream via cancel callback
+        cancelFn?.(sessionId);
+      },
+      async *promptStream(sessionId, text, options) {
+        // Simulate a stream that never produces events — waits forever
+        yield {
+          sessionId,
+          update: { sessionUpdate: 'session_init', agentInfo: { name: 'test' } },
+        };
+        // Block forever — cancel must break us out
+        await new Promise(() => {});
+      },
+    };
+
+    const release1 = () => {
+      releaseCalls++;
+    };
+    let acquireCount = 0;
+    const mockPool = {
+      acquire: async () => {
+        acquireCount++;
+        if (acquireCount > 1) {
+          // Second acquire — lease must have been released
+          return {
+            client: {
+              ...fakeClient,
+              async *promptStream() {
+                yield {
+                  sessionId: 'second-sess',
+                  update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'ok' } },
+                };
+              },
+            },
+            release: () => {},
+          };
+        }
+        return { client: fakeClient, release: release1 };
+      },
+      rememberSession() {},
+      closeAll: async () => {},
+    };
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      idleTtlMs: 60_000,
+    });
+
+    // First invoke with abort
+    const ac = new AbortController();
+    const iter1 = adapter.invoke('hello', { signal: ac.signal })[Symbol.asyncIterator]();
+
+    // Get first event (session_init)
+    const first = await iter1.next();
+    assert.ok(!first.done, 'Should get first event');
+
+    // Abort — this triggers cancelSession which should settle promptStream
+    ac.abort();
+
+    // Drain remaining events (error + done)
+    const remaining = [];
+    for (;;) {
+      const r = await iter1.next();
+      remaining.push(r);
+      if (r.done) break;
+    }
+
+    // The lease should have been released
+    assert.equal(releaseCalls, 1, 'Lease must be released after cancel');
+
+    // Second invoke should succeed (pool not at capacity)
+    const msgs2 = [];
+    for await (const msg of adapter.invoke('world')) {
+      msgs2.push(msg);
+    }
+    assert.ok(msgs2.length > 0, 'Second invoke must succeed after first lease released');
+    assert.equal(acquireCount, 2, 'Pool must have been acquired twice');
+  });
+});
+
+// #1186 P2: idle stall fires before turn budget when thresholds differ
+describe('#1186: idle stall fires before turn budget (P2)', () => {
+  it('produces AcpStreamIdleError (not AcpTimeoutError) when idle exceeds configured TTL', async () => {
+    const { AcpStreamIdleError } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpClient.js');
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: {
+        acquire: async () => ({
+          client: {
+            recentCapacitySignal: null,
+            onCapacity() {},
+            offCapacity() {},
+            async newSession() {
+              return { sessionId: 'idle-race-sess' };
+            },
+            cancelSession() {},
+            async *promptStream(sessionId, text, options) {
+              // Verify budget > stall
+              assert.ok(
+                options.timeoutMs > options.idleStallMs,
+                `timeoutMs (${options.timeoutMs}) must exceed idleStallMs (${options.idleStallMs})`,
+              );
+              // Emit one event then go silent — idle stall should fire first
+              yield {
+                sessionId,
+                update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start' } },
+              };
+              // Wait for idle stall to terminate us
+              await new Promise((_, reject) => {
+                setTimeout(
+                  () => reject(new AcpStreamIdleError(sessionId, options.idleStallMs, 1, options.idleStallMs)),
+                  options.idleStallMs + 50,
+                );
+              });
+            },
+          },
+          release: () => {},
+        }),
+        rememberSession() {},
+        closeAll: async () => {},
+      },
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      idleTtlMs: 200, // Short for testing
+    });
+
+    const msgs = [];
+    for await (const msg of adapter.invoke('hello')) {
+      msgs.push(msg);
+    }
+
+    const errorMsg = msgs.find((m) => m.type === 'error');
+    assert.ok(errorMsg, 'Should yield error');
+    // The error should be stream_idle_stall, NOT turn_budget_exceeded
+    assert.equal(
+      errorMsg.errorCode,
+      'stream_idle_stall',
+      `Expected stream_idle_stall, got ${errorMsg.errorCode}: ${errorMsg.error}`,
     );
   });
 });

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -3341,3 +3341,138 @@ describe('#1186: idle stall fires before turn budget (P2)', () => {
     );
   });
 });
+
+// #1186 P1: Cancel must settle the pending prompt sendRequest so a non-multiplexed
+// process can be safely reused. Without the fix, the sendRequest promise stays alive
+// with a 1h timer after the generator exits, leaving a stale entry in `pending`.
+describe('#1186: cancel settles pending prompt request for safe non-multiplexed reuse', () => {
+  let pool = null;
+
+  afterEach(async () => {
+    if (pool) {
+      await pool.closeAll();
+      pool = null;
+    }
+  });
+
+  it('second prompt succeeds on same single-flight process after cancelled prompt is settled', async () => {
+    const { child, clientStdin, agentStdout, ee } = createMockChild();
+    let sessionCounter = 0;
+    const capturedCancels = [];
+    const promptsBySession = new Map();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          setImmediate(() =>
+            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: INIT_RESULT }) + '\n'),
+          );
+        } else if (msg.method === 'session/new') {
+          sessionCounter++;
+          const sid = `sess-${sessionCounter}`;
+          setImmediate(() =>
+            agentStdout.write(JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { sessionId: sid } }) + '\n'),
+          );
+        } else if (msg.method === 'session/prompt') {
+          const sid = msg.params.sessionId;
+          promptsBySession.set(sid, msg.id);
+
+          if (sid === 'sess-1') {
+            // Emit one event then go silent — never resolve prompt A.
+            // Provider ignores session/cancel — the worst case.
+            setImmediate(() => {
+              agentStdout.write(
+                JSON.stringify({
+                  jsonrpc: '2.0',
+                  method: 'session/update',
+                  params: {
+                    sessionId: sid,
+                    update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'start-A' } },
+                  },
+                }) + '\n',
+              );
+            });
+            // Deliberately NEVER send the prompt response for sess-1
+          } else if (sid === 'sess-2') {
+            // Second prompt — respond normally
+            setImmediate(() => {
+              agentStdout.write(
+                JSON.stringify({
+                  jsonrpc: '2.0',
+                  method: 'session/update',
+                  params: {
+                    sessionId: sid,
+                    update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'result-B' } },
+                  },
+                }) + '\n',
+              );
+              setTimeout(
+                () =>
+                  agentStdout.write(
+                    JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { stopReason: 'end_turn' } }) + '\n',
+                  ),
+                10,
+              );
+            });
+          }
+        } else if (msg.method === 'session/cancel') {
+          capturedCancels.push(msg.params?.sessionId);
+          // Provider IGNORES cancel — does NOT resolve the pending prompt
+        }
+      }
+    });
+
+    // Non-multiplexed pool with maxLiveProcesses=1 — forces process reuse
+    pool = new AcpProcessPool(
+      { maxLiveProcesses: 1, idleTtlMs: 999_999, healthCheckIntervalMs: 999_999 },
+      {},
+      () => new AcpClient({ command: 'fake', args: [], cwd: '/tmp', spawnFn: () => child }),
+    );
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+      providerName: 'google',
+      modelName: 'gemini-acp',
+    });
+
+    // --- Invocation A: start, get one event, then abort ---
+    const ac1 = new AbortController();
+    const msgs1 = [];
+    const invoke1 = (async () => {
+      for await (const msg of adapter.invoke('task-A', { signal: ac1.signal })) {
+        msgs1.push(msg);
+        // Abort after receiving the first real text event
+        if (msg.type === 'text') {
+          ac1.abort();
+        }
+      }
+    })();
+    await invoke1;
+
+    // Verify cancel was sent
+    assert.ok(capturedCancels.includes('sess-1'), `Should cancel sess-1, got: ${JSON.stringify(capturedCancels)}`);
+
+    // After cancel + lease release, the pending prompt request must be settled.
+    const metrics = pool.getMetrics();
+    assert.equal(metrics.activeLeaseCount, 0, 'All leases should be released after cancel');
+
+    // --- Invocation B: should reuse the same process and succeed ---
+    const msgs2 = [];
+    for await (const msg of adapter.invoke('task-B')) {
+      msgs2.push(msg);
+    }
+
+    const types2 = msgs2.map((m) => m.type);
+    assert.ok(types2.includes('text'), `Invocation B should have text, got: ${JSON.stringify(types2)}`);
+    assert.ok(types2.includes('done'), `Invocation B should have done, got: ${JSON.stringify(types2)}`);
+
+    // The critical assertion: invocation B got sess-2, proving the process was
+    // reused (not stuck) and the second prompt was sent cleanly without the
+    // first prompt's stale pending entry interfering.
+    assert.equal(promptsBySession.size, 2, 'Both prompts should have been received by the provider');
+    assert.ok(promptsBySession.has('sess-2'), 'Provider should have received prompt for sess-2');
+  });
+});

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -2688,6 +2688,89 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.ok(sessionStores.includes('new-sess'), 'new session should be stored after recovery');
   });
 
+  // #1186: Active-lease guard regression — proves invoke-single-cat.ts:3368-3369
+  // calls .return() on the first service iterator (releasing the ACP lease) BEFORE
+  // starting the second service.invoke() (which acquires a new lease).
+  // Without this, constrained pools hit "Pool at capacity" on the retry.
+  it('#1186: self-heal releases first lease before retry acquire (active-lease guard)', async () => {
+    let invokeCount = 0;
+    const timeline = [];
+    let activeLease = false;
+
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        invokeCount++;
+        const label = invokeCount === 1 ? 'first' : 'second';
+
+        // Simulate constrained pool: reject if a lease is already active
+        if (activeLease) {
+          throw new Error('Pool at capacity — all processes have active leases');
+        }
+        activeLease = true;
+        timeline.push(`acquire:${label}`);
+
+        try {
+          if (label === 'first') {
+            // First attempt: yield missing-session error + done
+            yield {
+              type: 'error',
+              catId: 'opus',
+              error: 'No conversation found with session ID: lease-sess',
+              timestamp: Date.now(),
+            };
+            yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+            return;
+          }
+          // Second attempt: succeed
+          yield { type: 'session_init', catId: 'opus', sessionId: 'fresh-sess', timestamp: Date.now() };
+          yield { type: 'text', catId: 'opus', content: 'recovered', timestamp: Date.now() };
+          yield { type: 'done', catId: 'opus', timestamp: Date.now() };
+        } finally {
+          // Release lease in finally — mirrors AcpAgentService.invoke() line 630
+          activeLease = false;
+          timeline.push(`release:${label}`);
+        }
+      },
+    };
+
+    const deps = makeDeps();
+    deps.sessionManager = {
+      get: async () => 'lease-sess',
+      store: async () => {},
+      delete: async () => {},
+    };
+
+    const msgs = await collect(
+      invokeSingleCat(deps, {
+        catId: 'opus',
+        service,
+        prompt: 'test',
+        userId: 'user-lease',
+        threadId: 'thread-lease',
+        isLastCat: true,
+      }),
+    );
+
+    // Self-heal should succeed
+    assert.equal(invokeCount, 2, 'should invoke service twice (initial + retry)');
+    assert.ok(
+      msgs.some((m) => m.type === 'text' && m.content === 'recovered'),
+      'retry should produce recovered content',
+    );
+
+    // Ordering: release:first MUST precede acquire:second
+    // This protects invoke-single-cat.ts:3368-3369 (await serviceIter.return())
+    const releaseFirstIdx = timeline.indexOf('release:first');
+    const acquireSecondIdx = timeline.indexOf('acquire:second');
+    assert.ok(releaseFirstIdx >= 0, 'first lease must be released');
+    assert.ok(acquireSecondIdx >= 0, 'second lease must be acquired');
+    assert.ok(
+      releaseFirstIdx < acquireSecondIdx,
+      `release:first (${releaseFirstIdx}) must precede acquire:second (${acquireSecondIdx}). Timeline: ${timeline.join(' → ')}`,
+    );
+  });
+
   it('F118 P2-fix: self-heal retry clears cliSessionId from baseOptions', async () => {
     const optionsSeen = [];
     let invokeCount = 0;


### PR DESCRIPTION
## Summary

Fixes #1186: make the active ACP prompt watchdog honor the member-configured idle TTL and prevent ACP process-pool lease exhaustion.

## Root causes and fixes

1. **Configured idle TTL was not applied to active prompts**
   - Resolve the 30-minute default at the service boundary.
   - Thread `idleTtlMs` from the service factory into both stdio and HTTP `promptStream` watchdog options.
   - Use the configured threshold for ordinary silence and pending-tool execution.
   - Keep the total request budget above the idle threshold and refresh its ceiling when activity arrives.

2. **Manual iterator consumption leaked pool leases**
   - Close the service iterator on normal early exit and self-heal retry.
   - Avoid awaiting `.return()` behind an unresolved `.next()` on abort paths.
   - Settle canceled prompt streams so the service `finally` releases the lease.

3. **Canceled sessions could be reused unsafely**
   - Seal only the affected active session.
   - Preserve unrelated sessions on multiplexed carriers.
   - Create a fresh replacement session before the canceled identity can be reused.

4. **Watchdog errors could lose their structured cause**
   - Start idle tracking before the first event.
   - Preserve `AcpStreamIdleError` and its configured threshold when cancellation rejects the underlying request.
   - Cover delayed warning drain, zero-first-event, cancel, tool stall, self-heal, pool-capacity, and multiplexing races.

## Validation

- [x] Exact HEAD: `cfce421324217c6d0e1a507dd8f6ea65ecbffc1e`
- [x] `pnpm gate --no-rebase` passed: build, TypeScript, full tests, lint, and repository checks
- [x] ACP regression suite: 269/269 passed
- [x] Invocation, timeout-guard, and parallel-cancel regression suites: 142/142 passed
- [x] GitHub CI: Build, Lint, Test Public, Test Windows, and Directory Size Guard passed
- [x] Stateful non-author review approved the exact HEAD
- [x] All 19 review threads resolved

[砚砚/gpt-5.6-sol🐾]