### PR TITLE
fix(acp): isolate test bootstrap root and stop internal-event chat bubbles (#1203)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpAgentService.ts
@@ -203,7 +203,6 @@ export class AcpAgentService implements AgentService {
     // (same process = same API key = same quota), so signals from any phase are relevant.
     let capacitySignal: AcpCapacitySignal | null = null;
     let capacityWarningYielded = false; // F149: dedup — at most one warning per invoke
-    let idleWarningYielded = false; // F149: dedup — at most one idle warning per invoke
     const onCapacity = (signal: AcpCapacitySignal) => {
       capacitySignal = signal;
     };
@@ -453,24 +452,25 @@ export class AcpAgentService implements AgentService {
           continue; // Not a real ACP event — don't count, don't transform
         }
         // F149: Stream idle warning injected by AcpClient idle watchdog.
+        // #1203: Internal telemetry only — in the zero-first-event case this
+        // fires before any reply exists, making the '已开始回复但后续停滞' bubble
+        // factually wrong. The terminal stall still errors via AcpStreamIdleError.
         if (event.update?.sessionUpdate === 'stream_idle_warning') {
-          if (!idleWarningYielded) {
-            idleWarningYielded = true;
-            log.info(
-              { ...ctx, sessionId, idleSinceMs: event.update.idleSinceMs },
-              'Stream idle warning yielded to frontend',
-            );
-            yield makeIdleWarning(this.catId, this.providerName, event, metadata);
-          }
+          log.info(
+            { ...ctx, sessionId, idleSinceMs: event.update.idleSinceMs },
+            'Stream idle warning (suppressed — internal telemetry)',
+          );
           continue; // Not a real ACP event — don't count, don't transform
         }
-        // Tool wait warning — agent is waiting for MCP tool result, idle is expected
+        // Tool wait warning — agent is waiting for MCP tool result, idle is expected.
+        // #1203: Internal watchdog telemetry only — the CLI shows no such bubble,
+        // so don't surface one in chat. The client-side watchdog + stall ceiling
+        // still protect against genuinely hung tools.
         if (event.update?.sessionUpdate === 'stream_tool_wait_warning') {
           log.info(
             { ...ctx, sessionId, idleSinceMs: event.update.idleSinceMs },
             'Stream tool wait warning (idle suppressed — tool executing)',
           );
-          yield makeToolWaitWarning(this.catId, this.providerName, event, metadata);
           continue;
         }
         // F149: Fallback — capacity signal captured before promptStream started
@@ -726,46 +726,6 @@ function makeCapacityWarning(
     content: JSON.stringify({
       type: 'warning',
       message: `${providerName} 服务端容量不足，正在重试 (${signal.message.slice(0, 100)})`,
-    }),
-    metadata,
-    timestamp: Date.now(),
-  };
-}
-
-/** F149: Build a liveness_signal warning for stream idle watchdog. */
-function makeIdleWarning(
-  catId: CatId,
-  providerName: string,
-  event: import('./types.js').AcpSessionUpdate,
-  metadata: MessageMetadata,
-): AgentMessage {
-  const idleSinceMs = (event.update?.idleSinceMs as number) ?? 0;
-  return {
-    type: 'liveness_signal',
-    catId,
-    content: JSON.stringify({
-      type: 'warning',
-      message: `${providerName} 已开始回复但后续停滞 (idle ${Math.round(idleSinceMs / 1000)}s)`,
-    }),
-    metadata,
-    timestamp: Date.now(),
-  };
-}
-
-/** Build a liveness_signal info for tool wait — agent is executing MCP tool, idle is expected. */
-function makeToolWaitWarning(
-  catId: CatId,
-  providerName: string,
-  event: import('./types.js').AcpSessionUpdate,
-  metadata: MessageMetadata,
-): AgentMessage {
-  const idleSinceMs = (event.update?.idleSinceMs as number) ?? 0;
-  return {
-    type: 'liveness_signal',
-    catId,
-    content: JSON.stringify({
-      type: 'info',
-      message: `${providerName} 正在等待工具返回 (${Math.round(idleSinceMs / 1000)}s)`,
     }),
     metadata,
     timestamp: Date.now(),

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -12,7 +12,7 @@
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync } from 'node:fs';
+import { mkdirSync, statSync } from 'node:fs';
 import { dirname, isAbsolute } from 'node:path';
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
 
@@ -160,6 +160,22 @@ interface PendingAcpRequest {
   refreshTimeout: () => void;
 }
 
+/**
+ * #1203: Identity of a directory entry, not just its path. dev+ino identifies
+ * the inode on POSIX; ino is 0 on Windows, where birthtimeMs distinguishes a
+ * delete→recreate at the same path. A pooled child whose cwd was unlinked and
+ * later recreated still holds the dead inode — getcwd() fails — so comparing
+ * paths or existence is not enough.
+ */
+function statDirIdentity(path: string): string | null {
+  try {
+    const stat = statSync(path);
+    return `${stat.dev}:${stat.ino}:${stat.birthtimeMs}`;
+  } catch {
+    return null; // missing dir, or a fake spawn config pointing at a fake path
+  }
+}
+
 export class AcpClient {
   private child: ChildProcess | null = null;
   private rl: ReadlineInterface | null = null;
@@ -190,6 +206,8 @@ export class AcpClient {
   /** Client-level capacity signal — always captured regardless of listeners.
    *  Fallback for delayed stderr arriving after invoke listener is removed. */
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
+  /** #1203: Directory identity captured at spawn — see statDirIdentity. */
+  private cwdIdentity: string | null = null;
 
   constructor(private readonly config: AcpClientConfig) {}
 
@@ -218,6 +236,9 @@ export class AcpClient {
     if (!this.config.spawnFn) {
       mkdirSync(this.config.cwd, { recursive: true, mode: 0o700 });
     }
+    // #1203: Capture the cwd's directory identity at spawn so isCwdIntact can
+    // detect delete→recreate at the same path, not just deletion.
+    this.cwdIdentity = statDirIdentity(this.config.cwd);
 
     const spawnOpts: SpawnOptions & { stdio: ['pipe', 'pipe', 'pipe'] } = {
       cwd: this.config.cwd,
@@ -792,6 +813,22 @@ export class AcpClient {
 
   get isAlive(): boolean {
     return this.child !== null && !this.child.killed && !this.closed && !this.exited;
+  }
+
+  /**
+   * #1203: False when the bootstrap cwd was deleted after spawn (e.g. by an
+   * external cleaner emptying the shared /tmp bootstrap root) — including the
+   * delete→recreate case where the path exists again but the child still holds
+   * the dead inode, so getcwd() keeps failing. The pool retires cwd-less
+   * processes and cold-starts fresh ones (initialize re-creates the cwd).
+   */
+  get isCwdIntact(): boolean {
+    const current = statDirIdentity(this.config.cwd);
+    if (current === null) return false;
+    // Fake spawn configs (tests) may point at fake paths — no identity was
+    // captured, so fall back to plain existence.
+    if (this.cwdIdentity === null) return true;
+    return current === this.cwdIdentity;
   }
 
   get isSafeForSingleFlightReuse(): boolean {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpClient.ts
@@ -12,13 +12,14 @@
 import type { ChildProcess, SpawnOptions } from 'node:child_process';
 import { spawn as nodeSpawn } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, statSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import { dirname, isAbsolute } from 'node:path';
 import { createInterface, type Interface as ReadlineInterface } from 'node:readline';
 
 import { createModuleLogger } from '../../../../../../infrastructure/logger.js';
 import { resolveCliCommandOrBare } from '../../../../../../utils/cli-resolve.js';
 import { resolveWindowsSpawnPlan } from '../../../../../../utils/cli-spawn-win.js';
+import { AcpCwdIdentityTracker } from './acp-cwd-identity.js';
 import type {
   AcpAgentRequest,
   AcpContentBlock,
@@ -160,22 +161,6 @@ interface PendingAcpRequest {
   refreshTimeout: () => void;
 }
 
-/**
- * #1203: Identity of a directory entry, not just its path. dev+ino identifies
- * the inode on POSIX; ino is 0 on Windows, where birthtimeMs distinguishes a
- * delete→recreate at the same path. A pooled child whose cwd was unlinked and
- * later recreated still holds the dead inode — getcwd() fails — so comparing
- * paths or existence is not enough.
- */
-function statDirIdentity(path: string): string | null {
-  try {
-    const stat = statSync(path);
-    return `${stat.dev}:${stat.ino}:${stat.birthtimeMs}`;
-  } catch {
-    return null; // missing dir, or a fake spawn config pointing at a fake path
-  }
-}
-
 export class AcpClient {
   private child: ChildProcess | null = null;
   private rl: ReadlineInterface | null = null;
@@ -206,10 +191,12 @@ export class AcpClient {
   /** Client-level capacity signal — always captured regardless of listeners.
    *  Fallback for delayed stderr arriving after invoke listener is removed. */
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
-  /** #1203: Directory identity captured at spawn — see statDirIdentity. */
-  private cwdIdentity: string | null = null;
+  /** #1203: Directory identity captured at spawn. */
+  private readonly cwdIdentityTracker: AcpCwdIdentityTracker;
 
-  constructor(private readonly config: AcpClientConfig) {}
+  constructor(private readonly config: AcpClientConfig) {
+    this.cwdIdentityTracker = new AcpCwdIdentityTracker(this.config.cwd);
+  }
 
   // ── Lifecycle ────────────────────────────────────────────────
 
@@ -238,7 +225,7 @@ export class AcpClient {
     }
     // #1203: Capture the cwd's directory identity at spawn so isCwdIntact can
     // detect delete→recreate at the same path, not just deletion.
-    this.cwdIdentity = statDirIdentity(this.config.cwd);
+    this.cwdIdentityTracker.capture();
 
     const spawnOpts: SpawnOptions & { stdio: ['pipe', 'pipe', 'pipe'] } = {
       cwd: this.config.cwd,
@@ -823,12 +810,7 @@ export class AcpClient {
    * processes and cold-starts fresh ones (initialize re-creates the cwd).
    */
   get isCwdIntact(): boolean {
-    const current = statDirIdentity(this.config.cwd);
-    if (current === null) return false;
-    // Fake spawn configs (tests) may point at fake paths — no identity was
-    // captured, so fall back to plain existence.
-    if (this.cwdIdentity === null) return true;
-    return current === this.cwdIdentity;
+    return this.cwdIdentityTracker.isIntact;
   }
 
   get isSafeForSingleFlightReuse(): boolean {

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.ts
@@ -34,6 +34,7 @@ import {
   AcpTimeoutError,
   buildAcpSpawnLogFields,
 } from './AcpClient.js';
+import { AcpCwdIdentityTracker } from './acp-cwd-identity.js';
 import type {
   AcpAgentRequest,
   AcpInitializeResult,
@@ -87,8 +88,12 @@ export class AcpHttpStreamClient {
   /** #1186 P1: Per-session cancel callbacks — settles the local prompt stream on cancel. */
   private readonly sessionCancelCallbacks = new Map<string, () => void>();
   private _recentCapacitySignal: AcpCapacitySignal | null = null;
+  /** #1203: Directory identity captured at spawn. */
+  private readonly cwdIdentityTracker: AcpCwdIdentityTracker;
 
-  constructor(private readonly config: AcpHttpStreamClientConfig) {}
+  constructor(private readonly config: AcpHttpStreamClientConfig) {
+    this.cwdIdentityTracker = new AcpCwdIdentityTracker(this.config.cwd);
+  }
 
   // ── Lifecycle ────────────────────────────────────────────────
 
@@ -108,6 +113,9 @@ export class AcpHttpStreamClient {
     if (!this.config.spawnFn) {
       mkdirSync(this.config.cwd, { recursive: true, mode: 0o700 });
     }
+    // #1203: Capture the cwd's directory identity at spawn so isCwdIntact can
+    // detect delete→recreate at the same path, not just deletion.
+    this.cwdIdentityTracker.capture();
 
     const spawnOpts: SpawnOptions & { stdio: ['pipe', 'pipe', 'pipe'] } = {
       cwd: this.config.cwd,
@@ -575,6 +583,14 @@ export class AcpHttpStreamClient {
   }
   get isAlive(): boolean {
     return this.child !== null && !this.child.killed && !this.closed && !this.exited;
+  }
+  /**
+   * #1203: False when the bootstrap cwd was deleted after spawn — including the
+   * delete→recreate case. HTTP-stream carriers also spawn a local child with a
+   * local cwd, so they must participate in the same retirement contract as stdio.
+   */
+  get isCwdIntact(): boolean {
+    return this.cwdIdentityTracker.isIntact;
   }
   get isSafeForSingleFlightReuse(): boolean {
     return this.unquiescedSessionIds.size === 0;

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
@@ -55,6 +55,14 @@ export interface AcpAcquireOptions {
 export interface AcpPoolClient {
   readonly isAlive: boolean;
   /**
+   * #1203: False when the process's bootstrap cwd was deleted after spawn (e.g.
+   * by an external cleaner). The child stays alive but any prompt dies with
+   * getcwd ENOENT, so the pool must retire it and cold-start a fresh process
+   * (cold start re-creates the cwd before spawn). Optional: transports without
+   * a local cwd (e.g. HTTP) omit it and are never retired for this reason.
+   */
+  readonly isCwdIntact?: boolean;
+  /**
    * False after a cancelled prompt may still be running upstream. The pool only
    * acts on this for non-multiplexed carriers; multiplexed clients can keep
    * serving unrelated sessions.
@@ -78,6 +86,7 @@ interface AcpPoolVariantConfig {
 
 interface PoolEntry {
   client: AcpPoolClient;
+  poolKey: PoolKey;
   leaseCount: number;
   /** Bumped on stale-lease force-release so old lease closures become no-ops (#992). */
   leaseGeneration: number;
@@ -151,6 +160,17 @@ export class AcpProcessPool {
     const entries = this.entries.get(key) ?? [];
     const sessionId = options.sessionId?.trim();
     let canResumeRequestedSession = true;
+
+    // #1203: Retire ready processes whose bootstrap cwd was deleted after spawn.
+    // The child is still alive, but getcwd() inside it fails — the next prompt
+    // would surface ACP -32603 ENOENT. Retiring here covers both the warm-reuse
+    // path and the session-owner path (retireEntry forgets owned sessions), so
+    // the caller cold-starts a fresh process that re-creates the cwd at spawn.
+    for (const entry of [...entries]) {
+      if (entry.state === 'ready' && entry.client.isAlive && entry.client.isCwdIntact === false) {
+        this.retireEntry(entry, poolKey, 'bootstrap cwd missing');
+      }
+    }
 
     if (sessionId) {
       const sessionKey = serializeSessionKey(poolKey, sessionId);
@@ -406,6 +426,7 @@ export class AcpProcessPool {
     const client = this.clientFactory();
     const entry: PoolEntry = {
       client,
+      poolKey,
       leaseCount: 0, // caller manages lease count after spawn
       leaseGeneration: 0,
       lastUsedAt: Date.now(),
@@ -502,6 +523,12 @@ export class AcpProcessPool {
             }
             this._metrics.zombieCleanupCount++;
             log.warn({ key }, 'Zombie process cleaned up');
+          } else if (entry.client.isCwdIntact === false) {
+            // #1203: Alive but cwd-less — full retirement semantics, not the
+            // zombie shortcut: the process must actually be closed, and an
+            // active lease's generation must be invalidated so its late
+            // release() becomes a no-op instead of double-decrementing metrics.
+            this.retireEntry(entry, entry.poolKey, 'bootstrap cwd missing');
           }
         }
         if (entries.length === 0) this.entries.delete(key);

--- a/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/AcpProcessPool.ts
@@ -58,10 +58,11 @@ export interface AcpPoolClient {
    * #1203: False when the process's bootstrap cwd was deleted after spawn (e.g.
    * by an external cleaner). The child stays alive but any prompt dies with
    * getcwd ENOENT, so the pool must retire it and cold-start a fresh process
-   * (cold start re-creates the cwd before spawn). Optional: transports without
-   * a local cwd (e.g. HTTP) omit it and are never retired for this reason.
+   * (cold start re-creates the cwd before spawn). Required: transports without
+   * a local cwd must explicitly return true; undefined is no longer allowed to
+   * silently escape retirement.
    */
-  readonly isCwdIntact?: boolean;
+  readonly isCwdIntact: boolean;
   /**
    * False after a cancelled prompt may still be running upstream. The pool only
    * acts on this for non-multiplexed carriers; multiplexed clients can keep

--- a/packages/api/src/domains/cats/services/agents/providers/acp/acp-bootstrap-cwd.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/acp-bootstrap-cwd.ts
@@ -78,12 +78,17 @@ function enforceOwnerOnlyPermissions(path: string): void {
  * launched directly from repo cwd. Bootstrap from an isolated tmp dir, then pass
  * the real project cwd + MCP servers later via session/new.
  */
-export function resolveAcpBootstrapCwd(projectRoot: string, providerProfile: string): string {
+export function resolveAcpBootstrapCwd(
+  projectRoot: string,
+  providerProfile: string,
+  // #1203: Test-isolation injection point — tests pass a throwaway root so
+  // their fixtures and cleanup never touch the uid-shared production root.
+  bootstrapRoot: string = resolveAcpBootstrapRoot(),
+): string {
   const normalizedProjectRoot = resolve(projectRoot);
   const projectSlug = sanitizeSegment(basename(normalizedProjectRoot), 'project');
   const providerSlug = sanitizeSegment(providerProfile, 'profile');
   const digest = createHash('sha1').update(`${normalizedProjectRoot}::${providerProfile}`).digest('hex').slice(0, 12);
-  const bootstrapRoot = resolveAcpBootstrapRoot();
   mkdirSync(bootstrapRoot, { recursive: true, mode: OWNER_ONLY_MODE });
   assertRealDirectory(bootstrapRoot, 'ACP bootstrap root');
   enforceOwnerOnlyPermissions(bootstrapRoot);

--- a/packages/api/src/domains/cats/services/agents/providers/acp/acp-cwd-identity.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/acp-cwd-identity.ts
@@ -1,0 +1,68 @@
+/**
+ * #1203: Shared directory identity primitive for ACP carriers.
+ *
+ * A pooled ACP child's bootstrap cwd can be deleted by an external cleaner
+ * (e.g. a stray test teardown emptying the shared /tmp bootstrap root). The
+ * child process stays alive, but any prompt dies with getcwd() ENOENT. Worse,
+ * the same path may be recreated later with a different inode; existence alone
+ * is not enough to detect the loss.
+ *
+ * This module captures a directory's identity at spawn time and compares it
+ * against the current identity on demand. dev+ino identifies the inode on
+ * POSIX; ino is 0 on Windows, where birthtimeMs distinguishes a
+ * delete→recreate at the same path.
+ */
+
+import { statSync } from 'node:fs';
+
+/** String identity of a directory entry: dev:ino:birthtimeMs. */
+export type AcpCwdIdentity = string;
+
+function sampleDirIdentity(path: string): AcpCwdIdentity | null {
+  try {
+    const stat = statSync(path);
+    return `${stat.dev}:${stat.ino}:${stat.birthtimeMs}`;
+  } catch {
+    // Missing dir, or a fake spawn config pointing at a fake path.
+    return null;
+  }
+}
+
+/**
+ * Tracks the identity of a directory across its lifetime.
+ *
+ * - If no identity was captured (e.g. a test injects a fake spawnFn and the
+ *   cwd path does not exist), `isIntact` returns true. There is no baseline,
+ *   so we cannot prove the cwd was lost.
+ * - Transports that genuinely have no local cwd should not use this tracker
+ *   as an excuse: `AcpPoolClient.isCwdIntact` is a required contract and such
+ *   transports must explicitly return true.
+ */
+export class AcpCwdIdentityTracker {
+  private capturedIdentity: AcpCwdIdentity | null = null;
+
+  constructor(private readonly path: string) {}
+
+  /** Capture the current identity of `path`. Call after mkdir, before spawn. */
+  capture(): AcpCwdIdentity | null {
+    this.capturedIdentity = sampleDirIdentity(this.path);
+    return this.capturedIdentity;
+  }
+
+  /** The most recently captured identity, or null if none was captured. */
+  get captured(): AcpCwdIdentity | null {
+    return this.capturedIdentity;
+  }
+
+  /**
+   * False when the directory is missing or its identity no longer matches the
+   * captured baseline. True when the identity matches, or when no baseline was
+   * captured (fake/test path).
+   */
+  get isIntact(): boolean {
+    const current = sampleDirIdentity(this.path);
+    if (current === null) return false;
+    if (this.capturedIdentity === null) return true;
+    return current === this.capturedIdentity;
+  }
+}

--- a/packages/api/src/domains/cats/services/agents/providers/acp/acp-event-transformer.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/acp/acp-event-transformer.ts
@@ -327,14 +327,20 @@ export function transformAcpEvent(
       ]);
     }
 
-    case 'plan':
+    case 'plan': {
+      // #1203: Empty/whitespace plan text carries no information and the
+      // frontend has no plan formatter — drop it instead of leaking raw
+      // `{"type":"plan","text":""}` JSON into chat. Non-empty plans unchanged.
+      const planText = typeof content?.text === 'string' ? content.text : '';
+      if (!planText.trim()) return withFlush(null);
       return withFlush({
         type: 'system_info',
         catId,
-        content: JSON.stringify({ type: 'plan', text: content?.text ?? '' }),
+        content: JSON.stringify({ type: 'plan', text: planText }),
         metadata,
         timestamp: now,
       });
+    }
 
     case 'user_message_chunk':
       return withFlush(null);

--- a/packages/api/test/acp/acp-bootstrap-cwd.test.js
+++ b/packages/api/test/acp/acp-bootstrap-cwd.test.js
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, relative, resolve, win32 } from 'node:path';
+import { isAbsolute, join, relative, resolve, win32 } from 'node:path';
 import { after, afterEach, before, describe, it } from 'node:test';
 
 const {
@@ -40,7 +40,9 @@ describe('acp bootstrap cwd', () => {
   const assertSafeCleanupDir = (dir) => {
     const resolved = resolve(dir);
     for (const root of cleanupAllowlist) {
-      if (resolved === root || resolved.startsWith(`${root}/`)) return;
+      // Platform-aware containment (PR #1207 codex P2): a hard-coded `/` prefix
+      // fails on Windows, where resolve() produces backslash paths.
+      if (isPathWithinRoot(root, resolved, { relative, isAbsolute })) return;
     }
     throw new Error(`REFUSING to delete path outside test cleanup allowlist: ${dir}`);
   };

--- a/packages/api/test/acp/acp-bootstrap-cwd.test.js
+++ b/packages/api/test/acp/acp-bootstrap-cwd.test.js
@@ -58,11 +58,15 @@ describe('acp bootstrap cwd', () => {
   const testBootstrapCwd = (projectRoot, profile) => resolveAcpBootstrapCwd(projectRoot, profile, testBootstrapRoot);
 
   before(() => {
-    testBootstrapRoot = mkdtempSync(join('/tmp', 'cat-cafe-acp-bootstrap-test-'));
+    // Portable throwaway root — never a hard-coded '/tmp' (PR #1207 sweep):
+    // os.tmpdir() exists on every platform, '/tmp' does not on Windows.
+    testBootstrapRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-acp-bootstrap-test-'));
     allowCleanup(testBootstrapRoot);
   });
 
   after(() => {
+    // Final teardown goes through the same safety guard as afterEach.
+    assertSafeCleanupDir(testBootstrapRoot);
     rmSync(testBootstrapRoot, { recursive: true, force: true });
   });
 
@@ -83,12 +87,12 @@ describe('acp bootstrap cwd', () => {
 
     assert.equal(first, second, 'same project/profile should reuse the same bootstrap dir');
     assert.ok(
-      first.startsWith('/tmp/cat-cafe-acp-bootstrap-'),
-      `bootstrap dir should live under /tmp/cat-cafe-acp-bootstrap-*, got ${first}`,
+      isPathWithinRoot(testBootstrapRoot, first, { relative, isAbsolute }),
+      `bootstrap dir should live under the injected test root ${testBootstrapRoot}, got ${first}`,
     );
     assert.ok(existsSync(first), 'bootstrap dir should be created eagerly');
     assert.ok(
-      !first.startsWith(`${projectRoot}/`) && first !== projectRoot,
+      !isPathWithinRoot(projectRoot, first, { relative, isAbsolute }),
       'bootstrap dir must not resolve inside the project root',
     );
   });
@@ -228,6 +232,12 @@ describe('acp bootstrap cwd', () => {
     // Registered test roots (and their children) are allowed.
     assertSafeCleanupDir(testBootstrapRoot);
     assertSafeCleanupDir(join(testBootstrapRoot, 'some-child-dir'));
+    // A sibling sharing the root's path prefix is NOT inside it (prefix trap).
+    assert.throws(
+      () => assertSafeCleanupDir(`${testBootstrapRoot}-evil`),
+      /outside test cleanup allowlist/,
+      'sibling directory sharing a path prefix must be rejected',
+    );
   });
 
   it('guards AcpServiceFactory against wiring ACP clients back to repo cwd', () => {

--- a/packages/api/test/acp/acp-bootstrap-cwd.test.js
+++ b/packages/api/test/acp/acp-bootstrap-cwd.test.js
@@ -11,7 +11,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, relative, resolve, win32 } from 'node:path';
-import { afterEach, describe, it } from 'node:test';
+import { after, afterEach, before, describe, it } from 'node:test';
 
 const {
   isPathWithinRoot,
@@ -23,9 +23,50 @@ const {
 
 describe('acp bootstrap cwd', () => {
   const createdDirs = new Set();
+  // #1203: Tests MUST run under a throwaway bootstrap root, injected explicitly
+  // into resolveAcpBootstrapCwd(). The production root
+  // (/tmp/cat-cafe-acp-bootstrap-uid-*) is shared with every running Clowder AI
+  // instance on this machine — deleting it (the previous afterEach did exactly
+  // that) pulls the cwd out from under live pooled ACP processes and the next
+  // prompt dies with ACP -32603 getcwd ENOENT.
+  let testBootstrapRoot;
+  // Explicit deletion allowlist: afterEach may only rmSync paths inside one of
+  // these roots. Anything else — above all the uid-shared production bootstrap
+  // root — throws instead of deleting.
+  const cleanupAllowlist = new Set();
+
+  const allowCleanup = (root) => cleanupAllowlist.add(resolve(root));
+
+  const assertSafeCleanupDir = (dir) => {
+    const resolved = resolve(dir);
+    for (const root of cleanupAllowlist) {
+      if (resolved === root || resolved.startsWith(`${root}/`)) return;
+    }
+    throw new Error(`REFUSING to delete path outside test cleanup allowlist: ${dir}`);
+  };
+
+  const makeTmpDir = (prefix) => {
+    const dir = mkdtempSync(join(tmpdir(), prefix));
+    allowCleanup(dir);
+    return dir;
+  };
+
+  // All resolveAcpBootstrapCwd() calls in this suite go through the injected
+  // throwaway root — the production root is never created, listed, or deleted.
+  const testBootstrapCwd = (projectRoot, profile) => resolveAcpBootstrapCwd(projectRoot, profile, testBootstrapRoot);
+
+  before(() => {
+    testBootstrapRoot = mkdtempSync(join('/tmp', 'cat-cafe-acp-bootstrap-test-'));
+    allowCleanup(testBootstrapRoot);
+  });
+
+  after(() => {
+    rmSync(testBootstrapRoot, { recursive: true, force: true });
+  });
 
   afterEach(() => {
     for (const dir of createdDirs) {
+      assertSafeCleanupDir(dir);
       rmSync(dir, { recursive: true, force: true });
     }
     createdDirs.clear();
@@ -33,12 +74,10 @@ describe('acp bootstrap cwd', () => {
 
   it('creates a deterministic bootstrap dir outside the project root', () => {
     const projectRoot = resolve('/tmp/cat-cafe-project');
-    const bootstrapRoot = resolveAcpBootstrapRoot();
 
-    const first = resolveAcpBootstrapCwd(projectRoot, 'gemini-default');
-    const second = resolveAcpBootstrapCwd(projectRoot, 'gemini-default');
+    const first = testBootstrapCwd(projectRoot, 'gemini-default');
+    const second = testBootstrapCwd(projectRoot, 'gemini-default');
     createdDirs.add(first);
-    createdDirs.add(bootstrapRoot);
 
     assert.equal(first, second, 'same project/profile should reuse the same bootstrap dir');
     assert.ok(
@@ -54,11 +93,10 @@ describe('acp bootstrap cwd', () => {
 
   it('recreates the deterministic bootstrap dir when it was cleaned up between cold starts', () => {
     const projectRoot = resolve('/tmp/cat-cafe-project');
-    createdDirs.add(resolveAcpBootstrapRoot());
 
-    const first = resolveAcpBootstrapCwd(projectRoot, 'recreate-guard');
+    const first = testBootstrapCwd(projectRoot, 'recreate-guard');
     rmSync(first, { recursive: true, force: true });
-    const second = resolveAcpBootstrapCwd(projectRoot, 'recreate-guard');
+    const second = testBootstrapCwd(projectRoot, 'recreate-guard');
     createdDirs.add(second);
 
     assert.equal(first, second, 'bootstrap path should stay deterministic across cold starts');
@@ -67,21 +105,20 @@ describe('acp bootstrap cwd', () => {
 
   it('enforces owner-only permissions on the bootstrap cwd', () => {
     const projectRoot = resolve('/tmp/cat-cafe-project');
-    const dir = resolveAcpBootstrapCwd(projectRoot, 'mode-guard');
+    const dir = testBootstrapCwd(projectRoot, 'mode-guard');
     createdDirs.add(dir);
-    createdDirs.add(resolveAcpBootstrapRoot());
 
     chmodSync(dir, 0o755);
-    resolveAcpBootstrapCwd(projectRoot, 'mode-guard');
+    testBootstrapCwd(projectRoot, 'mode-guard');
 
     assert.equal(statSync(dir).mode & 0o777, 0o700);
   });
 
   it('sanitizes provider profile so it cannot escape the bootstrap root', () => {
     const projectRoot = resolve('/tmp/cat-cafe-project');
-    const bootstrapRoot = resolveAcpBootstrapRoot();
+    const bootstrapRoot = testBootstrapRoot;
 
-    const escaped = resolveAcpBootstrapCwd(projectRoot, '../rogue/profile');
+    const escaped = testBootstrapCwd(projectRoot, '../rogue/profile');
     createdDirs.add(escaped);
 
     const relativeToBootstrapRoot = relative(bootstrapRoot, escaped);
@@ -98,16 +135,14 @@ describe('acp bootstrap cwd', () => {
 
   it('rejects a pre-created symlink at the bootstrap cwd path', () => {
     const projectRoot = resolve('/tmp/cat-cafe-project');
-    const bootstrapRoot = resolveAcpBootstrapRoot();
-    const target = mkdtempSync(join(tmpdir(), 'gemini-acp-target-'));
-    const bootstrapPath = resolveAcpBootstrapCwd(projectRoot, 'symlink-guard');
+    const target = makeTmpDir('gemini-acp-target-');
+    const bootstrapPath = testBootstrapCwd(projectRoot, 'symlink-guard');
     createdDirs.add(target);
     rmSync(bootstrapPath, { recursive: true, force: true });
     symlinkSync(target, bootstrapPath);
     createdDirs.add(bootstrapPath);
-    createdDirs.add(bootstrapRoot);
 
-    assert.throws(() => resolveAcpBootstrapCwd(projectRoot, 'symlink-guard'), /must not be a symlink/);
+    assert.throws(() => testBootstrapCwd(projectRoot, 'symlink-guard'), /must not be a symlink/);
   });
 
   it('uses platform-safe containment checks for Windows-style paths', () => {
@@ -120,7 +155,7 @@ describe('acp bootstrap cwd', () => {
   });
 
   it('resolves relative ACP commands against the project root', () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), 'acp-project-'));
+    const projectRoot = makeTmpDir('acp-project-');
     writeFileSync(join(projectRoot, 'agent.js'), 'console.log("ok");\n');
     writeFileSync(join(projectRoot, 'gemini'), 'echo hijack\n');
     createdDirs.add(projectRoot);
@@ -133,7 +168,7 @@ describe('acp bootstrap cwd', () => {
   });
 
   it('resolves path-like startupArgs against the project root', () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), 'acp-project-'));
+    const projectRoot = makeTmpDir('acp-project-');
     writeFileSync(join(projectRoot, 'settings.json'), '{}\n');
     writeFileSync(join(projectRoot, 'runner.js'), 'console.log("ok");\n');
     writeFileSync(join(projectRoot, 'yolo'), 'not-a-path\n');
@@ -159,7 +194,7 @@ describe('acp bootstrap cwd', () => {
   });
 
   it('expands model templates in startupArgs before spawning ACP clients', () => {
-    const projectRoot = mkdtempSync(join(tmpdir(), 'acp-project-'));
+    const projectRoot = makeTmpDir('acp-project-');
     createdDirs.add(projectRoot);
 
     assert.deepEqual(
@@ -171,11 +206,26 @@ describe('acp bootstrap cwd', () => {
   });
 
   it('scopes bootstrap root by current uid or equivalent user identity', () => {
+    // Pure path computation — no directories are created on the production root.
     const root = resolveAcpBootstrapRoot();
     assert.ok(
       root.startsWith('/tmp/cat-cafe-acp-bootstrap-'),
       `bootstrap root should match /tmp/cat-cafe-acp-bootstrap-*, got ${root}`,
     );
+    assert.notEqual(root, testBootstrapRoot, 'default root must not collapse into the test root');
+  });
+
+  it('cleanup allowlist refuses the uid-shared production bootstrap root (#1203 sentinel)', () => {
+    // The production root is the sentinel for every running instance on this
+    // machine. The afterEach guard must reject it — and any path outside the
+    // registered test roots — instead of deleting it.
+    const productionRoot = resolveAcpBootstrapRoot();
+    assert.throws(() => assertSafeCleanupDir(productionRoot), /outside test cleanup allowlist/);
+    assert.throws(() => assertSafeCleanupDir('/tmp'), /outside test cleanup allowlist/);
+    assert.throws(() => assertSafeCleanupDir(resolve('/')), /outside test cleanup allowlist/);
+    // Registered test roots (and their children) are allowed.
+    assertSafeCleanupDir(testBootstrapRoot);
+    assertSafeCleanupDir(join(testBootstrapRoot, 'some-child-dir'));
   });
 
   it('guards AcpServiceFactory against wiring ACP clients back to repo cwd', () => {

--- a/packages/api/test/acp/acp-client.test.js
+++ b/packages/api/test/acp/acp-client.test.js
@@ -4,6 +4,9 @@
 
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { afterEach, describe, it, mock } from 'node:test';
 
@@ -104,6 +107,36 @@ describe('AcpClient', () => {
     assert.equal(result.protocolVersion, 1);
     assert.equal(result.agentInfo.name, 'test');
     assert.ok(client.isAlive);
+  });
+
+  it('isCwdIntact detects deletion and delete→recreate of the bootstrap cwd (#1203)', async () => {
+    const { child, clientStdin, agentStdout } = createMockChild();
+
+    clientStdin.on('data', (chunk) => {
+      for (const line of chunk.toString().trim().split('\n')) {
+        const msg = JSON.parse(line);
+        if (msg.method === 'initialize') {
+          agentRespond(agentStdout, msg.id, INIT_RESULT);
+        }
+      }
+    });
+
+    const cwd = mkdtempSync(join(tmpdir(), 'acp-cwd-identity-'));
+    client = new AcpClient({ command: 'fake', args: [], cwd, spawnFn: () => child });
+    await client.initialize();
+
+    assert.equal(client.isCwdIntact, true, 'untouched cwd must be intact');
+
+    rmSync(cwd, { recursive: true, force: true });
+    assert.equal(client.isCwdIntact, false, 'deleted cwd must be reported as lost');
+
+    // A later cold start recreates the same path — but the pooled child still
+    // holds the dead inode, so getcwd() inside it keeps failing. Existence is
+    // not enough; the directory identity must mismatch.
+    mkdirSync(cwd);
+    assert.equal(client.isCwdIntact, false, 'recreated cwd at same path is a different inode — still lost');
+
+    rmSync(cwd, { recursive: true, force: true });
   });
 
   it('newSession sends cwd and mcpServers', async () => {

--- a/packages/api/test/acp/acp-event-transformer.test.js
+++ b/packages/api/test/acp/acp-event-transformer.test.js
@@ -424,6 +424,24 @@ describe('transformAcpEvent', () => {
     assert.equal(parsed.text, 'Step 1: Read file\nStep 2: Edit');
   });
 
+  it('plan with empty/whitespace/missing text → null (#1203)', () => {
+    // The frontend has no plan formatter — empty plans used to leak as raw
+    // `{"type":"plan","text":""}` JSON bubbles in chat.
+    for (const text of ['', '   ', '\n\t ']) {
+      const update = {
+        sessionId: 's1',
+        update: { sessionUpdate: 'plan', content: { type: 'text', text } },
+      };
+      assert.equal(
+        transformAcpEvent(update, catId, metadata),
+        null,
+        `empty plan text ${JSON.stringify(text)} must be dropped`,
+      );
+    }
+    const noContent = { sessionId: 's1', update: { sessionUpdate: 'plan' } };
+    assert.equal(transformAcpEvent(noContent, catId, metadata), null, 'plan without content must be dropped');
+  });
+
   it('user_message_chunk → null (skip echo)', () => {
     const update = {
       sessionId: 's1',

--- a/packages/api/test/acp/acp-httpstream-client.test.js
+++ b/packages/api/test/acp/acp-httpstream-client.test.js
@@ -4,7 +4,10 @@
 
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { PassThrough } from 'node:stream';
 import { afterEach, describe, it, mock } from 'node:test';
 
@@ -1094,5 +1097,40 @@ describe('AcpHttpStreamClient', () => {
     assert.equal(thrownError.configuredIdleStallMs, 100, 'Error should carry configured 100ms threshold');
     // Must terminate near 100ms, not at 20_000ms (the warning interval)
     assert.ok(elapsed < 2000, `Should terminate near 100ms, took ${elapsed}ms`);
+  });
+
+  it('isCwdIntact detects deletion and delete→recreate of the bootstrap cwd (#1203)', async () => {
+    server = await startJsonRpcServer((message) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    });
+    const { child, agentStdout } = createMockChild();
+    const port = serverPort(server);
+    const cwd = mkdtempSync(join(tmpdir(), 'acp-http-cwd-identity-'));
+
+    client = new AcpHttpStreamClient({
+      command: 'fake-http-acp',
+      args: [],
+      cwd,
+      spawnFn: () => {
+        setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+        return child;
+      },
+      portDiscoveryTimeoutMs: 500,
+    });
+
+    await client.initialize();
+
+    assert.equal(client.isCwdIntact, true, 'untouched cwd must be intact');
+
+    rmSync(cwd, { recursive: true, force: true });
+    assert.equal(client.isCwdIntact, false, 'deleted cwd must be reported as lost');
+
+    mkdirSync(cwd);
+    assert.equal(client.isCwdIntact, false, 'recreated cwd at same path is a different inode — still lost');
+
+    rmSync(cwd, { recursive: true, force: true });
   });
 });

--- a/packages/api/test/acp/acp-httpstream-pool-retirement.test.js
+++ b/packages/api/test/acp/acp-httpstream-pool-retirement.test.js
@@ -1,0 +1,180 @@
+/**
+ * #1203 P1: Actual AcpHttpStreamClient + AcpProcessPool integration.
+ *
+ * Proves that an HTTP-stream carrier, which also spawns a local child with a
+ * local cwd, participates in the same cwd-loss retirement contract as stdio.
+ */
+
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const { AcpHttpStreamClient } = await import(
+  '../../dist/domains/cats/services/agents/providers/acp/AcpHttpStreamClient.js'
+);
+const { AcpProcessPool } = await import('../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js');
+
+const INIT_RESULT = {
+  protocolVersion: 1,
+  authMethods: [],
+  agentInfo: { name: 'http-acp', title: 'HTTP ACP Test Agent', version: '1.0.0' },
+  agentCapabilities: { loadSession: true },
+};
+
+function createMockChild() {
+  const agentStdout = new PassThrough();
+  const agentStderr = new PassThrough();
+  const clientStdin = new PassThrough();
+  const ee = new EventEmitter();
+  const child = {
+    pid: 12345,
+    stdin: clientStdin,
+    stdout: agentStdout,
+    stderr: agentStderr,
+    killed: false,
+    kill: mock.fn(() => {
+      child.killed = true;
+      agentStdout.end();
+      agentStderr.end();
+      ee.emit('exit', 0, null);
+      return true;
+    }),
+    on: ee.on.bind(ee),
+    once: ee.once.bind(ee),
+    removeListener: ee.removeListener.bind(ee),
+  };
+  return { child, agentStdout };
+}
+
+function startJsonRpcServer(handler) {
+  const server = createServer(async (req, res) => {
+    const chunks = [];
+    for await (const chunk of req) chunks.push(chunk);
+    const message = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    const response = await handler(message, res);
+    if (response === undefined) return;
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(`${JSON.stringify(response)}\n`);
+  });
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server));
+  });
+}
+
+function serverPort(server) {
+  const address = server.address();
+  assert.ok(address && typeof address === 'object');
+  return address.port;
+}
+
+const httpstreamVariantConfig = {
+  command: 'fake-http-acp',
+  startupArgs: ['--acp'],
+  supportsMultiplexing: false,
+  transport: 'httpstream',
+};
+
+const poolKey = { projectPath: '/tmp/httpstream-pool-test', providerProfile: 'httpstream-default' };
+
+describe('AcpHttpStreamClient pool retirement (#1203)', () => {
+  let pool = null;
+  let cwd = null;
+  const servers = [];
+
+  afterEach(async () => {
+    if (pool) {
+      await pool.closeAll();
+      pool = null;
+    }
+    for (const server of servers.splice(0)) {
+      await new Promise((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+    if (cwd) {
+      rmSync(cwd, { recursive: true, force: true });
+      cwd = null;
+    }
+  });
+
+  it('retires an actual HTTP-stream carrier after cwd deletion and cold-starts a replacement', async () => {
+    cwd = mkdtempSync(join(tmpdir(), 'acp-http-pool-cwd-'));
+
+    // Pre-start a server for each cold start the pool may need. The pool's
+    // clientFactory is synchronous, so the server must already be listening.
+    const serverHandler = (message) => {
+      if (message.method === 'initialize') {
+        return { jsonrpc: '2.0', id: message.id, result: INIT_RESULT };
+      }
+      return { jsonrpc: '2.0', id: message.id, error: { code: -32601, message: 'not found' } };
+    };
+    const server1 = await startJsonRpcServer(serverHandler);
+    const server2 = await startJsonRpcServer(serverHandler);
+    const server3 = await startJsonRpcServer(serverHandler);
+    servers.push(server1, server2, server3);
+
+    let serverIndex = 0;
+    const createClient = () => {
+      const server = servers[serverIndex++];
+      const { child, agentStdout } = createMockChild();
+      const port = serverPort(server);
+      return new AcpHttpStreamClient({
+        command: 'fake-http-acp',
+        args: [],
+        cwd,
+        spawnFn: () => {
+          setImmediate(() => agentStdout.write(`Listening on port ${port}\n`));
+          return child;
+        },
+        portDiscoveryTimeoutMs: 500,
+      });
+    };
+
+    pool = new AcpProcessPool(
+      { maxLiveProcesses: 2, idleTtlMs: 999_999, healthCheckIntervalMs: 999_999 },
+      httpstreamVariantConfig,
+      createClient,
+    );
+
+    const lease1 = await pool.acquire(poolKey);
+    const staleClient = lease1.client;
+    assert.equal(staleClient.isCwdIntact, true, 'fresh HTTP carrier must report cwd intact');
+    lease1.release();
+
+    // External cleaner deletes the shared bootstrap root.
+    rmSync(cwd, { recursive: true, force: true });
+    assert.equal(staleClient.isCwdIntact, false, 'cwd-less HTTP carrier must report not intact');
+
+    // A real cold start would re-create the cwd before spawn. In tests spawnFn
+    // skips mkdir, so recreate it here to give the replacement a live inode.
+    mkdirSync(cwd);
+
+    const lease2 = await pool.acquire(poolKey);
+    assert.notStrictEqual(
+      lease2.client,
+      staleClient,
+      'pool must cold-start a fresh HTTP carrier instead of reusing cwd-less one',
+    );
+    assert.equal(staleClient.isAlive, false, 'retired HTTP carrier child must be closed');
+    assert.equal(lease2.client.isCwdIntact, true, 'replacement carrier must capture the new inode');
+
+    // Now the replacement child holds the live inode. Recreate the path again
+    // and confirm the carrier detects the inode change.
+    rmSync(cwd, { recursive: true, force: true });
+    mkdirSync(cwd);
+    assert.equal(
+      lease2.client.isCwdIntact,
+      false,
+      'recreated cwd at same path is a different inode — replacement carrier must also report lost',
+    );
+
+    const lease3 = await pool.acquire(poolKey);
+    assert.notStrictEqual(lease3.client, lease2.client, 'pool must cold-start again after recreate');
+    assert.equal(lease2.client.isAlive, false, 'second retired HTTP carrier child must be closed');
+    lease3.release();
+  });
+});

--- a/packages/api/test/acp/acp-process-pool.test.js
+++ b/packages/api/test/acp/acp-process-pool.test.js
@@ -18,11 +18,15 @@ function createMockClient() {
   const id = ++clientIdCounter;
   let alive = false;
   let closed = false;
+  let cwdIntact = true;
   const unsafeSessionIds = new Set();
   return {
     id,
     get isAlive() {
       return alive && !closed;
+    },
+    get isCwdIntact() {
+      return cwdIntact;
     },
     get isSafeForSingleFlightReuse() {
       return unsafeSessionIds.size === 0;
@@ -52,6 +56,9 @@ function createMockClient() {
     _markUnsafeForSingleFlightReuse(sessionId = '*') {
       unsafeSessionIds.add(sessionId);
     },
+    _deleteCwd() {
+      cwdIntact = false;
+    }, // #1203: simulate external deletion of the bootstrap cwd
   };
 }
 
@@ -540,6 +547,109 @@ describe('AcpProcessPool', () => {
       assert.notStrictEqual(lease2.client, deadClient);
       assert.strictEqual(pool.getMetrics().coldStartCount, 2);
       lease2.release();
+    });
+  });
+
+  describe('bootstrap cwd loss (#1203)', () => {
+    test('warm process whose bootstrap cwd was deleted is retired and cold-started on acquire', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(
+        { ...defaultPoolConfig, healthCheckIntervalMs: 999_999, idleTtlMs: 999_999 },
+        defaultVariantConfig,
+        createMockClient,
+      );
+      const lease1 = await pool.acquire(key1);
+      const staleClient = lease1.client;
+      lease1.release();
+
+      // External cleaner (e.g. a stray test) deletes the shared bootstrap root —
+      // the child process is alive but its cwd is gone, so any prompt dies with
+      // getcwd ENOENT. The pool must not hand this process out again.
+      staleClient._deleteCwd();
+
+      const lease2 = await pool.acquire(key1);
+      assert.notStrictEqual(lease2.client, staleClient, 'must cold-start instead of reusing cwd-less process');
+      assert.ok(lease2.client.isAlive);
+      assert.ok(staleClient._isClosed(), 'retired process must be closed');
+      const m = pool.getMetrics();
+      assert.strictEqual(m.coldStartCount, 2);
+      assert.strictEqual(m.liveProcessCount, 1);
+      lease2.release();
+    });
+
+    test('session owner whose bootstrap cwd was deleted is retired — re-acquire cold-starts', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(
+        { ...defaultPoolConfig, healthCheckIntervalMs: 999_999, idleTtlMs: 999_999 },
+        defaultVariantConfig,
+        createMockClient,
+      );
+      const lease1 = await pool.acquire(key1);
+      const staleClient = lease1.client;
+      pool.rememberSession(key1, 'sess-cwd-lost', lease1);
+      lease1.release();
+
+      staleClient._deleteCwd();
+
+      const lease2 = await pool.acquire(key1, { sessionId: 'sess-cwd-lost' });
+      assert.notStrictEqual(lease2.client, staleClient, 'must not resume on a cwd-less owner');
+      assert.ok(staleClient._isClosed(), 'retired owner must be closed');
+      assert.strictEqual(pool.getMetrics().coldStartCount, 2);
+      lease2.release();
+    });
+
+    test('health check proactively cleans alive-but-cwd-less processes', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(
+        { ...defaultPoolConfig, healthCheckIntervalMs: 30, idleTtlMs: 999_999 },
+        defaultVariantConfig,
+        createMockClient,
+      );
+      const lease = await pool.acquire(key1);
+      const client = lease.client;
+      lease.release();
+
+      client._deleteCwd();
+
+      await new Promise((r) => setTimeout(r, 80));
+      const m = pool.getMetrics();
+      assert.strictEqual(m.liveProcessCount, 0);
+      // FC-1: cwd-less retirement must close the process, not just unlink it
+      assert.ok(client._isClosed(), 'retired cwd-less process must be closed');
+    });
+
+    test('health check retires cwd-less process with active lease — late release() is a no-op (FC-1)', async () => {
+      const { AcpProcessPool } = await import(
+        '../../dist/domains/cats/services/agents/providers/acp/AcpProcessPool.js'
+      );
+      pool = new AcpProcessPool(
+        { ...defaultPoolConfig, healthCheckIntervalMs: 30, idleTtlMs: 999_999 },
+        defaultVariantConfig,
+        createMockClient,
+      );
+      const lease = await pool.acquire(key1);
+      const client = lease.client;
+      // Do NOT release — the lease is still active when the cwd disappears
+      // (e.g. mid-prompt). Retirement must invalidate the lease generation.
+      client._deleteCwd();
+
+      await new Promise((r) => setTimeout(r, 80));
+      assert.strictEqual(pool.getMetrics().liveProcessCount, 0);
+      assert.strictEqual(pool.getMetrics().activeLeaseCount, 0);
+      assert.ok(client._isClosed(), 'retired cwd-less process must be closed');
+
+      // The in-flight consumer's finally block releases the stale lease — it
+      // must not decrement metrics a second time.
+      lease.release();
+      const m = pool.getMetrics();
+      assert.strictEqual(m.activeLeaseCount, 0, 'stale release must not double-decrement activeLeaseCount');
+      assert.strictEqual(m.liveProcessCount, 0);
     });
   });
 

--- a/packages/api/test/acp/gemini-acp-adapter.test.js
+++ b/packages/api/test/acp/gemini-acp-adapter.test.js
@@ -2252,7 +2252,7 @@ describe('GeminiAcpAdapter integration', () => {
 
   // ─── F149: Stream Idle Watchdog Tests ─────────────────────────
 
-  it('F149: stream idle warning after events yields liveness_signal', async () => {
+  it('F149/#1203: ordinary stream idle warning stays internal — no liveness bubble', async () => {
     const fakeClient = {
       isAlive: true,
       initialize: async () => ({}),
@@ -2305,17 +2305,15 @@ describe('GeminiAcpAdapter integration', () => {
       messages.push(msg);
     }
 
-    // Should have a liveness_signal warning
+    // #1203: Ordinary (non-terminal) idle warnings are internal watchdog
+    // telemetry — the CLI shows no such bubble, and in the zero-first-event
+    // case the '已开始回复但后续停滞' text was factually wrong.
     const warnings = messages.filter((m) => m.type === 'liveness_signal');
     assert.equal(
       warnings.length,
-      1,
-      `Expected 1 liveness_signal, got ${warnings.length}: ${JSON.stringify(messages.map((m) => m.type))}`,
+      0,
+      `Expected 0 liveness_signal bubbles, got ${warnings.length}: ${JSON.stringify(messages.map((m) => m.type))}`,
     );
-
-    const parsed = JSON.parse(warnings[0].content);
-    assert.equal(parsed.type, 'warning');
-    assert.match(parsed.message, /停滞|idle|silent/i);
 
     // Normal text should still be present
     const texts = messages.filter((m) => m.type === 'text');
@@ -2502,7 +2500,7 @@ describe('GeminiAcpAdapter integration', () => {
     assert.ok(doneIdx > errorIdx, 'done should be emitted only after the compaction error');
   });
 
-  it('F149: liveness_signal warning appears before stream_idle_stall error', async () => {
+  it('F149/#1203: terminal stream_idle_stall still errors — no preceding liveness bubble', async () => {
     const fakeClient = {
       isAlive: true,
       initialize: async () => ({}),
@@ -2553,18 +2551,16 @@ describe('GeminiAcpAdapter integration', () => {
       messages.push(msg);
     }
 
-    const warningIdx = messages.findIndex((m) => m.type === 'liveness_signal');
+    // #1203: No user-visible warning bubble; the terminal stall error must
+    // still surface unchanged (#1189 TTL semantics preserved).
+    const warnings = messages.filter((m) => m.type === 'liveness_signal');
+    assert.equal(warnings.length, 0, `Expected 0 liveness_signal bubbles, got ${warnings.length}`);
     const errorIdx = messages.findIndex((m) => m.type === 'error');
-    assert.ok(
-      warningIdx >= 0,
-      `Should have liveness_signal, got types: ${JSON.stringify(messages.map((m) => m.type))}`,
-    );
     assert.ok(errorIdx >= 0, 'Should have error');
-    assert.ok(warningIdx < errorIdx, `Warning (idx ${warningIdx}) should come before error (idx ${errorIdx})`);
     assert.equal(messages[errorIdx].errorCode, 'stream_idle_stall');
   });
 
-  it('F149: stream idle warning is deduped (only one liveness_signal per invoke)', async () => {
+  it('F149/#1203: multiple ordinary idle warnings produce zero liveness bubbles', async () => {
     const fakeClient = {
       isAlive: true,
       initialize: async () => ({}),
@@ -2621,13 +2617,67 @@ describe('GeminiAcpAdapter integration', () => {
     }
 
     const warnings = messages.filter((m) => m.type === 'liveness_signal');
-    assert.equal(warnings.length, 1, `Expected exactly 1 liveness_signal (deduped), got ${warnings.length}`);
+    assert.equal(warnings.length, 0, `Expected 0 liveness_signal bubbles, got ${warnings.length}`);
 
     const texts = messages.filter((m) => m.type === 'text');
     assert.equal(texts.length, 3, `Expected 3 text messages, got ${texts.length}`);
   });
 
-  it('stream_tool_wait_warning yields info liveness_signal (not error)', async () => {
+  it('#1203: zero-first-event idle warning produces no bubble and no error', async () => {
+    // The reported incident: kimi's first real ACP event arrived at +61s, but
+    // the watchdog fired at +20s with eventCount=0 — the '已开始回复但后续停滞'
+    // bubble was factually wrong. Zero-first-event warnings stay internal too.
+    const fakeClient = {
+      isAlive: true,
+      initialize: async () => ({}),
+      close: async () => {},
+      onCapacity: () => {},
+      offCapacity: () => {},
+      recentCapacitySignal: null,
+      clearRecentCapacitySignal: () => {},
+      newSession: async () => ({ sessionId: 'idle-zero-sess' }),
+      cancelSession: () => {},
+      async *promptStream() {
+        // Watchdog fires BEFORE any real event (zero-first-event)
+        yield {
+          sessionId: 'idle-zero-sess',
+          update: { sessionUpdate: 'stream_idle_warning', idleSinceMs: 20000, eventCount: 0, timestamp: Date.now() },
+        };
+        // First real event finally arrives
+        yield {
+          sessionId: 'idle-zero-sess',
+          update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'late first chunk' } },
+        };
+        return 'end_turn';
+      },
+    };
+
+    const mockPool = {
+      acquire: async () => ({ client: fakeClient, release: () => {} }),
+      closeAll: async () => {},
+    };
+
+    const adapter = new GeminiAcpAdapter({
+      catId: 'gemini',
+      pool: mockPool,
+      poolKey: TEST_POOL_KEY,
+      projectRoot: '/tmp',
+    });
+
+    const messages = [];
+    for await (const msg of adapter.invoke('hello')) {
+      messages.push(msg);
+    }
+
+    const warnings = messages.filter((m) => m.type === 'liveness_signal');
+    assert.equal(warnings.length, 0, `Expected 0 liveness_signal bubbles, got ${warnings.length}`);
+    const errors = messages.filter((m) => m.type === 'error');
+    assert.equal(errors.length, 0, 'Zero-first-event warning must not error the stream');
+    const texts = messages.filter((m) => m.type === 'text');
+    assert.equal(texts.length, 1, `Expected 1 text message, got ${texts.length}`);
+  });
+
+  it('stream_tool_wait_warning stays internal — no chat bubble, no error (#1203)', async () => {
     const fakeClient = {
       isAlive: true,
       initialize: async () => ({}),
@@ -2643,12 +2693,23 @@ describe('GeminiAcpAdapter integration', () => {
           sessionId: 'tool-wait-sess',
           update: { sessionUpdate: 'agent_message_chunk', content: { type: 'text', text: 'thinking...' } },
         };
-        // Gemini calls a tool — idle watchdog fires tool_wait instead of idle_warning
+        // Gemini calls a tool — idle watchdog fires tool_wait instead of idle_warning.
+        // #1203: inject TWO consecutive warnings (the real watchdog re-fires every
+        // 20s while the tool runs) — none of them may produce a chat bubble.
         yield {
           sessionId: 'tool-wait-sess',
           update: {
             sessionUpdate: 'stream_tool_wait_warning',
             idleSinceMs: 20000,
+            eventCount: 2,
+            timestamp: Date.now(),
+          },
+        };
+        yield {
+          sessionId: 'tool-wait-sess',
+          update: {
+            sessionUpdate: 'stream_tool_wait_warning',
+            idleSinceMs: 40000,
             eventCount: 2,
             timestamp: Date.now(),
           },
@@ -2679,11 +2740,14 @@ describe('GeminiAcpAdapter integration', () => {
       messages.push(msg);
     }
 
+    // #1203: Tool-wait is an internal watchdog signal — the CLI shows no such
+    // bubble, so the chat surface must stay silent while the stream continues.
     const liveness = messages.filter((m) => m.type === 'liveness_signal');
-    assert.equal(liveness.length, 1, `Expected 1 tool wait liveness_signal, got ${liveness.length}`);
-    const parsed = JSON.parse(liveness[0].content);
-    assert.equal(parsed.type, 'info', 'Tool wait should be info, not warning');
-    assert.ok(parsed.message.includes('等待工具'), `Message should mention tool wait: ${parsed.message}`);
+    assert.equal(liveness.length, 0, `Expected 0 liveness_signal bubbles for tool wait, got ${liveness.length}`);
+
+    // Stream content still flows after the suppressed tool-wait signal
+    const texts = messages.filter((m) => m.type === 'text');
+    assert.ok(texts.length >= 1, 'Tool wait must not swallow subsequent text output');
 
     // No error — tool wait doesn't kill the stream
     const errors = messages.filter((m) => m.type === 'error');


### PR DESCRIPTION
## Summary

Fixes #1203 (two delivery units + two adjacent symptoms, evidence in the issue body and [comment 5053985714](https://github.com/zts212653/clowder-ai/issues/1203#issuecomment-5053985714)).

1. **Test no longer deletes the uid-shared ACP bootstrap root.** `acp-bootstrap-cwd.test.js`'s `afterEach` recursively deleted `/tmp/cat-cafe-acp-bootstrap-uid-*`, pulling the cwd out from under live pooled ACP processes of any running instance on the machine — the next prompt then died with `ACP -32603 getcwd ENOENT`. `resolveAcpBootstrapCwd` now takes an explicit `bootstrapRoot` parameter; the suite injects a throwaway root, and an explicit deletion allowlist makes cleanup refuse any path outside registered test roots (sentinel-tested against the production root).
2. **Pool retires cwd-less processes instead of surfacing -32603.** `AcpClient` captures the cwd's directory identity (`dev:ino:birthtime`) at spawn, so `isCwdIntact` detects both deletion and delete→recreate at the same path (the old child still holds the dead inode). The pool retires ready-but-cwd-less processes on acquire and in the health check with full retirement semantics (close + lease-generation invalidation, so late `release()` is a no-op); cold start re-creates the cwd at spawn.
3. **Internal watchdog events no longer become chat bubbles.** `stream_tool_wait_warning` and ordinary `stream_idle_warning` are log-only telemetry now — the CLI shows no such bubbles, and in the zero-first-event case the '已开始回复但后续停滞' text was factually wrong (first event arrived at +61s, warning fired at +20s). Terminal `AcpStreamIdleError`/TTL behavior from #1189 is unchanged.
4. **Empty ACP plan updates are dropped** in the event transformer instead of leaking raw `{"type":"plan","text":""}` JSON into chat (the frontend has no plan formatter). Non-empty plan contract unchanged.

## Test plan

- TDD red→green throughout; every new/changed test was verified red against the pre-fix build first.
- New/updated regression coverage:
  - cleanup allowlist refuses the production bootstrap root / `/tmp` / `/` (sentinel);
  - `isCwdIntact`: untouched → true, deleted → false, delete→recreate at same path → false;
  - pool: warm + session-owner cwd-less retirement with cold-start, health-check retirement closes the process, late `release()` after active-lease retirement does not double-decrement metrics;
  - adapter: zero-first-event and mid-stream ordinary idle warnings produce **zero** `liveness_signal` bubbles, terminal `stream_idle_stall` error unchanged, two consecutive tool-wait warnings produce zero bubbles;
  - transformer: empty/whitespace/missing plan text → null, non-empty plan unchanged.
- Full pre-merge gate green on the exact review SHA: 806s (build + lint/check + full test suites).

Review: peer-reviewed and APPROVEd by a second maintainer-agent at SHA `31131d3a06ed9f20be1b7bdde3a003f11d721b19` (independent rebuild + 5 ACP suites, 182/0).

[小狸/k3🐾]