### PR TITLE
docs(F204): add User Journey section to weixin-mp plugin spec

### DIFF
--- a/docs/features/F204-weixin-mp-publisher-plugin.md
+++ b/docs/features/F204-weixin-mp-publisher-plugin.md
@@ -44,6 +44,21 @@ Expected scope:
 - Health check and configuration surface for `APP_ID` / `APP_SECRET`.
 - Platform-aware limb adapter only where the F202 generic limb contract cannot express Weixin MP behavior.
 
+## User Journey
+
+**Scope unit**: Plugin settings → Limb tool invocation → WeChat Official Account article
+
+1. User enables the `weixin-mp` plugin in the Plugin settings tab and enters their WeChat Official Account credentials (`App ID` / `App Secret`).
+2. Plugin registers its limb declaration; the health check (`check_status`) verifies API connectivity and access-token acquisition via the WeChat token endpoint.
+3. Cats discover the `weixin-mp` limb tools through `limb_list_available` / `limb_list_tools` and can invoke publishing workflows during conversations.
+4. Typical publish flow driven by cats:
+   - `convert_markdown` — convert Markdown content to WeChat-compatible inline-styled HTML
+   - `upload_image` / `upload_media` — upload cover art and inline images to the WeChat CDN
+   - `create_draft` — assemble a draft article in the WeChat drafts box
+   - `publish_draft` — submit the draft for publication
+5. User can review draft status (`list_drafts`, `get_publish_status`) and manage published articles (`list_published`, `delete_published`) through cat-invoked limb commands.
+6. Errors (expired tokens, invalid credentials, content-safety rejections) surface as actionable messages in the conversation — the plugin auto-refreshes tokens on `40001`/`40014`/`42001` error codes.
+
 ## Non-Goals
 
 - Do not reopen personal WeChat iLink Bot messaging from F137.

--- a/docs/features/F204-weixin-mp-publisher-plugin.md
+++ b/docs/features/F204-weixin-mp-publisher-plugin.md
@@ -53,10 +53,10 @@ Expected scope:
 3. Cats discover the `weixin-mp` limb tools through `limb_list_available` / `limb_list_tools` and can invoke publishing workflows during conversations.
 4. Typical publish flow driven by cats:
    - `convert_markdown` — convert Markdown content to WeChat-compatible inline-styled HTML
-   - `upload_image` / `upload_media` — upload cover art and inline images to the WeChat CDN
+   - `upload_image` / `upload_material` — upload inline images and permanent cover-art media to the WeChat CDN
    - `create_draft` — assemble a draft article in the WeChat drafts box
-   - `publish_draft` — submit the draft for publication
-5. User can review draft status (`list_drafts`, `get_publish_status`) and manage published articles (`list_published`, `delete_published`) through cat-invoked limb commands.
+   - `submit_publish` — submit the draft for publication
+5. User can review draft status (`list_drafts`, `publish_status`) and manage published articles (`list_articles`, `delete_article`) through cat-invoked limb commands.
 6. Errors (expired tokens, invalid credentials, content-safety rejections) surface as actionable messages in the conversation — the plugin auto-refreshes tokens on `40001`/`40014`/`42001` error codes.
 
 ## Non-Goals


### PR DESCRIPTION
## Summary

- Add `## User Journey` section to `docs/features/F204-weixin-mp-publisher-plugin.md`
- F204 was merged (PR #1058) before the `check-feature-truth.mjs` User Journey gate existed, creating a spec debt
- Any branch whose diff includes the F204 doc (e.g. PR #1105) now fails `[user-journey-missing] F204`
- The journey covers the full plugin lifecycle: enable → configure credentials → health check → markdown conversion → image upload → draft creation → publish → status tracking

## Verification

- `node scripts/check-feature-truth.mjs` → PASS (journey_docs_checked=1)
- Doc-only change, no code impact

## Test plan

- [ ] `pnpm check:features` passes on this branch
- [ ] PR #1105 can rebase onto main (after this merges) and clear the F204 gate

🐾 Generated by 宪宪/claude-opus-4-6