### PR TITLE
fix(messaging): atomic Lua transitions for delivery-order concurrency

### DIFF
--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -778,13 +778,13 @@ export class MessageStore {
 
   /**
    * F117: Mark a queued message as canceled (withdraw/clear).
-   * F258: CAS guard — only transitions queued → canceled. Delivered or
+   * PR #1193: CAS guard — only transitions queued → canceled. Delivered or
    * immediate messages are left untouched, matching Redis Lua behavior.
    */
   markCanceled(id: string): StoredMessage | null {
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return null;
-    if (!isQueuedForDeliveryTransition(msg)) return msg;
+    if (!isQueuedForDeliveryTransition(msg)) return null; // CAS no-op: not queued
     msg.deliveryStatus = 'canceled';
     return msg;
   }

--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -770,7 +770,7 @@ export class MessageStore {
     assertValidStoredMessageTimestamp(deliveredAt);
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return null;
-    if (!isQueuedForDeliveryTransition(msg)) return msg;
+    if (!isQueuedForDeliveryTransition(msg)) return null; // CAS no-op: not queued
     msg.deliveredAt = deliveredAt;
     msg.deliveryStatus = 'delivered';
     return msg;

--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -334,9 +334,17 @@ export interface IMessageStore {
     id: string,
     patch: StreamMetadataAugmentInput,
   ): StoredMessage | null | Promise<StoredMessage | null>;
-  /** F098-D: Deliver a queued message at a non-negative integral ECMAScript Date value. Null if not found. */
+  /**
+   * F098-D: CAS transition queued → delivered at an admitted non-negative integral ECMAScript Date value.
+   * Returns the transitioned message when this call won the CAS;
+   * null on no-op (not found / already delivered / already canceled).
+   */
   markDelivered(id: string, deliveredAt: number): StoredMessage | null | Promise<StoredMessage | null>;
-  /** F117: Mark a queued message as canceled (withdraw/clear). Returns null if not found. */
+  /**
+   * F117: CAS transition queued → canceled (withdraw/clear).
+   * Returns the transitioned message when this call won the CAS;
+   * null on no-op (not found / already canceled / already delivered / immediate).
+   */
   markCanceled(id: string): StoredMessage | null | Promise<StoredMessage | null>;
   /**
    * Atomic content-dedup claim. Returns true if this fingerprint was newly claimed

--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -337,7 +337,7 @@ export interface IMessageStore {
   /**
    * F098-D: CAS transition queued → delivered at an admitted non-negative integral ECMAScript Date value.
    * Returns the transitioned message when this call won the CAS;
-   * null on no-op (not found / already delivered / already canceled).
+   * null on no-op (not found / already delivered / already canceled / immediate).
    */
   markDelivered(id: string, deliveredAt: number): StoredMessage | null | Promise<StoredMessage | null>;
   /**

--- a/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/MessageStore.ts
@@ -776,7 +776,11 @@ export class MessageStore {
     return msg;
   }
 
-  /** F117: Mark a queued message as canceled (withdraw/clear). */
+  /**
+   * F117: Mark a queued message as canceled (withdraw/clear).
+   * F258: CAS guard — only transitions queued → canceled. Delivered or
+   * immediate messages are left untouched, matching Redis Lua behavior.
+   */
   markCanceled(id: string): StoredMessage | null {
     const msg = this.messages.find((m) => m.id === id);
     if (!msg) return null;

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -23,10 +23,10 @@ import {
   DEFAULT_THREAD_ID,
   generateSortableId,
   isDelivered,
-  isQueuedForDeliveryTransition,
 } from '../ports/MessageStore.js';
 import { MessageKeys } from '../redis-keys/message-keys.js';
 import { isSystemUserMessage } from '../visibility.js';
+import { CANCEL_LUA, DELIVER_LUA, REASSIGN_LUA } from './redis-message-delivery-lua-scripts.js';
 import {
   safeParseConnectorSource,
   safeParseContentBlocks,
@@ -335,27 +335,29 @@ export class RedisMessageStore {
     return results;
   }
 
-  /** Reassign a message to a different userId and move user-timeline membership. */
+  /**
+   * Reassign a message to a different userId and move user-timeline membership.
+   * F258: atomic Lua — derives currentUserId and effectiveOrder from the hash
+   * inside the script, eliminating stale-snapshot races with markDelivered.
+   */
   async reassignUserId(id: string, nextUserId: string): Promise<StoredMessage | null> {
-    const msg = await this.getById(id);
-    if (!msg) return null;
-    if (msg.userId === nextUserId) return msg;
+    const hashKey = MessageKeys.detail(id);
+    const result = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix)) as [
+      number,
+      string,
+      string,
+    ];
 
-    const oldUserKey = MessageKeys.user(msg.userId);
-    const newUserKey = MessageKeys.user(nextUserId);
-    const score = (await this.redis.zscore(oldUserKey, id)) ?? String(msg.deliveredAt ?? msg.timestamp);
+    // -1 = message not found in hash
+    if (result[0] === -1) return null;
 
-    const pipeline = this.redis.multi();
-    pipeline.hset(MessageKeys.detail(id), { userId: nextUserId });
-    pipeline.zrem(oldUserKey, id);
-    pipeline.zadd(newUserKey, score, id);
-    if (this.ttlSeconds !== null) {
-      pipeline.expire(newUserKey, this.ttlSeconds);
+    // Apply TTL to the new user key if configured
+    if (result[0] === 1 && this.ttlSeconds !== null) {
+      await this.redis.expire(MessageKeys.user(nextUserId), this.ttlSeconds);
     }
-    await pipeline.exec();
 
-    msg.userId = nextUserId;
-    return msg;
+    // Always return canonical state from Redis (not stale JS object)
+    return this.getById(id);
   }
 
   async getRecent(limit?: number, userId?: string): Promise<StoredMessage[]> {
@@ -872,37 +874,45 @@ export class RedisMessageStore {
     return augmented;
   }
 
-  /** F098-D: Mark a queued message as delivered at an admitted non-negative integral Date value. */
+  /**
+   * F098-D: Mark a queued message as delivered at an admitted non-negative integral Date value.
+   * F258: atomic Lua — reads userId/threadId inside the script so concurrent
+   * reassignUserId cannot cause the score update to land on a stale user key.
+   */
   async markDelivered(id: string, deliveredAt: number): Promise<StoredMessage | null> {
     assertValidStoredMessageTimestamp(deliveredAt);
-    const msg = await this.getById(id);
-    if (!msg) return null;
-    if (!isQueuedForDeliveryTransition(msg)) return msg;
-    const pipeline = this.redis.multi();
-    pipeline.hset(MessageKeys.detail(id), {
-      deliveredAt: String(deliveredAt),
-      deliveryStatus: 'delivered',
-    });
-    // Update sorted set scores so history queries return messages at delivery
-    // position, not original send-time slot (Bug A: queue message ordering).
-    const scoreStr = String(deliveredAt);
-    pipeline.zadd(MessageKeys.thread(msg.threadId), scoreStr, id);
-    pipeline.zadd(MessageKeys.TIMELINE, scoreStr, id);
-    pipeline.zadd(MessageKeys.user(msg.userId), scoreStr, id);
-    await pipeline.exec();
-    msg.deliveredAt = deliveredAt;
-    msg.deliveryStatus = 'delivered';
-    return msg;
+    const hashKey = MessageKeys.detail(id);
+    const exists = await this.redis.exists(hashKey);
+    if (!exists) return null;
+
+    const result = (await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix)) as [
+      number,
+      string,
+      string,
+      string,
+    ];
+
+    // applied=0 means status was not 'queued' — return canonical state
+    // applied=1 means transition succeeded — return canonical state
+    return this.getById(id);
   }
 
-  /** F117: Mark a queued message as canceled (withdraw/clear). */
+  /**
+   * F117: Mark a queued message as canceled (withdraw/clear).
+   * F258: CAS guard — only transitions queued → canceled. A delivered or
+   * immediate message is left untouched (no-op), preventing cancel from
+   * overwriting a completed delivery.
+   */
   async markCanceled(id: string): Promise<StoredMessage | null> {
-    const msg = await this.getById(id);
-    if (!msg) return null;
-    if (!isQueuedForDeliveryTransition(msg)) return msg;
-    await this.redis.hset(MessageKeys.detail(id), { deliveryStatus: 'canceled' });
-    msg.deliveryStatus = 'canceled';
-    return msg;
+    const hashKey = MessageKeys.detail(id);
+    const exists = await this.redis.exists(hashKey);
+    if (!exists) return null;
+
+    // Atomic CAS: queued → canceled, anything else → no-op
+    await this.redis.eval(CANCEL_LUA, 1, hashKey);
+
+    // Return canonical state (reflects whether the transition actually applied)
+    return this.getById(id);
   }
 
   /**

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -337,7 +337,7 @@ export class RedisMessageStore {
 
   /**
    * Reassign a message to a different userId and move user-timeline membership.
-   * F258: atomic Lua — derives currentUserId and effectiveOrder from the hash
+   * PR #1193: atomic Lua — derives currentUserId and effectiveOrder from the hash
    * inside the script, eliminating stale-snapshot races with markDelivered.
    */
   async reassignUserId(id: string, nextUserId: string): Promise<StoredMessage | null> {
@@ -868,7 +868,7 @@ export class RedisMessageStore {
 
   /**
    * F098-D: Mark a queued message as delivered at an admitted non-negative integral Date value.
-   * F258: atomic Lua — reads userId/threadId inside the script so concurrent
+   * PR #1193: atomic Lua — reads userId/threadId inside the script so concurrent
    * reassignUserId cannot cause the score update to land on a stale user key.
    */
   async markDelivered(id: string, deliveredAt: number): Promise<StoredMessage | null> {
@@ -881,15 +881,17 @@ export class RedisMessageStore {
 
   /**
    * F117: Mark a queued message as canceled (withdraw/clear).
-   * F258: CAS guard — only transitions queued → canceled. A delivered or
+   * PR #1193: CAS guard — only transitions queued → canceled. A delivered or
    * immediate message is left untouched (no-op), preventing cancel from
    * overwriting a completed delivery.
    */
   async markCanceled(id: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
-    // Atomic CAS: queued → canceled, anything else → no-op
-    // Lua handles missing hash (HGET returns nil → no-op); getById returns null
-    await this.redis.eval(CANCEL_LUA, 1, hashKey);
+    // Atomic CAS: queued → canceled, anything else → no-op.
+    // Returns the transitioned message ONLY when this call won the CAS;
+    // null means no-op (already canceled / delivered / not found).
+    const applied = (await this.redis.eval(CANCEL_LUA, 1, hashKey)) as number;
+    if (applied === 0) return null;
     return this.getById(id);
   }
 

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -342,15 +342,11 @@ export class RedisMessageStore {
    */
   async reassignUserId(id: string, nextUserId: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
-    const applied = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix)) as number;
+    const ttlArg = String(this.ttlSeconds ?? 0);
+    const applied = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix, ttlArg)) as number;
 
     // -1 = message not found in hash
     if (applied === -1) return null;
-
-    // Apply TTL to the new user key if configured
-    if (applied === 1 && this.ttlSeconds !== null) {
-      await this.redis.expire(MessageKeys.user(nextUserId), this.ttlSeconds);
-    }
 
     // Always return canonical state from Redis (not stale JS object)
     return this.getById(id);

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -342,17 +342,13 @@ export class RedisMessageStore {
    */
   async reassignUserId(id: string, nextUserId: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
-    const result = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix)) as [
-      number,
-      string,
-      string,
-    ];
+    const applied = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix)) as number;
 
     // -1 = message not found in hash
-    if (result[0] === -1) return null;
+    if (applied === -1) return null;
 
     // Apply TTL to the new user key if configured
-    if (result[0] === 1 && this.ttlSeconds !== null) {
+    if (applied === 1 && this.ttlSeconds !== null) {
       await this.redis.expire(MessageKeys.user(nextUserId), this.ttlSeconds);
     }
 
@@ -882,18 +878,8 @@ export class RedisMessageStore {
   async markDelivered(id: string, deliveredAt: number): Promise<StoredMessage | null> {
     assertValidStoredMessageTimestamp(deliveredAt);
     const hashKey = MessageKeys.detail(id);
-    const exists = await this.redis.exists(hashKey);
-    if (!exists) return null;
-
-    const result = (await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix)) as [
-      number,
-      string,
-      string,
-      string,
-    ];
-
-    // applied=0 means status was not 'queued' — return canonical state
-    // applied=1 means transition succeeded — return canonical state
+    // Lua handles missing hash (HGET returns nil → no-op); getById returns null
+    await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix);
     return this.getById(id);
   }
 
@@ -905,13 +891,9 @@ export class RedisMessageStore {
    */
   async markCanceled(id: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
-    const exists = await this.redis.exists(hashKey);
-    if (!exists) return null;
-
     // Atomic CAS: queued → canceled, anything else → no-op
+    // Lua handles missing hash (HGET returns nil → no-op); getById returns null
     await this.redis.eval(CANCEL_LUA, 1, hashKey);
-
-    // Return canonical state (reflects whether the transition actually applied)
     return this.getById(id);
   }
 

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -874,8 +874,11 @@ export class RedisMessageStore {
   async markDelivered(id: string, deliveredAt: number): Promise<StoredMessage | null> {
     assertValidStoredMessageTimestamp(deliveredAt);
     const hashKey = MessageKeys.detail(id);
-    // Lua handles missing hash (HGET returns nil → no-op); getById returns null
-    await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix);
+    // Atomic CAS: queued → delivered, anything else → no-op.
+    // Returns the transitioned message ONLY when this call won the CAS;
+    // null means no-op (already delivered / canceled / not found).
+    const applied = (await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix)) as number;
+    if (applied === 0) return null;
     return this.getById(id);
   }
 

--- a/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts
@@ -226,6 +226,14 @@ export class RedisMessageStore {
 
   async getById(id: string): Promise<StoredMessage | null> {
     const data = await this.redis.hgetall(MessageKeys.detail(id));
+    return this.hydrateHash(data);
+  }
+
+  /**
+   * Convert a Redis hash (Record<string, string> from HGETALL) into a StoredMessage.
+   * Shared by getById (direct HGETALL) and parseLuaHgetall (Lua-returned HGETALL).
+   */
+  private hydrateHash(data: Record<string, string>): StoredMessage | null {
     if (!data || !data.id) return null;
 
     const contentBlocks = safeParseContentBlocks(data.contentBlocks);
@@ -261,6 +269,21 @@ export class RedisMessageStore {
       ...(data.mentionsUser === '1' ? { mentionsUser: true } : {}),
       ...(data.replyTo ? { replyTo: data.replyTo } : {}),
     };
+  }
+
+  /**
+   * Parse a Lua HGETALL return (flat [key, val, key, val, ...] array) into StoredMessage.
+   * Used by CAS methods (markDelivered, markCanceled, reassignUserId) to hydrate
+   * the winning hash state atomically — no separate getById round-trip needed,
+   * eliminating the gap where a transient failure could lose the CAS receipt.
+   */
+  private parseLuaHgetall(result: unknown): StoredMessage | null {
+    if (!Array.isArray(result)) return null;
+    const data: Record<string, string> = {};
+    for (let i = 0; i < result.length; i += 2) {
+      data[result[i] as string] = result[i + 1] as string;
+    }
+    return this.hydrateHash(data);
   }
 
   /** Scan all stored message hashes (Redis-only repair helper). */
@@ -343,13 +366,14 @@ export class RedisMessageStore {
   async reassignUserId(id: string, nextUserId: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
     const ttlArg = String(this.ttlSeconds ?? 0);
-    const applied = (await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix, ttlArg)) as number;
+    const result = await this.redis.eval(REASSIGN_LUA, 1, hashKey, id, nextUserId, this.keyPrefix, ttlArg);
 
     // -1 = message not found in hash
-    if (applied === -1) return null;
-
-    // Always return canonical state from Redis (not stale JS object)
-    return this.getById(id);
+    if (result === -1) return null;
+    // 0 = same user (no-op) — no mutation committed, safe to read separately
+    if (result === 0) return this.getById(id);
+    // CAS won: result is HGETALL flat array — hydrate atomically (no getById gap)
+    return this.parseLuaHgetall(result);
   }
 
   async getRecent(limit?: number, userId?: string): Promise<StoredMessage[]> {
@@ -875,11 +899,10 @@ export class RedisMessageStore {
     assertValidStoredMessageTimestamp(deliveredAt);
     const hashKey = MessageKeys.detail(id);
     // Atomic CAS: queued → delivered, anything else → no-op.
-    // Returns the transitioned message ONLY when this call won the CAS;
-    // null means no-op (already delivered / canceled / not found).
-    const applied = (await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix)) as number;
-    if (applied === 0) return null;
-    return this.getById(id);
+    // Lua returns HGETALL on CAS win (no separate getById round-trip needed).
+    const result = await this.redis.eval(DELIVER_LUA, 1, hashKey, id, String(deliveredAt), this.keyPrefix);
+    if (result === 0) return null;
+    return this.parseLuaHgetall(result);
   }
 
   /**
@@ -891,11 +914,10 @@ export class RedisMessageStore {
   async markCanceled(id: string): Promise<StoredMessage | null> {
     const hashKey = MessageKeys.detail(id);
     // Atomic CAS: queued → canceled, anything else → no-op.
-    // Returns the transitioned message ONLY when this call won the CAS;
-    // null means no-op (already canceled / delivered / not found).
-    const applied = (await this.redis.eval(CANCEL_LUA, 1, hashKey)) as number;
-    if (applied === 0) return null;
-    return this.getById(id);
+    // Lua returns HGETALL on CAS win (no separate getById round-trip needed).
+    const result = await this.redis.eval(CANCEL_LUA, 1, hashKey);
+    if (result === 0) return null;
+    return this.parseLuaHgetall(result);
   }
 
   /**

--- a/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
@@ -31,9 +31,10 @@
  * ARGV[2] = deliveredAt (string number)
  * ARGV[3] = keyPrefix (e.g. "cat-cafe:") — for constructing zset keys inside Lua
  *
- * Returns: [applied (0|1)]
- * JS side discards the return — canonical state is re-read via getById().
- * Lua handles missing hash: HGET returns false → status ~= 'queued' → no-op.
+ * Returns: 0 on CAS no-op (not queued / missing), or HGETALL flat array on CAS win.
+ * Returning HGETALL eliminates the separate getById round-trip — the winning caller
+ * receives the post-mutation hash atomically, with no gap where a transient Redis
+ * failure could lose the CAS receipt.
  */
 export const DELIVER_LUA = `
 local hash = KEYS[1]
@@ -55,7 +56,7 @@ redis.call('ZADD', kp .. 'msg:thread:' .. threadId, tonumber(deliveredAt), msgId
 redis.call('ZADD', kp .. 'msg:timeline', tonumber(deliveredAt), msgId)
 redis.call('ZADD', kp .. 'msg:user:' .. userId, tonumber(deliveredAt), msgId)
 
-return 1
+return redis.call('HGETALL', hash)
 `;
 
 /**
@@ -63,8 +64,7 @@ return 1
  *
  * KEYS[1] = detail hash key (auto-prefixed by ioredis)
  *
- * Returns: [applied (0|1)]
- * Lua handles missing hash: HGET returns false → status ~= 'queued' → no-op.
+ * Returns: 0 on CAS no-op (not queued / missing), or HGETALL flat array on CAS win.
  */
 export const CANCEL_LUA = `
 local hash = KEYS[1]
@@ -73,7 +73,7 @@ if status ~= 'queued' then
   return 0
 end
 redis.call('HSET', hash, 'deliveryStatus', 'canceled')
-return 1
+return redis.call('HGETALL', hash)
 `;
 
 /**
@@ -90,10 +90,7 @@ return 1
  * Derives currentUserId and effectiveOrder (deliveredAt ?? timestamp) from
  * the hash INSIDE the script — never from a stale JS snapshot.
  *
- * Returns: applied (-1 | 0 | 1)
- * - -1 → message not found (hash missing)
- * -  0 → currentUserId already equals nextUserId (no-op)
- * -  1 → ownership transferred, user zset membership moved, TTL applied
+ * Returns: -1 (not found), 0 (same user / no-op), or HGETALL flat array on CAS win.
  */
 export const REASSIGN_LUA = `
 local hash = KEYS[1]
@@ -124,5 +121,5 @@ if ttl > 0 then
   redis.call('EXPIRE', newUserKey, ttl)
 end
 
-return 1
+return redis.call('HGETALL', hash)
 `;

--- a/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
@@ -1,0 +1,124 @@
+/**
+ * Lua scripts for atomic delivery-order transitions (F258).
+ *
+ * Bug: reassignUserId / markDelivered / markCanceled each read a JS snapshot
+ * then write via independent MULTI — no shared atomic boundary. Two concurrent
+ * writers interleave and leave hash vs zset state inconsistent.
+ *
+ * Fix: each transition is a single Lua script that reads AND writes inside
+ * Redis's single-threaded Lua executor. No OCC / WATCH / retry needed —
+ * Lua atomicity guarantees linearizability.
+ *
+ * Key convention: all keys are derived INSIDE the Lua script from the hash
+ * (except the hash key itself which is KEYS[1]). This eliminates stale-key
+ * bugs — the script always reads the canonical state.
+ *
+ * ioredis keyPrefix caveat: ioredis auto-prepends keyPrefix to KEYS[] args
+ * in eval(), but NOT to keys constructed dynamically inside Lua. We pass the
+ * keyPrefix via ARGV so scripts can build fully-qualified keys internally.
+ * (See redis-pitfalls.md for background.)
+ *
+ * Note: cat-cafe runs single-instance Redis (no Cluster). Lua scripts access
+ * keys across slots freely. If Cluster is adopted, these scripts must be
+ * restructured with hash tags.
+ */
+
+/**
+ * DELIVER: transition queued → delivered.
+ *
+ * KEYS[1] = detail hash key (auto-prefixed by ioredis)
+ * ARGV[1] = message id
+ * ARGV[2] = deliveredAt (string number)
+ * ARGV[3] = keyPrefix (e.g. "cat-cafe:") — for constructing zset keys inside Lua
+ *
+ * Returns: [applied (0|1), status, userId, deliveredAt]
+ * - applied=0 → status was not 'queued', no change made
+ * - applied=1 → transitioned to 'delivered', zsets updated
+ */
+export const DELIVER_LUA = `
+local hash = KEYS[1]
+local msgId = ARGV[1]
+local deliveredAt = ARGV[2]
+local kp = ARGV[3]
+
+local status = redis.call('HGET', hash, 'deliveryStatus')
+if status ~= 'queued' then
+  local curUserId = redis.call('HGET', hash, 'userId') or ''
+  local curDeliveredAt = redis.call('HGET', hash, 'deliveredAt') or ''
+  return {0, status or '', curUserId, curDeliveredAt}
+end
+
+local userId = redis.call('HGET', hash, 'userId')
+local threadId = redis.call('HGET', hash, 'threadId')
+
+redis.call('HSET', hash, 'deliveredAt', deliveredAt, 'deliveryStatus', 'delivered')
+
+local score = deliveredAt
+redis.call('ZADD', kp .. 'msg:thread:' .. threadId, score, msgId)
+redis.call('ZADD', kp .. 'msg:timeline', score, msgId)
+redis.call('ZADD', kp .. 'msg:user:' .. userId, score, msgId)
+
+return {1, 'delivered', userId, deliveredAt}
+`;
+
+/**
+ * CANCEL: CAS transition queued → canceled.
+ *
+ * KEYS[1] = detail hash key (auto-prefixed by ioredis)
+ *
+ * Returns: [applied (0|1), status]
+ * - applied=0 → status was not 'queued', no change (protects delivered state)
+ * - applied=1 → transitioned to 'canceled', no zset change (score stays at timestamp)
+ */
+export const CANCEL_LUA = `
+local hash = KEYS[1]
+local status = redis.call('HGET', hash, 'deliveryStatus')
+if status ~= 'queued' then
+  return {0, status or ''}
+end
+redis.call('HSET', hash, 'deliveryStatus', 'canceled')
+return {1, 'canceled'}
+`;
+
+/**
+ * REASSIGN: move message ownership atomically.
+ *
+ * KEYS[1] = detail hash key (auto-prefixed by ioredis)
+ * ARGV[1] = message id
+ * ARGV[2] = nextUserId
+ * ARGV[3] = keyPrefix (e.g. "cat-cafe:") — for constructing user zset keys inside Lua
+ *
+ * Derives currentUserId and effectiveOrder (deliveredAt ?? timestamp) from
+ * the hash INSIDE the script — never from a stale JS snapshot.
+ *
+ * Returns: [applied (0|1), userId, effectiveOrder]
+ * - applied=-1 → message not found
+ * - applied=0 → currentUserId already equals nextUserId
+ * - applied=1 → ownership transferred, user zset membership moved
+ */
+export const REASSIGN_LUA = `
+local hash = KEYS[1]
+local msgId = ARGV[1]
+local nextUserId = ARGV[2]
+local kp = ARGV[3]
+
+local curUserId = redis.call('HGET', hash, 'userId')
+if not curUserId then
+  return {-1, '', ''}
+end
+if curUserId == nextUserId then
+  local eff = redis.call('HGET', hash, 'deliveredAt') or redis.call('HGET', hash, 'timestamp')
+  return {0, curUserId, eff or ''}
+end
+
+local eff = redis.call('HGET', hash, 'deliveredAt')
+if not eff or eff == '' then
+  eff = redis.call('HGET', hash, 'timestamp')
+end
+
+redis.call('HSET', hash, 'userId', nextUserId)
+redis.call('ZREM', kp .. 'msg:user:' .. curUserId, msgId)
+redis.call('ZADD', kp .. 'msg:user:' .. nextUserId, tonumber(eff), msgId)
+
+return {1, nextUserId, eff}
+`;

--- a/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
@@ -83,6 +83,9 @@ return 1
  * ARGV[1] = message id
  * ARGV[2] = nextUserId
  * ARGV[3] = keyPrefix (e.g. "cat-cafe:") — for constructing user zset keys inside Lua
+ * ARGV[4] = ttlSeconds (string number, "0" = no expiry) — applied atomically to the
+ *           new user zset key, eliminating the crash window between ownership transfer
+ *           and TTL application (codex P2 fix)
  *
  * Derives currentUserId and effectiveOrder (deliveredAt ?? timestamp) from
  * the hash INSIDE the script — never from a stale JS snapshot.
@@ -90,13 +93,14 @@ return 1
  * Returns: applied (-1 | 0 | 1)
  * - -1 → message not found (hash missing)
  * -  0 → currentUserId already equals nextUserId (no-op)
- * -  1 → ownership transferred, user zset membership moved
+ * -  1 → ownership transferred, user zset membership moved, TTL applied
  */
 export const REASSIGN_LUA = `
 local hash = KEYS[1]
 local msgId = ARGV[1]
 local nextUserId = ARGV[2]
 local kp = ARGV[3]
+local ttl = tonumber(ARGV[4])
 
 local curUserId = redis.call('HGET', hash, 'userId')
 if not curUserId then
@@ -113,7 +117,12 @@ end
 
 redis.call('HSET', hash, 'userId', nextUserId)
 redis.call('ZREM', kp .. 'msg:user:' .. curUserId, msgId)
-redis.call('ZADD', kp .. 'msg:user:' .. nextUserId, tonumber(eff), msgId)
+local newUserKey = kp .. 'msg:user:' .. nextUserId
+redis.call('ZADD', newUserKey, tonumber(eff), msgId)
+
+if ttl > 0 then
+  redis.call('EXPIRE', newUserKey, ttl)
+end
 
 return 1
 `;

--- a/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
@@ -1,5 +1,5 @@
 /**
- * Lua scripts for atomic delivery-order transitions (F258).
+ * Lua scripts for atomic delivery-order transitions (PR #1193).
  *
  * Bug: reassignUserId / markDelivered / markCanceled each read a JS snapshot
  * then write via independent MULTI — no shared atomic boundary. Two concurrent

--- a/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts
@@ -31,9 +31,9 @@
  * ARGV[2] = deliveredAt (string number)
  * ARGV[3] = keyPrefix (e.g. "cat-cafe:") — for constructing zset keys inside Lua
  *
- * Returns: [applied (0|1), status, userId, deliveredAt]
- * - applied=0 → status was not 'queued', no change made
- * - applied=1 → transitioned to 'delivered', zsets updated
+ * Returns: [applied (0|1)]
+ * JS side discards the return — canonical state is re-read via getById().
+ * Lua handles missing hash: HGET returns false → status ~= 'queued' → no-op.
  */
 export const DELIVER_LUA = `
 local hash = KEYS[1]
@@ -43,9 +43,7 @@ local kp = ARGV[3]
 
 local status = redis.call('HGET', hash, 'deliveryStatus')
 if status ~= 'queued' then
-  local curUserId = redis.call('HGET', hash, 'userId') or ''
-  local curDeliveredAt = redis.call('HGET', hash, 'deliveredAt') or ''
-  return {0, status or '', curUserId, curDeliveredAt}
+  return 0
 end
 
 local userId = redis.call('HGET', hash, 'userId')
@@ -53,12 +51,11 @@ local threadId = redis.call('HGET', hash, 'threadId')
 
 redis.call('HSET', hash, 'deliveredAt', deliveredAt, 'deliveryStatus', 'delivered')
 
-local score = deliveredAt
-redis.call('ZADD', kp .. 'msg:thread:' .. threadId, score, msgId)
-redis.call('ZADD', kp .. 'msg:timeline', score, msgId)
-redis.call('ZADD', kp .. 'msg:user:' .. userId, score, msgId)
+redis.call('ZADD', kp .. 'msg:thread:' .. threadId, tonumber(deliveredAt), msgId)
+redis.call('ZADD', kp .. 'msg:timeline', tonumber(deliveredAt), msgId)
+redis.call('ZADD', kp .. 'msg:user:' .. userId, tonumber(deliveredAt), msgId)
 
-return {1, 'delivered', userId, deliveredAt}
+return 1
 `;
 
 /**
@@ -66,18 +63,17 @@ return {1, 'delivered', userId, deliveredAt}
  *
  * KEYS[1] = detail hash key (auto-prefixed by ioredis)
  *
- * Returns: [applied (0|1), status]
- * - applied=0 → status was not 'queued', no change (protects delivered state)
- * - applied=1 → transitioned to 'canceled', no zset change (score stays at timestamp)
+ * Returns: [applied (0|1)]
+ * Lua handles missing hash: HGET returns false → status ~= 'queued' → no-op.
  */
 export const CANCEL_LUA = `
 local hash = KEYS[1]
 local status = redis.call('HGET', hash, 'deliveryStatus')
 if status ~= 'queued' then
-  return {0, status or ''}
+  return 0
 end
 redis.call('HSET', hash, 'deliveryStatus', 'canceled')
-return {1, 'canceled'}
+return 1
 `;
 
 /**
@@ -91,10 +87,10 @@ return {1, 'canceled'}
  * Derives currentUserId and effectiveOrder (deliveredAt ?? timestamp) from
  * the hash INSIDE the script — never from a stale JS snapshot.
  *
- * Returns: [applied (0|1), userId, effectiveOrder]
- * - applied=-1 → message not found
- * - applied=0 → currentUserId already equals nextUserId
- * - applied=1 → ownership transferred, user zset membership moved
+ * Returns: applied (-1 | 0 | 1)
+ * - -1 → message not found (hash missing)
+ * -  0 → currentUserId already equals nextUserId (no-op)
+ * -  1 → ownership transferred, user zset membership moved
  */
 export const REASSIGN_LUA = `
 local hash = KEYS[1]
@@ -104,11 +100,10 @@ local kp = ARGV[3]
 
 local curUserId = redis.call('HGET', hash, 'userId')
 if not curUserId then
-  return {-1, '', ''}
+  return -1
 end
 if curUserId == nextUserId then
-  local eff = redis.call('HGET', hash, 'deliveredAt') or redis.call('HGET', hash, 'timestamp')
-  return {0, curUserId, eff or ''}
+  return 0
 end
 
 local eff = redis.call('HGET', hash, 'deliveredAt')
@@ -120,5 +115,5 @@ redis.call('HSET', hash, 'userId', nextUserId)
 redis.call('ZREM', kp .. 'msg:user:' .. curUserId, msgId)
 redis.call('ZADD', kp .. 'msg:user:' .. nextUserId, tonumber(eff), msgId)
 
-return {1, nextUserId, eff}
+return 1
 `;

--- a/packages/api/src/routes/queue.ts
+++ b/packages/api/src/routes/queue.ts
@@ -284,11 +284,11 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
       );
 
       // F117: Mark queued messages as canceled + emit message_deleted
-      // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
+      // CAS gate: markCanceled returns null on no-op (already canceled / delivered / not found)
       if (messageStore) {
         for (const msgId of messageIds) {
           const canceled = await messageStore.markCanceled(msgId);
-          if (canceled?.deliveryStatus === 'canceled') {
+          if (canceled) {
             socketManager.emitToUser(guard.userId, 'message_deleted', {
               messageId: msgId,
               threadId,
@@ -419,11 +419,11 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
           // executeEntry self-aborts BEFORE its markDelivered block, so without this the original
           // user message stays permanently 'queued' (undelivered + excluded from context) even though
           // its queue entry is gone. Mark it canceled + emit message_deleted.
-          // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
+          // CAS gate: markCanceled returns null on no-op (already canceled / delivered / not found)
           if (messageStore) {
             for (const msgId of tombstonedMsgIds) {
               const canceled = await messageStore.markCanceled(msgId);
-              if (canceled?.deliveryStatus === 'canceled') {
+              if (canceled) {
                 socketManager.emitToUser(guard.userId, 'message_deleted', {
                   messageId: msgId,
                   threadId,
@@ -596,11 +596,11 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
     await emitQueueUpdated(socketManager, guard.userId, threadId, [], messageStore, 'cleared');
 
     // F117: Mark all queued messages as canceled + emit message_deleted
-    // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
+    // CAS gate: markCanceled returns null on no-op (already canceled / delivered / not found)
     if (messageStore) {
       for (const msgId of allMessageIds) {
         const canceled = await messageStore.markCanceled(msgId);
-        if (canceled?.deliveryStatus === 'canceled') {
+        if (canceled) {
           socketManager.emitToUser(guard.userId, 'message_deleted', {
             messageId: msgId,
             threadId,

--- a/packages/api/src/routes/queue.ts
+++ b/packages/api/src/routes/queue.ts
@@ -284,14 +284,17 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
       );
 
       // F117: Mark queued messages as canceled + emit message_deleted
+      // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
       if (messageStore) {
         for (const msgId of messageIds) {
-          await messageStore.markCanceled(msgId);
-          socketManager.emitToUser(guard.userId, 'message_deleted', {
-            messageId: msgId,
-            threadId,
-            deletedBy: guard.userId,
-          });
+          const canceled = await messageStore.markCanceled(msgId);
+          if (canceled?.deliveryStatus === 'canceled') {
+            socketManager.emitToUser(guard.userId, 'message_deleted', {
+              messageId: msgId,
+              threadId,
+              deletedBy: guard.userId,
+            });
+          }
         }
       }
 
@@ -416,14 +419,17 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
           // executeEntry self-aborts BEFORE its markDelivered block, so without this the original
           // user message stays permanently 'queued' (undelivered + excluded from context) even though
           // its queue entry is gone. Mark it canceled + emit message_deleted.
+          // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
           if (messageStore) {
             for (const msgId of tombstonedMsgIds) {
-              await messageStore.markCanceled(msgId);
-              socketManager.emitToUser(guard.userId, 'message_deleted', {
-                messageId: msgId,
-                threadId,
-                deletedBy: guard.userId,
-              });
+              const canceled = await messageStore.markCanceled(msgId);
+              if (canceled?.deliveryStatus === 'canceled') {
+                socketManager.emitToUser(guard.userId, 'message_deleted', {
+                  messageId: msgId,
+                  threadId,
+                  deletedBy: guard.userId,
+                });
+              }
             }
           }
           invocationQueue.promote(threadId, guard.userId, entryId);
@@ -590,14 +596,17 @@ export const queueRoutes: FastifyPluginAsync<QueueRoutesOptions> = async (app, o
     await emitQueueUpdated(socketManager, guard.userId, threadId, [], messageStore, 'cleared');
 
     // F117: Mark all queued messages as canceled + emit message_deleted
+    // F258: only emit if cancel actually applied (CAS guard: non-queued → no-op)
     if (messageStore) {
       for (const msgId of allMessageIds) {
-        await messageStore.markCanceled(msgId);
-        socketManager.emitToUser(guard.userId, 'message_deleted', {
-          messageId: msgId,
-          threadId,
-          deletedBy: guard.userId,
-        });
+        const canceled = await messageStore.markCanceled(msgId);
+        if (canceled?.deliveryStatus === 'canceled') {
+          socketManager.emitToUser(guard.userId, 'message_deleted', {
+            messageId: msgId,
+            threadId,
+            deletedBy: guard.userId,
+          });
+        }
       }
     }
 

--- a/packages/api/test/delivery-status.test.js
+++ b/packages/api/test/delivery-status.test.js
@@ -80,9 +80,12 @@ describe('F117: deliveryStatus + isDelivered', () => {
     assert.equal(msg.deliveryStatus, undefined, 'precondition: no deliveryStatus');
 
     const result = store.markDelivered(msg.id, Date.now());
-    // undefined is not queued — no-op, prevents timeline re-scoring
-    assert.equal(result?.deliveryStatus, undefined, 'must not overwrite undefined to delivered');
-    assert.equal(result?.deliveredAt, undefined, 'must not set deliveredAt');
+    // CAS no-op: deliveryStatus is undefined (not 'queued') → returns null (PR #1193)
+    assert.equal(result, null, 'CAS no-op: legacy message must return null');
+    // Canonical stored state must be unchanged
+    const stored = store.getById(msg.id);
+    assert.equal(stored.deliveryStatus, undefined, 'must not overwrite undefined to delivered');
+    assert.equal(stored.deliveredAt, undefined, 'must not set deliveredAt');
   });
 
   test('markDelivered is no-op for already-delivered messages', async () => {
@@ -100,9 +103,13 @@ describe('F117: deliveryStatus + isDelivered', () => {
     store.markDelivered(msg.id, firstDeliveredAt);
     assert.equal(msg.deliveryStatus, 'delivered');
 
-    // Second call should be no-op
+    // Second call is CAS no-op — already delivered → returns null (PR #1193)
     const result = store.markDelivered(msg.id, Date.now());
-    assert.equal(result?.deliveredAt, firstDeliveredAt, 'must not overwrite deliveredAt');
+    assert.equal(result, null, 'CAS no-op: already-delivered message must return null');
+    // Canonical stored state retains original deliveredAt
+    const stored = store.getById(msg.id);
+    assert.equal(stored.deliveredAt, firstDeliveredAt, 'stored deliveredAt must not be overwritten');
+    assert.equal(stored.deliveryStatus, 'delivered', 'stored status must remain delivered');
   });
 });
 

--- a/packages/api/test/message-store.test.js
+++ b/packages/api/test/message-store.test.js
@@ -136,13 +136,14 @@ describe('MessageStore', () => {
     assert.equal(canceled.deliveryStatus, 'canceled');
     assert.equal(canceled.deliveredAt, undefined);
 
-    assert.deepEqual(store.markCanceled(legacy.id), legacyBefore, 'legacy-immediate must remain unchanged');
+    assert.equal(store.markCanceled(legacy.id), null);
     assert.deepEqual(store.getById(legacy.id), legacyBefore);
-    assert.deepEqual(store.markCanceled(delivered.id), deliveredBefore, 'delivered state must remain unchanged');
+    assert.equal(store.markCanceled(delivered.id), null);
     assert.deepEqual(store.getById(delivered.id), deliveredBefore);
 
     const canceledBefore = { ...canceled };
-    assert.deepEqual(store.markCanceled(queued.id), canceledBefore, 'repeated cancellation must be a no-op');
+    assert.equal(store.markCanceled(queued.id), null);
+    assert.deepEqual(store.getById(queued.id), canceledBefore, 'repeated cancellation must preserve state');
   });
 
   test('markDelivered() rejects unsafe order timestamps before state transition and permits a valid retry', async () => {

--- a/packages/api/test/queue-api.test.js
+++ b/packages/api/test/queue-api.test.js
@@ -649,10 +649,10 @@ describe('Queue Management API', () => {
     assert.equal(del.arguments[2].messageId, 'msg-inflight');
   });
 
-  it('POST /queue/:entryId/steer immediate does NOT emit message_deleted when markCanceled is no-op (F258 phantom-emit guard)', async () => {
-    // F258: if the message was already delivered (or otherwise non-queued), markCanceled
-    // returns a non-canceled status. The gate must suppress the message_deleted emit —
-    // otherwise the client would flash-delete a delivered message.
+  it('POST /queue/:entryId/steer immediate does NOT emit message_deleted when markCanceled is no-op (phantom-emit guard)', async () => {
+    // If the message was already canceled/delivered, markCanceled returns null (CAS no-op).
+    // The truthy gate must suppress the message_deleted emit — otherwise the client would
+    // flash-delete a delivered message or duplicate-delete an already-canceled one.
     enqueueEntry(deps.invocationQueue, { userId: 'user-a', content: 'inflight', targetCats: ['opus'] });
     deps.invocationQueue.markProcessing('t1', 'user-a');
     const inflight = deps.invocationQueue.findProcessingByCat('t1', 'opus');
@@ -660,8 +660,8 @@ describe('Queue Management API', () => {
     const steered = enqueueEntry(deps.invocationQueue, { userId: 'user-a', content: 'steered', targetCats: ['opus'] });
 
     deps.invocationTracker.has = mock.fn(() => false);
-    // Override: markCanceled returns delivered status (CAS no-op — message already delivered)
-    deps.messageStore.markCanceled = mock.fn(async () => ({ deliveryStatus: 'delivered' }));
+    // Override: markCanceled returns null (CAS no-op — message already delivered/canceled)
+    deps.messageStore.markCanceled = mock.fn(async () => null);
 
     const res = await app.inject({
       method: 'POST',

--- a/packages/api/test/queue-api.test.js
+++ b/packages/api/test/queue-api.test.js
@@ -41,7 +41,7 @@ function buildDeps(overrides = {}) {
       emitToUser: mock.fn(),
     },
     messageStore: {
-      markCanceled: mock.fn(async () => {}),
+      markCanceled: mock.fn(async () => ({ deliveryStatus: 'canceled' })),
     },
     ...overrides,
   };
@@ -647,6 +647,33 @@ describe('Queue Management API', () => {
     const del = deps.socketManager.emitToUser.mock.calls.find((c) => c.arguments[1] === 'message_deleted');
     assert.ok(del, 'message_deleted must be emitted');
     assert.equal(del.arguments[2].messageId, 'msg-inflight');
+  });
+
+  it('POST /queue/:entryId/steer immediate does NOT emit message_deleted when markCanceled is no-op (F258 phantom-emit guard)', async () => {
+    // F258: if the message was already delivered (or otherwise non-queued), markCanceled
+    // returns a non-canceled status. The gate must suppress the message_deleted emit —
+    // otherwise the client would flash-delete a delivered message.
+    enqueueEntry(deps.invocationQueue, { userId: 'user-a', content: 'inflight', targetCats: ['opus'] });
+    deps.invocationQueue.markProcessing('t1', 'user-a');
+    const inflight = deps.invocationQueue.findProcessingByCat('t1', 'opus');
+    inflight.messageId = 'msg-already-delivered';
+    const steered = enqueueEntry(deps.invocationQueue, { userId: 'user-a', content: 'steered', targetCats: ['opus'] });
+
+    deps.invocationTracker.has = mock.fn(() => false);
+    // Override: markCanceled returns delivered status (CAS no-op — message already delivered)
+    deps.messageStore.markCanceled = mock.fn(async () => ({ deliveryStatus: 'delivered' }));
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/threads/t1/queue/${steered.entry.id}/steer`,
+      headers: { 'x-cat-cafe-user': 'user-a', 'content-type': 'application/json' },
+      payload: { mode: 'immediate' },
+    });
+
+    assert.equal(res.statusCode, 202);
+    assert.equal(deps.messageStore.markCanceled.mock.calls.length, 1, 'markCanceled must be called');
+    const del = deps.socketManager.emitToUser.mock.calls.find((c) => c.arguments[1] === 'message_deleted');
+    assert.equal(del, undefined, 'message_deleted must NOT be emitted when cancel is a no-op');
   });
 
   it('POST /queue/:entryId/steer immediate scopes cancel broadcast to steered cat only (P1 cloud review)', async () => {

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -1,0 +1,340 @@
+/**
+ * F258: Delivery-order transition atomicity tests.
+ *
+ * Bug: reassignUserId / markDelivered / markCanceled each read a JS snapshot
+ * then write via independent MULTI/HSET — no shared atomic boundary. Two
+ * concurrent writers can interleave and leave hash vs zset state inconsistent.
+ *
+ * Fix: single Lua script per transition (deliver / cancel / reassign) that
+ * reads + writes inside Redis's single-threaded Lua executor.
+ *
+ * RED tests — written BEFORE the fix, expected to fail against base 128263c9b.
+ * Deterministic failures: markCanceled-on-delivered guard (both stores).
+ * Concurrent invariant tests: Promise.all with consistency assertions.
+ */
+
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import {
+  assertRedisIsolationOrThrow,
+  cleanupPrefixedRedisKeys,
+  redisIsolationSkipReason,
+} from './helpers/redis-test-helpers.js';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+const MSG_PATTERNS = ['msg:*'];
+
+describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkipReason(REDIS_URL) }, () => {
+  let RedisMessageStore;
+  let MessageKeys;
+  let createRedisClient;
+  let redis;
+  let store;
+  let connected = false;
+
+  before(async () => {
+    assertRedisIsolationOrThrow(REDIS_URL, 'F258-delivery-atomicity');
+
+    const storeModule = await import('../dist/domains/cats/services/stores/redis/RedisMessageStore.js');
+    RedisMessageStore = storeModule.RedisMessageStore;
+    const keysModule = await import('../dist/domains/cats/services/stores/redis-keys/message-keys.js');
+    MessageKeys = keysModule.MessageKeys;
+    const redisModule = await import('@cat-cafe/shared/utils');
+    createRedisClient = redisModule.createRedisClient;
+
+    redis = createRedisClient({ url: REDIS_URL });
+    try {
+      await redis.ping();
+      connected = true;
+    } catch {
+      console.warn('[F258-delivery-atomicity] Redis unreachable, skipping');
+      await redis.quit().catch(() => {});
+      return;
+    }
+    store = new RedisMessageStore(redis);
+  });
+
+  after(async () => {
+    if (redis && connected) {
+      await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+      await redis.quit();
+    }
+  });
+
+  beforeEach(async (t) => {
+    if (!connected) return t.skip('Redis not connected');
+    await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+  });
+
+  // ── Helper: create a queued message for testing ──
+  const createQueued = (userId, threadId, ts) =>
+    store.append({
+      userId,
+      catId: null,
+      content: `queued-msg-${ts}`,
+      mentions: [],
+      timestamp: ts,
+      threadId,
+      deliveryStatus: 'queued',
+    });
+
+  // ── Helper: assert hash/zset consistency invariant ──
+  const assertConsistency = async (msgId, label) => {
+    const msg = await store.getById(msgId);
+    assert.ok(msg, `${label}: message must exist`);
+
+    const expectedScore = String(msg.deliveredAt ?? msg.timestamp);
+    const threadScore = await redis.zscore(MessageKeys.thread(msg.threadId), msgId);
+    const timelineScore = await redis.zscore(MessageKeys.TIMELINE, msgId);
+    const userScore = await redis.zscore(MessageKeys.user(msg.userId), msgId);
+
+    assert.equal(threadScore, expectedScore, `${label}: thread zset score must match hash`);
+    assert.equal(timelineScore, expectedScore, `${label}: timeline zset score must match hash`);
+    assert.equal(userScore, expectedScore, `${label}: user zset score must match hash`);
+
+    // User zset membership: msg must only be in its current owner's zset
+    return msg;
+  };
+
+  // ── sol's 6 RED test cases ──
+
+  // 1. reassign snapshot → delivery commit → reassign commit
+  it('concurrent reassign+deliver: reassign reads stale → deliver writes → reassign overwrites stale score', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-rd-1';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Run both concurrently — event loop interleaving creates the race window
+    const [reassigned, delivered] = await Promise.all([
+      store.reassignUserId(msg.id, 'userB'),
+      store.markDelivered(msg.id, base + 500),
+    ]);
+
+    // Post-condition invariant: hash, thread, timeline, user zsets must all agree
+    const canonical = await assertConsistency(msg.id, 'reassign+deliver');
+
+    // Score must reflect deliveredAt if delivered, regardless of who owns it
+    if (canonical.deliveryStatus === 'delivered') {
+      const expectedScore = String(canonical.deliveredAt);
+      const userKey = MessageKeys.user(canonical.userId);
+      const userScore = await redis.zscore(userKey, msg.id);
+      assert.equal(userScore, expectedScore, 'user zset score must equal deliveredAt after delivery');
+    }
+  });
+
+  // 2. delivery snapshot → reassign commit → delivery retry (now: delivery commit)
+  it('concurrent deliver+reassign: deliver reads stale userId → reassign writes → deliver writes to old user', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-dr-2';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Reverse order from test 1
+    const [delivered, reassigned] = await Promise.all([
+      store.markDelivered(msg.id, base + 300),
+      store.reassignUserId(msg.id, 'userC'),
+    ]);
+
+    const canonical = await assertConsistency(msg.id, 'deliver+reassign');
+
+    // The old user (userA) must NOT have a dangling zset entry
+    if (canonical.userId !== 'userA') {
+      const oldUserScore = await redis.zscore(MessageKeys.user('userA'), msg.id);
+      assert.equal(oldUserScore, null, 'old user must not have dangling zset entry after reassign');
+    }
+  });
+
+  // 3. cancel vs deliver: exactly one winner
+  it('concurrent cancel+deliver on queued msg: exactly one transition wins', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-cd-3';
+    const msg = await createQueued('userA', threadId, base);
+
+    await Promise.all([store.markCanceled(msg.id), store.markDelivered(msg.id, base + 100)]);
+
+    const canonical = await store.getById(msg.id);
+    assert.ok(
+      canonical.deliveryStatus === 'delivered' || canonical.deliveryStatus === 'canceled',
+      `status must be delivered or canceled, got: ${canonical.deliveryStatus}`,
+    );
+
+    // If delivered, zset scores updated; if canceled, score unchanged from timestamp
+    if (canonical.deliveryStatus === 'delivered') {
+      await assertConsistency(msg.id, 'cancel-loses-to-deliver');
+    } else {
+      // canceled: score stays at original timestamp
+      const threadScore = await redis.zscore(MessageKeys.thread(threadId), msg.id);
+      assert.equal(threadScore, String(base), 'canceled msg score must be original timestamp');
+    }
+  });
+
+  // 4. concurrent reassign A→B / A→C: exactly one final owner
+  it('concurrent reassign to two targets: final state has single owner', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-rr-4';
+    const msg = await createQueued('userA', threadId, base);
+    // Deliver first so the score is stable
+    await store.markDelivered(msg.id, base + 100);
+
+    await Promise.all([store.reassignUserId(msg.id, 'userB'), store.reassignUserId(msg.id, 'userC')]);
+
+    const canonical = await store.getById(msg.id);
+    const winner = canonical.userId;
+    assert.ok(winner === 'userB' || winner === 'userC', `winner must be userB or userC, got: ${winner}`);
+
+    // Winner has the entry, losers don't
+    const winnerScore = await redis.zscore(MessageKeys.user(winner), msg.id);
+    assert.ok(winnerScore !== null, 'winner must have zset entry');
+
+    const loser = winner === 'userB' ? 'userC' : 'userB';
+    const loserScore = await redis.zscore(MessageKeys.user(loser), msg.id);
+    assert.equal(loserScore, null, 'loser must not have zset entry');
+
+    // Original user must not have entry either
+    const origScore = await redis.zscore(MessageKeys.user('userA'), msg.id);
+    assert.equal(origScore, null, 'original user must not have zset entry after reassign');
+  });
+
+  // 5. return values must reflect canonical post-state (not stale JS snapshot)
+  it('return value of reassignUserId reflects canonical Redis state', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-ret-5';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Deliver, then reassign
+    await store.markDelivered(msg.id, base + 200);
+    const reassigned = await store.reassignUserId(msg.id, 'userD');
+
+    assert.equal(reassigned.userId, 'userD', 'returned msg must show new userId');
+    assert.equal(reassigned.deliveryStatus, 'delivered', 'returned msg must preserve delivered status');
+    assert.equal(reassigned.deliveredAt, base + 200, 'returned msg must preserve deliveredAt');
+  });
+
+  // 6. sequential delivery → reassign → startup backfill all stay green
+  it('sequential deliver → reassign preserves score=deliveredAt in new user zset', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-seq-6';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Sequential: deliver first, then reassign
+    await store.markDelivered(msg.id, base + 400);
+    await store.reassignUserId(msg.id, 'userE');
+
+    const canonical = await store.getById(msg.id);
+    assert.equal(canonical.userId, 'userE');
+    assert.equal(canonical.deliveredAt, base + 400);
+
+    // New user's zset score must be deliveredAt, not original timestamp
+    const userScore = await redis.zscore(MessageKeys.user('userE'), msg.id);
+    assert.equal(userScore, String(base + 400), 'new user zset score must be deliveredAt');
+
+    // Old user must be cleaned
+    const oldScore = await redis.zscore(MessageKeys.user('userA'), msg.id);
+    assert.equal(oldScore, null, 'old user must not have entry');
+  });
+
+  // ── Fable's 3 supplementary RED test cases ──
+
+  // 7. markCanceled on delivered message → must be no-op (DETERMINISTIC RED)
+  it('markCanceled on delivered message is no-op (guard: queued-only transition)', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-guard-7';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Deliver first
+    await store.markDelivered(msg.id, base + 100);
+
+    // Cancel should be no-op — delivered state must survive
+    const result = await store.markCanceled(msg.id);
+
+    const canonical = await store.getById(msg.id);
+    assert.equal(canonical.deliveryStatus, 'delivered', 'markCanceled must NOT overwrite delivered status');
+    assert.equal(canonical.deliveredAt, base + 100, 'deliveredAt must survive cancel attempt');
+  });
+
+  // 8. after concurrent ops, all three zset scores + hash are consistent
+  it('concurrent deliver+reassign: thread/timeline/user zset scores all agree with hash', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-zset-8';
+    // Run 5 rounds to increase chance of hitting the race
+    for (let round = 0; round < 5; round++) {
+      await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+      const msg = await createQueued('userA', threadId, base + round * 1000);
+
+      await Promise.all([
+        store.markDelivered(msg.id, base + round * 1000 + 500),
+        store.reassignUserId(msg.id, `userR${round}`),
+      ]);
+
+      // Full consistency check — this is the core invariant
+      await assertConsistency(msg.id, `round-${round}`);
+    }
+  });
+
+  // 9. regression: no caller depends on cancel-non-queued behavior (F117 withdraw)
+  it('markCanceled on immediate/no-status message is no-op', async () => {
+    const base = Date.now();
+    const threadId = 'thread-f258-imm-9';
+    // Create a message WITHOUT deliveryStatus (= immediate/legacy)
+    const msg = await store.append({
+      userId: 'userA',
+      catId: null,
+      content: 'immediate msg',
+      mentions: [],
+      timestamp: base,
+      threadId,
+    });
+
+    const result = await store.markCanceled(msg.id);
+    const canonical = await store.getById(msg.id);
+
+    // An immediate message must not become 'canceled'
+    assert.notEqual(canonical.deliveryStatus, 'canceled', 'immediate message must not be marked canceled');
+  });
+});
+
+// ── In-memory MessageStore: markCanceled guard (deterministic RED) ──
+
+describe('F258: in-memory MessageStore markCanceled guard', () => {
+  let MessageStore;
+
+  before(async () => {
+    const mod = await import('../dist/domains/cats/services/stores/ports/MessageStore.js');
+    MessageStore = mod.MessageStore;
+  });
+
+  it('markCanceled on delivered message is no-op (guard parity with Redis)', async () => {
+    const memStore = new MessageStore();
+    const base = Date.now();
+    const msg = await memStore.append({
+      userId: 'u1',
+      catId: null,
+      content: 'test',
+      mentions: [],
+      timestamp: base,
+      threadId: 'thread-mem-guard',
+      deliveryStatus: 'queued',
+    });
+
+    memStore.markDelivered(msg.id, base + 100);
+
+    // Cancel should be no-op
+    const result = memStore.markCanceled(msg.id);
+    assert.equal(result.deliveryStatus, 'delivered', 'in-memory markCanceled must NOT overwrite delivered status');
+  });
+
+  it('markCanceled on immediate/no-status message is no-op', async () => {
+    const memStore = new MessageStore();
+    const msg = await memStore.append({
+      userId: 'u1',
+      catId: null,
+      content: 'immediate',
+      mentions: [],
+      timestamp: Date.now(),
+      threadId: 'thread-mem-imm',
+    });
+
+    const result = memStore.markCanceled(msg.id);
+    assert.notEqual(result.deliveryStatus, 'canceled', 'immediate message must not be marked canceled in memory store');
+  });
+});

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -17,13 +17,14 @@ import assert from 'node:assert/strict';
 import { after, before, beforeEach, describe, it } from 'node:test';
 import {
   assertRedisIsolationOrThrow,
-  cleanupPrefixedRedisKeys,
+  cleanupClientKeyspace,
   redisIsolationSkipReason,
 } from './helpers/redis-test-helpers.js';
 
 const REDIS_URL = process.env.REDIS_URL;
 
-const MSG_PATTERNS = ['msg:*'];
+/** Per-file unique keyPrefix isolates this suite from concurrent redis-message-store / f232 tests. */
+const TEST_KEY_PREFIX = 'cat-cafe-f258:';
 
 describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkipReason(REDIS_URL) }, () => {
   let RedisMessageStore;
@@ -43,7 +44,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
     const redisModule = await import('@cat-cafe/shared/utils');
     createRedisClient = redisModule.createRedisClient;
 
-    redis = createRedisClient({ url: REDIS_URL });
+    redis = createRedisClient({ url: REDIS_URL, keyPrefix: TEST_KEY_PREFIX });
     try {
       await redis.ping();
       connected = true;
@@ -57,14 +58,14 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
 
   after(async () => {
     if (redis && connected) {
-      await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+      await cleanupClientKeyspace(redis);
       await redis.quit();
     }
   });
 
   beforeEach(async (t) => {
     if (!connected) return t.skip('Redis not connected');
-    await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+    await cleanupClientKeyspace(redis);
   });
 
   // ── Helper: create a queued message for testing ──
@@ -258,7 +259,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
     const threadId = 'thread-f258-zset-8';
     // Run 5 rounds to increase chance of hitting the race
     for (let round = 0; round < 5; round++) {
-      await cleanupPrefixedRedisKeys(redis, MSG_PATTERNS);
+      await cleanupClientKeyspace(redis);
       const msg = await createQueued('userA', threadId, base + round * 1000);
 
       await Promise.all([

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -145,25 +145,41 @@ describe('delivery-order transition atomicity (PR #1193)', { skip: redisIsolatio
     }
   });
 
-  // 3. cancel vs deliver: exactly one winner
-  it('concurrent cancel+deliver on queued msg: exactly one transition wins', async () => {
+  // 3. cancel vs deliver: exactly one CAS winner (applied-result contract)
+  it('concurrent cancel+deliver on queued msg: exactly one transition wins, return values prove it', async () => {
     const base = Date.now();
     const threadId = 'thread-dlv-cd-3';
     const msg = await createQueued('userA', threadId, base);
 
-    await Promise.all([store.markCanceled(msg.id), store.markDelivered(msg.id, base + 100)]);
+    const [cancelResult, deliverResult] = await Promise.all([
+      store.markCanceled(msg.id),
+      store.markDelivered(msg.id, base + 100),
+    ]);
 
+    // Exactly one CAS transition must return non-null — the loser gets null
+    const winners = [cancelResult, deliverResult].filter(Boolean);
+    assert.equal(winners.length, 1, 'exactly one CAS transition must return non-null');
+
+    // The non-null winner must match canonical delivery status
     const canonical = await store.getById(msg.id);
     assert.ok(
       canonical.deliveryStatus === 'delivered' || canonical.deliveryStatus === 'canceled',
       `status must be delivered or canceled, got: ${canonical.deliveryStatus}`,
     );
 
-    // If delivered, zset scores updated; if canceled, score unchanged from timestamp
+    if (cancelResult) {
+      assert.equal(deliverResult, null, 'deliver must return null when cancel wins');
+      assert.equal(canonical.deliveryStatus, 'canceled', 'cancel winner matches canonical state');
+    } else {
+      assert.equal(cancelResult, null, 'cancel must return null when deliver wins');
+      assert.equal(canonical.deliveryStatus, 'delivered', 'deliver winner matches canonical state');
+      assert.equal(canonical.deliveredAt, base + 100, 'deliveredAt matches the winning delivery');
+    }
+
+    // Zset consistency: delivered → scores updated; canceled → scores unchanged
     if (canonical.deliveryStatus === 'delivered') {
       await assertConsistency(msg.id, 'cancel-loses-to-deliver');
     } else {
-      // canceled: score stays at original timestamp
       const threadScore = await redis.zscore(MessageKeys.thread(threadId), msg.id);
       assert.equal(threadScore, String(base), 'canceled msg score must be original timestamp');
     }

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -325,6 +325,91 @@ describe('delivery-order transition atomicity (PR #1193)', { skip: redisIsolatio
     const second = await store.markCanceled(msg.id);
     assert.equal(second, null, 'second markCanceled must return null (already canceled)');
   });
+
+  // 11. CAS receipt survives without getById (Lua-side HGETALL hydration regression)
+  it('markDelivered returns complete StoredMessage from Lua (no getById gap)', async () => {
+    const base = Date.now();
+    const threadId = 'thread-dlv-receipt-11';
+    const msg = await createQueued('userA', threadId, base);
+
+    // Monkey-patch getById to throw — proves CAS winner is hydrated from Lua, not getById
+    const origGetById = store.getById.bind(store);
+    store.getById = () => {
+      throw new Error('getById must not be called for CAS-win hydration');
+    };
+
+    try {
+      const delivered = await store.markDelivered(msg.id, base + 777);
+
+      assert.ok(delivered, 'CAS winner must return non-null');
+      assert.equal(delivered.id, msg.id, 'id must match');
+      assert.equal(delivered.userId, 'userA', 'userId must be hydrated');
+      assert.equal(delivered.threadId, threadId, 'threadId must be hydrated');
+      assert.equal(delivered.deliveryStatus, 'delivered', 'status must be delivered');
+      assert.equal(delivered.deliveredAt, base + 777, 'deliveredAt must be hydrated');
+      assert.equal(delivered.content, `queued-msg-${base}`, 'content must be hydrated');
+      assert.equal(delivered.timestamp, base, 'timestamp must be hydrated');
+    } finally {
+      store.getById = origGetById;
+    }
+  });
+
+  // 12. Analogous cancel path: CAS receipt without getById
+  it('markCanceled returns complete StoredMessage from Lua (no getById gap)', async () => {
+    const base = Date.now();
+    const threadId = 'thread-dlv-receipt-12';
+    const msg = await createQueued('userA', threadId, base);
+
+    const origGetById = store.getById.bind(store);
+    store.getById = () => {
+      throw new Error('getById must not be called for CAS-win hydration');
+    };
+
+    try {
+      const canceled = await store.markCanceled(msg.id);
+
+      assert.ok(canceled, 'CAS winner must return non-null');
+      assert.equal(canceled.id, msg.id, 'id must match');
+      assert.equal(canceled.deliveryStatus, 'canceled', 'status must be canceled');
+      assert.equal(canceled.userId, 'userA', 'userId must be hydrated');
+      assert.equal(canceled.threadId, threadId, 'threadId must be hydrated');
+      assert.equal(canceled.timestamp, base, 'timestamp must be hydrated');
+    } finally {
+      store.getById = origGetById;
+    }
+  });
+
+  // 13. TTL branch: reassign with ttlSeconds > 0 applies EXPIRE inside Lua
+  it('reassignUserId with positive TTL sets EXPIRE on new user zset key', async () => {
+    const base = Date.now();
+    const threadId = 'thread-dlv-ttl-13';
+
+    // Create a store WITH ttlSeconds to exercise the EXPIRE branch
+    const ttlStore = new RedisMessageStore(redis, { ttlSeconds: 60 });
+    const msg = await ttlStore.append({
+      userId: 'userA',
+      catId: null,
+      content: 'ttl-test-msg',
+      mentions: [],
+      timestamp: base,
+      threadId,
+      deliveryStatus: 'queued',
+    });
+    await ttlStore.markDelivered(msg.id, base + 100);
+
+    // Reassign to userF — EXPIRE should fire inside Lua
+    const reassigned = await ttlStore.reassignUserId(msg.id, 'userF');
+    assert.ok(reassigned, 'reassign must succeed');
+    assert.equal(reassigned.userId, 'userF');
+
+    // Verify the new user zset key has a positive TTL
+    const ttl = await redis.ttl(MessageKeys.user('userF'));
+    assert.ok(ttl > 0 && ttl <= 60, `new user zset key must have TTL (got ${ttl}s)`);
+
+    // Old user key should NOT have the message
+    const oldScore = await redis.zscore(MessageKeys.user('userA'), msg.id);
+    assert.equal(oldScore, null, 'old user must not have entry');
+  });
 });
 
 // ── In-memory MessageStore: markCanceled guard (deterministic RED) ──

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -1,5 +1,5 @@
 /**
- * F258: Delivery-order transition atomicity tests.
+ * Delivery-order transition atomicity tests (PR #1193).
  *
  * Bug: reassignUserId / markDelivered / markCanceled each read a JS snapshot
  * then write via independent MULTI/HSET — no shared atomic boundary. Two
@@ -24,9 +24,9 @@ import {
 const REDIS_URL = process.env.REDIS_URL;
 
 /** Per-file unique keyPrefix isolates this suite from concurrent redis-message-store / f232 tests. */
-const TEST_KEY_PREFIX = 'cat-cafe-f258:';
+const TEST_KEY_PREFIX = 'cat-cafe-dlv-atomicity:';
 
-describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkipReason(REDIS_URL) }, () => {
+describe('delivery-order transition atomicity (PR #1193)', { skip: redisIsolationSkipReason(REDIS_URL) }, () => {
   let RedisMessageStore;
   let MessageKeys;
   let createRedisClient;
@@ -35,7 +35,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   let connected = false;
 
   before(async () => {
-    assertRedisIsolationOrThrow(REDIS_URL, 'F258-delivery-atomicity');
+    assertRedisIsolationOrThrow(REDIS_URL, 'delivery-atomicity');
 
     const storeModule = await import('../dist/domains/cats/services/stores/redis/RedisMessageStore.js');
     RedisMessageStore = storeModule.RedisMessageStore;
@@ -49,7 +49,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
       await redis.ping();
       connected = true;
     } catch {
-      console.warn('[F258-delivery-atomicity] Redis unreachable, skipping');
+      console.warn('[delivery-atomicity] Redis unreachable, skipping');
       await redis.quit().catch(() => {});
       return;
     }
@@ -103,7 +103,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 1. reassign snapshot → delivery commit → reassign commit
   it('concurrent reassign+deliver: reassign reads stale → deliver writes → reassign overwrites stale score', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-rd-1';
+    const threadId = 'thread-dlv-rd-1';
     const msg = await createQueued('userA', threadId, base);
 
     // Run both concurrently — event loop interleaving creates the race window
@@ -127,7 +127,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 2. delivery snapshot → reassign commit → delivery retry (now: delivery commit)
   it('concurrent deliver+reassign: deliver reads stale userId → reassign writes → deliver writes to old user', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-dr-2';
+    const threadId = 'thread-dlv-dr-2';
     const msg = await createQueued('userA', threadId, base);
 
     // Reverse order from test 1
@@ -148,7 +148,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 3. cancel vs deliver: exactly one winner
   it('concurrent cancel+deliver on queued msg: exactly one transition wins', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-cd-3';
+    const threadId = 'thread-dlv-cd-3';
     const msg = await createQueued('userA', threadId, base);
 
     await Promise.all([store.markCanceled(msg.id), store.markDelivered(msg.id, base + 100)]);
@@ -172,7 +172,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 4. concurrent reassign A→B / A→C: exactly one final owner
   it('concurrent reassign to two targets: final state has single owner', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-rr-4';
+    const threadId = 'thread-dlv-rr-4';
     const msg = await createQueued('userA', threadId, base);
     // Deliver first so the score is stable
     await store.markDelivered(msg.id, base + 100);
@@ -199,7 +199,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 5. return values must reflect canonical post-state (not stale JS snapshot)
   it('return value of reassignUserId reflects canonical Redis state', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-ret-5';
+    const threadId = 'thread-dlv-ret-5';
     const msg = await createQueued('userA', threadId, base);
 
     // Deliver, then reassign
@@ -214,7 +214,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 6. sequential delivery → reassign → startup backfill all stay green
   it('sequential deliver → reassign preserves score=deliveredAt in new user zset', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-seq-6';
+    const threadId = 'thread-dlv-seq-6';
     const msg = await createQueued('userA', threadId, base);
 
     // Sequential: deliver first, then reassign
@@ -239,14 +239,15 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 7. markCanceled on delivered message → must be no-op (DETERMINISTIC RED)
   it('markCanceled on delivered message is no-op (guard: queued-only transition)', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-guard-7';
+    const threadId = 'thread-dlv-guard-7';
     const msg = await createQueued('userA', threadId, base);
 
     // Deliver first
     await store.markDelivered(msg.id, base + 100);
 
-    // Cancel should be no-op — delivered state must survive
+    // Cancel should be CAS no-op — returns null, delivered state survives
     const result = await store.markCanceled(msg.id);
+    assert.equal(result, null, 'CAS no-op must return null (message already delivered)');
 
     const canonical = await store.getById(msg.id);
     assert.equal(canonical.deliveryStatus, 'delivered', 'markCanceled must NOT overwrite delivered status');
@@ -256,7 +257,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 8. after concurrent ops, all three zset scores + hash are consistent
   it('concurrent deliver+reassign: thread/timeline/user zset scores all agree with hash', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-zset-8';
+    const threadId = 'thread-dlv-zset-8';
     // Run 5 rounds to increase chance of hitting the race
     for (let round = 0; round < 5; round++) {
       await cleanupClientKeyspace(redis);
@@ -275,7 +276,7 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
   // 9. regression: no caller depends on cancel-non-queued behavior (F117 withdraw)
   it('markCanceled on immediate/no-status message is no-op', async () => {
     const base = Date.now();
-    const threadId = 'thread-f258-imm-9';
+    const threadId = 'thread-dlv-imm-9';
     // Create a message WITHOUT deliveryStatus (= immediate/legacy)
     const msg = await store.append({
       userId: 'userA',
@@ -287,16 +288,32 @@ describe('F258: delivery-order transition atomicity', { skip: redisIsolationSkip
     });
 
     const result = await store.markCanceled(msg.id);
-    const canonical = await store.getById(msg.id);
+    assert.equal(result, null, 'CAS no-op must return null (message not queued)');
 
-    // An immediate message must not become 'canceled'
+    const canonical = await store.getById(msg.id);
     assert.notEqual(canonical.deliveryStatus, 'canceled', 'immediate message must not be marked canceled');
+  });
+
+  // 10. already-canceled: second markCanceled must return null (CAS idempotency)
+  it('markCanceled on already-canceled message returns null (CAS idempotency)', async () => {
+    const base = Date.now();
+    const threadId = 'thread-dlv-idem-10';
+    const msg = await createQueued('userA', threadId, base);
+
+    // First cancel wins
+    const first = await store.markCanceled(msg.id);
+    assert.ok(first, 'first markCanceled must succeed (CAS applied)');
+    assert.equal(first.deliveryStatus, 'canceled', 'first cancel must transition to canceled');
+
+    // Second cancel is a no-op — CAS sees 'canceled' not 'queued'
+    const second = await store.markCanceled(msg.id);
+    assert.equal(second, null, 'second markCanceled must return null (already canceled)');
   });
 });
 
 // ── In-memory MessageStore: markCanceled guard (deterministic RED) ──
 
-describe('F258: in-memory MessageStore markCanceled guard', () => {
+describe('in-memory MessageStore markCanceled guard (PR #1193)', () => {
   let MessageStore;
 
   before(async () => {
@@ -319,9 +336,10 @@ describe('F258: in-memory MessageStore markCanceled guard', () => {
 
     memStore.markDelivered(msg.id, base + 100);
 
-    // Cancel should be no-op
+    // Cancel should be CAS no-op → null
     const result = memStore.markCanceled(msg.id);
-    assert.equal(result.deliveryStatus, 'delivered', 'in-memory markCanceled must NOT overwrite delivered status');
+    assert.equal(result, null, 'in-memory CAS no-op must return null');
+    assert.equal(memStore.getById(msg.id).deliveryStatus, 'delivered', 'delivered status must survive cancel attempt');
   });
 
   it('markCanceled on immediate/no-status message is no-op', async () => {
@@ -336,6 +354,27 @@ describe('F258: in-memory MessageStore markCanceled guard', () => {
     });
 
     const result = memStore.markCanceled(msg.id);
-    assert.notEqual(result.deliveryStatus, 'canceled', 'immediate message must not be marked canceled in memory store');
+    assert.equal(result, null, 'in-memory CAS no-op must return null (not queued)');
+    assert.notEqual(memStore.getById(msg.id).deliveryStatus, 'canceled', 'immediate message must not become canceled');
+  });
+
+  it('markCanceled on already-canceled message returns null (CAS idempotency parity)', async () => {
+    const memStore = new MessageStore();
+    const msg = await memStore.append({
+      userId: 'u1',
+      catId: null,
+      content: 'test',
+      mentions: [],
+      timestamp: Date.now(),
+      threadId: 'thread-mem-idem',
+      deliveryStatus: 'queued',
+    });
+
+    const first = memStore.markCanceled(msg.id);
+    assert.ok(first, 'first cancel must succeed');
+    assert.equal(first.deliveryStatus, 'canceled');
+
+    const second = memStore.markCanceled(msg.id);
+    assert.equal(second, null, 'second cancel must return null (already canceled)');
   });
 });

--- a/packages/api/test/redis-message-delivery-atomicity.test.js
+++ b/packages/api/test/redis-message-delivery-atomicity.test.js
@@ -234,7 +234,7 @@ describe('delivery-order transition atomicity (PR #1193)', { skip: redisIsolatio
     assert.equal(oldScore, null, 'old user must not have entry');
   });
 
-  // ── Fable's 3 supplementary RED test cases ──
+  // ── Supplementary test cases (guard/idempotency) ──
 
   // 7. markCanceled on delivered message → must be no-op (DETERMINISTIC RED)
   it('markCanceled on delivered message is no-op (guard: queued-only transition)', async () => {

--- a/packages/api/test/redis-message-store.test.js
+++ b/packages/api/test/redis-message-store.test.js
@@ -215,16 +215,15 @@ describe('RedisMessageStore', { skip: redisIsolationSkipReason(REDIS_URL) }, () 
     assert.equal(await redis.zscore(`msg:user:${userId}`, queued.id), '100');
     assert.equal(await redis.zscore(`msg:thread:${threadId}`, queued.id), '100');
 
-    assert.deepEqual(await admissionStore.markCanceled(legacy.id), legacyBefore.message);
+    assert.equal(await admissionStore.markCanceled(legacy.id), null);
     assert.deepEqual(await snapshot(legacy), legacyBefore, 'legacy-immediate hash and scores must remain unchanged');
 
     const deliveredResult = await admissionStore.markCanceled(delivered.id);
-    assert.equal(deliveredResult.deliveryStatus, 'delivered');
-    assert.equal(deliveredResult.deliveredAt, 200);
+    assert.equal(deliveredResult, null);
     assert.deepEqual(await snapshot(delivered), deliveredBefore, 'delivered hash and scores must remain unchanged');
 
     const canceledBefore = await snapshot(queued);
-    assert.deepEqual(await admissionStore.markCanceled(queued.id), canceledBefore.message);
+    assert.equal(await admissionStore.markCanceled(queued.id), null);
     assert.deepEqual(await snapshot(queued), canceledBefore, 'repeated cancellation must be a no-op');
   });
 

--- a/packages/api/test/startup-reconciler.test.js
+++ b/packages/api/test/startup-reconciler.test.js
@@ -746,7 +746,10 @@ describe('StartupReconciler', () => {
       },
       markDelivered(id, deliveredAt) {
         deliveredIds.push({ id, deliveredAt });
-        return { id, deliveryStatus: 'delivered', deliveredAt };
+        // CAS contract (PR #1193): running invocation's message is already visible →
+        // markDelivered returns null (CAS no-op). Only queued orphans actually transition.
+        if (id === 'umsg-1') return null; // already visible (running invocation)
+        return { id, deliveryStatus: 'delivered', deliveredAt }; // queued orphan → CAS wins
       },
     };
 
@@ -759,13 +762,13 @@ describe('StartupReconciler', () => {
 
     const result = await reconciler.reconcileOrphans();
 
-    // Both umsg-1 (running) and umsg-2 (queued) get markDelivered called.
-    // The store's guard (deliveryStatus !== 'queued' → no-op) protects already-visible messages.
-    assert.equal(result.messagesRecovered, 2, 'ensureMessageVisible called for both');
+    // Both get markDelivered called, but CAS decides: umsg-1 (already visible) = no-op,
+    // umsg-2 (queued orphan) = recovered. Only the CAS winner counts.
+    assert.equal(result.messagesRecovered, 1, 'only queued orphan counts as recovered (running = CAS no-op)');
     assert.deepEqual(
       deliveredIds.map((d) => d.id).sort(),
       ['umsg-1', 'umsg-2'],
-      'markDelivered called for both (store decides actual effect)',
+      'markDelivered called for both (CAS decides actual effect)',
     );
   });
 
@@ -847,8 +850,8 @@ describe('StartupReconciler', () => {
       },
       markDelivered(id) {
         markDeliveredCallCount++;
-        // Simulates store guard: message is already delivered → return as-is
-        return { id, deliveryStatus: 'delivered', deliveredAt: Date.now() - 60_000 };
+        // CAS no-op: message already delivered → returns null (PR #1193 contract)
+        return null;
       },
     };
 
@@ -861,11 +864,10 @@ describe('StartupReconciler', () => {
 
     const result = await reconciler.reconcileOrphans();
 
-    // markDelivered is called, but the store's !== 'queued' guard makes it a no-op
-    // for already-visible messages. This is safe AND catches the edge case where
-    // process crashed between invocation→running and markDelivered.
+    // markDelivered IS called (ensures crash-recovery path is exercised), but CAS
+    // returns null for already-visible messages → not counted as recovered.
     assert.equal(markDeliveredCallCount, 1, 'markDelivered should be called');
-    assert.equal(result.messagesRecovered, 1);
+    assert.equal(result.messagesRecovered, 0, 'CAS no-op: already-visible message not counted as recovered');
     assert.equal(result.running, 1);
   });
 


### PR DESCRIPTION
Fixes #1204

## Summary

- **Bug**: `reassignUserId`, `markDelivered`, and `markCanceled` in `RedisMessageStore` read a JS-side snapshot and then wrote through independent Redis transactions. Concurrent writers could interleave and leave the hash and sorted-set indexes inconsistent.
- **Fix**: Move each transition's read, compare, hash write, index update, and TTL operation into one Redis Lua execution.
- **CAS contract**: `markCanceled` and `markDelivered` only apply `queued → canceled` / `queued → delivered`. They return the transitioned message when this call wins and `null` on no-op, so callers emit events only for an applied transition.
- **Atomic receipt**: The Lua scripts return `HGETALL` on a CAS win. JS hydrates that winning payload directly, avoiding an EVAL-to-`getById` failure gap that could consume the transition without emitting its event.
- **TTL and prefix safety**: Reassignment applies `EXPIRE` inside the script and all Lua keys are compatible with ioredis `keyPrefix`.

## Changes (10 files)

| File | What |
|---|---|
| `packages/api/src/domains/cats/services/stores/redis/redis-message-delivery-lua-scripts.ts` | Three atomic Lua transitions for deliver, cancel, and reassign; CAS winners return `HGETALL`; reassignment applies TTL atomically |
| `packages/api/src/domains/cats/services/stores/redis/RedisMessageStore.ts` | Replace snapshot-then-transaction paths with Lua evaluation and deterministic result hydration |
| `packages/api/src/domains/cats/services/stores/ports/MessageStore.ts` | Match the queued-only CAS contract in memory and document every no-op class, including immediate messages |
| `packages/api/src/routes/queue.ts` | Gate cancellation events on an applied transition |
| `packages/api/test/redis-message-delivery-atomicity.test.js` | Real isolated-Redis concurrency, CAS winner, hydration, custom-prefix, and TTL coverage |
| `packages/api/test/redis-message-store.test.js` | Store-level transition contract, canonical state/index, and timestamp-admission coverage |
| `packages/api/test/message-store.test.js` | In-memory CAS parity and timestamp-admission coverage |
| `packages/api/test/delivery-status.test.js` | Applied-only delivery/cancel expectations |
| `packages/api/test/startup-reconciler.test.js` | Recovery counts and mocks aligned with applied-only transitions |
| `packages/api/test/queue-api.test.js` | Negative coverage proving CAS no-ops do not emit phantom deletion events |

## Scope boundaries

- **In scope**: atomic deliver/cancel/reassign transitions; queued-only CAS semantics; event gating; atomic reassignment TTL; custom `keyPrefix`; deliver × reassign and cancel × deliver concurrency; Lua-side winning-payload hydration.
- **Reserved**: a dedicated cancel × reassign concurrency scenario. The transition implementations remain individually atomic, but this pair is not claimed as a separately specified product policy in this PR.
- **Governance**: this PR has no feature-number attribution. Canonical F258 remains Visible Café.

## Exact-head evidence

Current candidate: `a122315e8a7ff7ba34c33106da68c0d42b53a883`, refreshed onto `main@77ea5938a99a9d43fd9fbe495d38752935d1fee2`.

- [x] Merge-main continuity: the whole-PR stable patch-id remains `fa8d6177bcac8e5bb3ce16e50ed53595887d29f1`; the intervening base-only delta has no file overlap with the 10 PR paths.
- [x] API build
- [x] Focused non-Redis integration: 119/119
- [x] Real isolated Redis on DB 15 with `CAT_CAFE_REDIS_TEST_ISOLATED=1`: 57/57
  - 13 Redis delivery-order atomicity + 3 in-memory parity
  - 35 RedisMessageStore
  - 3 scheduler user-id backfill
  - 3 Redis-backed thread-artifact coexistence
- [x] `git diff --check`
- [x] All five exact-head GitHub checks passed, including Public Test
- [x] The identical stable patch previously passed the latest-main full `pnpm gate`; the current merge-main refresh was revalidated by exact-head target CI and focused local suites.

### Reproduce the Redis suite

```bash
CAT_CAFE_REDIS_TEST_ISOLATED=1 REDIS_URL=redis://127.0.0.1:6398/15 \
  pnpm -C packages/api exec node --test --test-concurrency=1 \
  test/redis-message-delivery-atomicity.test.js \
  test/redis-message-store.test.js \
  test/scheduler-reply-userid-backfill.test.js \
  test/f232-thread-artifacts-redis.test.js
```

## Review provenance

- Architecture and exact-head maintainer review: Sol / GPT-5.6 Sol
- Implementation: Opus / Claude Opus 4.6, TDD
- Independent cloud Codex review: clean on `fb6cb05d`, whose stable whole-PR patch is identical to the current candidate
- Earlier independent rounds: Fable and cloud Codex; superseded as SHA-bound verdicts by subsequent pushes

🐾 Generated with [Clowder AI](https://github.com/zts212653/clowder-ai) — cat-cafe multi-agent collaboration