### PR TITLE
feat(limb): add F270 macOS BLE device family (Phase A read-only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ assets/prototypes/
 desktop/node_modules/
 desktop-dist/
 bundled/
+native/ble-helper/macos/.build/
 docs/bug-report/werewolf-investigation/poster-screenshot.png
 .worktrees/
 .review-worktrees/

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -38,6 +38,10 @@
       "identity": null,
       "hardenedRuntime": false,
       "gatekeeperAssess": false,
+      "extendInfo": {
+        "NSBluetoothAlwaysUsageDescription": "Clowder AI uses Bluetooth to discover and read devices explicitly bound by the operator.",
+        "NSBluetoothPeripheralUsageDescription": "Clowder AI uses Bluetooth to read devices explicitly bound by the operator."
+      },
       "extraResources": [
         {
           "from": "../bundled/node-darwin-${arch}",
@@ -46,6 +50,10 @@
         {
           "from": "../bundled/redis-darwin-${arch}",
           "to": ".cat-cafe/redis/darwin-${arch}"
+        },
+        {
+          "from": "../bundled/ble-helper-darwin-${arch}",
+          "to": "packages/api/ble-helper"
         }
       ]
     },

--- a/desktop/scripts/build-mac.sh
+++ b/desktop/scripts/build-mac.sh
@@ -196,6 +196,40 @@ for arch in "${ARCHS[@]}"; do
   build_redis "$arch"
 done
 
+# Build the native CoreBluetooth helper for each packaged architecture.
+# The helper carries its own Bluetooth usage description and communicates
+# with the API only through the versioned NDJSON protocol on stdio.
+build_ble_helper() {
+  local arch="$1"
+  local target_arch="$arch"
+  if [[ "$arch" == "x64" ]]; then target_arch="x86_64"; fi
+  local source_dir="${PROJECT_ROOT}/native/ble-helper/macos"
+  local out_dir="${BUNDLED_DIR}/ble-helper-darwin-${arch}"
+  mkdir -p "$out_dir"
+  swiftc \
+    -target "${target_arch}-apple-macos13.0" \
+    -O \
+    -whole-module-optimization \
+    -framework CoreBluetooth \
+    -Xlinker -sectcreate \
+    -Xlinker __TEXT \
+    -Xlinker __info_plist \
+    -Xlinker "${source_dir}/Info.plist" \
+    "${source_dir}/Protocol.swift" \
+    "${source_dir}/BleSupport.swift" \
+    "${source_dir}/BleController.swift" \
+    "${source_dir}/BleController+Delegates.swift" \
+    "${source_dir}/main.swift" \
+    -o "${out_dir}/ble-helper" \
+    || die "BLE helper ${arch} build failed"
+  chmod +x "${out_dir}/ble-helper"
+  ok "ble-helper-darwin-${arch} built"
+}
+
+for arch in "${ARCHS[@]}"; do
+  build_ble_helper "$arch"
+done
+
 # ─── Step 5: (macOS skips CLI tarball bundling) ──────────────────────────
 bold "Step 5/6 — CLI tools (skipped on macOS)"
 # macOS DMG has no post-install execution phase (unlike Windows Inno Setup),

--- a/native/ble-helper/macos/BleController+Delegates.swift
+++ b/native/ble-helper/macos/BleController+Delegates.swift
@@ -1,0 +1,128 @@
+import CoreBluetooth
+import Foundation
+
+extension BleController {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        let state: String
+        switch central.state {
+        case .poweredOn: state = "poweredOn"
+        case .poweredOff: state = "poweredOff"
+        case .unauthorized: state = "unauthorized"
+        case .unsupported: state = "unsupported"
+        case .resetting: state = "resetting"
+        default: state = "unknown"
+        }
+        writer.event(name: "adapter.state", data: ["state": state])
+        if central.state != .poweredOn, activeScanSessionId != nil {
+            finishScan(state: "stopped")
+        }
+    }
+
+    func centralManager(
+        _ central: CBCentralManager,
+        didDiscover peripheral: CBPeripheral,
+        advertisementData: [String: Any],
+        rssi RSSI: NSNumber
+    ) {
+        guard let sessionId = activeScanSessionId else { return }
+        devices[peripheral.identifier] = peripheral
+        peripheral.delegate = self
+        let advertisedServices = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID]) ?? []
+        let rawName = (advertisementData[CBAdvertisementDataLocalNameKey] as? String) ?? peripheral.name
+        let name = rawName.map { String($0.prefix(128)) }
+        let rssi = min(20, max(-127, RSSI.intValue))
+        writer.event(name: "scan.discovered", data: [
+            "sessionId": sessionId,
+            "deviceId": peripheral.identifier.uuidString,
+            "name": name ?? NSNull(),
+            "rssi": rssi,
+            "serviceUuids": advertisedServices.prefix(64).map(\.uuidString),
+        ])
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        startDiscovery(for: peripheral)
+    }
+
+    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        failOperation(peripheral.identifier, code: "connect_failed")
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        if operations[peripheral.identifier] != nil {
+            failOperation(peripheral.identifier, code: "device_disconnected")
+        }
+        devices.removeValue(forKey: peripheral.identifier)
+        writer.event(name: "device.disconnected", data: [
+            "deviceId": peripheral.identifier.uuidString,
+            "reason": error.map { String($0.localizedDescription.prefix(256)) } ?? NSNull(),
+        ])
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard let operation = operations[peripheral.identifier] else { return }
+        guard error == nil, let services = peripheral.services, services.count <= 64 else {
+            failOperation(peripheral.identifier, code: "service_discovery_failed")
+            return
+        }
+        switch operation.kind {
+        case .inspect:
+            operation.pendingServiceCount = services.count
+            if services.isEmpty {
+                completeInspection(peripheral)
+                return
+            }
+            for service in services {
+                peripheral.discoverCharacteristics(nil, for: service)
+            }
+        case .read:
+            guard let target = operation.serviceUuid,
+                  let service = services.first(where: { $0.uuid == target })
+            else {
+                failOperation(peripheral.identifier, code: "service_not_found")
+                return
+            }
+            peripheral.discoverCharacteristics(operation.characteristicUuid.map { [$0] }, for: service)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        guard let operation = operations[peripheral.identifier] else { return }
+        guard error == nil, let characteristics = service.characteristics, characteristics.count <= 128 else {
+            failOperation(peripheral.identifier, code: "characteristic_discovery_failed")
+            return
+        }
+        if operation.kind == .inspect {
+            operation.pendingServiceCount -= 1
+            if operation.pendingServiceCount == 0 {
+                completeInspection(peripheral)
+            }
+            return
+        }
+        guard let target = operation.characteristicUuid,
+              let characteristic = characteristics.first(where: { $0.uuid == target })
+        else {
+            failOperation(peripheral.identifier, code: "characteristic_not_found")
+            return
+        }
+        guard characteristic.properties.contains(.read) else {
+            failOperation(peripheral.identifier, code: "characteristic_not_readable")
+            return
+        }
+        peripheral.readValue(for: characteristic)
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let operation = operations[peripheral.identifier], operation.kind == .read,
+           characteristic.uuid == operation.characteristicUuid {
+            guard error == nil, let value = characteristic.value, value.count <= bleMaxValueBytes else {
+                failOperation(peripheral.identifier, code: "characteristic_read_failed")
+                return
+            }
+            writer.response(requestId: operation.request.requestId, data: ["valueBase64": value.base64EncodedString()])
+            clearOperation(peripheral.identifier)
+            releasePeripheral(peripheral)
+            return
+        }
+    }
+}

--- a/native/ble-helper/macos/BleController.swift
+++ b/native/ble-helper/macos/BleController.swift
@@ -1,0 +1,215 @@
+import CoreBluetooth
+import Darwin
+import Foundation
+
+final class BleController: NSObject, BleCommandHandling, CBCentralManagerDelegate, CBPeripheralDelegate {
+    let writer: ProtocolWriter
+    var central: CBCentralManager!
+    var devices: [UUID: CBPeripheral] = [:]
+    var activeScanSessionId: String?
+    var scanTimeout: DispatchWorkItem?
+    var operations: [UUID: DeviceOperation] = [:]
+
+    init(writer: ProtocolWriter) {
+        self.writer = writer
+        super.init()
+        central = CBCentralManager(
+            delegate: self,
+            queue: DispatchQueue.main,
+            options: [CBCentralManagerOptionShowPowerAlertKey: false]
+        )
+    }
+
+    func handle(_ request: BleRequest) {
+        switch request.command {
+        case "scan.start": startScan(request)
+        case "scan.stop": stopScan(request)
+        case "device.inspect": beginDeviceOperation(request, kind: .inspect)
+        case "gatt.read": beginDeviceOperation(request, kind: .read)
+        case "device.disconnect": disconnect(request)
+        case "helper.shutdown": shutdown(request)
+        default: writer.error(requestId: request.requestId, code: "unsupported_command")
+        }
+    }
+
+    private func startScan(_ request: BleRequest) {
+        guard central.state == .poweredOn else {
+            writer.error(requestId: request.requestId, code: "bluetooth_not_powered_on")
+            return
+        }
+        guard activeScanSessionId == nil,
+              let sessionId = boundedString(request.params["sessionId"], max: 128),
+              let timeoutMs = boundedInt(request.params["timeoutMs"], min: 1, max: 30_000)
+        else {
+            writer.error(requestId: request.requestId, code: "invalid_or_active_scan")
+            return
+        }
+        activeScanSessionId = sessionId
+        central.scanForPeripherals(withServices: nil, options: [CBCentralManagerScanOptionAllowDuplicatesKey: false])
+        writer.response(requestId: request.requestId, data: ["started": true])
+        writer.event(name: "scan.state", data: ["sessionId": sessionId, "state": "started"])
+        let timeout = DispatchWorkItem { [weak self] in
+            guard self?.activeScanSessionId == sessionId else { return }
+            self?.finishScan(state: "timeout")
+        }
+        scanTimeout = timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(timeoutMs), execute: timeout)
+    }
+
+    private func stopScan(_ request: BleRequest) {
+        guard let sessionId = boundedString(request.params["sessionId"], max: 128),
+              sessionId == activeScanSessionId
+        else {
+            writer.error(requestId: request.requestId, code: "scan_session_mismatch")
+            return
+        }
+        finishScan(state: "stopped")
+        writer.response(requestId: request.requestId, data: ["stopped": true])
+    }
+
+    func finishScan(state: String) {
+        guard let sessionId = activeScanSessionId else { return }
+        central.stopScan()
+        scanTimeout?.cancel()
+        scanTimeout = nil
+        activeScanSessionId = nil
+        // Nearby, unbound peripherals are scan-session data. Retain only
+        // devices with an operation in flight.
+        for (identifier, peripheral) in devices where operations[identifier] == nil {
+            if peripheral.state == .connected || peripheral.state == .connecting {
+                central.cancelPeripheralConnection(peripheral)
+            }
+            devices.removeValue(forKey: identifier)
+        }
+        writer.event(name: "scan.state", data: ["sessionId": sessionId, "state": state])
+    }
+
+    private func beginDeviceOperation(_ request: BleRequest, kind: OperationKind) {
+        guard central.state == .poweredOn,
+              let deviceId = boundedString(request.params["deviceId"], max: 128),
+              let uuid = UUID(uuidString: deviceId),
+              let peripheral = resolvePeripheral(uuid)
+        else {
+            writer.error(requestId: request.requestId, code: "device_unavailable")
+            return
+        }
+        guard operations[uuid] == nil else {
+            writer.error(requestId: request.requestId, code: "device_busy")
+            return
+        }
+
+        var serviceUuid: CBUUID?
+        var characteristicUuid: CBUUID?
+        if kind != .inspect {
+            guard let service = boundedString(request.params["serviceUuid"], max: 64),
+                  let characteristic = boundedString(request.params["characteristicUuid"], max: 64)
+            else {
+                writer.error(requestId: request.requestId, code: "invalid_gatt_target")
+                return
+            }
+            serviceUuid = CBUUID(string: service)
+            characteristicUuid = CBUUID(string: characteristic)
+        }
+
+        let operation = DeviceOperation(
+            request: request,
+            kind: kind,
+            serviceUuid: serviceUuid,
+            characteristicUuid: characteristicUuid
+        )
+        let timeout = DispatchWorkItem { [weak self] in
+            self?.failOperation(uuid, code: "operation_timeout")
+        }
+        operation.timeout = timeout
+        operations[uuid] = operation
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: timeout)
+        peripheral.delegate = self
+        if peripheral.state == .connected {
+            startDiscovery(for: peripheral)
+        } else {
+            central.connect(peripheral, options: nil)
+        }
+    }
+
+    func startDiscovery(for peripheral: CBPeripheral) {
+        guard let operation = operations[peripheral.identifier] else { return }
+        if operation.kind == .inspect {
+            peripheral.discoverServices(nil)
+        } else if let serviceUuid = operation.serviceUuid {
+            peripheral.discoverServices([serviceUuid])
+        }
+    }
+
+    func completeInspection(_ peripheral: CBPeripheral) {
+        guard let operation = operations[peripheral.identifier] else { return }
+        let services = (peripheral.services ?? []).prefix(64).map { service -> [String: Any] in
+            let characteristics = (service.characteristics ?? []).prefix(128).map { characteristic in
+                [
+                    "uuid": characteristic.uuid.uuidString,
+                    "properties": propertyNames(characteristic.properties),
+                ] as [String: Any]
+            }
+            return ["uuid": service.uuid.uuidString, "characteristics": characteristics]
+        }
+        writer.response(requestId: operation.request.requestId, data: ["services": services])
+        clearOperation(peripheral.identifier)
+        releasePeripheral(peripheral)
+    }
+
+    private func disconnect(_ request: BleRequest) {
+        guard let deviceId = boundedString(request.params["deviceId"], max: 128),
+              let uuid = UUID(uuidString: deviceId),
+              let peripheral = resolvePeripheral(uuid)
+        else {
+            writer.error(requestId: request.requestId, code: "device_unavailable")
+            return
+        }
+        clearOperation(uuid)
+        if peripheral.state == .connected || peripheral.state == .connecting {
+            central.cancelPeripheralConnection(peripheral)
+        }
+        devices.removeValue(forKey: uuid)
+        writer.response(requestId: request.requestId, data: ["disconnected": true])
+    }
+
+    private func shutdown(_ request: BleRequest) {
+        if activeScanSessionId != nil { finishScan(state: "stopped") }
+        for operationId in operations.keys { clearOperation(operationId) }
+        for peripheral in devices.values where peripheral.state == .connected || peripheral.state == .connecting {
+            central.cancelPeripheralConnection(peripheral)
+        }
+        writer.response(requestId: request.requestId, data: ["stopping": true])
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            Darwin.exit(0)
+        }
+    }
+
+    private func resolvePeripheral(_ identifier: UUID) -> CBPeripheral? {
+        if let existing = devices[identifier] { return existing }
+        guard let retrieved = central.retrievePeripherals(withIdentifiers: [identifier]).first else { return nil }
+        devices[identifier] = retrieved
+        retrieved.delegate = self
+        return retrieved
+    }
+
+    func failOperation(_ identifier: UUID, code: String) {
+        guard let operation = operations[identifier] else { return }
+        writer.error(requestId: operation.request.requestId, code: code)
+        clearOperation(identifier)
+        if let peripheral = devices[identifier] {
+            releasePeripheral(peripheral)
+        }
+    }
+
+    func clearOperation(_ identifier: UUID) {
+        operations[identifier]?.timeout?.cancel()
+        operations.removeValue(forKey: identifier)
+    }
+
+    func releasePeripheral(_ peripheral: CBPeripheral) {
+        if peripheral.state == .connected || peripheral.state == .connecting {
+            central.cancelPeripheralConnection(peripheral)
+        }
+        devices.removeValue(forKey: peripheral.identifier)
+    }
+}

--- a/native/ble-helper/macos/BleSupport.swift
+++ b/native/ble-helper/macos/BleSupport.swift
@@ -1,0 +1,47 @@
+import CoreBluetooth
+import Foundation
+
+enum OperationKind {
+    case inspect
+    case read
+}
+
+final class DeviceOperation {
+    let request: BleRequest
+    let kind: OperationKind
+    let serviceUuid: CBUUID?
+    let characteristicUuid: CBUUID?
+    var pendingServiceCount = 0
+    var timeout: DispatchWorkItem?
+
+    init(request: BleRequest, kind: OperationKind, serviceUuid: CBUUID? = nil, characteristicUuid: CBUUID? = nil) {
+        self.request = request
+        self.kind = kind
+        self.serviceUuid = serviceUuid
+        self.characteristicUuid = characteristicUuid
+    }
+}
+
+func boundedString(_ value: Any?, max: Int) -> String? {
+    guard let string = value as? String, !string.isEmpty, string.utf8.count <= max else { return nil }
+    return string
+}
+
+func boundedInt(_ value: Any?, min: Int, max: Int) -> Int? {
+    guard let number = value as? NSNumber,
+          CFGetTypeID(number) != CFBooleanGetTypeID(),
+          number.doubleValue.rounded(.towardZero) == number.doubleValue
+    else { return nil }
+    let intValue = number.intValue
+    return intValue >= min && intValue <= max ? intValue : nil
+}
+
+func propertyNames(_ properties: CBCharacteristicProperties) -> [String] {
+    var names: [String] = []
+    if properties.contains(.read) { names.append("read") }
+    if properties.contains(.notify) { names.append("notify") }
+    if properties.contains(.indicate) { names.append("indicate") }
+    if properties.contains(.write) { names.append("write") }
+    if properties.contains(.writeWithoutResponse) { names.append("writeWithoutResponse") }
+    return names
+}

--- a/native/ble-helper/macos/Info.plist
+++ b/native/ble-helper/macos/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleIdentifier</key>
+  <string>ai.clowderai.ble-helper</string>
+  <key>CFBundleName</key>
+  <string>Clowder AI BLE Helper</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>LSBackgroundOnly</key>
+  <true/>
+  <key>NSBluetoothAlwaysUsageDescription</key>
+  <string>Clowder AI uses Bluetooth to discover and read devices explicitly bound by the operator.</string>
+  <key>NSBluetoothPeripheralUsageDescription</key>
+  <string>Clowder AI uses Bluetooth to read devices explicitly bound by the operator.</string>
+</dict>
+</plist>

--- a/native/ble-helper/macos/Protocol.swift
+++ b/native/ble-helper/macos/Protocol.swift
@@ -1,0 +1,221 @@
+import Darwin
+import Foundation
+
+let bleProtocolName = "ble-helper"
+let bleProtocolVersion = 1
+let bleMaxLineBytes = 64 * 1024
+let bleMaxValueBytes = 4 * 1024
+
+private let allowedCommands: Set<String> = [
+    "scan.start",
+    "scan.stop",
+    "device.inspect",
+    "gatt.read",
+    "device.disconnect",
+    "helper.shutdown",
+]
+
+struct BleRequest {
+    let requestId: String
+    let command: String
+    let params: [String: Any]
+}
+
+protocol BleCommandHandling: AnyObject {
+    func handle(_ request: BleRequest)
+}
+
+final class ProtocolWriter {
+    private let outputQueue = DispatchQueue(label: "ai.clowderai.ble-helper.stdout")
+
+    func hello() {
+        send([
+            "protocol": bleProtocolName,
+            "version": bleProtocolVersion,
+            "kind": "hello",
+        ])
+    }
+
+    func response(requestId: String, data: Any? = nil) {
+        var object: [String: Any] = [
+            "protocol": bleProtocolName,
+            "version": bleProtocolVersion,
+            "kind": "response",
+            "requestId": requestId,
+            "ok": true,
+        ]
+        if let data {
+            object["data"] = data
+        }
+        send(object, fallbackRequestId: requestId)
+    }
+
+    func error(requestId: String, code: String) {
+        send([
+            "protocol": bleProtocolName,
+            "version": bleProtocolVersion,
+            "kind": "response",
+            "requestId": requestId,
+            "ok": false,
+            "error": String(code.prefix(512)),
+        ])
+    }
+
+    func event(name: String, data: [String: Any]) {
+        send([
+            "protocol": bleProtocolName,
+            "version": bleProtocolVersion,
+            "kind": "event",
+            "event": name,
+            "data": data,
+        ])
+    }
+
+    func diagnostic(_ message: String) {
+        let line = "[ble-helper] \(message.prefix(512))\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+
+    private func send(_ object: [String: Any], fallbackRequestId: String? = nil) {
+        outputQueue.sync {
+            do {
+                var data = try JSONSerialization.data(withJSONObject: object, options: [])
+                if data.count > bleMaxLineBytes, let requestId = fallbackRequestId {
+                    data = try JSONSerialization.data(withJSONObject: [
+                        "protocol": bleProtocolName,
+                        "version": bleProtocolVersion,
+                        "kind": "response",
+                        "requestId": requestId,
+                        "ok": false,
+                        "error": "response_too_large",
+                    ])
+                }
+                guard data.count <= bleMaxLineBytes else {
+                    diagnostic("Dropping oversized protocol message")
+                    return
+                }
+                data.append(0x0A)
+                FileHandle.standardOutput.write(data)
+            } catch {
+                diagnostic("Unable to encode protocol message")
+            }
+        }
+    }
+}
+
+final class BleProtocolServer {
+    private let writer: ProtocolWriter
+    private let handler: BleCommandHandling
+
+    init(writer: ProtocolWriter, handler: BleCommandHandling) {
+        self.writer = writer
+        self.handler = handler
+    }
+
+    func handleLine(_ line: Data) {
+        guard line.count <= bleMaxLineBytes else {
+            writer.diagnostic("Rejected oversized input line")
+            return
+        }
+        guard
+            let value = try? JSONSerialization.jsonObject(with: line),
+            let object = value as? [String: Any]
+        else {
+            writer.diagnostic("Rejected invalid JSON")
+            return
+        }
+
+        let requestId = object["requestId"] as? String
+        guard
+            object["protocol"] as? String == bleProtocolName,
+            (object["version"] as? NSNumber)?.intValue == bleProtocolVersion,
+            let requestId,
+            !requestId.isEmpty,
+            requestId.utf8.count <= 128,
+            let command = object["command"] as? String,
+            !command.isEmpty,
+            command.utf8.count <= 128,
+            let params = object["params"] as? [String: Any]
+        else {
+            if let requestId {
+                writer.error(requestId: requestId, code: "invalid_request")
+            } else {
+                writer.diagnostic("Rejected request without a valid requestId")
+            }
+            return
+        }
+
+        guard allowedCommands.contains(command) else {
+            writer.error(requestId: requestId, code: "unsupported_command")
+            return
+        }
+        handler.handle(BleRequest(requestId: requestId, command: command, params: params))
+    }
+}
+
+final class StdinLineReader {
+    private let writer: ProtocolWriter
+    private let onLine: (Data) -> Void
+
+    init(writer: ProtocolWriter, onLine: @escaping (Data) -> Void) {
+        self.writer = writer
+        self.onLine = onLine
+    }
+
+    func start() {
+        DispatchQueue.global(qos: .userInitiated).async { [self] in
+            var buffer = Data()
+            while true {
+                let chunk = FileHandle.standardInput.availableData
+                if chunk.isEmpty {
+                    // The API process owns the helper lifetime. Queue shutdown
+                    // behind any lines already dispatched to the main queue so
+                    // their responses are flushed before an orderly EOF exit.
+                    DispatchQueue.main.async {
+                        Darwin.exit(0)
+                    }
+                    return
+                }
+                buffer.append(chunk)
+                while let newline = buffer.firstIndex(of: 0x0A) {
+                    var line = buffer.prefix(upTo: newline)
+                    buffer.removeSubrange(...newline)
+                    if line.last == 0x0D {
+                        line = line.dropLast()
+                    }
+                    guard line.count <= bleMaxLineBytes else {
+                        writer.diagnostic("Input line exceeded 64 KiB")
+                        Darwin.exit(2)
+                    }
+                    let ownedLine = Data(line)
+                    DispatchQueue.main.async { [onLine] in
+                        onLine(ownedLine)
+                    }
+                }
+                if buffer.count > bleMaxLineBytes {
+                    writer.diagnostic("Input line exceeded 64 KiB")
+                    Darwin.exit(2)
+                }
+            }
+        }
+    }
+}
+
+final class ProtocolSmokeHandler: BleCommandHandling {
+    private let writer: ProtocolWriter
+
+    init(writer: ProtocolWriter) {
+        self.writer = writer
+    }
+
+    func handle(_ request: BleRequest) {
+        if request.command == "helper.shutdown" {
+            writer.response(requestId: request.requestId, data: ["stopping": true])
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.02) {
+                Darwin.exit(0)
+            }
+            return
+        }
+        writer.error(requestId: request.requestId, code: "protocol_smoke_no_hardware")
+    }
+}

--- a/native/ble-helper/macos/main.swift
+++ b/native/ble-helper/macos/main.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+let writer = ProtocolWriter()
+let smokeOnly = CommandLine.arguments.contains("--protocol-smoke")
+let handler: BleCommandHandling = smokeOnly ? ProtocolSmokeHandler(writer: writer) : BleController(writer: writer)
+let server = BleProtocolServer(writer: writer, handler: handler)
+let reader = StdinLineReader(writer: writer) { line in
+    server.handleLine(line)
+}
+
+writer.hello()
+reader.start()
+RunLoop.main.run()

--- a/native/ble-helper/macos/test-protocol.sh
+++ b/native/ble-helper/macos/test-protocol.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTPUT_DIR="${SCRIPT_DIR}/.build/$(uname -m)"
+OUTPUT="${OUTPUT_DIR}/ble-helper"
+
+mkdir -p "$OUTPUT_DIR"
+swiftc \
+  -framework CoreBluetooth \
+  -Xlinker -sectcreate \
+  -Xlinker __TEXT \
+  -Xlinker __info_plist \
+  -Xlinker "${SCRIPT_DIR}/Info.plist" \
+  "${SCRIPT_DIR}/Protocol.swift" \
+  "${SCRIPT_DIR}/BleSupport.swift" \
+  "${SCRIPT_DIR}/BleController.swift" \
+  "${SCRIPT_DIR}/BleController+Delegates.swift" \
+  "${SCRIPT_DIR}/main.swift" \
+  -o "$OUTPUT"
+
+REQUESTS="$(mktemp)"
+OUTPUT_LOG="$(mktemp)"
+trap 'rm -f "$REQUESTS" "$OUTPUT_LOG"' EXIT
+
+printf '%s\n' \
+  '{"protocol":"ble-helper","version":1,"requestId":"write-1","command":"gatt.write","params":{"deviceId":"d","valueBase64":"AQ=="}}' \
+  '{"protocol":"ble-helper","version":1,"requestId":"stop-1","command":"helper.shutdown","params":{}}' \
+  > "$REQUESTS"
+
+"$OUTPUT" --protocol-smoke < "$REQUESTS" > "$OUTPUT_LOG"
+
+grep -q '"kind":"hello"' "$OUTPUT_LOG"
+grep -q '"requestId":"write-1"' "$OUTPUT_LOG"
+grep -q '"ok":false' "$OUTPUT_LOG"
+grep -q '"error":"unsupported_command"' "$OUTPUT_LOG"
+grep -q '"requestId":"stop-1"' "$OUTPUT_LOG"
+grep -q '"ok":true' "$OUTPUT_LOG"
+
+# The helper must not outlive an API parent that closes stdin unexpectedly.
+"$OUTPUT" --protocol-smoke </dev/null >/dev/null 2>&1 &
+EOF_PID=$!
+for _ in $(seq 1 40); do
+  if ! kill -0 "$EOF_PID" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+if kill -0 "$EOF_PID" 2>/dev/null; then
+  kill "$EOF_PID" 2>/dev/null || true
+  wait "$EOF_PID" 2>/dev/null || true
+  echo "BLE helper did not exit after stdin EOF" >&2
+  exit 1
+fi
+wait "$EOF_PID"
+
+echo "BLE helper protocol smoke passed"

--- a/packages/api/src/domains/limb/ble/BleAdapterReadiness.ts
+++ b/packages/api/src/domains/limb/ble/BleAdapterReadiness.ts
@@ -1,0 +1,72 @@
+import type { BleHelperEvent } from './BleHelperProtocol.js';
+
+type BleAdapterState = Extract<BleHelperEvent, { event: 'adapter.state' }>['data']['state'];
+
+interface BleEventSource {
+  on(event: 'event', listener: (message: BleHelperEvent) => void): unknown;
+  off(event: 'event', listener: (message: BleHelperEvent) => void): unknown;
+}
+
+export class BleAdapterReadiness {
+  private state: BleAdapterState | null = null;
+  private readonly rejectWaiters = new Set<(error: Error) => void>();
+
+  constructor(
+    private readonly events: BleEventSource,
+    private readonly timeoutMs: number,
+  ) {}
+
+  reset(): void {
+    this.state = null;
+    const error = new Error('BLE adapter readiness was reset');
+    for (const rejectWaiter of [...this.rejectWaiters]) rejectWaiter(error);
+  }
+
+  observe(message: BleHelperEvent): void {
+    if (message.event === 'adapter.state') this.state = message.data.state;
+  }
+
+  waitForPoweredOn(): Promise<void> {
+    const currentError = this.stateError();
+    if (currentError) return Promise.reject(currentError);
+    if (this.state === 'poweredOn') return Promise.resolve();
+
+    return new Promise<void>((resolveReady, rejectReady) => {
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        this.events.off('event', onEvent);
+        this.rejectWaiters.delete(rejectWaiter);
+      };
+      const rejectWaiter = (error: Error): void => {
+        cleanup();
+        rejectReady(error);
+      };
+      const checkState = (): void => {
+        const error = this.stateError();
+        if (error) {
+          rejectWaiter(error);
+        } else if (this.state === 'poweredOn') {
+          cleanup();
+          resolveReady();
+        }
+      };
+      const onEvent = (message: BleHelperEvent): void => {
+        if (message.event === 'adapter.state') checkState();
+      };
+      const timer = setTimeout(() => {
+        rejectWaiter(new Error('BLE adapter state timed out before poweredOn'));
+      }, this.timeoutMs);
+      timer.unref();
+      this.rejectWaiters.add(rejectWaiter);
+      this.events.on('event', onEvent);
+      checkState();
+    });
+  }
+
+  private stateError(): Error | null {
+    if (this.state === 'poweredOff' || this.state === 'unauthorized' || this.state === 'unsupported') {
+      return new Error(`BLE adapter is not powered on: ${this.state}`);
+    }
+    return null;
+  }
+}

--- a/packages/api/src/domains/limb/ble/BleAdapters.ts
+++ b/packages/api/src/domains/limb/ble/BleAdapters.ts
@@ -1,0 +1,190 @@
+import type { LimbCapability, LimbCommandSchema } from '@cat-cafe/shared';
+
+export interface BleGattCharacteristic {
+  uuid: string;
+  properties: string[];
+}
+
+export interface BleGattService {
+  uuid: string;
+  characteristics: BleGattCharacteristic[];
+}
+
+export interface BleAdapterCommand {
+  command: string;
+  capability: string;
+  serviceUuid: string;
+  characteristicUuid: string;
+  mode: 'read';
+  decode(value: Buffer): BleDecodedValue;
+}
+
+export interface BleAdapterDefinition {
+  id: string;
+  displayName: string;
+  commands: readonly BleAdapterCommand[];
+}
+
+export interface BleDecodedValue {
+  kind: 'battery' | 'temperature' | 'humidity';
+  value: number;
+  unit: '%' | '°C';
+}
+
+const BLUETOOTH_BASE_SUFFIX = '-0000-1000-8000-00805f9b34fb';
+
+export function normalizeGattUuid(uuid: string): string {
+  const normalized = uuid.trim().toLowerCase();
+  if (normalized.startsWith('0000') && normalized.endsWith(BLUETOOTH_BASE_SUFFIX)) {
+    return normalized.slice(4, 8);
+  }
+  return normalized;
+}
+
+function requireLength(value: Buffer, expected: number, label: string): void {
+  if (value.byteLength !== expected) {
+    throw new Error(`${label} value has invalid length: expected ${expected}, received ${value.byteLength}`);
+  }
+}
+
+function requireRange(value: number, min: number, max: number, label: string): number {
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${label} value ${value} is outside ${min}..${max}`);
+  }
+  return value;
+}
+
+function decodeBattery(value: Buffer): BleDecodedValue {
+  requireLength(value, 1, 'Battery');
+  return { kind: 'battery', value: requireRange(value.readUInt8(0), 0, 100, 'Battery'), unit: '%' };
+}
+
+function decodeTemperature(value: Buffer): BleDecodedValue {
+  requireLength(value, 2, 'Temperature');
+  const decoded = value.readInt16LE(0) / 100;
+  return { kind: 'temperature', value: requireRange(decoded, -273.15, 200, 'Temperature'), unit: '°C' };
+}
+
+function decodeHumidity(value: Buffer): BleDecodedValue {
+  requireLength(value, 2, 'Humidity');
+  const decoded = value.readUInt16LE(0) / 100;
+  return { kind: 'humidity', value: requireRange(decoded, 0, 100, 'Humidity'), unit: '%' };
+}
+
+const BATTERY_COMMAND: BleAdapterCommand = {
+  command: 'ble.battery.read',
+  capability: 'ble.battery',
+  serviceUuid: '180f',
+  characteristicUuid: '2a19',
+  mode: 'read',
+  decode: decodeBattery,
+};
+
+const ENVIRONMENTAL_COMMANDS: readonly BleAdapterCommand[] = [
+  {
+    command: 'ble.temperature.read',
+    capability: 'ble.environment',
+    serviceUuid: '181a',
+    characteristicUuid: '2a6e',
+    mode: 'read',
+    decode: decodeTemperature,
+  },
+  {
+    command: 'ble.humidity.read',
+    capability: 'ble.environment',
+    serviceUuid: '181a',
+    characteristicUuid: '2a6f',
+    mode: 'read',
+    decode: decodeHumidity,
+  },
+];
+
+export const BLE_ADAPTERS: Readonly<Record<string, BleAdapterDefinition>> = {
+  'standard.environmental': {
+    id: 'standard.environmental',
+    displayName: 'Environmental Sensing',
+    commands: ENVIRONMENTAL_COMMANDS,
+  },
+  'standard.battery': {
+    id: 'standard.battery',
+    displayName: 'Battery Service',
+    commands: [BATTERY_COMMAND],
+  },
+};
+
+export function getBleAdapter(adapterId: string): BleAdapterDefinition | null {
+  return BLE_ADAPTERS[adapterId] ?? null;
+}
+
+function hasCharacteristic(services: readonly BleGattService[], command: BleAdapterCommand): boolean {
+  const serviceUuid = normalizeGattUuid(command.serviceUuid);
+  const characteristicUuid = normalizeGattUuid(command.characteristicUuid);
+  return services.some(
+    (service) =>
+      normalizeGattUuid(service.uuid) === serviceUuid &&
+      service.characteristics.some((characteristic) => {
+        if (normalizeGattUuid(characteristic.uuid) !== characteristicUuid) return false;
+        return characteristic.properties.includes('read');
+      }),
+  );
+}
+
+export function selectBleAdapter(services: readonly BleGattService[]): BleAdapterDefinition | null {
+  const preference = ['standard.environmental', 'standard.battery'];
+  for (const adapterId of preference) {
+    const adapter = BLE_ADAPTERS[adapterId];
+    if (adapter?.commands.some((command) => hasCharacteristic(services, command))) return adapter;
+  }
+  return null;
+}
+
+export function availableBleCommands(
+  adapter: BleAdapterDefinition,
+  services?: readonly BleGattService[],
+): BleAdapterCommand[] {
+  return adapter.commands.filter((command) => !services || hasCharacteristic(services, command));
+}
+
+export function findBleAdapterCommand(adapterId: string, commandName: string): BleAdapterCommand | null {
+  return getBleAdapter(adapterId)?.commands.find((command) => command.command === commandName) ?? null;
+}
+
+export function decodeBleCommandValue(adapterId: string, commandName: string, value: Buffer): BleDecodedValue {
+  const command = findBleAdapterCommand(adapterId, commandName);
+  if (!command) throw new Error(`Command '${commandName}' is not declared by BLE adapter '${adapterId}'`);
+  return command.decode(value);
+}
+
+export function buildBleLimbCapabilities(adapterId: string, allowedCommands?: readonly string[]): LimbCapability[] {
+  const adapter = getBleAdapter(adapterId);
+  if (!adapter) return [];
+  const allowed = allowedCommands ? new Set(allowedCommands) : null;
+  const grouped = new Map<string, string[]>();
+  for (const command of adapter.commands) {
+    if (allowed && !allowed.has(command.command)) continue;
+    const commands = grouped.get(command.capability) ?? [];
+    commands.push(command.command);
+    grouped.set(command.capability, commands);
+  }
+  return [...grouped].map(([cap, commands]) => ({ cap, commands, authLevel: 'free' as const }));
+}
+
+export function buildBleCommandSchemas(
+  adapterId: string,
+  allowedCommands?: readonly string[],
+): Record<string, LimbCommandSchema> {
+  const adapter = getBleAdapter(adapterId);
+  if (!adapter) return {};
+  const allowed = allowedCommands ? new Set(allowedCommands) : null;
+  return Object.fromEntries(
+    adapter.commands
+      .filter((command) => !allowed || allowed.has(command.command))
+      .map((command) => [
+        command.command,
+        {
+          description: `Read typed ${command.capability} data from the bound BLE device.`,
+          params: {},
+        },
+      ]),
+  );
+}

--- a/packages/api/src/domains/limb/ble/BleBindingRecovery.ts
+++ b/packages/api/src/domains/limb/ble/BleBindingRecovery.ts
@@ -1,0 +1,115 @@
+import type { BleBinding, IBleBindingStore } from './BleBindingStore.js';
+import {
+  type BleDeviceContract,
+  BleUnsupportedProfileError,
+  hasSameBleContract,
+  inspectBleDevice,
+} from './BleDeviceInspection.js';
+import type { BleScanSession } from './BleScanSession.js';
+
+interface BleRecoveryHelper {
+  request(command: string, params: Record<string, unknown>): Promise<unknown>;
+}
+
+interface LoggerLike {
+  warn(message: string): void;
+}
+
+export interface BleBindingProbeResult {
+  bindingId: string;
+  state: 'reachable' | 'unreachable' | 'profile_mismatch';
+  checkedAt: number;
+  reason?: 'busy' | 'connection_failed' | 'disconnected' | 'inspection_failed' | 'timeout' | 'unavailable';
+}
+
+interface BleBindingRecoveryOptions {
+  helper: BleRecoveryHelper;
+  store: IBleBindingStore;
+  scan: BleScanSession;
+  bindings: Map<string, BleBinding>;
+  reservedDeviceIds: Set<string>;
+  acquireBindingOperation: (bindingId: string) => () => void;
+  logger: LoggerLike;
+}
+
+function failureReason(error: unknown): NonNullable<BleBindingProbeResult['reason']> {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/device_busy|already in progress/i.test(message)) return 'busy';
+  if (/timed out|timeout/i.test(message)) return 'timeout';
+  if (/connect_failed/i.test(message)) return 'connection_failed';
+  if (/device_disconnected/i.test(message)) return 'disconnected';
+  if (/service_discovery|inspection|characteristic/i.test(message)) return 'inspection_failed';
+  return 'unavailable';
+}
+
+export class BleBindingRecovery {
+  constructor(private readonly options: BleBindingRecoveryOptions) {}
+
+  async probe(bindingId: string): Promise<BleBindingProbeResult | null> {
+    const binding = this.options.bindings.get(bindingId);
+    if (!binding) return null;
+    const releaseBinding = this.options.acquireBindingOperation(bindingId);
+    const checkedAt = Date.now();
+    try {
+      let contract: BleDeviceContract;
+      try {
+        contract = await inspectBleDevice(this.options.helper, binding.platformDeviceId);
+      } catch (error) {
+        if (error instanceof BleUnsupportedProfileError) return { bindingId, state: 'profile_mismatch', checkedAt };
+        return { bindingId, state: 'unreachable', reason: failureReason(error), checkedAt };
+      }
+      if (!hasSameBleContract(binding, contract)) return { bindingId, state: 'profile_mismatch', checkedAt };
+      const updated = { ...binding, commands: [...binding.commands], lastConnectedAt: checkedAt };
+      await this.options.store.put(updated);
+      this.options.bindings.set(bindingId, updated);
+      return { bindingId, state: 'reachable', checkedAt };
+    } finally {
+      releaseBinding();
+    }
+  }
+
+  async rebind(bindingId: string, input: { sessionId: string; discoveryId: string }): Promise<BleBinding | null> {
+    const binding = this.options.bindings.get(bindingId);
+    if (!binding) return null;
+    const discovery = this.options.scan.resolveDiscovery(input.sessionId, input.discoveryId);
+    if (!discovery) throw new Error('BLE discovery is not available in the active scan session');
+    const deviceId = discovery.platformDeviceId;
+    if (
+      this.options.reservedDeviceIds.has(deviceId) ||
+      [...this.options.bindings.values()].some(
+        (candidate) => candidate.bindingId !== bindingId && candidate.platformDeviceId === deviceId,
+      )
+    ) {
+      throw new Error('BLE device is already bound or binding is already in progress');
+    }
+    const releaseBinding = this.options.acquireBindingOperation(bindingId);
+    this.options.reservedDeviceIds.add(deviceId);
+    try {
+      const contract = await inspectBleDevice(this.options.helper, deviceId);
+      if (!hasSameBleContract(binding, contract)) {
+        throw new Error('BLE rebind target is not compatible with the existing binding');
+      }
+      const updated: BleBinding = {
+        ...binding,
+        platformDeviceId: deviceId,
+        commands: [...binding.commands],
+        lastConnectedAt: Date.now(),
+      };
+      await this.options.store.put(updated);
+      this.options.bindings.set(bindingId, updated);
+      if (binding.platformDeviceId !== deviceId) await this.disconnectPreviousIdentity(binding.platformDeviceId);
+      return { ...updated, commands: [...updated.commands] };
+    } finally {
+      this.options.reservedDeviceIds.delete(deviceId);
+      releaseBinding();
+    }
+  }
+
+  private async disconnectPreviousIdentity(deviceId: string): Promise<void> {
+    try {
+      await this.options.helper.request('device.disconnect', { deviceId });
+    } catch (error) {
+      this.options.logger.warn(`BLE previous device disconnect after rebind failed: ${String(error)}`);
+    }
+  }
+}

--- a/packages/api/src/domains/limb/ble/BleBindingStore.ts
+++ b/packages/api/src/domains/limb/ble/BleBindingStore.ts
@@ -1,0 +1,134 @@
+import type { RedisClient } from '@cat-cafe/shared/utils';
+
+export const BLE_BINDING_SCOPE = 'instance' as const;
+export const BLE_BINDING_INDEX_KEY = (scopeId: string): string => `limb:ble:bindings:${scopeId}:index`;
+export const bleBindingKey = (scopeId: string, bindingId: string): string =>
+  `limb:ble:bindings:${scopeId}:${bindingId}`;
+
+export interface BleBinding {
+  bindingId: string;
+  scopeId: string;
+  platformDeviceId: string;
+  displayName: string;
+  adapterId: string;
+  commands: string[];
+  nodeId: string;
+  createdAt: number;
+  lastConnectedAt: number | null;
+}
+
+export interface IBleBindingStore {
+  get(scopeId: string, bindingId: string): Promise<BleBinding | null>;
+  list(scopeId: string): Promise<BleBinding[]>;
+  put(binding: BleBinding): Promise<void>;
+  delete(scopeId: string, bindingId: string): Promise<void>;
+}
+
+interface LoggerLike {
+  warn(message: string): void;
+}
+
+type BindingRedis = Pick<RedisClient, 'get' | 'smembers' | 'multi'>;
+
+function isBleBinding(value: unknown): value is BleBinding {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.bindingId === 'string' &&
+    candidate.bindingId.length > 0 &&
+    typeof candidate.scopeId === 'string' &&
+    candidate.scopeId.length > 0 &&
+    typeof candidate.platformDeviceId === 'string' &&
+    candidate.platformDeviceId.length > 0 &&
+    typeof candidate.displayName === 'string' &&
+    candidate.displayName.length <= 128 &&
+    typeof candidate.adapterId === 'string' &&
+    Array.isArray(candidate.commands) &&
+    candidate.commands.length > 0 &&
+    candidate.commands.length <= 32 &&
+    candidate.commands.every((command) => typeof command === 'string' && command.length > 0 && command.length <= 128) &&
+    typeof candidate.nodeId === 'string' &&
+    Number.isFinite(candidate.createdAt) &&
+    (candidate.lastConnectedAt === null || Number.isFinite(candidate.lastConnectedAt))
+  );
+}
+
+function parseBinding(raw: string, expectedScope: string, expectedId: string): BleBinding | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!isBleBinding(parsed) || parsed.scopeId !== expectedScope || parsed.bindingId !== expectedId) return null;
+  return parsed;
+}
+
+export class RedisBleBindingStore implements IBleBindingStore {
+  constructor(
+    private readonly redis: BindingRedis,
+    private readonly logger: LoggerLike = console,
+  ) {}
+
+  async get(scopeId: string, bindingId: string): Promise<BleBinding | null> {
+    const raw = await this.redis.get(bleBindingKey(scopeId, bindingId));
+    if (!raw) return null;
+    const binding = parseBinding(raw, scopeId, bindingId);
+    if (!binding) this.logger.warn(`Ignoring invalid BLE binding record: ${scopeId}/${bindingId}`);
+    return binding;
+  }
+
+  async list(scopeId: string): Promise<BleBinding[]> {
+    const ids = await this.redis.smembers(BLE_BINDING_INDEX_KEY(scopeId));
+    const bindings = await Promise.all(ids.map((id) => this.get(scopeId, id)));
+    return bindings
+      .filter((binding): binding is BleBinding => binding !== null)
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  async put(binding: BleBinding): Promise<void> {
+    if (!isBleBinding(binding)) throw new Error('Invalid BLE binding');
+    const transaction = this.redis.multi();
+    transaction.set(bleBindingKey(binding.scopeId, binding.bindingId), JSON.stringify(binding));
+    transaction.sadd(BLE_BINDING_INDEX_KEY(binding.scopeId), binding.bindingId);
+    const result = await transaction.exec();
+    if (result === null || result.some(([error]) => error)) throw new Error('Failed to persist BLE binding');
+  }
+
+  async delete(scopeId: string, bindingId: string): Promise<void> {
+    const transaction = this.redis.multi();
+    transaction.del(bleBindingKey(scopeId, bindingId));
+    transaction.srem(BLE_BINDING_INDEX_KEY(scopeId), bindingId);
+    const result = await transaction.exec();
+    if (result === null || result.some(([error]) => error)) throw new Error('Failed to delete BLE binding');
+  }
+}
+
+export class MemoryBleBindingStore implements IBleBindingStore {
+  private readonly bindings = new Map<string, BleBinding>();
+
+  private key(scopeId: string, bindingId: string): string {
+    return `${scopeId}:${bindingId}`;
+  }
+
+  async get(scopeId: string, bindingId: string): Promise<BleBinding | null> {
+    const binding = this.bindings.get(this.key(scopeId, bindingId));
+    return binding ? { ...binding, commands: [...binding.commands] } : null;
+  }
+
+  async list(scopeId: string): Promise<BleBinding[]> {
+    return [...this.bindings.values()]
+      .filter((binding) => binding.scopeId === scopeId)
+      .sort((a, b) => a.createdAt - b.createdAt)
+      .map((binding) => ({ ...binding, commands: [...binding.commands] }));
+  }
+
+  async put(binding: BleBinding): Promise<void> {
+    if (!isBleBinding(binding)) throw new Error('Invalid BLE binding');
+    this.bindings.set(this.key(binding.scopeId, binding.bindingId), { ...binding, commands: [...binding.commands] });
+  }
+
+  async delete(scopeId: string, bindingId: string): Promise<void> {
+    this.bindings.delete(this.key(scopeId, bindingId));
+  }
+}

--- a/packages/api/src/domains/limb/ble/BleDeviceInspection.ts
+++ b/packages/api/src/domains/limb/ble/BleDeviceInspection.ts
@@ -1,0 +1,63 @@
+import { availableBleCommands, type BleGattService, selectBleAdapter } from './BleAdapters.js';
+
+interface BleInspectionRequester {
+  request(command: string, params: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface BleDeviceContract {
+  adapterId: string;
+  commands: string[];
+}
+
+export class BleUnsupportedProfileError extends Error {}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseGattServices(value: unknown): BleGattService[] {
+  if (!isRecord(value) || !Array.isArray(value.services) || value.services.length > 64) {
+    throw new Error('BLE helper returned an invalid GATT inspection');
+  }
+  return value.services.map((service): BleGattService => {
+    if (!isRecord(service) || typeof service.uuid !== 'string' || service.uuid.length > 64) {
+      throw new Error('BLE helper returned an invalid GATT service');
+    }
+    if (!Array.isArray(service.characteristics) || service.characteristics.length > 128) {
+      throw new Error('BLE helper returned an invalid characteristic list');
+    }
+    return {
+      uuid: service.uuid,
+      characteristics: service.characteristics.map((characteristic) => {
+        if (
+          !isRecord(characteristic) ||
+          typeof characteristic.uuid !== 'string' ||
+          characteristic.uuid.length > 64 ||
+          !Array.isArray(characteristic.properties) ||
+          !characteristic.properties.every((property) => typeof property === 'string' && property.length <= 32)
+        ) {
+          throw new Error('BLE helper returned an invalid GATT characteristic');
+        }
+        return { uuid: characteristic.uuid, properties: [...characteristic.properties] as string[] };
+      }),
+    };
+  });
+}
+
+export async function inspectBleDevice(helper: BleInspectionRequester, deviceId: string): Promise<BleDeviceContract> {
+  const inspection = await helper.request('device.inspect', { deviceId });
+  const services = parseGattServices(inspection);
+  const adapter = selectBleAdapter(services);
+  if (!adapter) throw new BleUnsupportedProfileError('BLE device does not expose a supported adapter profile');
+  const commands = availableBleCommands(adapter, services).map((command) => command.command);
+  if (commands.length === 0) {
+    throw new BleUnsupportedProfileError('BLE device has no supported readable characteristics');
+  }
+  return { adapterId: adapter.id, commands };
+}
+
+export function hasSameBleContract(binding: { adapterId: string; commands: string[] }, contract: BleDeviceContract) {
+  if (binding.adapterId !== contract.adapterId || binding.commands.length !== contract.commands.length) return false;
+  const expected = new Set(binding.commands);
+  return contract.commands.every((command) => expected.has(command));
+}

--- a/packages/api/src/domains/limb/ble/BleDeviceManager.ts
+++ b/packages/api/src/domains/limb/ble/BleDeviceManager.ts
@@ -1,0 +1,287 @@
+import { Buffer } from 'node:buffer';
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import type { LimbNodeStatus } from '@cat-cafe/shared';
+import type { LimbRegistry } from '../LimbRegistry.js';
+import { decodeBleCommandValue, findBleAdapterCommand, getBleAdapter } from './BleAdapters.js';
+import { type BleBindingProbeResult, BleBindingRecovery } from './BleBindingRecovery.js';
+import { BLE_BINDING_SCOPE, type BleBinding, type IBleBindingStore } from './BleBindingStore.js';
+import { inspectBleDevice } from './BleDeviceInspection.js';
+import type { BleHelperClientStatus } from './BleHelperClientTypes.js';
+import type { BleHelperEvent } from './BleHelperProtocol.js';
+import { BleLimbNode, type BleLimbNodeExecutor } from './BleLimbNode.js';
+import { type BleHelperRequester, BleScanSession, type BleScanSnapshot } from './BleScanSession.js';
+
+export interface BleManagerHelper extends BleHelperRequester {
+  readonly status: BleHelperClientStatus;
+  on(event: 'state', listener: (status: BleHelperClientStatus) => void): this;
+  on(event: 'event', listener: (message: BleHelperEvent) => void): this;
+  off(event: 'state', listener: (status: BleHelperClientStatus) => void): this;
+  off(event: 'event', listener: (message: BleHelperEvent) => void): this;
+}
+
+interface LoggerLike {
+  warn(message: string): void;
+  info(message: string): void;
+}
+
+export interface BleDeviceManagerOptions {
+  helper: BleManagerHelper;
+  store: IBleBindingStore;
+  registry: LimbRegistry;
+  platform?: string;
+  logger?: LoggerLike;
+}
+
+export interface BleBindingView {
+  bindingId: string;
+  displayName: string;
+  adapterId: string;
+  commands: string[];
+  nodeId: string;
+  createdAt: number;
+  lastConnectedAt: number | null;
+}
+
+export interface BleManagerStatus {
+  platform: string;
+  available: boolean;
+  state: BleHelperClientStatus['state'];
+  reason: string | null;
+  restartAttempts: number;
+  bindingCount: number;
+}
+
+export interface BleBindingDiscoveryInput {
+  sessionId: string;
+  discoveryId: string;
+}
+
+function toBindingView(binding: BleBinding): BleBindingView {
+  return {
+    bindingId: binding.bindingId,
+    displayName: binding.displayName,
+    adapterId: binding.adapterId,
+    commands: [...binding.commands],
+    nodeId: binding.nodeId,
+    createdAt: binding.createdAt,
+    lastConnectedAt: binding.lastConnectedAt,
+  };
+}
+
+function decodeBase64Value(value: unknown): Buffer {
+  if (
+    typeof value !== 'object' ||
+    value === null ||
+    Array.isArray(value) ||
+    !('valueBase64' in value) ||
+    typeof value.valueBase64 !== 'string' ||
+    value.valueBase64.length > 5_464
+  ) {
+    throw new Error('BLE helper returned an invalid characteristic value');
+  }
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value.valueBase64)) {
+    throw new Error('BLE helper returned malformed base64 data');
+  }
+  const decoded = Buffer.from(value.valueBase64, 'base64');
+  if (decoded.byteLength > 4 * 1024) throw new Error('BLE characteristic value exceeds 4 KiB');
+  return decoded;
+}
+
+export class BleDeviceManager extends EventEmitter implements BleLimbNodeExecutor {
+  private readonly helper: BleManagerHelper;
+  private readonly store: IBleBindingStore;
+  private readonly registry: LimbRegistry;
+  private readonly platform: string;
+  private readonly logger: LoggerLike;
+  private readonly scan: BleScanSession;
+  private readonly recovery: BleBindingRecovery;
+  private readonly bindings = new Map<string, BleBinding>();
+  private readonly bindingDeviceIds = new Set<string>();
+  private readonly bindingOperations = new Set<string>();
+
+  constructor(options: BleDeviceManagerOptions) {
+    super();
+    this.helper = options.helper;
+    this.store = options.store;
+    this.registry = options.registry;
+    this.platform = options.platform ?? process.platform;
+    this.logger = options.logger ?? console;
+    this.scan = new BleScanSession(this.helper);
+    this.recovery = new BleBindingRecovery({
+      helper: this.helper,
+      store: this.store,
+      scan: this.scan,
+      bindings: this.bindings,
+      reservedDeviceIds: this.bindingDeviceIds,
+      acquireBindingOperation: (bindingId) => this.acquireBindingOperation(bindingId),
+      logger: this.logger,
+    });
+    this.helper.on('state', this.handleHelperState);
+  }
+
+  async initialize(): Promise<void> {
+    const persisted = await this.store.list(BLE_BINDING_SCOPE);
+    for (const binding of persisted) {
+      const adapter = getBleAdapter(binding.adapterId);
+      const declared = new Set(adapter?.commands.map((command) => command.command) ?? []);
+      if (!adapter || binding.commands.some((command) => !declared.has(command))) {
+        this.logger.warn(`Ignoring BLE binding with unknown adapter or command: ${binding.bindingId}`);
+        continue;
+      }
+      try {
+        await this.registerBinding(binding);
+      } catch (error) {
+        this.logger.warn(`Failed to hydrate BLE binding '${binding.bindingId}': ${String(error)}`);
+      }
+    }
+  }
+
+  status(): BleManagerStatus {
+    const helperStatus = this.helper.status;
+    return {
+      platform: this.platform,
+      available: this.platform === 'darwin' && helperStatus.state !== 'unsupported',
+      state: helperStatus.state,
+      reason: helperStatus.reason,
+      restartAttempts: helperStatus.restartAttempts,
+      bindingCount: this.bindings.size,
+    };
+  }
+
+  async listBindings(): Promise<BleBindingView[]> {
+    return [...this.bindings.values()].map(toBindingView).sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  startScan(): Promise<{ sessionId: string; startedAt: number; expiresAt: number }> {
+    return this.scan.start();
+  }
+
+  stopScan(): Promise<void> {
+    return this.scan.stop();
+  }
+
+  scanSnapshot(): BleScanSnapshot {
+    return this.scan.snapshot();
+  }
+
+  async bind(input: BleBindingDiscoveryInput): Promise<BleBindingView> {
+    const discovery = this.scan.resolveDiscovery(input.sessionId, input.discoveryId);
+    if (!discovery) throw new Error('BLE discovery is not available in the active scan session');
+    const deviceId = discovery.platformDeviceId;
+    if (
+      this.bindingDeviceIds.has(deviceId) ||
+      [...this.bindings.values()].some((binding) => binding.platformDeviceId === deviceId)
+    ) {
+      throw new Error('BLE device is already bound or binding is already in progress');
+    }
+    this.bindingDeviceIds.add(deviceId);
+
+    try {
+      const contract = await inspectBleDevice(this.helper, deviceId);
+
+      const bindingId = randomUUID();
+      const now = Date.now();
+      const binding: BleBinding = {
+        bindingId,
+        scopeId: BLE_BINDING_SCOPE,
+        platformDeviceId: deviceId,
+        displayName: discovery.name?.trim().slice(0, 128) || `BLE ${bindingId.slice(0, 8)}`,
+        adapterId: contract.adapterId,
+        commands: contract.commands,
+        nodeId: `ble:${bindingId}`,
+        createdAt: now,
+        lastConnectedAt: now,
+      };
+
+      await this.store.put(binding);
+      try {
+        await this.registerBinding(binding);
+      } catch (error) {
+        await this.store.delete(binding.scopeId, binding.bindingId);
+        throw error;
+      }
+      return toBindingView(binding);
+    } finally {
+      this.bindingDeviceIds.delete(deviceId);
+    }
+  }
+
+  probeBinding(bindingId: string): Promise<BleBindingProbeResult | null> {
+    return this.recovery.probe(bindingId);
+  }
+
+  async rebindBinding(bindingId: string, input: BleBindingDiscoveryInput): Promise<BleBindingView | null> {
+    const binding = await this.recovery.rebind(bindingId, input);
+    return binding ? toBindingView(binding) : null;
+  }
+
+  async unbind(bindingId: string): Promise<boolean> {
+    const binding = this.bindings.get(bindingId);
+    if (!binding) return false;
+    const releaseBinding = this.acquireBindingOperation(bindingId);
+    try {
+      await this.store.delete(binding.scopeId, binding.bindingId);
+      this.bindings.delete(bindingId);
+      this.registry.deregister(binding.nodeId);
+      try {
+        await this.helper.request('device.disconnect', { deviceId: binding.platformDeviceId });
+      } catch (error) {
+        this.logger.warn(`BLE device disconnect after unbind failed: ${String(error)}`);
+      }
+      return true;
+    } finally {
+      releaseBinding();
+    }
+  }
+
+  async execute(binding: BleBinding, commandName: string): Promise<unknown> {
+    const releaseBinding = this.acquireBindingOperation(binding.bindingId);
+    try {
+      const liveBinding = this.bindings.get(binding.bindingId);
+      if (!liveBinding || !liveBinding.commands.includes(commandName))
+        throw new Error('BLE binding is no longer active');
+      const command = findBleAdapterCommand(liveBinding.adapterId, commandName);
+      if (!command) throw new Error(`BLE adapter does not declare command: ${commandName}`);
+      const params = {
+        deviceId: liveBinding.platformDeviceId,
+        serviceUuid: command.serviceUuid,
+        characteristicUuid: command.characteristicUuid,
+      };
+      const result = await this.helper.request('gatt.read', params);
+      return decodeBleCommandValue(liveBinding.adapterId, commandName, decodeBase64Value(result));
+    } finally {
+      releaseBinding();
+    }
+  }
+
+  nodeHealth(): LimbNodeStatus {
+    return this.helper.status.state === 'degraded' || this.helper.status.state === 'unsupported'
+      ? 'degraded'
+      : 'online';
+  }
+
+  dispose(): void {
+    this.scan.dispose();
+    this.helper.off('state', this.handleHelperState);
+  }
+
+  private async registerBinding(binding: BleBinding): Promise<void> {
+    if (this.registry.getNode(binding.nodeId)) throw new Error(`Limb node already registered: ${binding.nodeId}`);
+    await this.registry.register(new BleLimbNode(binding, this));
+    this.bindings.set(binding.bindingId, { ...binding, commands: [...binding.commands] });
+  }
+
+  private acquireBindingOperation(bindingId: string): () => void {
+    if (this.bindingOperations.has(bindingId)) throw new Error('BLE binding operation is already in progress');
+    this.bindingOperations.add(bindingId);
+    return () => this.bindingOperations.delete(bindingId);
+  }
+
+  private readonly handleHelperState = (status: BleHelperClientStatus): void => {
+    const nodeStatus: LimbNodeStatus =
+      status.state === 'degraded' || status.state === 'unsupported' ? 'degraded' : 'online';
+    for (const binding of this.bindings.values()) this.registry.updateStatus(binding.nodeId, nodeStatus);
+    this.emit('state', this.status());
+  };
+}

--- a/packages/api/src/domains/limb/ble/BleHelperClient.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperClient.ts
@@ -1,0 +1,349 @@
+import { randomUUID } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { StringDecoder } from 'node:string_decoder';
+import { BleAdapterReadiness } from './BleAdapterReadiness.js';
+import type {
+  BleHelperClientOptions,
+  BleHelperClientState,
+  BleHelperClientStatus,
+  BleHelperLogger,
+} from './BleHelperClientTypes.js';
+import { asError, BleHelperCompatibilityError, isCompatibilityError } from './BleHelperErrors.js';
+import { type BleHelperProcess, spawnBleHelperProcess } from './BleHelperProcess.js';
+import { type BleHelperEvent, type BleHelperInboundMessage, encodeBleHelperRequest } from './BleHelperProtocol.js';
+import { frameBleHelperChunk, tryParseBleHelperMessage } from './BleHelperStream.js';
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer: NodeJS.Timeout;
+}
+
+const RESTART_DELAYS_MS = [1_000, 2_000, 4_000] as const;
+
+export class BleHelperClient extends EventEmitter {
+  private readonly platform: string;
+  private readonly spawnProcess: () => BleHelperProcess;
+  private readonly handshakeTimeoutMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly setRequestTimer: (callback: () => void, ms: number) => NodeJS.Timeout;
+  private readonly clearRequestTimer: (timer: NodeJS.Timeout) => void;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly logger: BleHelperLogger;
+  private process: BleHelperProcess | null = null;
+  private state: BleHelperClientState;
+  private reason: string | null = null;
+  private restartAttempts = 0;
+  private recoveryPromise: Promise<void> | null = null;
+  private readonly pending = new Map<string, PendingRequest>();
+  private readonly adapterReadiness: BleAdapterReadiness;
+  private stopping = false;
+  private lastError: Error | null = null;
+
+  constructor(options: BleHelperClientOptions = {}) {
+    super();
+    this.platform = options.platform ?? process.platform;
+    this.spawnProcess = options.spawnProcess ?? (() => spawnBleHelperProcess(options.helperPath));
+    this.handshakeTimeoutMs = options.handshakeTimeoutMs ?? 3_000;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? 10_000;
+    this.setRequestTimer = options.setRequestTimer ?? ((callback, ms) => setTimeout(callback, ms));
+    this.clearRequestTimer = options.clearRequestTimer ?? ((timer) => clearTimeout(timer));
+    this.sleep = options.sleep ?? ((ms) => new Promise((resolveSleep) => setTimeout(resolveSleep, ms)));
+    this.logger = options.logger ?? console;
+    this.adapterReadiness = new BleAdapterReadiness(this, this.handshakeTimeoutMs);
+    this.state = this.platform === 'darwin' ? 'idle' : 'unsupported';
+    if (this.state === 'unsupported') this.reason = 'BLE helper is only available on macOS in Phase A';
+  }
+
+  get status(): BleHelperClientStatus {
+    return { state: this.state, reason: this.reason, restartAttempts: this.restartAttempts };
+  }
+
+  /** @internal Test-only inspection; production callers use status and request(). */
+  get currentProcessForTest(): BleHelperProcess | null {
+    return this.process;
+  }
+
+  async start(): Promise<void> {
+    if (this.state === 'ready') return;
+    if (this.state === 'unsupported') throw new Error(this.reason ?? 'BLE helper is unsupported');
+    if (!this.recoveryPromise) this.beginRecovery(true);
+    await this.recoveryPromise;
+    if (this.status.state !== 'ready') {
+      throw new Error(`BLE helper unavailable: ${this.lastError?.message ?? this.reason ?? 'unknown error'}`);
+    }
+  }
+
+  async request(command: string, params: Record<string, unknown>): Promise<unknown> {
+    await this.start();
+    if (command !== 'helper.shutdown') await this.adapterReadiness.waitForPoweredOn();
+    const child = this.process;
+    if (!child || this.state !== 'ready') throw new Error('BLE helper is not ready');
+
+    const requestId = randomUUID();
+    const line = encodeBleHelperRequest(command, params, requestId);
+    return new Promise<unknown>((resolveRequest, rejectRequest) => {
+      const timer = this.setRequestTimer(() => {
+        this.pending.delete(requestId);
+        rejectRequest(new Error(`BLE helper request timed out: ${command}`));
+      }, this.requestTimeoutMs);
+      timer.unref();
+      this.pending.set(requestId, { resolve: resolveRequest, reject: rejectRequest, timer });
+      try {
+        child.stdin.write(line, (error) => {
+          if (!error) return;
+          const pending = this.pending.get(requestId);
+          if (!pending) return;
+          this.clearRequestTimer(pending.timer);
+          this.pending.delete(requestId);
+          pending.reject(asError(error));
+        });
+      } catch (error) {
+        this.clearRequestTimer(timer);
+        this.pending.delete(requestId);
+        rejectRequest(asError(error));
+      }
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    this.stopping = true;
+    const activeRecovery = this.recoveryPromise;
+    const child = this.process;
+    if (child && this.state === 'ready') {
+      try {
+        await this.request('helper.shutdown', {});
+      } catch {
+        // Continue with process termination.
+      }
+    }
+    this.rejectPending(new Error('BLE helper is shutting down'));
+    child?.kill('SIGTERM');
+    this.process = null;
+    this.adapterReadiness.reset();
+    this.setState(this.platform === 'darwin' ? 'idle' : 'unsupported', null);
+    if (activeRecovery) {
+      // Keep the stop barrier raised until an in-flight backoff wakes and
+      // observes it. Otherwise a delayed recovery can spawn a new helper
+      // after API shutdown has already completed.
+      void activeRecovery
+        .finally(() => {
+          this.stopping = false;
+        })
+        .catch(() => {});
+    } else {
+      this.stopping = false;
+    }
+  }
+
+  private beginRecovery(initialStart: boolean): void {
+    if (this.recoveryPromise) return;
+    const recovery = this.runRecovery(initialStart).finally(() => {
+      if (this.recoveryPromise === recovery) this.recoveryPromise = null;
+    });
+    this.recoveryPromise = recovery;
+  }
+
+  private async runRecovery(initialStart: boolean): Promise<void> {
+    if (this.stopping) return;
+    this.restartAttempts = 0;
+    if (initialStart && (await this.attemptRecovery())) return;
+    for (const delayMs of RESTART_DELAYS_MS) {
+      if (await this.attemptRecovery(delayMs)) return;
+    }
+    this.setState('degraded', this.lastError?.message ?? 'BLE helper restart attempts exhausted');
+  }
+
+  private async attemptRecovery(delayMs?: number): Promise<boolean> {
+    if (this.stopping) return true;
+    if (delayMs !== undefined) {
+      this.restartAttempts += 1;
+      await this.sleep(delayMs);
+      if (this.stopping) return true;
+    }
+    try {
+      await this.spawnAndHandshake();
+      return true;
+    } catch (error) {
+      this.lastError = asError(error);
+      if (!isCompatibilityError(this.lastError)) return false;
+      this.setState('degraded', this.lastError.message);
+      return true;
+    }
+  }
+
+  private spawnAndHandshake(): Promise<void> {
+    this.setState('starting', null);
+    this.adapterReadiness.reset();
+    let child: BleHelperProcess;
+    try {
+      child = this.spawnProcess();
+    } catch (error) {
+      return Promise.reject(asError(error));
+    }
+    this.process = child;
+
+    return new Promise<void>((resolveHandshake, rejectHandshake) => {
+      let ready = false;
+      let settled = false;
+      let buffer = '';
+      const decoder = new StringDecoder('utf8');
+
+      const cleanup = (): void => {
+        clearTimeout(handshakeTimer);
+        child.stdout.off('data', onData);
+        child.stderr.off('data', onStderr);
+        child.off('exit', onExit);
+        child.off('error', onError);
+      };
+
+      const failBeforeReady = (error: Error): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (this.process === child) this.process = null;
+        child.kill('SIGTERM');
+        rejectHandshake(error);
+      };
+
+      const handleRuntimeProtocolViolation = (error: Error): void => {
+        cleanup();
+        if (this.process === child) this.process = null;
+        this.lastError = error;
+        this.rejectPending(error);
+        child.kill('SIGTERM');
+        this.setState('degraded', error.message);
+      };
+
+      const handleProtocolError = (error: Error): boolean => {
+        if (!ready) {
+          const handshakeError = isCompatibilityError(error) ? new BleHelperCompatibilityError(error.message) : error;
+          failBeforeReady(handshakeError);
+          return true;
+        }
+        if (isCompatibilityError(error)) {
+          handleRuntimeProtocolViolation(new BleHelperCompatibilityError(error.message));
+          return true;
+        }
+        this.logger.warn(`Ignoring invalid BLE helper message: ${error.message}`);
+        return false;
+      };
+
+      const acceptMessage = (message: BleHelperInboundMessage): boolean => {
+        if (ready) {
+          this.dispatchMessage(message);
+          return true;
+        }
+        if (message.kind !== 'hello') {
+          failBeforeReady(new BleHelperCompatibilityError('BLE helper did not send hello before other messages'));
+          return false;
+        }
+        ready = true;
+        settled = true;
+        clearTimeout(handshakeTimer);
+        this.lastError = null;
+        this.setState('ready', null);
+        resolveHandshake();
+        return true;
+      };
+
+      const handleLine = (line: string): boolean => {
+        const parsed = tryParseBleHelperMessage(line);
+        return parsed.ok ? acceptMessage(parsed.message) : !handleProtocolError(parsed.error);
+      };
+
+      const onData = (chunk: Buffer | string): void => {
+        const framed = frameBleHelperChunk(buffer, Buffer.isBuffer(chunk) ? decoder.write(chunk) : chunk);
+        buffer = framed.rest;
+        if (framed.oversizedRest) {
+          handleProtocolError(new BleHelperCompatibilityError('BLE helper message exceeds line size limit'));
+          return;
+        }
+        framed.lines.every(handleLine);
+      };
+
+      const onStderr = (chunk: Buffer | string): void => {
+        const message = (Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk).trim().slice(0, 512);
+        if (message) this.logger.warn(`BLE helper: ${message}`);
+      };
+
+      const onExit = (code: number | null, signal: NodeJS.Signals | null): void => {
+        const error = new Error(`BLE helper exited (code=${String(code)}, signal=${String(signal)})`);
+        if (!ready) {
+          failBeforeReady(error);
+          return;
+        }
+        cleanup();
+        this.handleUnexpectedExit(child, error);
+      };
+
+      const onError = (error: Error): void => {
+        if (!ready) {
+          failBeforeReady(error);
+          return;
+        }
+        cleanup();
+        this.handleUnexpectedExit(child, error);
+      };
+
+      const handshakeTimer = setTimeout(
+        () => failBeforeReady(new Error('BLE helper handshake timed out')),
+        this.handshakeTimeoutMs,
+      );
+      handshakeTimer.unref();
+      child.stdout.on('data', onData);
+      child.stderr.on('data', onStderr);
+      child.on('exit', onExit);
+      child.on('error', onError);
+    });
+  }
+
+  private dispatchMessage(message: BleHelperInboundMessage): void {
+    if (message.kind === 'event') {
+      this.adapterReadiness.observe(message as BleHelperEvent);
+      this.emit('event', message as BleHelperEvent);
+      return;
+    }
+    if (message.kind === 'hello') {
+      this.logger.warn('Ignoring duplicate BLE helper hello');
+      return;
+    }
+    const pending = this.pending.get(message.requestId);
+    if (!pending) {
+      this.logger.warn(`Ignoring BLE helper response for unknown request: ${message.requestId}`);
+      return;
+    }
+    this.clearRequestTimer(pending.timer);
+    this.pending.delete(message.requestId);
+    if (message.ok) pending.resolve(message.data);
+    else pending.reject(new Error(message.error ?? 'BLE helper request failed'));
+  }
+
+  private handleUnexpectedExit(child: BleHelperProcess, error: Error): void {
+    if (this.process !== child) return;
+    this.process = null;
+    this.adapterReadiness.reset();
+    this.lastError = error;
+    this.rejectPending(error);
+    if (this.stopping) {
+      this.setState('idle', null);
+      return;
+    }
+    this.setState('degraded', error.message);
+    this.beginRecovery(false);
+  }
+
+  private rejectPending(error: Error): void {
+    for (const pending of this.pending.values()) {
+      this.clearRequestTimer(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+
+  private setState(state: BleHelperClientState, reason: string | null): void {
+    this.state = state;
+    this.reason = reason;
+    this.emit('state', this.status);
+  }
+}

--- a/packages/api/src/domains/limb/ble/BleHelperClientTypes.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperClientTypes.ts
@@ -1,0 +1,26 @@
+import type { BleHelperProcess } from './BleHelperProcess.js';
+
+export type BleHelperClientState = 'idle' | 'starting' | 'ready' | 'degraded' | 'unsupported';
+
+export interface BleHelperClientStatus {
+  state: BleHelperClientState;
+  reason: string | null;
+  restartAttempts: number;
+}
+
+export interface BleHelperLogger {
+  info(message: string): void;
+  warn(message: string): void;
+}
+
+export interface BleHelperClientOptions {
+  platform?: NodeJS.Platform | string;
+  spawnProcess?: () => BleHelperProcess;
+  helperPath?: string;
+  handshakeTimeoutMs?: number;
+  requestTimeoutMs?: number;
+  setRequestTimer?: (callback: () => void, ms: number) => NodeJS.Timeout;
+  clearRequestTimer?: (timer: NodeJS.Timeout) => void;
+  sleep?: (ms: number) => Promise<void>;
+  logger?: BleHelperLogger;
+}

--- a/packages/api/src/domains/limb/ble/BleHelperErrors.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperErrors.ts
@@ -1,0 +1,13 @@
+export class BleHelperCompatibilityError extends Error {}
+
+export function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export function isCompatibilityError(error: Error): boolean {
+  return (
+    error instanceof BleHelperCompatibilityError ||
+    error.message.startsWith('Unsupported BLE helper protocol') ||
+    error.message.startsWith('BLE helper message exceeds')
+  );
+}

--- a/packages/api/src/domains/limb/ble/BleHelperProcess.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperProcess.ts
@@ -1,0 +1,39 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface BleHelperProcess extends EventEmitter {
+  stdin: {
+    write(data: string, callback?: (error?: Error | null) => void): boolean;
+  };
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill(signal?: NodeJS.Signals): boolean;
+}
+
+export function resolveBleHelperExecutable(
+  arch = process.arch,
+  fileExists: (path: string) => boolean = existsSync,
+): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  const apiRoot = resolve(moduleDir, '../../../..');
+  const packagedArchitecture = arch === 'arm64' ? 'arm64' : 'x64';
+  const localBuildArchitecture = arch === 'x64' ? 'x86_64' : packagedArchitecture;
+  const candidates = [
+    resolve(apiRoot, 'ble-helper', 'ble-helper'),
+    resolve(apiRoot, '..', '..', 'bundled', `ble-helper-darwin-${packagedArchitecture}`, 'ble-helper'),
+    resolve(apiRoot, '..', '..', 'native', 'ble-helper', 'macos', '.build', localBuildArchitecture, 'ble-helper'),
+  ];
+  const executable = candidates.find(fileExists);
+  if (!executable) {
+    throw new Error('BLE helper executable not found');
+  }
+  return executable;
+}
+
+export function spawnBleHelperProcess(helperPath?: string): BleHelperProcess {
+  const executable = helperPath ?? resolveBleHelperExecutable();
+  return spawn(executable, [], { stdio: ['pipe', 'pipe', 'pipe'], shell: false }) as ChildProcessWithoutNullStreams;
+}

--- a/packages/api/src/domains/limb/ble/BleHelperProtocol.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperProtocol.ts
@@ -1,0 +1,183 @@
+import { Buffer } from 'node:buffer';
+import { z } from 'zod';
+
+export const BLE_HELPER_PROTOCOL = 'ble-helper' as const;
+export const BLE_HELPER_PROTOCOL_VERSION = 1 as const;
+export const BLE_HELPER_MAX_LINE_BYTES = 64 * 1024;
+export const BLE_HELPER_COMMANDS = [
+  'scan.start',
+  'scan.stop',
+  'device.inspect',
+  'gatt.read',
+  'device.disconnect',
+  'helper.shutdown',
+] as const;
+
+export type BleHelperCommand = (typeof BLE_HELPER_COMMANDS)[number];
+
+const boundedId = z.string().min(1).max(128);
+const boundedUuid = z.string().min(1).max(64);
+const base = {
+  protocol: z.literal(BLE_HELPER_PROTOCOL),
+  version: z.literal(BLE_HELPER_PROTOCOL_VERSION),
+};
+
+const helloSchema = z
+  .object({
+    ...base,
+    kind: z.literal('hello'),
+  })
+  .strict();
+
+const responseSchema = z
+  .object({
+    ...base,
+    kind: z.literal('response'),
+    requestId: boundedId,
+    ok: z.boolean(),
+    data: z.unknown().optional(),
+    error: z.string().max(512).optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!value.ok && !value.error) {
+      context.addIssue({ code: z.ZodIssueCode.custom, message: 'Failed response requires an error' });
+    }
+  });
+
+const scanDiscoveredEventSchema = z
+  .object({
+    ...base,
+    kind: z.literal('event'),
+    event: z.literal('scan.discovered'),
+    data: z
+      .object({
+        sessionId: boundedId,
+        deviceId: boundedId,
+        name: z.string().max(128).nullable(),
+        rssi: z.number().int().min(-127).max(20),
+        serviceUuids: z.array(boundedUuid).max(64),
+      })
+      .strict(),
+  })
+  .strict();
+
+const scanStateEventSchema = z
+  .object({
+    ...base,
+    kind: z.literal('event'),
+    event: z.literal('scan.state'),
+    data: z
+      .object({
+        sessionId: boundedId,
+        state: z.enum(['started', 'stopped', 'timeout']),
+      })
+      .strict(),
+  })
+  .strict();
+
+const adapterStateEventSchema = z
+  .object({
+    ...base,
+    kind: z.literal('event'),
+    event: z.literal('adapter.state'),
+    data: z
+      .object({
+        state: z.enum(['poweredOn', 'poweredOff', 'unauthorized', 'unsupported', 'resetting', 'unknown']),
+      })
+      .strict(),
+  })
+  .strict();
+
+const disconnectedEventSchema = z
+  .object({
+    ...base,
+    kind: z.literal('event'),
+    event: z.literal('device.disconnected'),
+    data: z
+      .object({
+        deviceId: boundedId,
+        reason: z.string().max(256).nullable(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const inboundSchema = z.union([
+  helloSchema,
+  responseSchema,
+  scanDiscoveredEventSchema,
+  scanStateEventSchema,
+  adapterStateEventSchema,
+  disconnectedEventSchema,
+]);
+
+export type BleHelperHello = z.infer<typeof helloSchema>;
+export type BleHelperResponse = z.infer<typeof responseSchema>;
+export type BleHelperEvent =
+  | z.infer<typeof scanDiscoveredEventSchema>
+  | z.infer<typeof scanStateEventSchema>
+  | z.infer<typeof adapterStateEventSchema>
+  | z.infer<typeof disconnectedEventSchema>;
+export type BleHelperInboundMessage = BleHelperHello | BleHelperResponse | BleHelperEvent;
+
+const requestParamsSchemas: Record<BleHelperCommand, z.ZodType<Record<string, unknown>>> = {
+  'scan.start': z.object({ sessionId: boundedId, timeoutMs: z.number().int().min(1).max(30_000) }).strict(),
+  'scan.stop': z.object({ sessionId: boundedId }).strict(),
+  'device.inspect': z.object({ deviceId: boundedId }).strict(),
+  'gatt.read': z.object({ deviceId: boundedId, serviceUuid: boundedUuid, characteristicUuid: boundedUuid }).strict(),
+  'device.disconnect': z.object({ deviceId: boundedId }).strict(),
+  'helper.shutdown': z.object({}).strict(),
+};
+
+export function encodeBleHelperRequest(command: string, params: Record<string, unknown>, requestId: string): string {
+  if (!BLE_HELPER_COMMANDS.includes(command as BleHelperCommand)) {
+    throw new Error(`Unsupported BLE helper command: ${command}`);
+  }
+  const parsedParams = requestParamsSchemas[command as BleHelperCommand].safeParse(params);
+  if (!parsedParams.success) {
+    throw new Error(`Invalid BLE helper params for ${command}: ${parsedParams.error.message}`);
+  }
+  const parsedRequestId = boundedId.safeParse(requestId);
+  if (!parsedRequestId.success) throw new Error('Invalid BLE helper requestId');
+  const line = JSON.stringify({
+    protocol: BLE_HELPER_PROTOCOL,
+    version: BLE_HELPER_PROTOCOL_VERSION,
+    requestId,
+    command,
+    params: parsedParams.data,
+  });
+  if (Buffer.byteLength(line, 'utf8') > BLE_HELPER_MAX_LINE_BYTES) {
+    throw new Error('BLE helper request exceeds line size limit');
+  }
+  return `${line}\n`;
+}
+
+export function parseBleHelperMessage(line: string): BleHelperInboundMessage {
+  if (Buffer.byteLength(line, 'utf8') > BLE_HELPER_MAX_LINE_BYTES) {
+    throw new Error(`BLE helper message exceeds ${BLE_HELPER_MAX_LINE_BYTES} bytes`);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(line);
+  } catch {
+    throw new Error('Invalid BLE helper JSON');
+  }
+
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'version' in value &&
+    value.version !== BLE_HELPER_PROTOCOL_VERSION
+  ) {
+    throw new Error(`Unsupported BLE helper protocol version: ${String(value.version)}`);
+  }
+  if (typeof value === 'object' && value !== null && 'protocol' in value && value.protocol !== BLE_HELPER_PROTOCOL) {
+    throw new Error(`Unsupported BLE helper protocol: ${String(value.protocol)}`);
+  }
+
+  const parsed = inboundSchema.safeParse(value);
+  if (!parsed.success) throw new Error(`Invalid BLE helper message: ${parsed.error.message}`);
+  return parsed.data as BleHelperInboundMessage;
+}

--- a/packages/api/src/domains/limb/ble/BleHelperStream.ts
+++ b/packages/api/src/domains/limb/ble/BleHelperStream.ts
@@ -1,0 +1,28 @@
+import { Buffer } from 'node:buffer';
+import { BLE_HELPER_MAX_LINE_BYTES, type BleHelperInboundMessage, parseBleHelperMessage } from './BleHelperProtocol.js';
+
+export interface BleHelperFrame {
+  rest: string;
+  lines: string[];
+  oversizedRest: boolean;
+}
+
+export type BleHelperParseResult = { ok: true; message: BleHelperInboundMessage } | { ok: false; error: Error };
+
+export function frameBleHelperChunk(previous: string, chunk: string): BleHelperFrame {
+  const parts = `${previous}${chunk}`.split('\n');
+  const rest = parts.pop() ?? '';
+  return {
+    rest,
+    lines: parts.map((line) => line.replace(/\r$/, '')).filter(Boolean),
+    oversizedRest: Buffer.byteLength(rest, 'utf8') > BLE_HELPER_MAX_LINE_BYTES,
+  };
+}
+
+export function tryParseBleHelperMessage(line: string): BleHelperParseResult {
+  try {
+    return { ok: true, message: parseBleHelperMessage(line) };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
+  }
+}

--- a/packages/api/src/domains/limb/ble/BleLimbNode.ts
+++ b/packages/api/src/domains/limb/ble/BleLimbNode.ts
@@ -1,0 +1,48 @@
+import type { ILimbNode, LimbCapability, LimbCommandSchema, LimbInvokeResult, LimbNodeStatus } from '@cat-cafe/shared';
+import { buildBleCommandSchemas, buildBleLimbCapabilities } from './BleAdapters.js';
+import type { BleBinding } from './BleBindingStore.js';
+
+export interface BleLimbNodeExecutor {
+  execute(binding: BleBinding, command: string): Promise<unknown>;
+  nodeHealth(): LimbNodeStatus;
+}
+
+export class BleLimbNode implements ILimbNode {
+  readonly nodeId: string;
+  readonly displayName: string;
+  readonly platform = 'macos-ble';
+  readonly capabilities: LimbCapability[];
+  readonly commandSchemas: Readonly<Record<string, LimbCommandSchema>>;
+
+  constructor(
+    private readonly binding: BleBinding,
+    private readonly executor: BleLimbNodeExecutor,
+  ) {
+    this.nodeId = binding.nodeId;
+    this.displayName = binding.displayName;
+    this.capabilities = buildBleLimbCapabilities(binding.adapterId, binding.commands);
+    this.commandSchemas = buildBleCommandSchemas(binding.adapterId, binding.commands);
+  }
+
+  async register(): Promise<void> {}
+
+  async invoke(command: string, params: Record<string, unknown>): Promise<LimbInvokeResult> {
+    if (!this.binding.commands.includes(command)) {
+      return { success: false, error: `BLE command is not allowed by binding '${this.binding.bindingId}': ${command}` };
+    }
+    if (Object.keys(params).length > 0) {
+      return { success: false, error: `BLE command '${command}' does not accept agent-supplied parameters` };
+    }
+    try {
+      return { success: true, data: await this.executor.execute(this.binding, command) };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async healthCheck(): Promise<LimbNodeStatus> {
+    return this.executor.nodeHealth();
+  }
+
+  async deregister(): Promise<void> {}
+}

--- a/packages/api/src/domains/limb/ble/BleScanSession.ts
+++ b/packages/api/src/domains/limb/ble/BleScanSession.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from 'node:crypto';
+import type { BleHelperEvent } from './BleHelperProtocol.js';
+
+export const BLE_SCAN_TIMEOUT_MS = 30_000;
+
+export interface BleHelperRequester {
+  request(command: string, params: Record<string, unknown>): Promise<unknown>;
+  on(event: 'event', listener: (message: BleHelperEvent) => void): this;
+  off(event: 'event', listener: (message: BleHelperEvent) => void): this;
+}
+
+export interface BleDiscoveryView {
+  discoveryId: string;
+  name: string | null;
+  rssi: number;
+  serviceUuids: string[];
+}
+
+export interface BleResolvedDiscovery extends BleDiscoveryView {
+  platformDeviceId: string;
+}
+
+export interface BleScanSnapshot {
+  active: boolean;
+  sessionId: string | null;
+  startedAt: number | null;
+  expiresAt: number | null;
+  discoveries: BleDiscoveryView[];
+}
+
+interface ActiveScan {
+  sessionId: string;
+  startedAt: number;
+  expiresAt: number;
+}
+
+interface TimerOptions {
+  now?: () => number;
+  setTimer?: (callback: () => void, ms: number) => NodeJS.Timeout | number;
+  clearTimer?: (timer: NodeJS.Timeout | number) => void;
+}
+
+export class BleScanSession {
+  private active: ActiveScan | null = null;
+  private timer: NodeJS.Timeout | number | null = null;
+  private readonly discoveries = new Map<string, BleResolvedDiscovery>();
+  private readonly platformToDiscovery = new Map<string, string>();
+  private readonly now: () => number;
+  private readonly setTimer: (callback: () => void, ms: number) => NodeJS.Timeout | number;
+  private readonly clearTimer: (timer: NodeJS.Timeout | number) => void;
+
+  constructor(
+    private readonly helper: BleHelperRequester,
+    options: TimerOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.setTimer = options.setTimer ?? ((callback, ms) => setTimeout(callback, ms));
+    this.clearTimer = options.clearTimer ?? ((timer) => clearTimeout(timer));
+    this.helper.on('event', this.handleHelperEvent);
+  }
+
+  async start(): Promise<ActiveScan> {
+    if (this.active) throw new Error('A BLE scan session is already active');
+    const startedAt = this.now();
+    const active = {
+      sessionId: randomUUID(),
+      startedAt,
+      expiresAt: startedAt + BLE_SCAN_TIMEOUT_MS,
+    };
+    this.active = active;
+    this.discoveries.clear();
+    this.platformToDiscovery.clear();
+    try {
+      await this.helper.request('scan.start', { sessionId: active.sessionId, timeoutMs: BLE_SCAN_TIMEOUT_MS });
+    } catch (error) {
+      this.clearLocalState();
+      throw error;
+    }
+    // The helper can report an early stop immediately after acknowledging
+    // scan.start (for example when Bluetooth powers off). Do not resurrect a
+    // local timeout after that event already cleared the session.
+    if (this.active !== active) return active;
+    this.timer = this.setTimer(() => {
+      void this.stop('timeout');
+    }, BLE_SCAN_TIMEOUT_MS);
+    if (typeof this.timer === 'object' && 'unref' in this.timer) this.timer.unref();
+    return active;
+  }
+
+  async stop(_reason: 'explicit' | 'timeout' = 'explicit'): Promise<void> {
+    const session = this.active;
+    if (!session) return;
+    this.clearLocalState();
+    try {
+      await this.helper.request('scan.stop', { sessionId: session.sessionId });
+    } catch {
+      // Privacy state is already cleared. A helper failure must not restore discoveries.
+    }
+  }
+
+  snapshot(): BleScanSnapshot {
+    return {
+      active: this.active !== null,
+      sessionId: this.active?.sessionId ?? null,
+      startedAt: this.active?.startedAt ?? null,
+      expiresAt: this.active?.expiresAt ?? null,
+      discoveries: [...this.discoveries.values()].map(({ platformDeviceId: _privateId, ...view }) => ({ ...view })),
+    };
+  }
+
+  resolveDiscovery(sessionId: string, discoveryId: string): BleResolvedDiscovery | null {
+    if (!this.active || this.active.sessionId !== sessionId) return null;
+    const discovery = this.discoveries.get(discoveryId);
+    return discovery ? { ...discovery, serviceUuids: [...discovery.serviceUuids] } : null;
+  }
+
+  dispose(): void {
+    this.clearLocalState();
+    this.helper.off('event', this.handleHelperEvent);
+  }
+
+  private readonly handleHelperEvent = (message: BleHelperEvent): void => {
+    if (!this.active) return;
+    if (message.event === 'scan.state') {
+      if (message.data.sessionId === this.active.sessionId && message.data.state !== 'started') this.clearLocalState();
+      return;
+    }
+    if (message.event !== 'scan.discovered' || message.data.sessionId !== this.active.sessionId) return;
+    let discoveryId = this.platformToDiscovery.get(message.data.deviceId);
+    if (!discoveryId) {
+      discoveryId = randomUUID();
+      this.platformToDiscovery.set(message.data.deviceId, discoveryId);
+    }
+    this.discoveries.set(discoveryId, {
+      discoveryId,
+      platformDeviceId: message.data.deviceId,
+      name: message.data.name,
+      rssi: message.data.rssi,
+      serviceUuids: [...message.data.serviceUuids],
+    });
+  };
+
+  private clearLocalState(): void {
+    if (this.timer !== null) this.clearTimer(this.timer);
+    this.timer = null;
+    this.active = null;
+    this.discoveries.clear();
+    this.platformToDiscovery.clear();
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -2242,6 +2242,40 @@ async function main(): Promise<void> {
   const limbPairingStore = new LimbPairingStore();
   registerLimbNodeRoutes(app, { limbRegistry, pairingStore: limbPairingStore });
 
+  // F270 Phase A: macOS CoreBluetooth Limb. Persistent bindings fail closed
+  // without Redis; the helper itself stays lazy and is not spawned at startup.
+  const { registerBleRoutes } = await import('./routes/ble-routes.js');
+  if (process.platform === 'darwin' && redis) {
+    const [{ BleHelperClient }, { RedisBleBindingStore }, { BleDeviceManager }] = await Promise.all([
+      import('./domains/limb/ble/BleHelperClient.js'),
+      import('./domains/limb/ble/BleBindingStore.js'),
+      import('./domains/limb/ble/BleDeviceManager.js'),
+    ]);
+    const bleHelper = new BleHelperClient({ logger: app.log });
+    const bleManager = new BleDeviceManager({
+      helper: bleHelper,
+      store: new RedisBleBindingStore(redis, app.log),
+      registry: limbRegistry,
+      logger: app.log,
+    });
+    await bleManager.initialize();
+    registerBleRoutes(app, { manager: bleManager, platform: process.platform });
+    app.addHook('onClose', async () => {
+      bleManager.dispose();
+      await bleHelper.shutdown();
+    });
+    app.log.info(`[api] F270: hydrated ${bleManager.status().bindingCount} persistent BLE binding(s)`);
+  } else {
+    registerBleRoutes(app, {
+      manager: null,
+      platform: process.platform,
+      unavailableReason:
+        process.platform === 'darwin'
+          ? 'Redis is required for persistent BLE bindings'
+          : 'BLE helper is only available on macOS in Phase A',
+    });
+  }
+
   // F202-2B: Hoisted for late-binding GitHub schedule rehydration (closure set inside F202 block)
   let rehydrateGitHubSchedules: ((githubDeps: Record<string, unknown>) => Promise<void>) | undefined;
   let getGitHubPluginEnv: () => Record<string, string | undefined> = () => ({});

--- a/packages/api/src/routes/ble-routes.ts
+++ b/packages/api/src/routes/ble-routes.ts
@@ -1,0 +1,190 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { z } from 'zod';
+import type { BleDeviceManager } from '../domains/limb/ble/BleDeviceManager.js';
+import { isDirectLoopbackRequest } from '../utils/loopback-request.js';
+import { resolveOwnerGate } from '../utils/owner-gate.js';
+
+export interface BleRoutesOptions {
+  manager: BleDeviceManager | null;
+  platform?: string;
+  unavailableReason?: string;
+}
+
+const bindSchema = z
+  .object({
+    sessionId: z.string().min(1).max(128),
+    discoveryId: z.string().min(1).max(128),
+  })
+  .strict();
+
+const bindingParamsSchema = z.object({ bindingId: z.string().min(1).max(128) }).strict();
+
+function sessionUserId(request: FastifyRequest): string | null {
+  const userId = (request as FastifyRequest & { sessionUserId?: string }).sessionUserId;
+  return typeof userId === 'string' && userId.trim() ? userId.trim() : null;
+}
+
+function requireReadIdentity(request: FastifyRequest, reply: FastifyReply): string | null {
+  const userId = sessionUserId(request);
+  if (!userId) {
+    reply.status(401).send({ error: 'Authentication required' });
+    return null;
+  }
+  return userId;
+}
+
+function requireWriteIdentity(request: FastifyRequest, reply: FastifyReply): string | null {
+  const userId = sessionUserId(request);
+  if (!userId) {
+    reply.status(401).send({ error: 'Authentication required' });
+    return null;
+  }
+  if (!isDirectLoopbackRequest(request) && !process.env.DEFAULT_OWNER_USER_ID?.trim()) {
+    reply.status(403).send({
+      error: 'BLE device changes from non-localhost require DEFAULT_OWNER_USER_ID to be configured',
+    });
+    return null;
+  }
+  const ownerError = resolveOwnerGate(userId, {
+    errorMessage: 'BLE device changes can only be performed by the configured owner',
+  });
+  if (ownerError) {
+    reply.status(ownerError.status).send({ error: ownerError.error });
+    return null;
+  }
+  return userId;
+}
+
+function unavailable(reply: FastifyReply): void {
+  reply.status(503).send({ error: 'BLE binding storage is unavailable' });
+}
+
+function errorStatus(error: Error): number {
+  if (
+    error.message.includes('already active') ||
+    error.message.includes('already bound') ||
+    error.message.includes('already in progress')
+  )
+    return 409;
+  if (
+    error.message.includes('not available') ||
+    error.message.includes('not expose') ||
+    error.message.includes('not compatible')
+  )
+    return 422;
+  if (error.message.includes('timed out')) return 504;
+  if (error.message.includes('unsupported') || error.message.includes('unavailable')) return 503;
+  return 502;
+}
+
+function safeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : 'BLE operation failed';
+  return message.slice(0, 512);
+}
+
+export function registerBleRoutes(app: FastifyInstance, options: BleRoutesOptions): void {
+  const platform = options.platform ?? process.platform;
+  const unavailableReason =
+    options.unavailableReason ??
+    (platform === 'darwin'
+      ? 'Redis is required for persistent BLE bindings'
+      : 'BLE helper is only available on macOS in Phase A');
+
+  app.get('/api/limb/ble/status', async (request, reply) => {
+    if (!requireReadIdentity(request, reply)) return;
+    if (options.manager) return reply.send(options.manager.status());
+    return reply.send({
+      platform,
+      available: false,
+      state: platform === 'darwin' ? 'degraded' : 'unsupported',
+      reason: unavailableReason,
+      restartAttempts: 0,
+      bindingCount: 0,
+    });
+  });
+
+  app.get('/api/limb/ble/bindings', async (request, reply) => {
+    if (!requireReadIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    return reply.send({ bindings: await options.manager.listBindings() });
+  });
+
+  app.get('/api/limb/ble/scan', async (request, reply) => {
+    if (!requireReadIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    return reply.send(options.manager.scanSnapshot());
+  });
+
+  app.post('/api/limb/ble/scan', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    try {
+      return reply.status(201).send(await options.manager.startScan());
+    } catch (error) {
+      const message = safeError(error);
+      return reply.status(errorStatus(new Error(message))).send({ error: message });
+    }
+  });
+
+  app.delete('/api/limb/ble/scan', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    await options.manager.stopScan();
+    return reply.status(204).send();
+  });
+
+  app.post('/api/limb/ble/bindings', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    const parsed = bindSchema.safeParse(request.body);
+    if (!parsed.success) return reply.status(400).send({ error: parsed.error.message });
+    try {
+      return reply.status(201).send(await options.manager.bind(parsed.data));
+    } catch (error) {
+      const message = safeError(error);
+      return reply.status(errorStatus(new Error(message))).send({ error: message });
+    }
+  });
+
+  app.post('/api/limb/ble/bindings/:bindingId/probe', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    const params = bindingParamsSchema.safeParse(request.params);
+    if (!params.success) return reply.status(400).send({ error: params.error.message });
+    try {
+      const result = await options.manager.probeBinding(params.data.bindingId);
+      if (!result) return reply.status(404).send({ error: 'BLE binding not found' });
+      return reply.send(result);
+    } catch (error) {
+      const message = safeError(error);
+      return reply.status(errorStatus(new Error(message))).send({ error: message });
+    }
+  });
+
+  app.post('/api/limb/ble/bindings/:bindingId/rebind', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    const params = bindingParamsSchema.safeParse(request.params);
+    if (!params.success) return reply.status(400).send({ error: params.error.message });
+    const body = bindSchema.safeParse(request.body);
+    if (!body.success) return reply.status(400).send({ error: body.error.message });
+    try {
+      const binding = await options.manager.rebindBinding(params.data.bindingId, body.data);
+      if (!binding) return reply.status(404).send({ error: 'BLE binding not found' });
+      return reply.send(binding);
+    } catch (error) {
+      const message = safeError(error);
+      return reply.status(errorStatus(new Error(message))).send({ error: message });
+    }
+  });
+
+  app.delete('/api/limb/ble/bindings/:bindingId', async (request, reply) => {
+    if (!requireWriteIdentity(request, reply)) return;
+    if (!options.manager) return unavailable(reply);
+    const parsed = bindingParamsSchema.safeParse(request.params);
+    if (!parsed.success) return reply.status(400).send({ error: parsed.error.message });
+    const removed = await options.manager.unbind(parsed.data.bindingId);
+    if (!removed) return reply.status(404).send({ error: 'BLE binding not found' });
+    return reply.status(204).send();
+  });
+}

--- a/packages/api/test/ble-adapters.test.js
+++ b/packages/api/test/ble-adapters.test.js
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  BLE_ADAPTERS,
+  decodeBleCommandValue,
+  normalizeGattUuid,
+  selectBleAdapter,
+} from '../dist/domains/limb/ble/BleAdapters.js';
+
+describe('BLE standard adapters', () => {
+  it('normalizes Bluetooth base UUIDs', () => {
+    assert.equal(normalizeGattUuid('0000180F-0000-1000-8000-00805F9B34FB'), '180f');
+    assert.equal(normalizeGattUuid('2A19'), '2a19');
+  });
+
+  it('decodes battery, temperature, and humidity with units', () => {
+    assert.deepEqual(decodeBleCommandValue('standard.battery', 'ble.battery.read', Buffer.from([87])), {
+      kind: 'battery',
+      value: 87,
+      unit: '%',
+    });
+
+    const temperature = Buffer.alloc(2);
+    temperature.writeInt16LE(2156);
+    assert.deepEqual(decodeBleCommandValue('standard.environmental', 'ble.temperature.read', temperature), {
+      kind: 'temperature',
+      value: 21.56,
+      unit: '°C',
+    });
+
+    const humidity = Buffer.alloc(2);
+    humidity.writeUInt16LE(5034);
+    assert.deepEqual(decodeBleCommandValue('standard.environmental', 'ble.humidity.read', humidity), {
+      kind: 'humidity',
+      value: 50.34,
+      unit: '%',
+    });
+  });
+
+  it('rejects malformed and out-of-range sensor data', () => {
+    assert.throws(() => decodeBleCommandValue('standard.battery', 'ble.battery.read', Buffer.alloc(0)), /length/);
+    assert.throws(() => decodeBleCommandValue('standard.battery', 'ble.battery.read', Buffer.from([101])), /outside/);
+
+    const humidity = Buffer.alloc(2);
+    humidity.writeUInt16LE(10_001);
+    assert.throws(() => decodeBleCommandValue('standard.environmental', 'ble.humidity.read', humidity), /outside/);
+  });
+
+  it('selects only known adapters from inspected characteristics', () => {
+    const environmental = selectBleAdapter([
+      { uuid: '181a', characteristics: [{ uuid: '2a6e', properties: ['read'] }] },
+    ]);
+    assert.equal(environmental?.id, 'standard.environmental');
+
+    const unknown = selectBleAdapter([
+      { uuid: 'ffff', characteristics: [{ uuid: 'eeee', properties: ['read', 'write'] }] },
+    ]);
+    assert.equal(unknown, null);
+    const writeOnlyEnvironmental = selectBleAdapter([
+      { uuid: '181a', characteristics: [{ uuid: '2a6e', properties: ['write'] }] },
+    ]);
+    assert.equal(writeOnlyEnvironmental, null);
+    assert.equal(Object.hasOwn(BLE_ADAPTERS, 'standard.environmental'), true);
+  });
+});

--- a/packages/api/test/ble-binding-recovery.test.js
+++ b/packages/api/test/ble-binding-recovery.test.js
@@ -1,0 +1,314 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, it } from 'node:test';
+import { MemoryBleBindingStore } from '../dist/domains/limb/ble/BleBindingStore.js';
+import { BleDeviceManager } from '../dist/domains/limb/ble/BleDeviceManager.js';
+import { LimbRegistry } from '../dist/domains/limb/LimbRegistry.js';
+
+class FakeHelper extends EventEmitter {
+  requests = [];
+  status = { state: 'idle', reason: null, restartAttempts: 0 };
+
+  async request(command, params) {
+    this.requests.push({ command, params });
+    if (command === 'device.inspect') {
+      return {
+        services: [
+          {
+            uuid: '181a',
+            characteristics: [
+              { uuid: '2a6e', properties: ['read', 'notify'] },
+              { uuid: '2a6f', properties: ['read'] },
+            ],
+          },
+        ],
+      };
+    }
+    if (command === 'gatt.read') {
+      const value = Buffer.alloc(2);
+      value.writeInt16LE(2345);
+      return { valueBase64: value.toString('base64') };
+    }
+    return {};
+  }
+}
+
+function discoveryEvent(sessionId, deviceId = 'private-corebluetooth-id') {
+  return {
+    kind: 'event',
+    event: 'scan.discovered',
+    data: { sessionId, deviceId, name: 'Desk Sensor', rssi: -45, serviceUuids: ['181a'] },
+  };
+}
+
+describe('BLE binding recovery', () => {
+  let helper;
+  let store;
+  let registry;
+  let manager;
+
+  beforeEach(() => {
+    helper = new FakeHelper();
+    store = new MemoryBleBindingStore();
+    registry = new LimbRegistry();
+    manager = new BleDeviceManager({ helper, store, registry, platform: 'darwin' });
+  });
+
+  it('probes a binding without exposing its platform ID and records successful contact', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+
+    const reachable = await manager.probeBinding(binding.bindingId);
+    assert.equal(reachable.state, 'reachable');
+    assert.equal(reachable.bindingId, binding.bindingId);
+    assert.equal('platformDeviceId' in reachable, false);
+    assert.equal((await store.get('instance', binding.bindingId)).lastConnectedAt, reachable.checkedAt);
+
+    const originalRequest = helper.request.bind(helper);
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect') throw new Error('operation_timeout');
+      return originalRequest(command, params);
+    };
+    const unreachable = await manager.probeBinding(binding.bindingId);
+    assert.deepEqual(unreachable, {
+      bindingId: binding.bindingId,
+      state: 'unreachable',
+      reason: 'timeout',
+      checkedAt: unreachable.checkedAt,
+    });
+  });
+
+  it('distinguishes a reachable device with a changed GATT profile from an unreachable binding', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    const originalRequest = helper.request.bind(helper);
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect') {
+        return {
+          services: [
+            {
+              uuid: '180f',
+              characteristics: [{ uuid: '2a19', properties: ['read'] }],
+            },
+          ],
+        };
+      }
+      return originalRequest(command, params);
+    };
+
+    const result = await manager.probeBinding(binding.bindingId);
+    assert.deepEqual(result, {
+      bindingId: binding.bindingId,
+      state: 'profile_mismatch',
+      checkedAt: result.checkedAt,
+    });
+    assert.equal('platformDeviceId' in result, false);
+  });
+
+  it('explicitly rebinds a rotated platform identity while preserving the node identity', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'old-platform-id'));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'rotated-platform-id'));
+    const rotatedDiscovery = manager
+      .scanSnapshot()
+      .discoveries.find((discovery) => discovery.discoveryId !== manager.scanSnapshot().discoveries[0].discoveryId);
+
+    const rebound = await manager.rebindBinding(binding.bindingId, {
+      sessionId: session.sessionId,
+      discoveryId: rotatedDiscovery.discoveryId,
+    });
+    assert.equal(rebound.bindingId, binding.bindingId);
+    assert.equal(rebound.nodeId, binding.nodeId);
+    assert.equal(rebound.displayName, binding.displayName);
+    assert.equal('platformDeviceId' in rebound, false);
+    assert.equal((await store.get('instance', binding.bindingId)).platformDeviceId, 'rotated-platform-id');
+
+    await registry.invoke(binding.nodeId, 'ble.temperature.read', {}, { catId: 'sol' });
+    const readRequest = helper.requests.findLast((request) => request.command === 'gatt.read');
+    assert.equal(readRequest.params.deviceId, 'rotated-platform-id');
+    assert.deepEqual(helper.requests.filter((request) => request.command === 'device.disconnect').at(-1).params, {
+      deviceId: 'old-platform-id',
+    });
+  });
+
+  it('rejects a rebind target whose typed capability contract differs from the existing node', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'old-platform-id'));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'incompatible-platform-id'));
+    const candidate = manager.scanSnapshot().discoveries.at(-1);
+    const originalRequest = helper.request.bind(helper);
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect' && params.deviceId === 'incompatible-platform-id') {
+        return {
+          services: [
+            {
+              uuid: '180f',
+              characteristics: [{ uuid: '2a19', properties: ['read'] }],
+            },
+          ],
+        };
+      }
+      return originalRequest(command, params);
+    };
+
+    await assert.rejects(
+      manager.rebindBinding(binding.bindingId, {
+        sessionId: session.sessionId,
+        discoveryId: candidate.discoveryId,
+      }),
+      /not compatible/,
+    );
+    assert.equal((await store.get('instance', binding.bindingId)).platformDeviceId, 'old-platform-id');
+  });
+
+  it('rejects stale discoveries and a device identity owned by another binding', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'first-platform-id'));
+    const firstDiscovery = manager.scanSnapshot().discoveries[0];
+    const firstBinding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: firstDiscovery.discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'second-platform-id'));
+    const secondDiscovery = manager.scanSnapshot().discoveries.at(-1);
+    await manager.bind({ sessionId: session.sessionId, discoveryId: secondDiscovery.discoveryId });
+
+    await assert.rejects(
+      manager.rebindBinding(firstBinding.bindingId, { sessionId: 'stale-session', discoveryId: 'stale-discovery' }),
+      /not available/,
+    );
+    await assert.rejects(
+      manager.rebindBinding(firstBinding.bindingId, {
+        sessionId: session.sessionId,
+        discoveryId: secondDiscovery.discoveryId,
+      }),
+      /already bound/,
+    );
+    assert.equal((await store.get('instance', firstBinding.bindingId)).platformDeviceId, 'first-platform-id');
+    assert.equal((await store.list('instance')).length, 2);
+  });
+
+  it('serializes concurrent rebind attempts for the same persistent binding', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'old-platform-id'));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'rotated-platform-id'));
+    const candidate = manager.scanSnapshot().discoveries.at(-1);
+    const originalRequest = helper.request.bind(helper);
+    let releaseInspection;
+    let markInspectionStarted;
+    const inspectionGate = new Promise((resolve) => {
+      releaseInspection = resolve;
+    });
+    const inspectionStarted = new Promise((resolve) => {
+      markInspectionStarted = resolve;
+    });
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect' && params.deviceId === 'rotated-platform-id') {
+        markInspectionStarted();
+        await inspectionGate;
+      }
+      return originalRequest(command, params);
+    };
+
+    const input = { sessionId: session.sessionId, discoveryId: candidate.discoveryId };
+    const first = manager.rebindBinding(binding.bindingId, input);
+    await inspectionStarted;
+    const second = manager.rebindBinding(binding.bindingId, input);
+    await assert.rejects(second, /already bound|already in progress/);
+    releaseInspection();
+    await first;
+    assert.equal((await store.list('instance')).length, 1);
+  });
+
+  it('prevents unbind from racing with an in-flight rebind', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'old-platform-id'));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'rotated-platform-id'));
+    const candidate = manager.scanSnapshot().discoveries.at(-1);
+    const originalRequest = helper.request.bind(helper);
+    let releaseInspection;
+    let markInspectionStarted;
+    const inspectionGate = new Promise((resolve) => {
+      releaseInspection = resolve;
+    });
+    const inspectionStarted = new Promise((resolve) => {
+      markInspectionStarted = resolve;
+    });
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect' && params.deviceId === 'rotated-platform-id') {
+        markInspectionStarted();
+        await inspectionGate;
+      }
+      return originalRequest(command, params);
+    };
+
+    const rebind = manager.rebindBinding(binding.bindingId, {
+      sessionId: session.sessionId,
+      discoveryId: candidate.discoveryId,
+    });
+    await inspectionStarted;
+    await assert.rejects(manager.unbind(binding.bindingId), /already in progress/);
+    releaseInspection();
+    await rebind;
+
+    assert.ok(registry.getNode(binding.nodeId));
+    assert.equal((await store.list('instance')).length, 1);
+    assert.equal((await store.get('instance', binding.bindingId)).platformDeviceId, 'rotated-platform-id');
+  });
+
+  it('keeps the old binding active when rebind persistence fails and permits a retry', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId, 'old-platform-id'));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    helper.emit('event', discoveryEvent(session.sessionId, 'rotated-platform-id'));
+    const candidate = manager.scanSnapshot().discoveries.at(-1);
+    const originalPut = store.put.bind(store);
+    let failPut = true;
+    store.put = async (nextBinding) => {
+      if (failPut && nextBinding.platformDeviceId === 'rotated-platform-id') {
+        failPut = false;
+        throw new Error('persistence unavailable');
+      }
+      return originalPut(nextBinding);
+    };
+    const input = { sessionId: session.sessionId, discoveryId: candidate.discoveryId };
+
+    await assert.rejects(manager.rebindBinding(binding.bindingId, input), /persistence unavailable/);
+    assert.equal((await store.get('instance', binding.bindingId)).platformDeviceId, 'old-platform-id');
+    await registry.invoke(binding.nodeId, 'ble.temperature.read', {}, { catId: 'sol' });
+    assert.equal(
+      helper.requests.findLast((request) => request.command === 'gatt.read').params.deviceId,
+      'old-platform-id',
+    );
+
+    await manager.rebindBinding(binding.bindingId, input);
+    assert.equal((await store.get('instance', binding.bindingId)).platformDeviceId, 'rotated-platform-id');
+  });
+});

--- a/packages/api/test/ble-binding-store.test.js
+++ b/packages/api/test/ble-binding-store.test.js
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  BLE_BINDING_INDEX_KEY,
+  bleBindingKey,
+  MemoryBleBindingStore,
+  RedisBleBindingStore,
+} from '../dist/domains/limb/ble/BleBindingStore.js';
+
+const BINDING = {
+  bindingId: 'binding-1',
+  scopeId: 'instance',
+  platformDeviceId: 'device-1',
+  displayName: 'Desk Sensor',
+  adapterId: 'standard.environmental',
+  commands: ['ble.temperature.read'],
+  nodeId: 'ble:binding-1',
+  createdAt: 100,
+  lastConnectedAt: null,
+};
+
+class FakeRedis {
+  values = new Map();
+  sets = new Map();
+  operations = [];
+
+  multi() {
+    const queued = [];
+    return {
+      set: (key, value) => {
+        queued.push(['set', key, value]);
+        return this;
+      },
+      sadd: (key, value) => {
+        queued.push(['sadd', key, value]);
+        return this;
+      },
+      del: (key) => {
+        queued.push(['del', key]);
+        return this;
+      },
+      srem: (key, value) => {
+        queued.push(['srem', key, value]);
+        return this;
+      },
+      exec: async () => {
+        for (const op of queued) this.apply(op);
+        this.operations.push(...queued);
+        return queued.map(() => [null, 1]);
+      },
+    };
+  }
+
+  apply([command, key, value]) {
+    if (command === 'set') this.values.set(key, value);
+    if (command === 'sadd') {
+      const set = this.sets.get(key) ?? new Set();
+      set.add(value);
+      this.sets.set(key, set);
+    }
+    if (command === 'del') this.values.delete(key);
+    if (command === 'srem') this.sets.get(key)?.delete(value);
+  }
+
+  async get(key) {
+    return this.values.get(key) ?? null;
+  }
+
+  async smembers(key) {
+    return [...(this.sets.get(key) ?? [])];
+  }
+}
+
+describe('BLE binding stores', () => {
+  it('memory implementation is isolated for tests', async () => {
+    const store = new MemoryBleBindingStore();
+    await store.put(BINDING);
+    assert.deepEqual(await store.get('instance', 'binding-1'), BINDING);
+    assert.equal((await store.list('instance')).length, 1);
+    await store.delete('instance', 'binding-1');
+    assert.equal(await store.get('instance', 'binding-1'), null);
+  });
+
+  it('Redis implementation persists without EXPIRE and rehydrates', async () => {
+    const redis = new FakeRedis();
+    const store = new RedisBleBindingStore(redis);
+    await store.put(BINDING);
+
+    assert.deepEqual(
+      redis.operations.map((op) => op[0]),
+      ['set', 'sadd'],
+    );
+    assert.equal(
+      redis.operations.some((op) => op.includes('EX') || op[0] === 'expire'),
+      false,
+    );
+    assert.equal(redis.sets.get(BLE_BINDING_INDEX_KEY('instance')).has('binding-1'), true);
+
+    const restarted = new RedisBleBindingStore(redis);
+    assert.deepEqual(await restarted.get('instance', 'binding-1'), BINDING);
+    assert.deepEqual(await restarted.list('instance'), [BINDING]);
+  });
+
+  it('skips corrupt records without deleting persistent data', async () => {
+    const redis = new FakeRedis();
+    redis.sets.set(BLE_BINDING_INDEX_KEY('instance'), new Set(['bad']));
+    redis.values.set(bleBindingKey('instance', 'bad'), '{broken-json');
+    const warnings = [];
+    const store = new RedisBleBindingStore(redis, { warn: (message) => warnings.push(message) });
+
+    assert.deepEqual(await store.list('instance'), []);
+    assert.equal(redis.values.has(bleBindingKey('instance', 'bad')), true);
+    assert.equal(warnings.length, 1);
+  });
+});

--- a/packages/api/test/ble-device-manager.test.js
+++ b/packages/api/test/ble-device-manager.test.js
@@ -1,0 +1,241 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, it } from 'node:test';
+import { MemoryBleBindingStore } from '../dist/domains/limb/ble/BleBindingStore.js';
+import { BleDeviceManager } from '../dist/domains/limb/ble/BleDeviceManager.js';
+import { LimbAccessPolicy } from '../dist/domains/limb/LimbAccessPolicy.js';
+import { LimbActionLog } from '../dist/domains/limb/LimbActionLog.js';
+import { LimbLeaseManager } from '../dist/domains/limb/LimbLeaseManager.js';
+import { LimbRegistry } from '../dist/domains/limb/LimbRegistry.js';
+
+class FakeHelper extends EventEmitter {
+  requests = [];
+  status = { state: 'idle', reason: null, restartAttempts: 0 };
+
+  async request(command, params) {
+    this.requests.push({ command, params });
+    if (command === 'device.inspect') {
+      return {
+        services: [
+          {
+            uuid: '181a',
+            characteristics: [
+              { uuid: '2a6e', properties: ['read', 'notify'] },
+              { uuid: '2a6f', properties: ['read'] },
+            ],
+          },
+        ],
+      };
+    }
+    if (command === 'gatt.read') {
+      const value = Buffer.alloc(2);
+      value.writeInt16LE(2345);
+      return { valueBase64: value.toString('base64') };
+    }
+    return {};
+  }
+
+  setState(state, reason = null) {
+    this.status = { state, reason, restartAttempts: 0 };
+    this.emit('state', this.status);
+  }
+}
+
+function discoveryEvent(sessionId, deviceId = 'private-corebluetooth-id') {
+  return {
+    kind: 'event',
+    event: 'scan.discovered',
+    data: { sessionId, deviceId, name: 'Desk Sensor', rssi: -45, serviceUuids: ['181a'] },
+  };
+}
+
+describe('BleDeviceManager + BleLimbNode', () => {
+  let helper;
+  let store;
+  let registry;
+  let actionLog;
+  let manager;
+
+  beforeEach(() => {
+    helper = new FakeHelper();
+    store = new MemoryBleBindingStore();
+    registry = new LimbRegistry();
+    actionLog = new LimbActionLog();
+    registry.setDeps({
+      accessPolicy: new LimbAccessPolicy(),
+      leaseManager: new LimbLeaseManager(),
+      actionLog,
+    });
+    manager = new BleDeviceManager({ helper, store, registry, platform: 'darwin' });
+  });
+
+  it('hydrates persistent bindings without spawning the helper', async () => {
+    await store.put({
+      bindingId: 'persisted',
+      scopeId: 'instance',
+      platformDeviceId: 'private-id',
+      displayName: 'Persisted Sensor',
+      adapterId: 'standard.environmental',
+      commands: ['ble.temperature.read'],
+      nodeId: 'ble:persisted',
+      createdAt: 100,
+      lastConnectedAt: null,
+    });
+
+    await manager.initialize();
+    assert.ok(registry.getNode('ble:persisted'));
+    assert.deepEqual(helper.requests, []);
+    const listed = await manager.listBindings();
+    assert.equal('platformDeviceId' in listed[0], false);
+  });
+
+  it('binds only a discovery from the active scan and registers a typed node', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const discovery = manager.scanSnapshot().discoveries[0];
+
+    const binding = await manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId });
+    assert.equal(binding.adapterId, 'standard.environmental');
+    assert.deepEqual(binding.commands, ['ble.temperature.read', 'ble.humidity.read']);
+    assert.equal('platformDeviceId' in binding, false);
+    assert.ok(registry.getNode(binding.nodeId));
+    assert.equal((await store.list('instance')).length, 1);
+  });
+
+  it('serializes concurrent bind attempts for the same discovered device', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const discovery = manager.scanSnapshot().discoveries[0];
+    const originalRequest = helper.request.bind(helper);
+    let releaseInspection;
+    let markInspectionStarted;
+    const inspectionGate = new Promise((resolve) => {
+      releaseInspection = resolve;
+    });
+    const inspectionStarted = new Promise((resolve) => {
+      markInspectionStarted = resolve;
+    });
+    let inspectionCount = 0;
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect') {
+        inspectionCount += 1;
+        markInspectionStarted();
+        await inspectionGate;
+      }
+      return originalRequest(command, params);
+    };
+
+    const firstBind = manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId });
+    await inspectionStarted;
+    const secondBind = manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId });
+    await Promise.resolve();
+    releaseInspection();
+
+    const [first, second] = await Promise.allSettled([firstBind, secondBind]);
+    assert.equal(first.status, 'fulfilled');
+    assert.equal(second.status, 'rejected');
+    assert.match(second.reason.message, /already bound|binding is already in progress/);
+    assert.equal(inspectionCount, 1);
+    assert.equal((await store.list('instance')).length, 1);
+  });
+
+  it('releases the bind reservation after inspection fails', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const discovery = manager.scanSnapshot().discoveries[0];
+    const originalRequest = helper.request.bind(helper);
+    let failInspection = true;
+    helper.request = async (command, params) => {
+      if (command === 'device.inspect' && failInspection) {
+        failInspection = false;
+        throw new Error('inspection failed');
+      }
+      return originalRequest(command, params);
+    };
+
+    await assert.rejects(
+      manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId }),
+      /inspection failed/,
+    );
+    const binding = await manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId });
+
+    assert.equal(binding.adapterId, 'standard.environmental');
+    assert.equal((await store.list('instance')).length, 1);
+  });
+
+  it('rejects stale or unknown discoveries without persistence', async () => {
+    await assert.rejects(manager.bind({ sessionId: 'stale', discoveryId: 'unknown' }), /not available/);
+    assert.deepEqual(await store.list('instance'), []);
+  });
+
+  it('reads through the F126 pipeline and records an Action Log entry', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const discovery = manager.scanSnapshot().discoveries[0];
+    const binding = await manager.bind({ sessionId: session.sessionId, discoveryId: discovery.discoveryId });
+
+    const result = await registry.invoke(
+      binding.nodeId,
+      'ble.temperature.read',
+      {},
+      { catId: 'sol', invocationId: 'inv-1' },
+    );
+    assert.deepEqual(result, {
+      success: true,
+      data: { kind: 'temperature', value: 23.45, unit: '°C' },
+    });
+    const entries = actionLog.getByNode(binding.nodeId);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].status, 'completed');
+    assert.equal(entries[0].catId, 'sol');
+  });
+
+  it('rejects arbitrary GATT writes before reaching the helper', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+    const before = helper.requests.length;
+
+    const result = await registry.invoke(binding.nodeId, 'gatt.write', { valueBase64: 'AQ==' }, { catId: 'sol' });
+    assert.equal(result.success, false);
+    assert.match(result.error, /not in any capability whitelist/);
+    assert.equal(helper.requests.length, before);
+  });
+
+  it('deregisters and disconnects on explicit unbind', async () => {
+    const session = await manager.startScan();
+    helper.emit('event', discoveryEvent(session.sessionId));
+    const binding = await manager.bind({
+      sessionId: session.sessionId,
+      discoveryId: manager.scanSnapshot().discoveries[0].discoveryId,
+    });
+
+    assert.equal(await manager.unbind(binding.bindingId), true);
+    assert.equal(registry.getNode(binding.nodeId), undefined);
+    assert.equal(await store.get('instance', binding.bindingId), null);
+    assert.equal(helper.requests.at(-1).command, 'device.disconnect');
+  });
+
+  it('projects helper degradation onto every BLE node', async () => {
+    await store.put({
+      bindingId: 'persisted',
+      scopeId: 'instance',
+      platformDeviceId: 'private-id',
+      displayName: 'Persisted Sensor',
+      adapterId: 'standard.environmental',
+      commands: ['ble.temperature.read'],
+      nodeId: 'ble:persisted',
+      createdAt: 100,
+      lastConnectedAt: null,
+    });
+    await manager.initialize();
+
+    helper.setState('degraded', 'helper crashed');
+    assert.equal(registry.getNode('ble:persisted').status, 'degraded');
+    helper.setState('ready');
+    assert.equal(registry.getNode('ble:persisted').status, 'online');
+  });
+});

--- a/packages/api/test/ble-helper-client.test.js
+++ b/packages/api/test/ble-helper-client.test.js
@@ -1,0 +1,328 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, it } from 'node:test';
+import { BleHelperClient } from '../dist/domains/limb/ble/BleHelperClient.js';
+
+class FakeStream extends EventEmitter {}
+
+class FakeProcess extends EventEmitter {
+  stdout = new FakeStream();
+  stderr = new FakeStream();
+  killed = false;
+  writes = [];
+
+  stdin = {
+    write: (line, callback) => {
+      this.writes.push(line);
+      this.onWrite?.(JSON.parse(line));
+      callback?.();
+      return true;
+    },
+  };
+
+  send(message) {
+    this.stdout.emit('data', Buffer.from(`${JSON.stringify(message)}\n`));
+  }
+
+  sendHello(version = 1) {
+    this.send({ protocol: 'ble-helper', version, kind: 'hello' });
+  }
+
+  sendAdapterState(state = 'poweredOn') {
+    this.send({ protocol: 'ble-helper', version: 1, kind: 'event', event: 'adapter.state', data: { state } });
+  }
+
+  crash(code = 1) {
+    this.emit('exit', code, null);
+  }
+
+  kill() {
+    this.killed = true;
+    return true;
+  }
+}
+
+function respondingProcess() {
+  const process = new FakeProcess();
+  process.onWrite = (request) => {
+    queueMicrotask(() =>
+      process.send({
+        protocol: 'ble-helper',
+        version: 1,
+        kind: 'response',
+        requestId: request.requestId,
+        ok: true,
+        data: { accepted: request.command },
+      }),
+    );
+  };
+  queueMicrotask(() => {
+    process.sendHello();
+    process.sendAdapterState();
+  });
+  return process;
+}
+
+describe('BleHelperClient', () => {
+  it('spawns lazily and correlates responses', async () => {
+    let spawnCount = 0;
+    const process = respondingProcess();
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => {
+        spawnCount += 1;
+        return process;
+      },
+    });
+
+    assert.equal(client.status.state, 'idle');
+    assert.equal(spawnCount, 0);
+    const result = await client.request('scan.start', { sessionId: 'scan-1', timeoutMs: 30_000 });
+    assert.deepEqual(result, { accepted: 'scan.start' });
+    assert.equal(spawnCount, 1);
+    assert.equal(client.status.state, 'ready');
+  });
+
+  it('waits for CoreBluetooth poweredOn before sending the first operational request', async () => {
+    const process = new FakeProcess();
+    process.onWrite = (request) => {
+      queueMicrotask(() =>
+        process.send({
+          protocol: 'ble-helper',
+          version: 1,
+          kind: 'response',
+          requestId: request.requestId,
+          ok: true,
+          data: { accepted: request.command },
+        }),
+      );
+    };
+    queueMicrotask(() => process.sendHello());
+    const client = new BleHelperClient({ platform: 'darwin', spawnProcess: () => process });
+
+    const request = client.request('scan.start', { sessionId: 'scan-powered-on', timeoutMs: 30_000 });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(process.writes.length, 0);
+    process.sendAdapterState('resetting');
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(process.writes.length, 0);
+    process.sendAdapterState('poweredOn');
+
+    assert.deepEqual(await request, { accepted: 'scan.start' });
+    assert.equal(process.writes.length, 1);
+  });
+
+  it('fails an operational request without writing when Bluetooth is powered off', async () => {
+    const process = new FakeProcess();
+    queueMicrotask(() => {
+      process.sendHello();
+      process.sendAdapterState('poweredOff');
+    });
+    const client = new BleHelperClient({ platform: 'darwin', spawnProcess: () => process });
+
+    await assert.rejects(
+      client.request('scan.start', { sessionId: 'scan-powered-off', timeoutMs: 30_000 }),
+      /not powered on: poweredOff/,
+    );
+    assert.equal(process.writes.length, 0);
+  });
+
+  it('rejects an unknown handshake version without retrying', async () => {
+    let spawnCount = 0;
+    const process = new FakeProcess();
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => {
+        spawnCount += 1;
+        queueMicrotask(() => process.sendHello(2));
+        return process;
+      },
+      sleep: async () => {},
+    });
+
+    await assert.rejects(client.start(), /Unsupported BLE helper protocol version/);
+    assert.equal(spawnCount, 1);
+    assert.equal(process.killed, true);
+    assert.equal(client.status.state, 'degraded');
+  });
+
+  it('recovers from a crash after 1 second and keeps the API caller alive', async () => {
+    const firstProcess = respondingProcess();
+    let spawnCount = 0;
+    const delays = [];
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => {
+        spawnCount += 1;
+        return spawnCount === 1 ? firstProcess : respondingProcess();
+      },
+      sleep: async (ms) => delays.push(ms),
+    });
+
+    await client.start();
+    const first = client.currentProcessForTest;
+    first.crash();
+    const result = await client.request('scan.start', { sessionId: 'scan-2', timeoutMs: 30_000 });
+
+    assert.deepEqual(result, { accepted: 'scan.start' });
+    assert.deepEqual(delays, [1_000]);
+    assert.equal(client.status.state, 'ready');
+  });
+
+  it('marks the capability degraded after three failed restart attempts', async () => {
+    const first = respondingProcess();
+    let spawnCount = 0;
+    const delays = [];
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => {
+        spawnCount += 1;
+        if (spawnCount === 1) return first;
+        const failed = new FakeProcess();
+        queueMicrotask(() => failed.crash());
+        return failed;
+      },
+      sleep: async (ms) => delays.push(ms),
+      handshakeTimeoutMs: 20,
+    });
+
+    await client.start();
+    first.crash();
+    await assert.rejects(client.start(), /unavailable/);
+    assert.equal(spawnCount, 4);
+    assert.deepEqual(delays, [1_000, 2_000, 4_000]);
+    assert.equal(client.status.state, 'degraded');
+  });
+
+  it('does not restart after shutdown interrupts a recovery backoff', async () => {
+    const first = respondingProcess();
+    let spawnCount = 0;
+    let releaseSleep;
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => {
+        spawnCount += 1;
+        return spawnCount === 1 ? first : respondingProcess();
+      },
+      sleep: () =>
+        new Promise((resolve) => {
+          releaseSleep = resolve;
+        }),
+    });
+
+    await client.start();
+    first.crash();
+    assert.equal(typeof releaseSleep, 'function');
+
+    await client.shutdown();
+    releaseSleep();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(spawnCount, 1);
+    assert.equal(client.status.state, 'idle');
+  });
+
+  it('times out a request without exiting the process', async () => {
+    const process = new FakeProcess();
+    queueMicrotask(() => {
+      process.sendHello();
+      process.sendAdapterState();
+    });
+    let fireRequestTimeout;
+    let unrefCalled = false;
+    const requestTimer = {
+      unref: () => {
+        unrefCalled = true;
+      },
+    };
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => process,
+      requestTimeoutMs: 5,
+      setRequestTimer: (callback, ms) => {
+        assert.equal(ms, 5);
+        fireRequestTimeout = callback;
+        return requestTimer;
+      },
+    });
+
+    await client.start();
+    const request = client.request('scan.start', { sessionId: 'scan-timeout', timeoutMs: 30_000 });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(typeof fireRequestTimeout, 'function');
+    assert.equal(unrefCalled, true);
+    fireRequestTimeout();
+
+    await assert.rejects(request, /timed out/);
+    assert.equal(client.status.state, 'ready');
+  });
+
+  it('ignores malformed runtime messages and accepts the next valid response', async () => {
+    const warnings = [];
+    const process = new FakeProcess();
+    process.onWrite = (request) => {
+      queueMicrotask(() => {
+        process.stdout.emit('data', Buffer.from('{bad-json}\n'));
+        process.send({
+          protocol: 'ble-helper',
+          version: 1,
+          kind: 'response',
+          requestId: request.requestId,
+          ok: true,
+          data: { ok: true },
+        });
+      });
+    };
+    queueMicrotask(() => {
+      process.sendHello();
+      process.sendAdapterState();
+    });
+    const client = new BleHelperClient({
+      platform: 'darwin',
+      spawnProcess: () => process,
+      logger: { warn: (message) => warnings.push(message), info: () => {} },
+    });
+
+    assert.deepEqual(await client.request('scan.start', { sessionId: 'scan-3', timeoutMs: 30_000 }), { ok: true });
+    assert.equal(warnings.length, 1);
+    assert.equal(client.status.state, 'ready');
+  });
+
+  it('preserves UTF-8 event data split across stdout chunks', async () => {
+    const process = new FakeProcess();
+    queueMicrotask(() => process.sendHello());
+    const client = new BleHelperClient({ platform: 'darwin', spawnProcess: () => process });
+    await client.start();
+
+    const eventPromise = new Promise((resolve) => client.once('event', resolve));
+    const encoded = Buffer.from(
+      `${JSON.stringify({
+        protocol: 'ble-helper',
+        version: 1,
+        kind: 'event',
+        event: 'scan.discovered',
+        data: {
+          sessionId: 'scan-utf8',
+          deviceId: 'device-utf8',
+          name: '桌面传感器',
+          rssi: -42,
+          serviceUuids: ['181a'],
+        },
+      })}\n`,
+    );
+    const splitAt = encoded.indexOf(Buffer.from('桌')) + 1;
+    process.stdout.emit('data', encoded.subarray(0, splitAt));
+    process.stdout.emit('data', encoded.subarray(splitAt));
+
+    const event = await eventPromise;
+    assert.equal(event.data.name, '桌面传感器');
+  });
+
+  it('reports unsupported without spawning on non-macOS platforms', async () => {
+    let spawned = false;
+    const client = new BleHelperClient({ platform: 'linux', spawnProcess: () => (spawned = true) });
+    await assert.rejects(client.start(), /only available on macOS/);
+    assert.equal(spawned, false);
+    assert.equal(client.status.state, 'unsupported');
+  });
+});

--- a/packages/api/test/ble-helper-process.test.js
+++ b/packages/api/test/ble-helper-process.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveBleHelperExecutable } from '../dist/domains/limb/ble/BleHelperProcess.js';
+
+describe('BleHelperProcess', () => {
+  it('resolves an Intel source build from the x86_64 Swift output directory', () => {
+    const executable = resolveBleHelperExecutable('x64', (candidate) =>
+      candidate.endsWith('/native/ble-helper/macos/.build/x86_64/ble-helper'),
+    );
+
+    assert.match(executable, /\/native\/ble-helper\/macos\/\.build\/x86_64\/ble-helper$/);
+  });
+
+  it('keeps the packaged Intel helper directory normalized as x64', () => {
+    const executable = resolveBleHelperExecutable('x64', (candidate) =>
+      candidate.endsWith('/bundled/ble-helper-darwin-x64/ble-helper'),
+    );
+
+    assert.match(executable, /\/bundled\/ble-helper-darwin-x64\/ble-helper$/);
+  });
+});

--- a/packages/api/test/ble-helper-protocol.test.js
+++ b/packages/api/test/ble-helper-protocol.test.js
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  BLE_HELPER_MAX_LINE_BYTES,
+  encodeBleHelperRequest,
+  parseBleHelperMessage,
+} from '../dist/domains/limb/ble/BleHelperProtocol.js';
+
+describe('BleHelperProtocol', () => {
+  it('encodes a versioned allowlisted request', () => {
+    const line = encodeBleHelperRequest('scan.start', { sessionId: 'scan-1', timeoutMs: 30_000 }, 'req-1');
+    assert.equal(line.endsWith('\n'), true);
+    assert.deepEqual(JSON.parse(line), {
+      protocol: 'ble-helper',
+      version: 1,
+      requestId: 'req-1',
+      command: 'scan.start',
+      params: { sessionId: 'scan-1', timeoutMs: 30_000 },
+    });
+  });
+
+  it('has no arbitrary GATT write command', () => {
+    assert.throws(
+      () => encodeBleHelperRequest('gatt.write', { deviceId: 'device-1', valueBase64: 'AQ==' }, 'req-1'),
+      /Unsupported BLE helper command/,
+    );
+  });
+
+  it('parses the required handshake', () => {
+    const message = parseBleHelperMessage('{"protocol":"ble-helper","version":1,"kind":"hello"}');
+    assert.equal(message.kind, 'hello');
+  });
+
+  it('rejects an unknown protocol version', () => {
+    assert.throws(
+      () => parseBleHelperMessage('{"protocol":"ble-helper","version":2,"kind":"hello"}'),
+      /Unsupported BLE helper protocol version/,
+    );
+  });
+
+  it('rejects malformed JSON and oversized lines', () => {
+    assert.throws(() => parseBleHelperMessage('{not-json}'), /Invalid BLE helper JSON/);
+    assert.throws(() => parseBleHelperMessage('x'.repeat(BLE_HELPER_MAX_LINE_BYTES + 1)), /exceeds/);
+  });
+});

--- a/packages/api/test/ble-routes.test.js
+++ b/packages/api/test/ble-routes.test.js
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import Fastify from 'fastify';
+import { registerBleRoutes } from '../dist/routes/ble-routes.js';
+
+function managerStub() {
+  return {
+    status: () => ({
+      platform: 'darwin',
+      available: true,
+      state: 'idle',
+      reason: null,
+      restartAttempts: 0,
+      bindingCount: 0,
+    }),
+    listBindings: async () => [],
+    scanSnapshot: () => ({
+      active: false,
+      sessionId: null,
+      startedAt: null,
+      expiresAt: null,
+      discoveries: [],
+    }),
+    startScan: async () => ({ sessionId: 'scan-1', startedAt: 100, expiresAt: 30_100 }),
+    stopScan: async () => {},
+    bind: async () => ({
+      bindingId: 'binding-1',
+      displayName: 'Sensor',
+      adapterId: 'standard.environmental',
+      commands: ['ble.temperature.read'],
+      nodeId: 'ble:binding-1',
+      createdAt: 100,
+      lastConnectedAt: 100,
+    }),
+    probeBinding: async (bindingId) =>
+      bindingId === 'binding-1' ? { bindingId, state: 'reachable', checkedAt: 200 } : null,
+    rebindBinding: async (bindingId) =>
+      bindingId === 'binding-1'
+        ? {
+            bindingId,
+            displayName: 'Sensor',
+            adapterId: 'standard.environmental',
+            commands: ['ble.temperature.read'],
+            nodeId: 'ble:binding-1',
+            createdAt: 100,
+            lastConnectedAt: 200,
+          }
+        : null,
+    unbind: async (bindingId) => bindingId === 'binding-1',
+  };
+}
+
+async function createApp({ manager = managerStub(), authenticated = true } = {}) {
+  const app = Fastify();
+  if (authenticated) {
+    app.addHook('onRequest', async (request) => {
+      request.sessionUserId = 'owner';
+    });
+  }
+  registerBleRoutes(app, { manager, platform: 'darwin' });
+  await app.ready();
+  return app;
+}
+
+describe('BLE operator routes', () => {
+  it('requires a session identity for BLE status', async () => {
+    const app = await createApp({ authenticated: false });
+    const response = await app.inject({ method: 'GET', url: '/api/limb/ble/status' });
+    assert.equal(response.statusCode, 401);
+    const probe = await app.inject({ method: 'POST', url: '/api/limb/ble/bindings/binding-1/probe' });
+    assert.equal(probe.statusCode, 401);
+    const rebind = await app.inject({
+      method: 'POST',
+      url: '/api/limb/ble/bindings/binding-1/rebind',
+      payload: { sessionId: 'scan-1', discoveryId: 'discovery-1' },
+    });
+    assert.equal(rebind.statusCode, 401);
+  });
+
+  it('returns status and never exposes a platform device ID', async () => {
+    const app = await createApp();
+    const status = await app.inject({ method: 'GET', url: '/api/limb/ble/status' });
+    assert.equal(status.statusCode, 200);
+    assert.equal(status.json().state, 'idle');
+
+    const bindings = await app.inject({ method: 'GET', url: '/api/limb/ble/bindings' });
+    assert.equal(bindings.statusCode, 200);
+    assert.equal(bindings.payload.includes('platformDeviceId'), false);
+  });
+
+  it('starts and stops an explicit scan session', async () => {
+    const app = await createApp();
+    const started = await app.inject({ method: 'POST', url: '/api/limb/ble/scan', payload: {} });
+    assert.equal(started.statusCode, 201);
+    assert.equal(started.json().sessionId, 'scan-1');
+
+    const stopped = await app.inject({ method: 'DELETE', url: '/api/limb/ble/scan' });
+    assert.equal(stopped.statusCode, 204);
+  });
+
+  it('validates opaque bind input and supports explicit unbind', async () => {
+    const app = await createApp();
+    const invalid = await app.inject({ method: 'POST', url: '/api/limb/ble/bindings', payload: {} });
+    assert.equal(invalid.statusCode, 400);
+
+    const bound = await app.inject({
+      method: 'POST',
+      url: '/api/limb/ble/bindings',
+      payload: { sessionId: 'scan-1', discoveryId: 'discovery-1' },
+    });
+    assert.equal(bound.statusCode, 201);
+    assert.equal(bound.payload.includes('platformDeviceId'), false);
+
+    const removed = await app.inject({ method: 'DELETE', url: '/api/limb/ble/bindings/binding-1' });
+    assert.equal(removed.statusCode, 204);
+    const missing = await app.inject({ method: 'DELETE', url: '/api/limb/ble/bindings/missing' });
+    assert.equal(missing.statusCode, 404);
+  });
+
+  it('probes and explicitly rebinds without exposing a platform device ID', async () => {
+    const app = await createApp();
+    const probe = await app.inject({ method: 'POST', url: '/api/limb/ble/bindings/binding-1/probe' });
+    assert.equal(probe.statusCode, 200);
+    assert.equal(probe.json().state, 'reachable');
+    assert.equal(probe.payload.includes('platformDeviceId'), false);
+
+    const rebound = await app.inject({
+      method: 'POST',
+      url: '/api/limb/ble/bindings/binding-1/rebind',
+      payload: { sessionId: 'scan-1', discoveryId: 'discovery-1' },
+    });
+    assert.equal(rebound.statusCode, 200);
+    assert.equal(rebound.json().nodeId, 'ble:binding-1');
+    assert.equal(rebound.payload.includes('platformDeviceId'), false);
+
+    const invalid = await app.inject({
+      method: 'POST',
+      url: '/api/limb/ble/bindings/binding-1/rebind',
+      payload: { sessionId: 'scan-1', discoveryId: 'discovery-1', deviceId: 'private' },
+    });
+    assert.equal(invalid.statusCode, 400);
+    const missing = await app.inject({ method: 'POST', url: '/api/limb/ble/bindings/missing/probe' });
+    assert.equal(missing.statusCode, 404);
+  });
+
+  it('fails closed for mutating routes when persistent storage is unavailable', async () => {
+    const app = await createApp({ manager: null });
+    const status = await app.inject({ method: 'GET', url: '/api/limb/ble/status' });
+    assert.equal(status.statusCode, 200);
+    assert.equal(status.json().available, false);
+    assert.match(status.json().reason, /Redis/);
+
+    const scan = await app.inject({ method: 'POST', url: '/api/limb/ble/scan', payload: {} });
+    assert.equal(scan.statusCode, 503);
+  });
+
+  it('maps an active-scan conflict without crashing the API', async () => {
+    const manager = managerStub();
+    manager.startScan = async () => {
+      throw new Error('A BLE scan session is already active');
+    };
+    const app = await createApp({ manager });
+    const response = await app.inject({ method: 'POST', url: '/api/limb/ble/scan', payload: {} });
+    assert.equal(response.statusCode, 409);
+    assert.match(response.json().error, /already active/);
+  });
+
+  it('maps an incompatible explicit rebind to an actionable client error', async () => {
+    const manager = managerStub();
+    manager.rebindBinding = async () => {
+      throw new Error('BLE rebind target is not compatible with the existing binding');
+    };
+    const app = await createApp({ manager });
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/limb/ble/bindings/binding-1/rebind',
+      payload: { sessionId: 'scan-1', discoveryId: 'discovery-1' },
+    });
+    assert.equal(response.statusCode, 422);
+    assert.match(response.json().error, /not compatible/);
+  });
+});

--- a/packages/api/test/ble-scan-session.test.js
+++ b/packages/api/test/ble-scan-session.test.js
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { describe, it } from 'node:test';
+import { BleScanSession } from '../dist/domains/limb/ble/BleScanSession.js';
+
+class FakeHelper extends EventEmitter {
+  requests = [];
+
+  async request(command, params) {
+    this.requests.push({ command, params });
+    return {};
+  }
+}
+
+describe('BleScanSession', () => {
+  it('keeps platform device IDs private and clears discoveries on stop', async () => {
+    const helper = new FakeHelper();
+    let timerCallback;
+    const scan = new BleScanSession(helper, {
+      now: () => 1_000,
+      setTimer: (callback) => {
+        timerCallback = callback;
+        return 1;
+      },
+      clearTimer: () => {},
+    });
+
+    const started = await scan.start();
+    helper.emit('event', {
+      kind: 'event',
+      event: 'scan.discovered',
+      data: {
+        sessionId: started.sessionId,
+        deviceId: 'core-bluetooth-private-id',
+        name: 'Sensor',
+        rssi: -48,
+        serviceUuids: ['181a'],
+      },
+    });
+
+    const snapshot = scan.snapshot();
+    assert.equal(snapshot.discoveries.length, 1);
+    assert.equal('deviceId' in snapshot.discoveries[0], false);
+    assert.notEqual(snapshot.discoveries[0].discoveryId, 'core-bluetooth-private-id');
+    assert.equal(
+      scan.resolveDiscovery(started.sessionId, snapshot.discoveries[0].discoveryId).platformDeviceId,
+      'core-bluetooth-private-id',
+    );
+
+    await scan.stop();
+    assert.deepEqual(scan.snapshot().discoveries, []);
+    assert.equal(scan.resolveDiscovery(started.sessionId, snapshot.discoveries[0].discoveryId), null);
+    assert.equal(typeof timerCallback, 'function');
+  });
+
+  it('ends after 30 seconds and ignores events from another session', async () => {
+    const helper = new FakeHelper();
+    let timerCallback;
+    let scheduledMs;
+    const scan = new BleScanSession(helper, {
+      now: () => 5_000,
+      setTimer: (callback, ms) => {
+        timerCallback = callback;
+        scheduledMs = ms;
+        return 1;
+      },
+      clearTimer: () => {},
+    });
+
+    const started = await scan.start();
+    assert.equal(scheduledMs, 30_000);
+    helper.emit('event', {
+      kind: 'event',
+      event: 'scan.discovered',
+      data: { sessionId: 'other', deviceId: 'device', name: null, rssi: -60, serviceUuids: [] },
+    });
+    assert.deepEqual(scan.snapshot().discoveries, []);
+
+    timerCallback();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(scan.snapshot().active, false);
+    assert.deepEqual(scan.snapshot().discoveries, []);
+    assert.equal(helper.requests.at(-1).command, 'scan.stop');
+    assert.equal(helper.requests.at(-1).params.sessionId, started.sessionId);
+  });
+
+  it('clears local discoveries when the helper reports an early stop', async () => {
+    const helper = new FakeHelper();
+    const scan = new BleScanSession(helper, { setTimer: () => 1, clearTimer: () => {} });
+    const started = await scan.start();
+    helper.emit('event', {
+      kind: 'event',
+      event: 'scan.discovered',
+      data: { sessionId: started.sessionId, deviceId: 'device', name: null, rssi: -60, serviceUuids: [] },
+    });
+    assert.equal(scan.snapshot().discoveries.length, 1);
+
+    helper.emit('event', {
+      kind: 'event',
+      event: 'scan.state',
+      data: { sessionId: started.sessionId, state: 'stopped' },
+    });
+    assert.equal(scan.snapshot().active, false);
+    assert.deepEqual(scan.snapshot().discoveries, []);
+  });
+
+  it('does not install a timeout after an early stop races with scan acknowledgement', async () => {
+    const helper = new FakeHelper();
+    let timerInstalled = false;
+    helper.request = async (command, params) => {
+      helper.requests.push({ command, params });
+      helper.emit('event', {
+        kind: 'event',
+        event: 'scan.state',
+        data: { sessionId: params.sessionId, state: 'stopped' },
+      });
+      return {};
+    };
+    const scan = new BleScanSession(helper, {
+      setTimer: () => {
+        timerInstalled = true;
+        return 1;
+      },
+      clearTimer: () => {},
+    });
+
+    await scan.start();
+
+    assert.equal(scan.snapshot().active, false);
+    assert.equal(timerInstalled, false);
+  });
+});

--- a/packages/api/test/redis-ble-binding-store.test.js
+++ b/packages/api/test/redis-ble-binding-store.test.js
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { after, before, beforeEach, describe, it } from 'node:test';
+import {
+  assertRedisIsolationOrThrow,
+  cleanupPrefixedRedisKeys,
+  redisIsolationSkipReason,
+} from './helpers/redis-test-helpers.js';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+describe('RedisBleBindingStore', { skip: redisIsolationSkipReason(REDIS_URL) }, () => {
+  let redis;
+  let RedisBleBindingStore;
+  let bleBindingKey;
+  let connected = false;
+
+  before(async () => {
+    assertRedisIsolationOrThrow(REDIS_URL, 'RedisBleBindingStore');
+    ({ RedisBleBindingStore, bleBindingKey } = await import('../dist/domains/limb/ble/BleBindingStore.js'));
+    const { createRedisClient } = await import('@cat-cafe/shared/utils');
+    redis = createRedisClient({ url: REDIS_URL });
+    try {
+      await redis.ping();
+      connected = true;
+    } catch {
+      await redis.quit().catch(() => {});
+    }
+  });
+
+  beforeEach(async (context) => {
+    if (!connected) return context.skip('Redis not connected');
+    await cleanupPrefixedRedisKeys(redis, ['limb:ble:bindings:*']);
+  });
+
+  after(async () => {
+    if (!connected) return;
+    await cleanupPrefixedRedisKeys(redis, ['limb:ble:bindings:*']);
+    await redis.quit();
+  });
+
+  it('persists a binding with TTL=0 semantics and rehydrates it', async () => {
+    const binding = {
+      bindingId: 'binding-redis',
+      scopeId: 'instance',
+      platformDeviceId: 'device-private',
+      displayName: 'Redis Sensor',
+      adapterId: 'standard.environmental',
+      commands: ['ble.temperature.read'],
+      nodeId: 'ble:binding-redis',
+      createdAt: 100,
+      lastConnectedAt: null,
+    };
+    const store = new RedisBleBindingStore(redis);
+    await store.put(binding);
+
+    assert.equal(await redis.ttl(bleBindingKey('instance', 'binding-redis')), -1);
+    const rehydrated = new RedisBleBindingStore(redis);
+    assert.deepEqual(await rehydrated.get('instance', 'binding-redis'), binding);
+  });
+});

--- a/packages/web/src/components/__tests__/settings-nav-search.test.ts
+++ b/packages/web/src/components/__tests__/settings-nav-search.test.ts
@@ -46,7 +46,7 @@ describe('SettingsNav search filtering', () => {
       root.render(React.createElement(SettingsNav, { activeSection: 'members', onSelect: vi.fn() }));
     });
     const buttons = Array.from(container.querySelectorAll('[data-active]'));
-    expect(buttons).toHaveLength(14);
+    expect(buttons).toHaveLength(15);
     expect(container.textContent).toContain('协作与规则');
   });
 
@@ -56,7 +56,7 @@ describe('SettingsNav search filtering', () => {
     });
 
     const buttons = Array.from(container.querySelectorAll('[data-active]'));
-    expect(buttons).toHaveLength(14);
+    expect(buttons).toHaveLength(15);
     for (const button of buttons) {
       expect(button.querySelector('svg.h-4.w-4')).toBeTruthy();
     }
@@ -104,6 +104,17 @@ describe('SettingsNav search filtering', () => {
     const buttons = Array.from(container.querySelectorAll('[data-active]'));
     expect(buttons).toHaveLength(1);
     expect(buttons[0].textContent).toContain('猫猫球');
+  });
+
+  it('filters Bluetooth keywords to the device section', () => {
+    act(() => {
+      root.render(
+        React.createElement(SettingsNav, { activeSection: 'members', onSelect: vi.fn(), searchQuery: '蓝牙' }),
+      );
+    });
+    const buttons = Array.from(container.querySelectorAll('[data-active]'));
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].textContent).toContain('设备与 Limb');
   });
 
   it('shows empty message when no match', () => {

--- a/packages/web/src/components/settings/BleDeviceCards.tsx
+++ b/packages/web/src/components/settings/BleDeviceCards.tsx
@@ -1,0 +1,147 @@
+import type { BleBindingCheckView, BleBindingView, BleDiscoveryView, BleStatus } from './ble-device-types';
+import {
+  SettingsBadge,
+  SettingsCard,
+  SettingsDeleteButton,
+  SettingsPrimaryButton,
+  SettingsSecondaryButton,
+  SettingsText,
+} from './primitives';
+
+function signalLabel(rssi: number): string {
+  if (rssi >= -55) return '信号强';
+  if (rssi >= -70) return '信号中等';
+  return '信号较弱';
+}
+
+export function bleStatusBadge(status: BleStatus): {
+  tone: 'emerald' | 'amber' | 'red' | 'slate';
+  label: string;
+} {
+  if (status.state === 'ready') return { tone: 'emerald', label: 'BLE 就绪' };
+  if (status.state === 'starting') return { tone: 'amber', label: '正在启动 helper' };
+  if (status.state === 'degraded') return { tone: 'red', label: 'BLE 已降级' };
+  if (status.state === 'unsupported') return { tone: 'slate', label: '当前不支持' };
+  return { tone: 'slate', label: '按需启动' };
+}
+
+export function BleDiscoveryCard({
+  discovery,
+  disabled,
+  onBind,
+  actionLabel = '绑定设备',
+}: {
+  discovery: BleDiscoveryView;
+  disabled: boolean;
+  onBind: () => void;
+  actionLabel?: string;
+}) {
+  return (
+    <SettingsCard className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <SettingsText as="p" variant="sm" tone="default" className="truncate font-semibold">
+          {discovery.name ?? '未命名 BLE 设备'}
+        </SettingsText>
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          <SettingsBadge tone={discovery.rssi >= -70 ? 'blue' : 'amber'}>{signalLabel(discovery.rssi)}</SettingsBadge>
+          <SettingsText className="hidden sm:inline">
+            {discovery.serviceUuids.length > 0 ? discovery.serviceUuids.join(' · ') : '服务待检查'}
+          </SettingsText>
+        </div>
+      </div>
+      <SettingsPrimaryButton onClick={onBind} disabled={disabled}>
+        {actionLabel}
+      </SettingsPrimaryButton>
+    </SettingsCard>
+  );
+}
+
+function bindingCheckPresentation(check?: BleBindingCheckView): {
+  tone: 'emerald' | 'amber' | 'red';
+  label: string;
+  reason: string | null;
+} {
+  if (!check) return { tone: 'emerald', label: '已绑定', reason: null };
+  if (check.state === 'reachable') return { tone: 'emerald', label: '可连接', reason: null };
+  if (check.state === 'profile_mismatch') {
+    return { tone: 'amber', label: '配置不匹配', reason: '设备可连接，但类型化能力与原绑定不一致。' };
+  }
+  if (check.reason === 'timeout') {
+    return { tone: 'red', label: '不可连接', reason: '连接超时，设备身份可能已轮换。' };
+  }
+  if (check.reason === 'busy') {
+    return { tone: 'red', label: '不可连接', reason: '设备当前正忙，请稍后重试。' };
+  }
+  return { tone: 'red', label: '不可连接', reason: '当前无法连接到已保存的设备身份。' };
+}
+
+function bindingCheckTime(checkedAt: number): string {
+  return new Date(checkedAt).toLocaleTimeString('zh-CN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}
+
+export function BleBindingCard({
+  binding,
+  check,
+  disabled,
+  probing,
+  onProbe,
+  onBeginRebind,
+  onUnbind,
+}: {
+  binding: BleBindingView;
+  check?: BleBindingCheckView;
+  disabled: boolean;
+  probing: boolean;
+  onProbe: () => void;
+  onBeginRebind: () => void;
+  onUnbind: () => void;
+}) {
+  const presentation = bindingCheckPresentation(check);
+  return (
+    <SettingsCard className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-center gap-2">
+          <SettingsText as="p" variant="sm" tone="default" className="font-semibold">
+            {binding.displayName}
+          </SettingsText>
+          <SettingsBadge tone={presentation.tone}>{presentation.label}</SettingsBadge>
+        </div>
+        <SettingsText as="p" className="mt-1">
+          {binding.adapterId}
+        </SettingsText>
+        {presentation.reason && (
+          <SettingsText as="p" className="mt-1">
+            {presentation.reason}
+          </SettingsText>
+        )}
+        {check && (
+          <SettingsText as="p" className="mt-1">
+            最近测试：{bindingCheckTime(check.checkedAt)}
+          </SettingsText>
+        )}
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {binding.commands.map((command) => (
+            <SettingsBadge key={command} tone="slate" size="xxs">
+              {command}
+            </SettingsBadge>
+          ))}
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-wrap items-center gap-2">
+        <SettingsSecondaryButton onClick={onProbe} disabled={disabled}>
+          {probing ? '测试中…' : '测试绑定状态'}
+        </SettingsSecondaryButton>
+        {check && check.state !== 'reachable' && (
+          <SettingsPrimaryButton onClick={onBeginRebind} disabled={disabled}>
+            重新关联
+          </SettingsPrimaryButton>
+        )}
+        <SettingsDeleteButton onClick={onUnbind} disabled={disabled} aria-label={`解除绑定 ${binding.displayName}`} />
+      </div>
+    </SettingsCard>
+  );
+}

--- a/packages/web/src/components/settings/BleDeviceSections.tsx
+++ b/packages/web/src/components/settings/BleDeviceSections.tsx
@@ -1,0 +1,197 @@
+import { HubIcon } from '../hub-icons';
+import { BleBindingCard, BleDiscoveryCard, bleStatusBadge } from './BleDeviceCards';
+import type { BleBindingCheckView, BleBindingView, BleScanSnapshot, BleStatus } from './ble-device-types';
+import {
+  SettingsBadge,
+  SettingsEmptyState,
+  SettingsPrimaryButton,
+  SettingsSecondaryButton,
+  SettingsSection,
+  SettingsStatusStrip,
+  SettingsText,
+} from './primitives';
+
+interface BleDeviceViewProps {
+  status: BleStatus;
+  bindings: BleBindingView[];
+  scan: BleScanSnapshot;
+  busyKey: string | null;
+  error: string | null;
+  bindingChecks: Record<string, BleBindingCheckView>;
+  rebindTarget: BleBindingView | null;
+  onStartScan: () => void;
+  onStopScan: () => void;
+  onBind: (discoveryId: string) => void;
+  onProbe: (binding: BleBindingView) => void;
+  onBeginRebind: (binding: BleBindingView) => void;
+  onCancelRebind: () => void;
+  onRebind: (discoveryId: string, discoveryName: string | null) => void;
+  onUnbind: (binding: BleBindingView) => void;
+}
+
+function BleStatusNotices({ status, error }: Pick<BleDeviceViewProps, 'status' | 'error'>) {
+  return (
+    <>
+      {!status.available && (
+        <SettingsStatusStrip tone="warn" bordered>
+          <span>
+            <strong>当前平台暂不支持 BLE。</strong> {status.reason}
+          </span>
+        </SettingsStatusStrip>
+      )}
+      {status.available && status.state === 'degraded' && (
+        <SettingsStatusStrip tone="error" bordered>
+          <span>
+            <strong>BLE helper 已降级。</strong> {status.reason}
+          </span>
+        </SettingsStatusStrip>
+      )}
+      {error && <SettingsStatusStrip tone="error">{error}</SettingsStatusStrip>}
+    </>
+  );
+}
+
+function BleScanControls({
+  status,
+  scan,
+  busyKey,
+  onStartScan,
+  onStopScan,
+}: Pick<BleDeviceViewProps, 'status' | 'scan' | 'busyKey' | 'onStartScan' | 'onStopScan'>) {
+  if (!status.available) return null;
+  if (!scan.active) {
+    const scanEnabled = status.state !== 'starting' && status.state !== 'unsupported';
+    return (
+      <SettingsPrimaryButton onClick={onStartScan} disabled={!scanEnabled || busyKey === 'scan'}>
+        {status.state === 'degraded' ? '重试并扫描' : '扫描附近设备'}
+      </SettingsPrimaryButton>
+    );
+  }
+
+  const remainingSeconds = scan.expiresAt ? Math.max(0, Math.ceil((scan.expiresAt - Date.now()) / 1_000)) : null;
+  return (
+    <>
+      <SettingsSecondaryButton onClick={onStopScan} disabled={busyKey === 'scan'}>
+        停止扫描
+      </SettingsSecondaryButton>
+      <SettingsBadge tone="blue">
+        正在扫描{remainingSeconds !== null ? ` · 剩余 ${remainingSeconds} 秒` : ''}
+      </SettingsBadge>
+    </>
+  );
+}
+
+function BleDiscoveryList({
+  status,
+  scan,
+  busyKey,
+  onBind,
+  rebindTarget,
+  onRebind,
+}: Pick<BleDeviceViewProps, 'status' | 'scan' | 'busyKey' | 'onBind' | 'rebindTarget' | 'onRebind'>) {
+  if (!status.available) return null;
+  if (scan.discoveries.length === 0) {
+    return (
+      <SettingsEmptyState
+        icon={<HubIcon name="activity" className="mb-3 h-6 w-6 text-cafe-muted" />}
+        title={scan.active ? '正在等待附近设备' : '当前扫描会话没有设备'}
+        description={scan.active ? '保持设备处于广播状态。' : '发起扫描后，附近设备会在此处短暂显示。'}
+      />
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {scan.discoveries.map((discovery) => (
+        <BleDiscoveryCard
+          key={discovery.discoveryId}
+          discovery={discovery}
+          disabled={busyKey !== null}
+          onBind={() =>
+            rebindTarget ? onRebind(discovery.discoveryId, discovery.name) : onBind(discovery.discoveryId)
+          }
+          actionLabel={rebindTarget ? '重新关联到此设备' : '绑定设备'}
+        />
+      ))}
+    </div>
+  );
+}
+
+function BleBindingsSection({
+  bindings,
+  busyKey,
+  bindingChecks,
+  onProbe,
+  onBeginRebind,
+  onUnbind,
+}: Pick<BleDeviceViewProps, 'bindings' | 'busyKey' | 'bindingChecks' | 'onProbe' | 'onBeginRebind' | 'onUnbind'>) {
+  return (
+    <SettingsSection title="已绑定设备" description="猫猫只能调用 adapter 声明的类型化能力，不能执行任意 GATT 写入。">
+      {bindings.length === 0 ? (
+        <SettingsText as="p">尚未绑定 BLE 设备。</SettingsText>
+      ) : (
+        <div className="space-y-2">
+          {bindings.map((binding) => (
+            <BleBindingCard
+              key={binding.bindingId}
+              binding={binding}
+              check={bindingChecks[binding.bindingId]}
+              disabled={busyKey !== null}
+              probing={busyKey === `probe:${binding.bindingId}`}
+              onProbe={() => onProbe(binding)}
+              onBeginRebind={() => onBeginRebind(binding)}
+              onUnbind={() => onUnbind(binding)}
+            />
+          ))}
+        </div>
+      )}
+    </SettingsSection>
+  );
+}
+
+export function BleDeviceSections(props: BleDeviceViewProps) {
+  const badge = bleStatusBadge(props.status);
+  return (
+    <div className="space-y-5">
+      <BleStatusNotices status={props.status} error={props.error} />
+      <SettingsSection
+        title="附近设备"
+        description="扫描结果只保留到停止扫描或 30 秒超时。只有显式绑定的设备会持久保存。"
+        badge={<SettingsBadge tone={badge.tone}>{badge.label}</SettingsBadge>}
+      >
+        {props.rebindTarget && (
+          <SettingsStatusStrip
+            tone="warn"
+            actions={<SettingsSecondaryButton onClick={props.onCancelRebind}>取消重新关联</SettingsSecondaryButton>}
+          >
+            正在为「{props.rebindTarget.displayName}」选择新的广播身份。请确认目标设备后再重新关联。
+          </SettingsStatusStrip>
+        )}
+        <div className="mb-3 flex flex-wrap gap-2">
+          <BleScanControls
+            status={props.status}
+            scan={props.scan}
+            busyKey={props.busyKey}
+            onStartScan={props.onStartScan}
+            onStopScan={props.onStopScan}
+          />
+        </div>
+        <BleDiscoveryList
+          status={props.status}
+          scan={props.scan}
+          busyKey={props.busyKey}
+          onBind={props.onBind}
+          rebindTarget={props.rebindTarget}
+          onRebind={props.onRebind}
+        />
+      </SettingsSection>
+      <BleBindingsSection
+        bindings={props.bindings}
+        busyKey={props.busyKey}
+        bindingChecks={props.bindingChecks}
+        onProbe={props.onProbe}
+        onBeginRebind={props.onBeginRebind}
+        onUnbind={props.onUnbind}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/settings/BleDevicesContent.tsx
+++ b/packages/web/src/components/settings/BleDevicesContent.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { apiFetch } from '@/utils/api-client';
+import { useConfirm } from '../useConfirm';
+import { BleDeviceSections } from './BleDeviceSections';
+import { type BleBindingView, type BleScanSnapshot, type BleStatus, EMPTY_BLE_SCAN } from './ble-device-types';
+import { SettingsStatusStrip } from './primitives';
+import { useBleBindingRecovery } from './useBleBindingRecovery';
+
+async function responseError(response: Response, fallback: string): Promise<string> {
+  const payload = (await response.json().catch(() => ({}))) as { error?: string };
+  return payload.error ?? `${fallback} (${response.status})`;
+}
+
+export function BleDevicesContent() {
+  const confirm = useConfirm();
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState<BleStatus | null>(null);
+  const [bindings, setBindings] = useState<BleBindingView[]>([]);
+  const [scan, setScan] = useState<BleScanSnapshot>(EMPTY_BLE_SCAN);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshStatus = useCallback(async (): Promise<BleStatus> => {
+    const response = await apiFetch('/api/limb/ble/status');
+    if (!response.ok) throw new Error(await responseError(response, 'BLE 状态加载失败'));
+    const nextStatus = (await response.json()) as BleStatus;
+    setStatus(nextStatus);
+    return nextStatus;
+  }, []);
+
+  const refreshBindings = useCallback(async () => {
+    const response = await apiFetch('/api/limb/ble/bindings');
+    if (!response.ok) throw new Error(await responseError(response, '设备绑定加载失败'));
+    const payload = (await response.json()) as { bindings: BleBindingView[] };
+    setBindings(payload.bindings);
+  }, []);
+
+  const refreshScan = useCallback(async () => {
+    const response = await apiFetch('/api/limb/ble/scan');
+    if (!response.ok) throw new Error(await responseError(response, '扫描状态加载失败'));
+    setScan((await response.json()) as BleScanSnapshot);
+  }, []);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const nextStatus = await refreshStatus();
+      if (nextStatus.available) await Promise.all([refreshBindings(), refreshScan()]);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'BLE 状态加载失败');
+    } finally {
+      setLoading(false);
+    }
+  }, [refreshBindings, refreshScan, refreshStatus]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (!scan.active) return;
+    const timer = window.setInterval(() => {
+      void refreshScan().catch((pollError) => {
+        setError(pollError instanceof Error ? pollError.message : '扫描状态刷新失败');
+      });
+    }, 1_000);
+    return () => window.clearInterval(timer);
+  }, [refreshScan, scan.active]);
+
+  const startScan = useCallback(async () => {
+    setBusyKey('scan');
+    setError(null);
+    try {
+      const response = await apiFetch('/api/limb/ble/scan', { method: 'POST' });
+      if (!response.ok) throw new Error(await responseError(response, '扫描启动失败'));
+      const started = (await response.json()) as Omit<BleScanSnapshot, 'active' | 'discoveries'>;
+      setScan({ active: true, discoveries: [], ...started });
+      await refreshStatus();
+    } catch (scanError) {
+      setError(scanError instanceof Error ? scanError.message : '扫描启动失败');
+    } finally {
+      setBusyKey(null);
+    }
+  }, [refreshStatus]);
+
+  const stopScan = useCallback(async () => {
+    setBusyKey('scan');
+    try {
+      const response = await apiFetch('/api/limb/ble/scan', { method: 'DELETE' });
+      if (!response.ok) throw new Error(await responseError(response, '扫描停止失败'));
+      setScan(EMPTY_BLE_SCAN);
+    } catch (scanError) {
+      setError(scanError instanceof Error ? scanError.message : '扫描停止失败');
+    } finally {
+      setBusyKey(null);
+    }
+  }, []);
+
+  const bind = useCallback(
+    async (discoveryId: string) => {
+      if (!scan.sessionId) return;
+      setBusyKey(discoveryId);
+      setError(null);
+      try {
+        const response = await apiFetch('/api/limb/ble/bindings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: scan.sessionId, discoveryId }),
+        });
+        if (!response.ok) throw new Error(await responseError(response, '设备绑定失败'));
+        await Promise.all([refreshBindings(), refreshScan()]);
+      } catch (bindError) {
+        setError(bindError instanceof Error ? bindError.message : '设备绑定失败');
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [refreshBindings, refreshScan, scan.sessionId],
+  );
+
+  const unbind = useCallback(
+    async (binding: BleBindingView) => {
+      const accepted = await confirm({
+        title: '解除 BLE 绑定',
+        message: `解除「${binding.displayName}」后，相关 Limb 能力会立即失效。`,
+        confirmLabel: '解除绑定',
+        variant: 'danger',
+      });
+      if (!accepted) return;
+      setBusyKey(binding.bindingId);
+      try {
+        const response = await apiFetch(`/api/limb/ble/bindings/${encodeURIComponent(binding.bindingId)}`, {
+          method: 'DELETE',
+        });
+        if (!response.ok) throw new Error(await responseError(response, '解除绑定失败'));
+        await refreshBindings();
+      } catch (unbindError) {
+        setError(unbindError instanceof Error ? unbindError.message : '解除绑定失败');
+      } finally {
+        setBusyKey(null);
+      }
+    },
+    [confirm, refreshBindings],
+  );
+
+  const recovery = useBleBindingRecovery({
+    scan,
+    startScan,
+    refreshBindings,
+    setBusyKey,
+    setError,
+  });
+
+  if (loading) {
+    return <SettingsStatusStrip tone="muted">正在加载 BLE 状态...</SettingsStatusStrip>;
+  }
+  if (!status) {
+    return <SettingsStatusStrip tone="error">{error ?? 'BLE 状态不可用'}</SettingsStatusStrip>;
+  }
+
+  return (
+    <BleDeviceSections
+      status={status}
+      bindings={bindings}
+      scan={scan}
+      busyKey={busyKey}
+      error={error}
+      bindingChecks={recovery.checks}
+      rebindTarget={recovery.rebindTarget}
+      onStartScan={() => void startScan()}
+      onStopScan={() => void stopScan()}
+      onBind={(discoveryId) => void bind(discoveryId)}
+      onProbe={(binding) => void recovery.probeBinding(binding)}
+      onBeginRebind={(binding) => void recovery.beginRebind(binding)}
+      onCancelRebind={recovery.cancelRebind}
+      onRebind={(discoveryId, discoveryName) => void recovery.rebindDiscovery(discoveryId, discoveryName)}
+      onUnbind={(binding) => void unbind(binding)}
+    />
+  );
+}

--- a/packages/web/src/components/settings/SettingsContent.tsx
+++ b/packages/web/src/components/settings/SettingsContent.tsx
@@ -14,6 +14,7 @@ import { HubEnvFilesTab } from '../HubEnvFilesTab';
 import { PushSettingsPanel } from '../PushSettingsPanel';
 import { useConfirm } from '../useConfirm';
 import { VoiceSettingsPanel } from '../VoiceSettingsPanel';
+import { BleDevicesContent } from './BleDevicesContent';
 import { CatDossierContent } from './CatDossierContent';
 import { ConciergeSettingsContent } from './ConciergeSettingsContent';
 import { MarketplaceContent } from './MarketplaceContent';
@@ -207,6 +208,8 @@ export function SettingsContent({ section, initialEditCatId }: SettingsContentPr
         return <HubEnvFilesTab excludeCategories={['connector']} />;
       case 'notify':
         return <PushSettingsPanel />;
+      case 'devices':
+        return <BleDevicesContent />;
       case 'ops':
         return <OpsContent />;
       case 'rules':

--- a/packages/web/src/components/settings/SettingsNav.tsx
+++ b/packages/web/src/components/settings/SettingsNav.tsx
@@ -78,6 +78,7 @@ const SECTION_KEYWORDS: Record<string, string> = {
   rules: '规则 家规 提示词 system prompt SOP 协作 governance',
   system: '配置 环境 .env bubble A2A codex',
   notify: '推送 通知 push web',
+  devices: '设备 Limb 蓝牙 Bluetooth BLE GATT 传感器 按钮 hardware',
   ops: '运维 监控 排行 记忆 健康 命令 救援 usage',
   concierge: '猫猫球 悬浮球 值班猫 前台 主动性 proactive ball persona',
 };

--- a/packages/web/src/components/settings/__tests__/BleDevicesContent.test.tsx
+++ b/packages/web/src/components/settings/__tests__/BleDevicesContent.test.tsx
@@ -1,0 +1,272 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { apiFetch, confirm } = vi.hoisted(() => ({ apiFetch: vi.fn(), confirm: vi.fn() }));
+vi.mock('@/utils/api-client', () => ({ apiFetch }));
+vi.mock('../../useConfirm', () => ({ useConfirm: () => confirm }));
+
+import { BleDevicesContent } from '../BleDevicesContent';
+
+function jsonResponse(payload: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => payload };
+}
+
+describe('BleDevicesContent', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    apiFetch.mockReset();
+    confirm.mockReset();
+    confirm.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('renders the unsupported state without offering a scan action', async () => {
+    apiFetch.mockResolvedValue(
+      jsonResponse({
+        platform: 'linux',
+        available: false,
+        state: 'unsupported',
+        reason: 'BLE helper is only available on macOS in Phase A',
+        restartAttempts: 0,
+        bindingCount: 0,
+      }),
+    );
+
+    await act(async () => root.render(<BleDevicesContent />));
+    await act(async () => Promise.resolve());
+
+    expect(container.textContent).toContain('当前平台暂不支持 BLE');
+    expect(container.textContent).toContain('BLE helper is only available on macOS');
+    expect(container.textContent).not.toContain('扫描附近设备');
+  });
+
+  it('renders scanning results and binds using opaque IDs only', async () => {
+    apiFetch.mockImplementation(async (path: string, init?: RequestInit) => {
+      const requestKey = `${init?.method ?? 'GET'} ${path}`;
+      switch (requestKey) {
+        case 'GET /api/limb/ble/status':
+          return jsonResponse({
+            platform: 'darwin',
+            available: true,
+            state: 'ready',
+            reason: null,
+            restartAttempts: 0,
+            bindingCount: 0,
+          });
+        case 'GET /api/limb/ble/bindings':
+          return jsonResponse({ bindings: [] });
+        case 'GET /api/limb/ble/scan':
+          return jsonResponse({
+            active: true,
+            sessionId: 'scan-opaque',
+            startedAt: Date.now(),
+            expiresAt: Date.now() + 30_000,
+            discoveries: [
+              {
+                discoveryId: 'discovery-opaque',
+                name: 'Desk Sensor',
+                rssi: -47,
+                serviceUuids: ['181a'],
+              },
+            ],
+          });
+        case 'POST /api/limb/ble/bindings':
+          return jsonResponse(
+            {
+              bindingId: 'binding-1',
+              displayName: 'Desk Sensor',
+              adapterId: 'standard.environmental',
+              commands: ['ble.temperature.read'],
+              nodeId: 'ble:binding-1',
+              createdAt: Date.now(),
+              lastConnectedAt: Date.now(),
+            },
+            true,
+            201,
+          );
+        default:
+          throw new Error(`Unexpected request: ${requestKey}`);
+      }
+    });
+
+    await act(async () => root.render(<BleDevicesContent />));
+    await act(async () => Promise.resolve());
+    expect(container.textContent).toContain('Desk Sensor');
+    expect(container.textContent).toContain('正在扫描');
+
+    const bindButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('绑定设备'),
+    );
+    expect(bindButton).toBeTruthy();
+    await act(async () => bindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    const bindCall = apiFetch.mock.calls.find(([, init]) => init?.method === 'POST');
+    expect(JSON.parse(bindCall?.[1]?.body as string)).toEqual({
+      sessionId: 'scan-opaque',
+      discoveryId: 'discovery-opaque',
+    });
+    expect(bindCall?.[1]?.body).not.toContain('deviceId');
+  });
+
+  it('shows degraded helper state and keeps existing bindings visible', async () => {
+    apiFetch.mockImplementation(async (path: string) => {
+      if (path.endsWith('/status')) {
+        return jsonResponse({
+          platform: 'darwin',
+          available: true,
+          state: 'degraded',
+          reason: 'helper restart attempts exhausted',
+          restartAttempts: 3,
+          bindingCount: 1,
+        });
+      }
+      if (path.endsWith('/bindings')) {
+        return jsonResponse({
+          bindings: [
+            {
+              bindingId: 'binding-1',
+              displayName: 'Desk Sensor',
+              adapterId: 'standard.environmental',
+              commands: ['ble.temperature.read'],
+              nodeId: 'ble:binding-1',
+              createdAt: 100,
+              lastConnectedAt: 100,
+            },
+          ],
+        });
+      }
+      if (path.endsWith('/scan')) {
+        return jsonResponse({ active: false, sessionId: null, startedAt: null, expiresAt: null, discoveries: [] });
+      }
+      throw new Error(`Unexpected request: ${path}`);
+    });
+
+    await act(async () => root.render(<BleDevicesContent />));
+    await act(async () => Promise.resolve());
+
+    expect(container.textContent).toContain('BLE helper 已降级');
+    expect(container.textContent).toContain('helper restart attempts exhausted');
+    expect(container.textContent).toContain('Desk Sensor');
+    expect(container.textContent).toContain('重试并扫描');
+    expect(
+      Array.from(container.querySelectorAll('button')).find((button) => button.textContent?.includes('重试并扫描'))
+        ?.disabled,
+    ).toBe(false);
+  });
+
+  it('tests an unreachable binding and explicitly rebinds it using opaque discovery IDs', async () => {
+    const binding = {
+      bindingId: 'binding-1',
+      displayName: 'Desk Sensor',
+      adapterId: 'standard.environmental',
+      commands: ['ble.temperature.read'],
+      nodeId: 'ble:binding-1',
+      createdAt: 100,
+      lastConnectedAt: 100,
+    };
+    apiFetch.mockImplementation(async (path: string, init?: RequestInit) => {
+      const requestKey = `${init?.method ?? 'GET'} ${path}`;
+      switch (requestKey) {
+        case 'GET /api/limb/ble/status':
+          return jsonResponse({
+            platform: 'darwin',
+            available: true,
+            state: 'ready',
+            reason: null,
+            restartAttempts: 0,
+            bindingCount: 1,
+          });
+        case 'GET /api/limb/ble/bindings':
+          return jsonResponse({ bindings: [binding] });
+        case 'GET /api/limb/ble/scan':
+          return jsonResponse({
+            active: true,
+            sessionId: 'scan-rotated',
+            startedAt: Date.now(),
+            expiresAt: Date.now() + 30_000,
+            discoveries: [
+              {
+                discoveryId: 'discovery-rotated',
+                name: 'Desk Sensor',
+                rssi: -45,
+                serviceUuids: ['181a'],
+              },
+            ],
+          });
+        case 'POST /api/limb/ble/bindings/binding-1/probe':
+          return jsonResponse({
+            bindingId: 'binding-1',
+            state: 'unreachable',
+            reason: 'timeout',
+            checkedAt: 200,
+          });
+        case 'POST /api/limb/ble/bindings/binding-1/rebind':
+          return jsonResponse({ ...binding, lastConnectedAt: 300 });
+        default:
+          throw new Error(`Unexpected request: ${requestKey}`);
+      }
+    });
+
+    await act(async () => root.render(<BleDevicesContent />));
+    await act(async () => Promise.resolve());
+    const probeButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('测试绑定状态'),
+    );
+    expect(probeButton).toBeTruthy();
+    await act(async () => probeButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(container.textContent).toContain('不可连接');
+
+    const beginRebindButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('重新关联'),
+    );
+    expect(beginRebindButton).toBeTruthy();
+    await act(async () => beginRebindButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    const candidateButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '重新关联到此设备',
+    );
+    expect(candidateButton).toBeTruthy();
+    confirm.mockResolvedValueOnce(false);
+    await act(async () => candidateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(
+      apiFetch.mock.calls.some(
+        ([path, init]) => path === '/api/limb/ble/bindings/binding-1/rebind' && init?.method === 'POST',
+      ),
+    ).toBe(false);
+    confirm.mockResolvedValueOnce(true);
+    await act(async () => candidateButton?.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+
+    const rebindCall = apiFetch.mock.calls.find(
+      ([path, init]) => path === '/api/limb/ble/bindings/binding-1/rebind' && init?.method === 'POST',
+    );
+    expect(JSON.parse(rebindCall?.[1]?.body as string)).toEqual({
+      sessionId: 'scan-rotated',
+      discoveryId: 'discovery-rotated',
+    });
+    expect(rebindCall?.[1]?.body).not.toContain('deviceId');
+    expect(confirm).toHaveBeenCalledWith({
+      title: '重新关联 BLE 设备',
+      message: '把「Desk Sensor」重新关联到「Desk Sensor」？原节点和审计关联会保留。',
+      confirmLabel: '确认重新关联',
+    });
+    expect(container.textContent).toContain('可连接');
+    expect(container.textContent).toContain('最近测试');
+  });
+});

--- a/packages/web/src/components/settings/__tests__/SettingsShell-deep-link.test.tsx
+++ b/packages/web/src/components/settings/__tests__/SettingsShell-deep-link.test.tsx
@@ -41,4 +41,15 @@ describe('SettingsShell deep-link routing', () => {
     expect(html).toContain('data-section="members"');
     expect(html).toContain('data-active="members"');
   });
+
+  it('restores the devices deep link without routing it into notifications or ops', () => {
+    mockSearchParams = new URLSearchParams('s=devices');
+
+    const html = renderToStaticMarkup(<SettingsShell />);
+
+    expect(html).toContain('data-section="devices"');
+    expect(html).toContain('data-active="devices"');
+    expect(html).not.toContain('data-section="notify"');
+    expect(html).not.toContain('data-section="ops"');
+  });
 });

--- a/packages/web/src/components/settings/ble-device-types.ts
+++ b/packages/web/src/components/settings/ble-device-types.ts
@@ -1,0 +1,48 @@
+export interface BleStatus {
+  platform: string;
+  available: boolean;
+  state: 'idle' | 'starting' | 'ready' | 'degraded' | 'unsupported';
+  reason: string | null;
+  restartAttempts: number;
+  bindingCount: number;
+}
+
+export interface BleBindingView {
+  bindingId: string;
+  displayName: string;
+  adapterId: string;
+  commands: string[];
+  nodeId: string;
+  createdAt: number;
+  lastConnectedAt: number | null;
+}
+
+export interface BleBindingCheckView {
+  bindingId: string;
+  state: 'reachable' | 'unreachable' | 'profile_mismatch';
+  checkedAt: number;
+  reason?: 'busy' | 'connection_failed' | 'disconnected' | 'inspection_failed' | 'timeout' | 'unavailable';
+}
+
+export interface BleDiscoveryView {
+  discoveryId: string;
+  name: string | null;
+  rssi: number;
+  serviceUuids: string[];
+}
+
+export interface BleScanSnapshot {
+  active: boolean;
+  sessionId: string | null;
+  startedAt: number | null;
+  expiresAt: number | null;
+  discoveries: BleDiscoveryView[];
+}
+
+export const EMPTY_BLE_SCAN: BleScanSnapshot = {
+  active: false,
+  sessionId: null,
+  startedAt: null,
+  expiresAt: null,
+  discoveries: [],
+};

--- a/packages/web/src/components/settings/settings-nav-config.ts
+++ b/packages/web/src/components/settings/settings-nav-config.ts
@@ -99,6 +99,13 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     description: '推送订阅、提醒策略与设备联动。',
   },
   {
+    id: 'devices',
+    label: '设备与 Limb',
+    icon: 'activity',
+    color: 'var(--color-gemini-primary)',
+    description: 'BLE 设备发现、显式绑定和类型化 Limb 能力。',
+  },
+  {
     id: 'ops',
     label: '运维监控',
     icon: 'activity',

--- a/packages/web/src/components/settings/useBleBindingRecovery.ts
+++ b/packages/web/src/components/settings/useBleBindingRecovery.ts
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { apiFetch } from '@/utils/api-client';
+import { useConfirm } from '../useConfirm';
+import type { BleBindingCheckView, BleBindingView, BleScanSnapshot } from './ble-device-types';
+
+interface BleBindingRecoveryOptions {
+  scan: BleScanSnapshot;
+  startScan: () => Promise<void>;
+  refreshBindings: () => Promise<void>;
+  setBusyKey: (key: string | null) => void;
+  setError: (error: string | null) => void;
+}
+
+async function responseError(response: Response, fallback: string): Promise<string> {
+  const payload = (await response.json().catch(() => ({}))) as { error?: string };
+  return payload.error ?? `${fallback} (${response.status})`;
+}
+
+export function useBleBindingRecovery(options: BleBindingRecoveryOptions) {
+  const confirm = useConfirm();
+  const [checks, setChecks] = useState<Record<string, BleBindingCheckView>>({});
+  const [rebindTarget, setRebindTarget] = useState<BleBindingView | null>(null);
+
+  const probeBinding = useCallback(
+    async (binding: BleBindingView) => {
+      options.setBusyKey(`probe:${binding.bindingId}`);
+      options.setError(null);
+      try {
+        const response = await apiFetch(`/api/limb/ble/bindings/${encodeURIComponent(binding.bindingId)}/probe`, {
+          method: 'POST',
+        });
+        if (!response.ok) throw new Error(await responseError(response, '绑定状态测试失败'));
+        const result = (await response.json()) as BleBindingCheckView;
+        setChecks((current) => ({ ...current, [binding.bindingId]: result }));
+      } catch (probeError) {
+        options.setError(probeError instanceof Error ? probeError.message : '绑定状态测试失败');
+      } finally {
+        options.setBusyKey(null);
+      }
+    },
+    [options],
+  );
+
+  const beginRebind = useCallback(
+    async (binding: BleBindingView) => {
+      setRebindTarget(binding);
+      options.setError(null);
+      if (!options.scan.active) await options.startScan();
+    },
+    [options],
+  );
+
+  const rebindDiscovery = useCallback(
+    async (discoveryId: string, discoveryName: string | null) => {
+      if (!rebindTarget || !options.scan.sessionId) return;
+      const accepted = await confirm({
+        title: '重新关联 BLE 设备',
+        message: `把「${rebindTarget.displayName}」重新关联到「${discoveryName ?? '未命名 BLE 设备'}」？原节点和审计关联会保留。`,
+        confirmLabel: '确认重新关联',
+      });
+      if (!accepted) return;
+      options.setBusyKey(`rebind:${rebindTarget.bindingId}`);
+      options.setError(null);
+      try {
+        const response = await apiFetch(`/api/limb/ble/bindings/${encodeURIComponent(rebindTarget.bindingId)}/rebind`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sessionId: options.scan.sessionId, discoveryId }),
+        });
+        if (!response.ok) throw new Error(await responseError(response, '重新关联失败'));
+        const binding = (await response.json()) as BleBindingView;
+        await options.refreshBindings();
+        setChecks((current) => ({
+          ...current,
+          [binding.bindingId]: {
+            bindingId: binding.bindingId,
+            state: 'reachable',
+            checkedAt: binding.lastConnectedAt ?? Date.now(),
+          },
+        }));
+        setRebindTarget(null);
+      } catch (rebindError) {
+        options.setError(rebindError instanceof Error ? rebindError.message : '重新关联失败');
+      } finally {
+        options.setBusyKey(null);
+      }
+    },
+    [confirm, options, rebindTarget],
+  );
+
+  return {
+    checks,
+    rebindTarget,
+    probeBinding,
+    beginRebind,
+    cancelRebind: () => setRebindTarget(null),
+    rebindDiscovery,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a host-owned CoreBluetooth helper and typed Battery / Environmental Sensing adapters so that Limb can read physical sensor state without exposing raw GATT operations. Preserves stable binding and audit identity across CoreBluetooth identifier rotation through explicit probe/rebind.

**Scope: Phase A — macOS-only, read-only BLE Central/GATT.**

- Extends existing Registry / Policy / Lease / ActionLog control plane — no parallel BLE path
- Versioned NDJSON helper protocol (`v1`) with crash recovery (1-2-4s backoff, 3 strikes → degraded)
- Three-layer write rejection: Core command allowlist, adapter capabilities, Swift helper allowlist
- Bounded ephemeral scans (30s TTL, `clearLocalState` on expiry)
- Binding persistence with `TTL=0` (no EXPIRE) and fail-closed Redis gate
- Privacy: `platformDeviceId` stripped from all API/UI responses; opaque `discoveryId` only
- Typed adapters: Battery (`0x180F`), Temperature (`0x2A6E`), Humidity (`0x2A6F`)
- Settings UI: scan → bind → status → probe/rebind → unbind flow
- **Explicitly not included**: notify/subscribe events, GATT Explorer, cross-platform helpers, any write operations — each requires separate design/security review

## Testing

- 54/54 BLE unit tests pass (adapters, binding store, device manager, helper client, helper process, helper protocol, routes, scan session)
- Redis binding store integration test with `ttl === -1` assertion
- Cross-individual code review by 布偶猫/宪宪 (claude-opus-4-6): ✅ approved, 0 P1, 0 P2

## Changes

47 files changed, +5150 lines, -2 lines across:
- **TS BLE domain** (10 files): `BleDeviceManager`, `BleHelperClient`, `BleLimbNode`, adapters, protocol, routes
- **Swift helper** (5 files): `BleController` (CoreBluetooth), `Protocol`, `main`
- **React UI** (7 files): Settings BLE panel, scan/bind/recovery hooks
- **Tests** (11 files): Full coverage of protocol, state machine, adapters, binding lifecycle

Refs: #1183

🐾 Clowder AI contribution by 缅因猫 Sol (gpt-5.6-sol), reviewed by 布偶猫/宪宪 (claude-opus-4-6)