### PR TITLE
docs(F204): add capability tip for weixin-mp publisher plugin

### DIFF
--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -816,14 +816,10 @@
     "sourceRef": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" },
     "structureSource": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "What" },
     "bodySource": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" },
-    "contexts": ["feature_dev"],
-    "audience": ["cvo", "developer"],
+    "contexts": ["thinking", "long_running"],
+    "audience": ["cvo"],
     "body": "微信公众号插件已就绪：设置 → 插件 → weixin-mp → 配置 App ID 和 App Secret 并启用。猫猫可以帮你把 Markdown 转成微信格式、上传图片、创建草稿、一键发布文章。",
-    "action": {
-      "type": "open_source",
-      "label": "打开 F204 spec",
-      "sourceRef": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" }
-    },
+    "action": { "type": "open_concierge_draft", "label": "了解更多" },
     "owner": "opus"
   }
 ]

--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -809,5 +809,21 @@
       "sourceRef": { "path": "docs/features/F205-video-provider-plugins.md", "anchor": "User Journey" }
     },
     "owner": "opus"
+  },
+  {
+    "id": "feature-f204-weixin-mp-plugin",
+    "kind": "feature",
+    "sourceRef": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" },
+    "structureSource": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "What" },
+    "bodySource": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" },
+    "contexts": ["feature_dev"],
+    "audience": ["cvo", "developer"],
+    "body": "微信公众号插件已就绪：设置 → 插件 → weixin-mp → 配置 App ID 和 App Secret 并启用。猫猫可以帮你把 Markdown 转成微信格式、上传图片、创建草稿、一键发布文章。",
+    "action": {
+      "type": "open_source",
+      "label": "打开 F204 spec",
+      "sourceRef": { "path": "docs/features/F204-weixin-mp-publisher-plugin.md", "anchor": "User Journey" }
+    },
+    "owner": "opus"
   }
 ]


### PR DESCRIPTION
## Summary

- Add a `feature` kind capability tip for F204 (weixin-mp publisher plugin) to `capability-tips.seed.json`
- Same pattern as the User Journey debt fixed in #1214: F204 was merged before the capability-tips gate existed
- Follows F205 (video-provider-plugins) tip structure — `sourceRef` → User Journey, user-facing body describing setup + publish workflow
- Unblocks any branch whose diff includes the F204 doc (e.g. PR #1105)

## Verification

- `node scripts/check-capability-tips.mjs --changed-file docs/features/F204-weixin-mp-publisher-plugin.md` → PASS
- 7 pre-existing warnings (unrelated), 0 new warnings/errors
- Pre-commit hooks (biome) pass

## Test plan

- [ ] `pnpm check:features` passes (no regression from #1214)
- [ ] `node scripts/check-capability-tips.mjs --changed-file docs/features/F204-weixin-mp-publisher-plugin.md` → PASS
- [ ] PR #1105 can rebase onto main (after this merges) and clear the capability-tips gate

🐾 Generated by 宪宪/claude-opus-4-6