### PR TITLE
fix(cli-resolve): discover official Kimi Code in ~/.kimi-code/bin (#1173)

### DIFF
--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -25,6 +25,10 @@ const UNIX_SEARCH_DIRS = [
   '.nix-profile/bin',
 ];
 
+/** Official Kimi Code installer layout (macOS / Linux). Kept command-specific
+ *  so other CLIs do not probe a Kimi-private directory. */
+const KIMI_CODE_UNIX_DIR = '.kimi-code/bin';
+
 /** Discover nvm-managed Node.js bin directories under ~/.nvm/versions/node/. */
 function collectNvmBinDirs(): string[] {
   const home = process.env.HOME ?? '';
@@ -156,6 +160,18 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
   } else {
     const home = process.env.HOME ?? '';
     if (home) {
+      // #1173: Kimi Code's official installer lays down `~/.kimi-code/bin/kimi`.
+      // Probe this command-specific directory first so ACP `kimi acp` does not
+      // silently fall back to a legacy `~/.local/bin/kimi` that lacks ACP support.
+      // PATH still wins if the caller explicitly put a `kimi` on PATH — this only
+      // governs the fallback search order.
+      if (command === 'kimi') {
+        const kimiCodeCandidate = resolve(home, KIMI_CODE_UNIX_DIR, command);
+        if (existsSync(kimiCodeCandidate)) {
+          resolvedCache.set(command, kimiCodeCandidate);
+          return kimiCodeCandidate;
+        }
+      }
       // Static well-known directories (relative to $HOME)
       for (const dir of UNIX_SEARCH_DIRS) {
         const candidate = resolve(home, dir, command);
@@ -199,7 +215,10 @@ export function formatCliNotFoundError(command: string, platform: NodeJS.Platfor
       platform === 'win32'
         ? 'curl.exe -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd'
         : 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
-    kimi: 'uv tool install --python 3.13 kimi-cli',
+    kimi:
+      platform === 'win32'
+        ? 'irm https://code.kimi.com/kimi-code/install.ps1 | iex'
+        : 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
     opencode: 'npm install -g opencode-ai',
   };
   const hint = installHints[command] ?? `install the "${command}" CLI`;

--- a/packages/api/src/utils/cli-resolve.ts
+++ b/packages/api/src/utils/cli-resolve.ts
@@ -111,6 +111,23 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
     resolvedCache.delete(command);
   }
 
+  // #1173: For the bare `kimi` command, probe the official Kimi Code layout
+  // before PATH. The official installer lays down `~/.kimi-code/bin/kimi`,
+  // while legacy `kimi-cli` users may still have a bare `kimi` on PATH that
+  // does not support ACP. Treating `kimi` as the official binary name keeps
+  // ACP `kimi acp` from silently selecting the legacy PATH hit. Users who want
+  // to force a specific PATH binary can still use a distinct command name.
+  if (!IS_WINDOWS && command === 'kimi') {
+    const home = process.env.HOME ?? '';
+    if (home) {
+      const kimiCodeCandidate = resolve(home, KIMI_CODE_UNIX_DIR, command);
+      if (existsSync(kimiCodeCandidate)) {
+        resolvedCache.set(command, kimiCodeCandidate);
+        return kimiCodeCandidate;
+      }
+    }
+  }
+
   // Fast path: already in PATH
   // #894: caller can skip this when PATH was already probed (e.g. client-detection
   // does its own `command -v`; repeating `which` is redundant + slower).
@@ -160,18 +177,6 @@ export function resolveCliCommand(command: string, opts?: { skipPathProbe?: bool
   } else {
     const home = process.env.HOME ?? '';
     if (home) {
-      // #1173: Kimi Code's official installer lays down `~/.kimi-code/bin/kimi`.
-      // Probe this command-specific directory first so ACP `kimi acp` does not
-      // silently fall back to a legacy `~/.local/bin/kimi` that lacks ACP support.
-      // PATH still wins if the caller explicitly put a `kimi` on PATH — this only
-      // governs the fallback search order.
-      if (command === 'kimi') {
-        const kimiCodeCandidate = resolve(home, KIMI_CODE_UNIX_DIR, command);
-        if (existsSync(kimiCodeCandidate)) {
-          resolvedCache.set(command, kimiCodeCandidate);
-          return kimiCodeCandidate;
-        }
-      }
       // Static well-known directories (relative to $HOME)
       for (const dir of UNIX_SEARCH_DIRS) {
         const candidate = resolve(home, dir, command);

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -465,6 +465,42 @@ test(
 );
 
 test(
+  'resolveCliCommand prefers official Kimi Code binary over legacy PATH hit (Unix)',
+  { skip: process.platform === 'win32' && 'Unix-only (Kimi Code PATH priority)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-kimi-code-path-priority-'));
+    const pathBin = join(tempRoot, 'path-bin');
+    const officialBin = join(tempRoot, '.kimi-code', 'bin');
+    mkdirSync(pathBin, { recursive: true });
+    mkdirSync(officialBin, { recursive: true });
+
+    const pathKimi = join(pathBin, 'kimi');
+    const officialKimi = join(officialBin, 'kimi');
+    writeFileSync(pathKimi, '#!/bin/sh\necho path-legacy\n', { mode: 0o755 });
+    writeFileSync(officialKimi, '#!/bin/sh\necho official\n', { mode: 0o755 });
+
+    const originalHome = process.env.HOME;
+    const originalPath = process.env.PATH;
+    try {
+      process.env.HOME = tempRoot;
+      // PATH contains a legacy `kimi`; official layout is also present.
+      process.env.PATH = pathBin;
+      invalidateCliCommand('kimi');
+
+      const result = resolveCliCommand('kimi');
+      assert.equal(result, officialKimi, 'should prefer official ~/.kimi-code/bin/kimi over legacy PATH hit');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      invalidateCliCommand('kimi');
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
   'resolveCliCommand does not search HOME/.kimi-code/bin for non-kimi commands (Unix)',
   { skip: process.platform === 'win32' && 'Unix-only (command-specific fallback isolation)' },
   () => {

--- a/packages/api/test/cli-resolve.test.js
+++ b/packages/api/test/cli-resolve.test.js
@@ -50,6 +50,16 @@ test('formatCliNotFoundError returns generic hint for unknown CLI', () => {
   assert.match(msg, /install the "unknown-tool" CLI/);
 });
 
+test('formatCliNotFoundError points Kimi users at official Kimi Code installer', () => {
+  const msg = formatCliNotFoundError('kimi');
+  assert.match(msg, /kimi CLI 未找到/);
+  if (process.platform === 'win32') {
+    assert.match(msg, /code\.kimi\.com\/kimi-code\/install\.ps1/);
+  } else {
+    assert.match(msg, /code\.kimi\.com\/kimi-code\/install\.sh/);
+  }
+});
+
 // --- resolveCliCommandOrBare ---
 
 test('resolveCliCommandOrBare returns bare name when CLI not found', () => {
@@ -379,6 +389,108 @@ test(
     } finally {
       if (originalHome === undefined) delete process.env.HOME;
       else process.env.HOME = originalHome;
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+// --- #1173: Kimi Code official installer layout ---
+
+test(
+  'resolveCliCommand finds official Kimi Code binary in HOME/.kimi-code/bin (Unix)',
+  { skip: process.platform === 'win32' && 'Unix-only (Kimi Code fallback)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-kimi-code-'));
+    const officialBin = join(tempRoot, '.kimi-code', 'bin');
+    mkdirSync(officialBin, { recursive: true });
+
+    const officialKimi = join(officialBin, 'kimi');
+    writeFileSync(officialKimi, '#!/bin/sh\necho official\n', { mode: 0o755 });
+
+    const originalHome = process.env.HOME;
+    const originalPath = process.env.PATH;
+    try {
+      process.env.HOME = tempRoot;
+      // Empty PATH so the test exercises HOME fallback, not PATH.
+      process.env.PATH = '';
+      invalidateCliCommand('kimi');
+
+      const result = resolveCliCommand('kimi');
+      assert.equal(result, officialKimi, 'should find official ~/.kimi-code/bin/kimi');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      invalidateCliCommand('kimi');
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  'resolveCliCommand prefers Kimi Code official binary over legacy HOME/.local/bin/kimi when PATH misses (Unix)',
+  { skip: process.platform === 'win32' && 'Unix-only (Kimi Code layout priority)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-kimi-code-priority-'));
+    const legacyBin = join(tempRoot, '.local', 'bin');
+    const officialBin = join(tempRoot, '.kimi-code', 'bin');
+    mkdirSync(legacyBin, { recursive: true });
+    mkdirSync(officialBin, { recursive: true });
+
+    const legacyKimi = join(legacyBin, 'kimi');
+    const officialKimi = join(officialBin, 'kimi');
+    writeFileSync(legacyKimi, '#!/bin/sh\necho legacy\n', { mode: 0o755 });
+    writeFileSync(officialKimi, '#!/bin/sh\necho official\n', { mode: 0o755 });
+
+    const originalHome = process.env.HOME;
+    const originalPath = process.env.PATH;
+    try {
+      process.env.HOME = tempRoot;
+      // Empty PATH: resolver must fall back to HOME directories.
+      process.env.PATH = '';
+      invalidateCliCommand('kimi');
+
+      const result = resolveCliCommand('kimi');
+      assert.equal(result, officialKimi, 'should prefer official ~/.kimi-code/bin/kimi over legacy ~/.local/bin/kimi');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      invalidateCliCommand('kimi');
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  'resolveCliCommand does not search HOME/.kimi-code/bin for non-kimi commands (Unix)',
+  { skip: process.platform === 'win32' && 'Unix-only (command-specific fallback isolation)' },
+  () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cli-resolve-kimi-code-isolation-'));
+    const officialBin = join(tempRoot, '.kimi-code', 'bin');
+    mkdirSync(officialBin, { recursive: true });
+
+    const cmdName = `fake-kimi-code-isolated-tool-${process.pid}-${Date.now()}`;
+    const fakeBin = join(officialBin, cmdName);
+    writeFileSync(fakeBin, '#!/bin/sh\necho ok\n', { mode: 0o755 });
+
+    const originalHome = process.env.HOME;
+    const originalPath = process.env.PATH;
+    try {
+      process.env.HOME = tempRoot;
+      process.env.PATH = '';
+      invalidateCliCommand(cmdName);
+
+      const result = resolveCliCommand(cmdName);
+      assert.equal(result, null, 'should not find non-kimi commands in ~/.kimi-code/bin');
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalPath === undefined) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      invalidateCliCommand(cmdName);
       rmSync(tempRoot, { recursive: true, force: true });
     }
   },


### PR DESCRIPTION
Part of #1173

Kimi Code 0.29.0 installs the `kimi` binary at `~/.kimi-code/bin/kimi`. The existing resolver only searched PATH and generic fallback directories, so ACP `kimi acp` failed with `spawn kimi ENOENT` in non-interactive environments.

Changes:
- `resolveCliCommand('kimi')` probes `~/.kimi-code/bin` before generic Unix fallback dirs, and now also before PATH when the official layout is present, so ACP `kimi acp` does not accidentally pick up a legacy `kimi` on PATH that lacks ACP support.
- Legacy users continue to use the distinct `kimi-cli` name (see KimiAgentService).
- Updates the Kimi not-found hint to the official installer script.
- Adds Unix regression tests for discovery, priority over legacy `~/.local/bin/kimi`, PATH-hit dual-install, and command-specific isolation.

Evidence:
- `pnpm --filter @cat-cafe/api build` ✅
- `node --test packages/api/test/cli-resolve.test.js` → 20 pass / 4 skipped (Windows-only) ✅
- `node --test packages/api/test/acp/*.test.js` → 269 pass / 0 fail ✅
- `CAT_KIMI_MODEL=... node --test packages/api/test/kimi-agent-service.test.js` → 19 pass / 0 fail ✅
- `pnpm check` ✅

Reviewed-by: @sol (in-thread APPROVE on `dc3d64cce`)

[小狸/k3🐾]