### PR TITLE
fix(agent-hooks): surface local detection failures

### DIFF
--- a/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
+++ b/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
@@ -74,6 +74,58 @@ tips_exempt:
 | **7. 用户可见交互修正** | 初始化完成立即以新请求复检，初始化前错误即使晚到也不会重新出现。 |
 | **8. 验收** | Red→Green 竞态测试验证 refresh 强制新请求且旧响应无法覆盖；项目切换、缓存、400/403、sync 测试全绿。 |
 
+### 补充诊断胶囊：Drift 读侧写权限必须复用完整授权门禁
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | 直接 localhost 页面在会话失效或当前用户不是 owner 时仍显示 Skill/MCP 写控件；真正调用 resolve 才返回 401/403。期望 check 保持可读，但 `syncAllowed` 与 resolve 的认证、localhost、owner 判据完全一致。 |
+| **2. 证据** | 精确 HEAD `c3f0b84dc` 上，`/api/drift/check` 仅调用 `isLocalCapabilityWriteRequest()`，而 `/api/drift/resolve` 依次调用 `resolveSessionUserId()`、localhost 门禁和 `resolveOwnerGate()`。 |
+| **3. 根因** | 同一写权限被拆成两个不同真相源：check 只暴露网络局部判据，resolve 才执行完整授权；客户端无法区分“本机但未认证/非 owner”。 |
+| **4. 诊断策略** | 抽取无副作用的统一授权评估函数；check 只读取 allowed 布尔值，resolve 再把同一评估结果映射为 HTTP 状态。 |
+| **5. 超时策略** | 若读取端复用授权会改变 check 的 200 语义，停止复用 reply 写入逻辑，保留纯评估结果与响应映射两层。 |
+| **6. 预警策略** | 若实现仍在 check 内单独判断 hostname、session 或 owner，说明权限第二真相源仍存在。 |
+| **7. 用户可见交互修正** | 会话失效或非 owner 仍可查看异常，但所有写控件保持只读；本机有效 owner 的操作不受影响。 |
+| **8. 验收** | API 回归覆盖无会话、非 owner、有效 owner、forwarded 和非 loopback bind；check 均保持可读并返回与 resolve 一致的 `syncAllowed`。 |
+
+### 补充诊断胶囊：MCP 弹窗写权限异步定案
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | 本机用户在写权限 check 尚未返回时打开外部 MCP，弹窗会永久停在只读状态；即使服务端随后返回 `syncAllowed=true`，也必须关闭重开才可编辑。 |
+| **2. 证据** | 精确 HEAD `c3f0b84dc` 上，`handleCardClick()` 把当时的 `!driftSync.canSync` 写入 `modal.readOnly`；渲染时只把最新权限传给 `allowLocalActions`，没有重新计算 `readOnly`。 |
+| **3. 根因** | 服务端权威权限的异步结果被错误地快照进弹窗状态；state 混合了 MCP 自身不可编辑属性与会变化的请求授权。 |
+| **4. 诊断策略** | 弹窗 state 只保存 MCP 自身的只读属性；渲染时再与最新 `canSync` 合成最终 `readOnly`。 |
+| **5. 超时策略** | 若 modal 内部初始化仍锁住旧 props，停止在父组件补 key，改为审计 modal effect 的依赖并保持同一实例响应 prop 更新。 |
+| **6. 预警策略** | 任何把 `canSync` 再次写入 `useState`、或靠关闭重开恢复的方案，都说明权威状态仍被复制。 |
+| **7. 用户可见交互修正** | 本机权限确认后，已经打开的外部 MCP 弹窗会原地恢复保存、探测与项目恢复操作；远程仍只读。 |
+| **8. 验收** | Web 回归在 drift check pending 时打开弹窗，随后返回 `syncAllowed=true`，无需重开即可看到保存控件。 |
+
+### 补充诊断胶囊：Thread detail 对账必须 latest-request-wins
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | mount 触发的 thread detail GET 与 invocation-end 触发的 GET 重叠时，较旧响应可能最后到达并把新的 `projectPath` 覆盖回旧值。 |
+| **2. 证据** | 精确 HEAD `c3f0b84dc` 上，两个触发点共用 `syncThreadState()`，每个成功响应都会无条件调用 `syncThreadDetailToLocalState()`，没有 abort 或 generation 检查。 |
+| **3. 根因** | 对同一权威资源的并发读取缺少请求世代；网络完成顺序被误当成数据新旧顺序。 |
+| **4. 诊断策略** | 在唯一 `syncThreadState()` 入口递增 generation；只有当前最新请求允许写 store，线程切换自然使旧 generation 失效。 |
+| **5. 超时策略** | 若组件级 generation 无法覆盖 thread 切换，改为带 threadId 的 token，而不是在每个触发 effect 增加独立布尔值。 |
+| **6. 预警策略** | 若只保护 `setCurrentProject` 或只保护 threads 数组，另一份镜像仍会回退；必须在调用统一对账函数前整体拦截旧响应。 |
+| **7. 用户可见交互修正** | invocation 结束后的最新项目绑定不会再被较早的 mount 请求回滚。 |
+| **8. 验收** | Web 回归让第二次 GET 先返回新路径、第一次 GET 后返回旧路径，最终 store 与 current project 都保持新路径。 |
+
+### 补充诊断胶囊：Skill 源根必须指向持久 workspace
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | Nalo 的 `anime-forge` 四个 provider 均链接到 `/Volumes/WorkSSD/clowder-ai/cat-cafe-skills/anime-forge`，runtime 却把它们报告为同名冲突，并警告立即同步会覆盖已有内容。 |
+| **2. 证据** | 四个实际链接均解析到持久 workspace 的 tracked `anime-forge` 目录；`/api/drift/check` 返回四个 conflict。`resolveCatCafeSkillsSource()` 只返回当前 runtime worktree 的 `cat-cafe-skills`，没有 runtime→workspace 重定向。 |
+| **3. 根因** | Skill 的 canonical source 仍绑定可丢弃 runtime checkout，而 capability 配置和既有项目链接以持久 workspace 为真相源；相同内容的不同绝对路径被 symlink 检测器正确地视为冲突。 |
+| **4. 诊断策略** | 让中央 `resolveCatCafeSkillsSource()` 对当前 worktree source 复用 `redirectRuntimeProjectPath()`；开发 worktree 保持自身 source，runtime 映射到 workspace 同相对路径。 |
+| **5. 超时策略** | 若中央重定向影响开发 worktree，停止在 route 层特判，给源根解析器注入 runtime/workspace 根并用纯单元测试钉住两种模式。 |
+| **6. 预警策略** | 若方案改写 Nalo 链接、复制 skill 内容或让 conflict 同步继续覆盖，说明在修数据而不是修坐标系。 |
+| **7. 用户可见交互修正** | Nalo 的四个合法 `anime-forge` 挂载不再显示冲突；无需备份或重新同步现有链接。 |
+| **8. 验收** | 路由回归模拟 runtime 与 workspace 分离，项目链接指向 workspace；`anime-forge` 不产生 drift。实际 Nalo 只读复查四个 provider 均为 configured。 |
+
 ## Bug report 五件套
 
 1. **报告人**：co-creator 在 cpolar 远程使用时发现 Agent 同步状态异常。

--- a/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
+++ b/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
@@ -1,3 +1,12 @@
+---
+topics: [agent-hooks, mcp, runtime, cpolar, drift]
+doc_kind: bug-report
+created: 2026-07-28
+updated: 2026-07-28
+tips_exempt:
+  reason: Correctness and safety fixes for existing Agent Hook and Skill/MCP drift workflows; no new user-facing capability.
+---
+
 # Agent Hook runtime MCP root bug
 
 ## Bug 诊断胶囊
@@ -12,6 +21,19 @@
 | **6. 预警策略** | 任何方案若需要复制 runtime `.cat-cafe/capabilities.json`、删除项目 MCP 或增加第二套配置真相源，立即停止。 |
 | **7. 用户可见交互修正** | 七类健康状态应全部 configured；本机同步不会删除核心 MCP。远程 localhost 门禁保持不变。 |
 | **8. 验收** | 新测试证明 runtime root 映射到持久 workspace；Agent Hook API 测试全绿；使用实际两套根目录复查 MCP drift 为 0，核心 MCP 数量保持 6。 |
+
+### 补充诊断胶囊：未初始化项目 Drift 同步边界
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | 历史项目目录缺少 `.cat-cafe` 时，单项目 Drift 页面仍展示同步入口，`POST /api/drift/resolve` 也会接受写入。期望未初始化项目只读，且服务端拒绝 Skill/MCP 同步。 |
+| **2. 证据** | 精确 HEAD `2488428aa` 上，Skill 与 MCP resolve 对临时未初始化目录均返回 200；`DriftBanner` 忽略 check 响应中的 `initialized=false`。 |
+| **3. 根因** | 全项目同步已过滤未初始化路径，但单项目共用组件和 resolve 写边界没有复用“显式项目必须已有 `.cat-cafe`”这一不变量。 |
+| **4. 诊断策略** | 用临时目录分别调用 Skill/MCP resolve，并对共用 `DriftBanner` 注入 `initialized=false`，验证服务端与 UI 两层边界。 |
+| **5. 超时策略** | 若两种 resolver 的根解析语义不同，停止抽象共用路径，分别验证解析后的 effective root 再收敛边界。 |
+| **6. 预警策略** | 若修复需要创建 `.cat-cafe`、补默认配置或静默跳过写入，说明仍在掩盖未初始化状态，应维持显式 400。 |
+| **7. 用户可见交互修正** | 未初始化历史项目仍可查看异常详情，但会显示初始化提示且不再提供同步按钮。 |
+| **8. 验收** | API 回归验证 Skill/MCP 均返回 400 且不创建 `.cat-cafe`；前端回归验证 localhost 下也隐藏同步入口；完整门禁通过。 |
 
 ## Bug report 五件套
 

--- a/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
+++ b/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
@@ -35,6 +35,19 @@ tips_exempt:
 | **7. 用户可见交互修正** | 未初始化历史项目仍可查看异常详情，但会显示初始化提示且不再提供同步按钮。 |
 | **8. 验收** | API 回归验证 Skill/MCP 均返回 400 且不创建 `.cat-cafe`；前端回归验证 localhost 下也隐藏同步入口；完整门禁通过。 |
 
+### 补充诊断胶囊：Capability 写权限的服务端权威性
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | 页面 hostname 为 localhost 时，`useDriftSync` 会展示全部 Skill/MCP 写控件；但若请求带 forwarding headers 或 API 绑定非 loopback，服务端仍返回 403。期望 UI 与服务端使用同一个可写性判据。 |
+| **2. 证据** | 精确 HEAD `97c4a716b` 上，客户端只检查 `window.location.hostname`；`isLocalCapabilityWriteRequest()` 还会检查 API bind host、socket peer、Host、Origin 和八类 proxy forwarding headers。 |
+| **3. 根因** | `canSync` 在客户端重新实现了服务端安全策略的一个子集，形成第二个权限真相源；反向代理的同源 localhost 页面因此可误判为可写。 |
+| **4. 诊断策略** | 用同一 `/api/drift/check` 请求验证 direct localhost、forwarded localhost 与 non-loopback API bind 三种状态，并让 Skill/MCP 共用 hook 只消费服务端返回值。 |
+| **5. 超时策略** | 若 check 与 resolve 请求无法共享同一门禁函数，停止添加客户端例外，改为独立的权限探测端点并由服务端复用门禁。 |
+| **6. 预警策略** | 若实现仍读取 `window.location`、复制 loopback host 列表或为不同控件分别探测，说明第二真相源尚未消除。 |
+| **7. 用户可见交互修正** | 只要服务端判定当前请求不可写，Skill/MCP 页面立即进入完整只读态，不再出现点击后必然 403 的操作。 |
+| **8. 验收** | API 回归覆盖三种权威状态；Web 回归证明 localhost hostname 不能覆盖服务端 `syncAllowed=false`，且 `syncAllowed=true` 时本地动作仍可用。 |
+
 ## Bug report 五件套
 
 1. **报告人**：co-creator 在 cpolar 远程使用时发现 Agent 同步状态异常。

--- a/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
+++ b/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
@@ -48,6 +48,32 @@ tips_exempt:
 | **7. 用户可见交互修正** | 只要服务端判定当前请求不可写，Skill/MCP 页面立即进入完整只读态，不再出现点击后必然 403 的操作。 |
 | **8. 验收** | API 回归覆盖三种权威状态；Web 回归证明 localhost hostname 不能覆盖服务端 `syncAllowed=false`，且 `syncAllowed=true` 时本地动作仍可用。 |
 
+### 补充诊断胶囊：Capability 写权限探测生命周期
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | Capability 列表仍在加载时切到项目 Skill/MCP，页面可能永久隐藏本地写控件。期望标签页只控制完整 Drift 报告，不能阻止服务端写权限首次定案。 |
+| **2. 证据** | 精确 HEAD `d1eef245c` 上，两个页面都在项目标签或列表 loading 时传入 `enabled=false`；`useDriftSync` 因此不发首次全局 check，`scopeDrift.global` 缺失使 `canSync` 永久为 false。 |
+| **3. 根因** | `enabled` 同时承担“是否加载所有项目报告”和“是否解析全局写权限”两个生命周期不同的职责，标签页优化意外关闭了权限真相源。 |
+| **4. 诊断策略** | 直接以 `enabled=false` 挂载共用 hook，验证仍只发一次 global check，并在服务端返回 `syncAllowed=true` 后开放写权限。 |
+| **5. 超时策略** | 若初始 global check 与后续完整报告发生覆盖竞态，停止在消费者层加例外，拆分 hook 内的 authority/report generation。 |
+| **6. 预警策略** | 若修复读取 `window.location`、在 Skill/MCP 两处复制探测逻辑或项目标签触发全部项目扫描，说明仍未分离职责。 |
+| **7. 用户可见交互修正** | 本机用户即使在加载期间切换标签，也会在服务端确认后正常看到 Skill/MCP 写控件；远程仍保持只读。 |
+| **8. 验收** | 共用 hook 回归证明 disabled report mode 仍解析 global `syncAllowed`，且不会请求项目范围；既有 Skill/MCP 只读与本地可写测试保持通过。 |
+
+### 补充诊断胶囊：Agent Hook 初始化后刷新竞态
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | 项目初始化完成后，Agent Hook 刷新可能继续显示初始化前的 400，直到用户再次刷新或重载页面。 |
+| **2. 证据** | 精确 HEAD `d1eef245c` 上，`refresh()` 只清 cache；同项目 `inFlightStatus` 仍被 `readAgentHookStatus()` 复用。旧请求还会在新状态之后写回模块 cache 和 hook state。 |
+| **3. 根因** | 模块缓存与组件状态都没有“最新请求获胜”的世代标识；cache invalidation 没有使在途请求失效，`.finally()` 也无条件清理共享请求槽。 |
+| **4. 诊断策略** | 让初始化前 GET 保持 pending，触发 refresh 后先返回 configured，再返回旧 400；断言确实发出第二次 GET，最终 UI/cache 都保持 configured。并审计项目切换与 sync 的同类覆盖路径。 |
+| **5. 超时策略** | 若单个 generation 无法同时保护 cache 与组件 state，停止追加布尔标志，统一所有 read/refresh/sync 走一个带 request id 的加载入口。 |
+| **6. 预警策略** | 若修复只是把 `inFlightStatus=null`、只 await 旧请求或只保护 cache，旧结果仍可能覆盖 UI；必须同时保护共享状态和 hook state。 |
+| **7. 用户可见交互修正** | 初始化完成立即以新请求复检，初始化前错误即使晚到也不会重新出现。 |
+| **8. 验收** | Red→Green 竞态测试验证 refresh 强制新请求且旧响应无法覆盖；项目切换、缓存、400/403、sync 测试全绿。 |
+
 ## Bug report 五件套
 
 1. **报告人**：co-creator 在 cpolar 远程使用时发现 Agent 同步状态异常。

--- a/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
+++ b/docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md
@@ -1,0 +1,22 @@
+# Agent Hook runtime MCP root bug
+
+## Bug 诊断胶囊
+
+| 栏位 | 内容 |
+|------|------|
+| **1. 现象** | Agent Hook 健康检查把当前 Clowder AI 项目的 6 个核心 `cat-cafe-*` MCP 报为 stale；直接同步会把它们当作 project orphan 删除。期望 runtime 模式使用持久工作区作为全局 MCP 基线。 |
+| **2. 证据** | Runtime API PID 40025 运行于 commit `7f86fd208`；`getAgentHookStatus` 返回其余 6 类 configured、MCP `6 drift issues`。逐项检查为 6 个 `project-orphan`，而 runtime worktree 的 capabilities 中没有 MCP，持久工作区包含全部 6 个核心 MCP。 |
+| **3. 根因** | `agent-hooks/health.ts` 直接使用 `resolveStartupProjectRoot()` 作为 MCP 全局根。在 runtime 模式该值是一次性二进制 worktree；它没有持久 MCP 配置。其他 MCP/Skills 路由会先用 `redirectRuntimeProjectPath()` 映射到 `CAT_CAFE_WORKSPACE_ROOT`，Agent Hook 健康检查遗漏了这一步。 |
+| **4. 诊断策略** | 对照 `routes/mcp-drift.ts` 的工作实现；给 Agent Hook 全局根解析增加同样的 runtime→workspace 映射，并让检测与同步复用同一解析结果。 |
+| **5. 超时策略** | 若根映射回归测试不能稳定复现，停止修改同步器，转而把根解析抽成可注入依赖后测试。 |
+| **6. 预警策略** | 任何方案若需要复制 runtime `.cat-cafe/capabilities.json`、删除项目 MCP 或增加第二套配置真相源，立即停止。 |
+| **7. 用户可见交互修正** | 七类健康状态应全部 configured；本机同步不会删除核心 MCP。远程 localhost 门禁保持不变。 |
+| **8. 验收** | 新测试证明 runtime root 映射到持久 workspace；Agent Hook API 测试全绿；使用实际两套根目录复查 MCP drift 为 0，核心 MCP 数量保持 6。 |
+
+## Bug report 五件套
+
+1. **报告人**：co-creator 在 cpolar 远程使用时发现 Agent 同步状态异常。
+2. **复现步骤**：runtime worktree 与持久 workspace 分离；runtime capabilities 无 MCP、workspace 有核心 MCP；运行 Agent Hook 健康检查。
+3. **根因分析**：Agent Hook MCP 路径遗漏持久根重定向，错误地把二进制 worktree 当作配置真相源。
+4. **修复方案**：复用 `redirectRuntimeProjectPath()`；不复制配置、不放宽远程门禁、不删除 MCP。
+5. **验证方式**：Red→Green 根映射测试、Agent Hook 定向测试、实际配置只读复查。

--- a/packages/api/src/agent-hooks/health.ts
+++ b/packages/api/src/agent-hooks/health.ts
@@ -5,6 +5,7 @@ import { checkMcpProject, type McpDriftResult, type McpIssue } from '../mcp/mcp-
 import { syncMcpDrift } from '../mcp/mcp-drift-resolver.js';
 import { computeSkillDrift } from '../routes/skills-drift.js';
 import { syncDrift } from '../skills/drift-resolver.js';
+import { redirectRuntimeProjectPath } from '../utils/persistent-project-path.js';
 import { resolveStartupProjectRoot } from '../utils/startup-root.js';
 import { claudeSettingsHealth, syncClaudeSettings } from './claude-settings.js';
 import {
@@ -242,6 +243,12 @@ function filterOrphanIssues(drift: McpDriftResult, globalConfigValid: boolean): 
   });
 }
 
+export async function resolveAgentHookGlobalRoot(
+  startupRoot: string = resolveStartupProjectRoot(),
+): Promise<string | null> {
+  return redirectRuntimeProjectPath(startupRoot);
+}
+
 async function checkMcpHealth(projectRoot: string): Promise<HealthResult> {
   try {
     // Skip MCP drift check if the project has no capabilities.json —
@@ -249,9 +256,18 @@ async function checkMcpHealth(projectRoot: string): Promise<HealthResult> {
     if (!existsSync(join(projectRoot, '.cat-cafe', 'capabilities.json'))) {
       return { name: 'mcp', drifted: false, status: 'configured', targetPath: '', reason: 'no project capabilities' };
     }
-    const startupRoot = resolveStartupProjectRoot();
-    const globalConfig = await readCapabilitiesConfig(startupRoot);
-    const drift = await checkMcpProject(projectRoot, startupRoot, globalConfig);
+    const globalRoot = await resolveAgentHookGlobalRoot();
+    if (!globalRoot) {
+      return {
+        name: 'mcp',
+        drifted: false,
+        status: 'error',
+        targetPath: '',
+        reason: 'persistent global MCP root is unavailable',
+      };
+    }
+    const globalConfig = await readCapabilitiesConfig(globalRoot);
+    const drift = await checkMcpProject(projectRoot, globalRoot, globalConfig);
     const actionableIssues = filterOrphanIssues(drift, globalConfig !== null);
     if (actionableIssues.length === 0) {
       return { name: 'mcp', drifted: false, status: 'configured', targetPath: '', reason: 'configured' };
@@ -266,6 +282,46 @@ async function checkMcpHealth(projectRoot: string): Promise<HealthResult> {
   } catch {
     return { name: 'mcp', drifted: false, status: 'configured', targetPath: '', reason: 'configured' };
   }
+}
+
+async function syncSkillCapabilities(projectRoot: string): Promise<void> {
+  try {
+    const ctx = await computeSkillDrift(projectRoot);
+    if (!ctx) return;
+
+    const { newSkills, stale, conflicts } = ctx.drift;
+    if (newSkills.length + stale.length + conflicts.length === 0) return;
+
+    await syncDrift(ctx.effectiveRoot, ctx.skillsSource, ctx.mountRules, ctx.drift, ctx.syncOpts, 'keep-project');
+  } catch {
+    /* skill sync failure should not block hook sync result */
+  }
+}
+
+async function syncMcpCapabilities(
+  projectRoot: string,
+  globalRoot: string,
+  globalConfig: Awaited<ReturnType<typeof readCapabilitiesConfig>>,
+): Promise<void> {
+  try {
+    const drift = await checkMcpProject(projectRoot, globalRoot, globalConfig);
+    const nonDestructiveIssues = filterOrphanIssues(drift, globalConfig !== null);
+    if (nonDestructiveIssues.length === 0) return;
+
+    const safeDrift = { ...drift, issues: nonDestructiveIssues };
+    await syncMcpDrift(projectRoot, globalRoot, safeDrift, undefined, 'keep-project');
+  } catch {
+    /* MCP sync failure should not block hook sync result */
+  }
+}
+
+async function syncCapabilities(projectRoot: string): Promise<void> {
+  const globalRoot = await resolveAgentHookGlobalRoot();
+  if (!globalRoot) return;
+
+  const globalConfig = await readCapabilitiesConfig(globalRoot);
+  if (globalConfig !== null) await syncSkillCapabilities(projectRoot);
+  await syncMcpCapabilities(projectRoot, globalRoot, globalConfig);
 }
 
 // ── Public API ───────────────────────────────────────────────────────────────
@@ -308,46 +364,10 @@ export async function syncAgentHooks(options: AgentHookOptions): Promise<AgentHo
   const projectConfig = options.ownerAuthorized === true ? await readCapabilitiesConfig(capRoot) : null;
   const hasCapabilities = projectConfig !== null;
 
-  if (hasCapabilities) {
-    // Read global config once — both skill and MCP sync compare project
-    // against global.  When global is unreadable (missing / malformed),
-    // every project entry looks like an orphan; skip destructive sync
-    // paths to avoid wiping valid project config.
-    const startupRoot = resolveStartupProjectRoot();
-    const globalConfig = await readCapabilitiesConfig(startupRoot);
-
-    if (globalConfig !== null) {
-      try {
-        const ctx = await computeSkillDrift(capRoot);
-        if (ctx) {
-          const { newSkills, stale, conflicts } = ctx.drift;
-          if (newSkills.length + stale.length + conflicts.length > 0) {
-            await syncDrift(
-              ctx.effectiveRoot,
-              ctx.skillsSource,
-              ctx.mountRules,
-              ctx.drift,
-              ctx.syncOpts,
-              'keep-project',
-            );
-          }
-        }
-      } catch {
-        /* skill sync failure should not block hook sync result */
-      }
-    }
-
-    try {
-      const drift = await checkMcpProject(capRoot, startupRoot, globalConfig);
-      const nonDestructiveIssues = filterOrphanIssues(drift, globalConfig !== null);
-      if (nonDestructiveIssues.length > 0) {
-        const safeDrift = { ...drift, issues: nonDestructiveIssues };
-        await syncMcpDrift(capRoot, startupRoot, safeDrift, undefined, 'keep-project');
-      }
-    } catch {
-      /* MCP sync failure should not block hook sync result */
-    }
-  }
+  // Read global config once — both skill and MCP sync compare project
+  // against global. When it is missing or malformed, skill sync is skipped
+  // and MCP orphan removal remains disabled.
+  if (hasCapabilities) await syncCapabilities(capRoot);
 
   const status = await getAgentHookStatus(options);
   // `hooks.json` semantic equality is canonicalized in health checks; preserve

--- a/packages/api/src/agent-hooks/health.ts
+++ b/packages/api/src/agent-hooks/health.ts
@@ -45,7 +45,7 @@ export interface AgentHookOptions {
   /**
    * When the thread targets an external project, this is that project's path.
    * Skill/MCP health and sync operate against this root instead of projectRoot.
-   * Defaults to projectRoot when not set (root project thread).
+   * Defaults to the persistent workspace root when not set (host-scope request).
    */
   capabilityProjectRoot?: string;
   /**
@@ -249,22 +249,33 @@ export async function resolveAgentHookGlobalRoot(
   return redirectRuntimeProjectPath(startupRoot);
 }
 
-async function checkMcpHealth(projectRoot: string): Promise<HealthResult> {
+async function resolveAgentHookCapabilityRoots(
+  options: AgentHookOptions,
+): Promise<{ capabilityRoot: string; globalRoot: string } | null> {
+  const globalRoot = await resolveAgentHookGlobalRoot(options.projectRoot);
+  if (!globalRoot) return null;
+  return {
+    capabilityRoot: options.capabilityProjectRoot ?? globalRoot,
+    globalRoot,
+  };
+}
+
+function unavailableCapabilityRootHealth(name: 'skills' | 'mcp'): HealthResult {
+  return {
+    name,
+    drifted: false,
+    status: 'error',
+    targetPath: '',
+    reason: 'persistent capability root is unavailable',
+  };
+}
+
+async function checkMcpHealth(projectRoot: string, globalRoot: string): Promise<HealthResult> {
   try {
     // Skip MCP drift check if the project has no capabilities.json —
     // uninitialised projects have no MCP config to drift against.
     if (!existsSync(join(projectRoot, '.cat-cafe', 'capabilities.json'))) {
       return { name: 'mcp', drifted: false, status: 'configured', targetPath: '', reason: 'no project capabilities' };
-    }
-    const globalRoot = await resolveAgentHookGlobalRoot();
-    if (!globalRoot) {
-      return {
-        name: 'mcp',
-        drifted: false,
-        status: 'error',
-        targetPath: '',
-        reason: 'persistent global MCP root is unavailable',
-      };
     }
     const globalConfig = await readCapabilitiesConfig(globalRoot);
     const drift = await checkMcpProject(projectRoot, globalRoot, globalConfig);
@@ -315,10 +326,7 @@ async function syncMcpCapabilities(
   }
 }
 
-async function syncCapabilities(projectRoot: string): Promise<void> {
-  const globalRoot = await resolveAgentHookGlobalRoot();
-  if (!globalRoot) return;
-
+async function syncCapabilities(projectRoot: string, globalRoot: string): Promise<void> {
   const globalConfig = await readCapabilitiesConfig(globalRoot);
   if (globalConfig !== null) await syncSkillCapabilities(projectRoot);
   await syncMcpCapabilities(projectRoot, globalRoot, globalConfig);
@@ -333,8 +341,13 @@ export async function getAgentHookStatus(options: AgentHookOptions): Promise<Age
   // #1049 Step 3: unified health check — hooks + skills + MCPs
   // capabilityProjectRoot targets the thread's project; projectRoot stays
   // the install repo for hook templates.
-  const capRoot = options.capabilityProjectRoot ?? options.projectRoot;
-  const [skillHealth, mcpHealth] = await Promise.all([checkSkillHealth(capRoot), checkMcpHealth(capRoot)]);
+  const capabilityRoots = await resolveAgentHookCapabilityRoots(options);
+  const [skillHealth, mcpHealth] = capabilityRoots
+    ? await Promise.all([
+        checkSkillHealth(capabilityRoots.capabilityRoot),
+        checkMcpHealth(capabilityRoots.capabilityRoot, capabilityRoots.globalRoot),
+      ])
+    : [unavailableCapabilityRootHealth('skills'), unavailableCapabilityRootHealth('mcp')];
   const results = [...hookResults, skillHealth, mcpHealth];
 
   return {
@@ -360,14 +373,19 @@ export async function syncAgentHooks(options: AgentHookOptions): Promise<AgentHo
   //      could cause skill/MCP sync to treat the project as empty and wipe entries.
   // capabilityProjectRoot targets the thread's project for skill/MCP sync;
   // projectRoot stays the install repo for hook templates.
-  const capRoot = options.capabilityProjectRoot ?? options.projectRoot;
-  const projectConfig = options.ownerAuthorized === true ? await readCapabilitiesConfig(capRoot) : null;
+  const capabilityRoots = await resolveAgentHookCapabilityRoots(options);
+  const projectConfig =
+    options.ownerAuthorized === true && capabilityRoots
+      ? await readCapabilitiesConfig(capabilityRoots.capabilityRoot)
+      : null;
   const hasCapabilities = projectConfig !== null;
 
   // Read global config once — both skill and MCP sync compare project
   // against global. When it is missing or malformed, skill sync is skipped
   // and MCP orphan removal remains disabled.
-  if (hasCapabilities) await syncCapabilities(capRoot);
+  if (hasCapabilities && capabilityRoots) {
+    await syncCapabilities(capabilityRoots.capabilityRoot, capabilityRoots.globalRoot);
+  }
 
   const status = await getAgentHookStatus(options);
   // `hooks.json` semantic equality is canonicalized in health checks; preserve

--- a/packages/api/src/agent-hooks/index.ts
+++ b/packages/api/src/agent-hooks/index.ts
@@ -5,6 +5,7 @@ export {
   type AgentHookStatusResponse,
   getAgentHookStatus,
   type HealthResult,
+  resolveAgentHookGlobalRoot,
   syncAgentHooks,
 } from './health.js';
 export {

--- a/packages/api/src/routes/agent-hooks.ts
+++ b/packages/api/src/routes/agent-hooks.ts
@@ -108,8 +108,8 @@ function resolveOptions(options: AgentHooksRouteOptions, targetRoot: string, cap
   return {
     projectRoot: options.projectRoot ?? findMonorepoRoot(process.cwd()),
     targetRoot,
-    // When the thread targets an external project, skill/MCP checks use
-    // that project's config.  Hook templates always come from projectRoot.
+    // Explicit external projects override the persistent host capability scope.
+    // Hook templates always come from projectRoot.
     ...(capabilityProjectRoot ? { capabilityProjectRoot } : {}),
   };
 }

--- a/packages/api/src/routes/agent-hooks.ts
+++ b/packages/api/src/routes/agent-hooks.ts
@@ -100,13 +100,11 @@ async function validateExplicitProjectPath(
   return { ok: true, path: validated };
 }
 
-function resolveOptions(
-  options: AgentHooksRouteOptions,
-  request: FastifyRequest,
-  capabilityProjectRoot?: string | null,
-) {
-  const targetRoot = options.targetRoot ?? (isTrustedLocalApiRequest(request) ? homedir() : null);
-  if (!targetRoot) return null;
+function resolveTargetRoot(options: AgentHooksRouteOptions, request: FastifyRequest): string | null {
+  return options.targetRoot ?? (isTrustedLocalApiRequest(request) ? homedir() : null);
+}
+
+function resolveOptions(options: AgentHooksRouteOptions, targetRoot: string, capabilityProjectRoot?: string | null) {
   return {
     projectRoot: options.projectRoot ?? findMonorepoRoot(process.cwd()),
     targetRoot,
@@ -124,17 +122,19 @@ export const agentHooksRoutes: FastifyPluginAsync<AgentHooksRouteOptions> = asyn
       return { error: 'Session identity required for browser requests' };
     }
 
+    const targetRoot = resolveTargetRoot(options, request);
+    if (!targetRoot) {
+      reply.status(403);
+      return { error: 'Agent hook health requires an explicit targetRoot or a local API host' };
+    }
+
     const query = request.query as Record<string, unknown>;
     const projectValidation = await validateExplicitProjectPath(nonEmptyString(query.projectPath));
     if (!projectValidation.ok) {
       reply.status(400);
       return { error: projectValidation.error };
     }
-    const resolved = resolveOptions(options, request, projectValidation.path);
-    if (!resolved) {
-      reply.status(403);
-      return { error: 'Agent hook health requires an explicit targetRoot or a local API host' };
-    }
+    const resolved = resolveOptions(options, targetRoot, projectValidation.path);
 
     return getAgentHookStatus(resolved);
   });
@@ -146,17 +146,19 @@ export const agentHooksRoutes: FastifyPluginAsync<AgentHooksRouteOptions> = asyn
       return { error: 'Session identity required for browser requests' };
     }
 
+    const targetRoot = resolveTargetRoot(options, request);
+    if (!targetRoot) {
+      reply.status(403);
+      return { error: 'Agent hook sync requires an explicit targetRoot or a local API host' };
+    }
+
     const body = request.body as Record<string, unknown> | null;
     const projectValidation = await validateExplicitProjectPath(nonEmptyString(body?.projectPath));
     if (!projectValidation.ok) {
       reply.status(400);
       return { error: projectValidation.error };
     }
-    const resolved = resolveOptions(options, request, projectValidation.path);
-    if (!resolved) {
-      reply.status(403);
-      return { error: 'Agent hook sync requires an explicit targetRoot or a local API host' };
-    }
+    const resolved = resolveOptions(options, targetRoot, projectValidation.path);
 
     // Capability-level mutations (skill/MCP sync) require owner authorization.
     // Hook file sync (writing to targetRoot) always runs for any session user.

--- a/packages/api/src/routes/drift.ts
+++ b/packages/api/src/routes/drift.ts
@@ -10,6 +10,8 @@
  * one component, and one endpoint for both capability types.
  */
 
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { withCapabilityLock } from '../config/capabilities/capability-orchestrator.js';
 import { requireLocalCapabilityWriteRequest } from '../config/capabilities/capability-write-guards.js';
@@ -66,6 +68,10 @@ function parseType(body: Record<string, unknown>): DriftType | null {
   return null;
 }
 
+function isInitializedProjectScope(projectPath: string | undefined, effectiveRoot: string): boolean {
+  return !projectPath || existsSync(join(effectiveRoot, '.cat-cafe'));
+}
+
 export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
   // ── POST /api/drift/check ──
   app.post('/api/drift/check', async (request, reply) => {
@@ -97,7 +103,11 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
         mountPoint: i.mountPointId,
       }));
       return {
-        result: { issues, driftHash: ctx.drift.driftHash },
+        result: {
+          issues,
+          driftHash: ctx.drift.driftHash,
+          initialized: isInitializedProjectScope(projectPath, ctx.effectiveRoot),
+        },
         projectRoot: ctx.effectiveRoot,
       };
     }
@@ -118,7 +128,11 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
       hasOverride: i.hasOverride,
     }));
     return {
-      result: { issues, driftHash: drift.driftHash },
+      result: {
+        issues,
+        driftHash: drift.driftHash,
+        initialized: isInitializedProjectScope(projectPath, effectiveRoot),
+      },
       projectRoot: effectiveRoot,
     };
   });

--- a/packages/api/src/routes/drift.ts
+++ b/packages/api/src/routes/drift.ts
@@ -14,10 +14,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { withCapabilityLock } from '../config/capabilities/capability-orchestrator.js';
-import {
-  isLocalCapabilityWriteRequest,
-  requireLocalCapabilityWriteRequest,
-} from '../config/capabilities/capability-write-guards.js';
+import { requireLocalCapabilityWriteRequest } from '../config/capabilities/capability-write-guards.js';
 import { checkMcpProject } from '../mcp/mcp-drift-detector.js';
 import type { McpDriftResolution } from '../mcp/mcp-drift-resolver.js';
 import { syncMcpDrift, VALID_MCP_DRIFT_DECISIONS } from '../mcp/mcp-drift-resolver.js';
@@ -46,23 +43,22 @@ interface DriftIssue {
   hasOverride?: boolean;
 }
 
-function requireDriftWriteAccess(request: FastifyRequest, reply: FastifyReply): { userId?: string; error?: string } {
+type DriftWriteAccess = { allowed: true; userId: string } | { allowed: false; status: number; error: string };
+
+function resolveDriftWriteAccess(request: FastifyRequest): DriftWriteAccess {
   const userId = resolveSessionUserId(request);
   if (!userId) {
-    reply.status(401);
-    return { error: 'Authentication required' };
+    return { allowed: false, status: 401, error: 'Authentication required' };
   }
   const localError = requireLocalCapabilityWriteRequest(request);
   if (localError) {
-    reply.status(localError.status);
-    return { error: localError.error };
+    return { allowed: false, status: localError.status, error: localError.error };
   }
   const ownerError = resolveOwnerGate(userId, { errorMessage: 'Drift resolution requires owner authorization' });
   if (ownerError) {
-    reply.status(ownerError.status);
-    return { error: ownerError.error };
+    return { allowed: false, status: ownerError.status, error: ownerError.error };
   }
-  return { userId };
+  return { allowed: true, userId };
 }
 
 function parseType(body: Record<string, unknown>): DriftType | null {
@@ -102,7 +98,7 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const projectPath = typeof body.projectPath === 'string' ? body.projectPath : undefined;
-    const syncAllowed = isLocalCapabilityWriteRequest(request);
+    const syncAllowed = resolveDriftWriteAccess(request).allowed;
 
     if (type === 'skill') {
       const ctx = await computeSkillDrift(projectPath);
@@ -155,8 +151,11 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
 
   // ── POST /api/drift/resolve ──
   app.post('/api/drift/resolve', async (request, reply) => {
-    const access = requireDriftWriteAccess(request, reply);
-    if (!access.userId) return { error: access.error };
+    const access = resolveDriftWriteAccess(request);
+    if (!access.allowed) {
+      reply.status(access.status);
+      return { error: access.error };
+    }
 
     const body = (request.body ?? {}) as Record<string, unknown>;
     const type = parseType(body);

--- a/packages/api/src/routes/drift.ts
+++ b/packages/api/src/routes/drift.ts
@@ -72,6 +72,16 @@ function isInitializedProjectScope(projectPath: string | undefined, effectiveRoo
   return !projectPath || existsSync(join(effectiveRoot, '.cat-cafe'));
 }
 
+function rejectUninitializedProjectScope(
+  projectPath: string | undefined,
+  effectiveRoot: string,
+  reply: FastifyReply,
+): boolean {
+  if (isInitializedProjectScope(projectPath, effectiveRoot)) return false;
+  reply.status(400);
+  return true;
+}
+
 export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
   // ── POST /api/drift/check ──
   app.post('/api/drift/check', async (request, reply) => {
@@ -180,6 +190,9 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
         reply.status(400);
         return { error: 'Invalid project path' };
       }
+      if (rejectUninitializedProjectScope(projectPath, targetRoot, reply)) {
+        return { error: 'Project not initialized (missing .cat-cafe)' };
+      }
       return withCapabilityLock(targetRoot, async () => {
         const ctx = await computeSkillDrift(projectPath);
         if (!ctx) {
@@ -237,6 +250,9 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
     }
     const globalRoot = await resolveGlobalProjectRoot();
     const effectiveRoot = projectRoot ?? globalRoot;
+    if (rejectUninitializedProjectScope(projectPath, effectiveRoot, reply)) {
+      return { error: 'Project not initialized (missing .cat-cafe)' };
+    }
     const drift = await checkMcpProject(effectiveRoot, globalRoot);
     if (drift.issues.length === 0) {
       return {

--- a/packages/api/src/routes/drift.ts
+++ b/packages/api/src/routes/drift.ts
@@ -14,7 +14,10 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import type { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { withCapabilityLock } from '../config/capabilities/capability-orchestrator.js';
-import { requireLocalCapabilityWriteRequest } from '../config/capabilities/capability-write-guards.js';
+import {
+  isLocalCapabilityWriteRequest,
+  requireLocalCapabilityWriteRequest,
+} from '../config/capabilities/capability-write-guards.js';
 import { checkMcpProject } from '../mcp/mcp-drift-detector.js';
 import type { McpDriftResolution } from '../mcp/mcp-drift-resolver.js';
 import { syncMcpDrift, VALID_MCP_DRIFT_DECISIONS } from '../mcp/mcp-drift-resolver.js';
@@ -99,6 +102,7 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const projectPath = typeof body.projectPath === 'string' ? body.projectPath : undefined;
+    const syncAllowed = isLocalCapabilityWriteRequest(request);
 
     if (type === 'skill') {
       const ctx = await computeSkillDrift(projectPath);
@@ -117,6 +121,7 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
           issues,
           driftHash: ctx.drift.driftHash,
           initialized: isInitializedProjectScope(projectPath, ctx.effectiveRoot),
+          syncAllowed,
         },
         projectRoot: ctx.effectiveRoot,
       };
@@ -142,6 +147,7 @@ export const unifiedDriftRoutes: FastifyPluginAsync = async (app) => {
         issues,
         driftHash: drift.driftHash,
         initialized: isInitializedProjectScope(projectPath, effectiveRoot),
+        syncAllowed,
       },
       projectRoot: effectiveRoot,
     };

--- a/packages/api/src/utils/skill-source.ts
+++ b/packages/api/src/utils/skill-source.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readCapabilitiesConfig } from '../config/capabilities/capability-orchestrator.js';
 import { readSkillsSyncState } from '../skills/skill-sync-config.js';
+import { redirectRuntimeProjectPath } from './persistent-project-path.js';
 
 function resolveCurrentWorktreeSkillsSource(): string {
   let dir = dirname(fileURLToPath(import.meta.url));
@@ -18,7 +19,12 @@ function resolveCurrentWorktreeSkillsSource(): string {
 
 /** Canonical Clowder AI skill source used by capability writeback and drift resolution. */
 export async function resolveCatCafeSkillsSource(): Promise<string> {
-  return resolveCurrentWorktreeSkillsSource();
+  const worktreeSource = resolveCurrentWorktreeSkillsSource();
+  const persistentSource = await redirectRuntimeProjectPath(worktreeSource);
+  if (!persistentSource) {
+    throw new Error('Unable to resolve persistent Clowder AI skill source');
+  }
+  return persistentSource;
 }
 
 /**

--- a/packages/api/test/agent-hooks.test.js
+++ b/packages/api/test/agent-hooks.test.js
@@ -1,13 +1,18 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import Fastify from 'fastify';
-import { buildAgentHookTargets, getAgentHookStatus, syncAgentHooks } from '../dist/agent-hooks/index.js';
+import {
+  buildAgentHookTargets,
+  getAgentHookStatus,
+  resolveAgentHookGlobalRoot,
+  syncAgentHooks,
+} from '../dist/agent-hooks/index.js';
 import { agentHooksRoutes } from '../dist/routes/agent-hooks.js';
 import { resolveStartupProjectRoot } from '../dist/utils/startup-root.js';
 
@@ -43,6 +48,27 @@ describe('agent hook sync targets', () => {
   afterEach(async () => {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(targetRoot, { recursive: true, force: true });
+  });
+
+  it('maps the runtime MCP baseline to the persistent workspace root', async () => {
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-runtime-'));
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-workspace-'));
+    const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+
+    try {
+      assert.equal(await resolveAgentHookGlobalRoot(runtimeRoot), await realpath(workspaceRoot));
+    } finally {
+      if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
+      if (previousWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
+      await rm(runtimeRoot, { recursive: true, force: true });
+      await rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   it('selects only user-level hook targets and renders Codex/Gemini paths per target home', () => {

--- a/packages/api/test/agent-hooks.test.js
+++ b/packages/api/test/agent-hooks.test.js
@@ -565,6 +565,63 @@ describe('agent hook routes', () => {
     }
   });
 
+  it('GET rejects remote access before validating an explicit projectPath', async () => {
+    const implicitApp = Fastify();
+    addSessionTestHook(implicitApp);
+    await implicitApp.register(agentHooksRoutes, { projectRoot });
+    await implicitApp.ready();
+    const uninitDir = await mkdtemp(join(tmpdir(), 'agent-hooks-remote-uninit-'));
+
+    try {
+      const res = await implicitApp.inject({
+        method: 'GET',
+        url: `/api/agent-hooks/status?projectPath=${encodeURIComponent(uninitDir)}`,
+        headers: {
+          ...SESSION_HEADERS,
+          host: 'skycat-api.cpolar.top',
+          origin: 'https://skycat.cpolar.top',
+        },
+        remoteAddress: '127.0.0.1',
+      });
+
+      assert.equal(res.statusCode, 403);
+      assert.match(res.payload, /local API host/);
+      assert.doesNotMatch(res.payload, /Project not initialized|missing \.cat-cafe/);
+    } finally {
+      await implicitApp.close();
+      await rm(uninitDir, { recursive: true, force: true });
+    }
+  });
+
+  it('POST rejects remote access before validating an explicit projectPath', async () => {
+    const implicitApp = Fastify();
+    addSessionTestHook(implicitApp);
+    await implicitApp.register(agentHooksRoutes, { projectRoot });
+    await implicitApp.ready();
+    const uninitDir = await mkdtemp(join(tmpdir(), 'agent-hooks-remote-uninit-sync-'));
+
+    try {
+      const res = await implicitApp.inject({
+        method: 'POST',
+        url: '/api/agent-hooks/sync',
+        headers: {
+          ...SESSION_HEADERS,
+          host: 'skycat-api.cpolar.top',
+          origin: 'https://skycat.cpolar.top',
+        },
+        payload: { projectPath: uninitDir },
+        remoteAddress: '127.0.0.1',
+      });
+
+      assert.equal(res.statusCode, 403);
+      assert.match(res.payload, /local API host/);
+      assert.doesNotMatch(res.payload, /Project not initialized|missing \.cat-cafe/);
+    } finally {
+      await implicitApp.close();
+      await rm(uninitDir, { recursive: true, force: true });
+    }
+  });
+
   it('allows implicit status checks for local browser hosts', async () => {
     const implicitApp = Fastify();
     addSessionTestHook(implicitApp);

--- a/packages/api/test/agent-hooks.test.js
+++ b/packages/api/test/agent-hooks.test.js
@@ -1,6 +1,5 @@
 import assert from 'node:assert/strict';
 import { randomUUID } from 'node:crypto';
-import { existsSync } from 'node:fs';
 import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -14,7 +13,6 @@ import {
   syncAgentHooks,
 } from '../dist/agent-hooks/index.js';
 import { agentHooksRoutes } from '../dist/routes/agent-hooks.js';
-import { resolveStartupProjectRoot } from '../dist/utils/startup-root.js';
 
 const HEADERS = { 'x-cat-cafe-user': 'test-user' };
 const SESSION_HEADERS = { 'x-test-session-user': 'test-user' };
@@ -39,20 +37,24 @@ async function createProjectRoot() {
 describe('agent hook sync targets', () => {
   let projectRoot;
   let targetRoot;
+  let capabilityProjectRoot;
 
   beforeEach(async () => {
     projectRoot = await createProjectRoot();
     targetRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-home-'));
+    capabilityProjectRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-capability-project-'));
   });
 
   afterEach(async () => {
     await rm(projectRoot, { recursive: true, force: true });
     await rm(targetRoot, { recursive: true, force: true });
+    await rm(capabilityProjectRoot, { recursive: true, force: true });
   });
 
-  it('maps the runtime MCP baseline to the persistent workspace root', async () => {
-    const runtimeRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-runtime-'));
+  it('uses the persistent workspace for implicit capabilities and preserves explicit project scope', async () => {
+    const runtimeRoot = await createProjectRoot();
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-workspace-'));
+    const externalRoot = await mkdtemp(join(tmpdir(), 'agent-hooks-external-'));
     const previousRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
     const previousWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
 
@@ -60,7 +62,48 @@ describe('agent hook sync targets', () => {
     process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
 
     try {
-      assert.equal(await resolveAgentHookGlobalRoot(runtimeRoot), await realpath(workspaceRoot));
+      const persistentRoot = await realpath(workspaceRoot);
+      assert.equal(await resolveAgentHookGlobalRoot(runtimeRoot), persistentRoot);
+
+      const runtimeCapabilitiesPath = join(runtimeRoot, '.cat-cafe', 'capabilities.json');
+      const workspaceCapabilitiesPath = join(workspaceRoot, '.cat-cafe', 'capabilities.json');
+      const externalCapabilitiesPath = join(externalRoot, '.cat-cafe', 'capabilities.json');
+      const emptyCapabilities = { version: 2, capabilities: [] };
+      const globalCapabilities = {
+        version: 2,
+        capabilities: [
+          {
+            type: 'mcp',
+            id: 'persistent-baseline',
+            source: 'cat-cafe',
+            enabled: true,
+            mcpServer: { command: 'echo', args: ['persistent'] },
+          },
+        ],
+      };
+      await mkdir(join(runtimeRoot, '.cat-cafe'), { recursive: true });
+      await mkdir(join(workspaceRoot, '.cat-cafe'), { recursive: true });
+      await mkdir(join(externalRoot, '.cat-cafe'), { recursive: true });
+      await writeFile(runtimeCapabilitiesPath, JSON.stringify(emptyCapabilities), 'utf-8');
+      await writeFile(workspaceCapabilitiesPath, JSON.stringify(globalCapabilities), 'utf-8');
+      await writeFile(externalCapabilitiesPath, JSON.stringify(emptyCapabilities), 'utf-8');
+
+      const implicitStatus = await getAgentHookStatus({ projectRoot: runtimeRoot, targetRoot });
+      const implicitMcp = implicitStatus.targets.find((target) => target.name === 'mcp');
+      assert.equal(implicitMcp?.status, 'configured');
+      assert.equal(implicitMcp?.drifted, false);
+
+      await syncAgentHooks({ projectRoot: runtimeRoot, targetRoot, ownerAuthorized: true });
+      assert.deepEqual(JSON.parse(await readFile(runtimeCapabilitiesPath, 'utf-8')), emptyCapabilities);
+
+      const explicitStatus = await getAgentHookStatus({
+        projectRoot: runtimeRoot,
+        targetRoot,
+        capabilityProjectRoot: externalRoot,
+      });
+      const explicitMcp = explicitStatus.targets.find((target) => target.name === 'mcp');
+      assert.equal(explicitMcp?.status, 'stale');
+      assert.equal(explicitMcp?.drifted, true);
     } finally {
       if (previousRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
       else process.env.CAT_CAFE_RUNTIME_ROOT = previousRuntimeRoot;
@@ -68,6 +111,7 @@ describe('agent hook sync targets', () => {
       else process.env.CAT_CAFE_WORKSPACE_ROOT = previousWorkspaceRoot;
       await rm(runtimeRoot, { recursive: true, force: true });
       await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(externalRoot, { recursive: true, force: true });
     }
   });
 
@@ -362,8 +406,15 @@ describe('agent hook sync targets', () => {
     // project-local MCP entries that are absent from the global config.
     // The keep-project policy only protects config-mismatch; project-orphan
     // issues must be filtered out of the health sync path entirely.
-    const catCafeDir = join(projectRoot, '.cat-cafe');
-    await mkdir(catCafeDir, { recursive: true });
+    const globalCatCafeDir = join(projectRoot, '.cat-cafe');
+    const projectCatCafeDir = join(capabilityProjectRoot, '.cat-cafe');
+    await mkdir(globalCatCafeDir, { recursive: true });
+    await mkdir(projectCatCafeDir, { recursive: true });
+    await writeFile(
+      join(globalCatCafeDir, 'capabilities.json'),
+      JSON.stringify({ version: 2, capabilities: [] }),
+      'utf-8',
+    );
 
     const pluginMcpId = `probe-plugin-${randomUUID().slice(0, 8)}`;
     const capabilities = {
@@ -379,11 +430,12 @@ describe('agent hook sync targets', () => {
         },
       ],
     };
-    await writeFile(join(catCafeDir, 'capabilities.json'), JSON.stringify(capabilities, null, 2), 'utf-8');
+    const projectCapabilitiesPath = join(projectCatCafeDir, 'capabilities.json');
+    await writeFile(projectCapabilitiesPath, JSON.stringify(capabilities, null, 2), 'utf-8');
 
-    await syncAgentHooks({ projectRoot, targetRoot, ownerAuthorized: true });
+    await syncAgentHooks({ projectRoot, targetRoot, capabilityProjectRoot, ownerAuthorized: true });
 
-    const afterSync = JSON.parse(await readFile(join(catCafeDir, 'capabilities.json'), 'utf-8'));
+    const afterSync = JSON.parse(await readFile(projectCapabilitiesPath, 'utf-8'));
     const pluginEntry = afterSync.capabilities.find((c) => c.id === pluginMcpId);
     assert.ok(pluginEntry, `Plugin MCP "${pluginMcpId}" must survive health sync (not removed as orphan)`);
     assert.equal(pluginEntry.pluginId, 'test-plugin');
@@ -394,28 +446,43 @@ describe('agent hook sync targets', () => {
     // syncAgentHooks does. Otherwise the UI shows an un-clearable stale badge
     // for projects with plugin MCPs not in global config.
     //
-    // Strategy: seed an empty capabilities.json so syncAgentHooks populates
-    // all global MCPs, then inject a plugin-owned orphan entry that has no
-    // global counterpart. After sync, global-new drift = 0; only orphan remains.
-    const catCafeDir = join(projectRoot, '.cat-cafe');
-    const capPath = join(catCafeDir, 'capabilities.json');
-    await mkdir(catCafeDir, { recursive: true });
-    await writeFile(capPath, JSON.stringify({ version: 2, capabilities: [] }), 'utf-8');
-    await syncAgentHooks({ projectRoot, targetRoot, ownerAuthorized: true });
-    const synced = JSON.parse(await readFile(capPath, 'utf-8'));
+    // Model host global and external project scopes independently. The global
+    // config is empty, so the project plugin entry is the only MCP difference.
+    const globalCatCafeDir = join(projectRoot, '.cat-cafe');
+    const projectCatCafeDir = join(capabilityProjectRoot, '.cat-cafe');
+    const projectCapabilitiesPath = join(projectCatCafeDir, 'capabilities.json');
+    await mkdir(globalCatCafeDir, { recursive: true });
+    await mkdir(projectCatCafeDir, { recursive: true });
+    await writeFile(
+      join(globalCatCafeDir, 'capabilities.json'),
+      JSON.stringify({ version: 2, capabilities: [] }),
+      'utf-8',
+    );
 
     const pluginMcpId = `orphan-only-${randomUUID().slice(0, 8)}`;
-    synced.capabilities.push({
-      type: 'mcp',
-      id: pluginMcpId,
-      source: 'cat-cafe',
-      pluginId: 'test-plugin',
-      enabled: true,
-      mcpServer: { command: 'echo', args: ['test'] },
-    });
-    await writeFile(capPath, JSON.stringify(synced, null, 2), 'utf-8');
+    await writeFile(
+      projectCapabilitiesPath,
+      JSON.stringify(
+        {
+          version: 2,
+          capabilities: [
+            {
+              type: 'mcp',
+              id: pluginMcpId,
+              source: 'cat-cafe',
+              pluginId: 'test-plugin',
+              enabled: true,
+              mcpServer: { command: 'echo', args: ['test'] },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
 
-    const status = await getAgentHookStatus({ projectRoot, targetRoot, ownerAuthorized: true });
+    const status = await getAgentHookStatus({ projectRoot, targetRoot, capabilityProjectRoot, ownerAuthorized: true });
     const mcpResult = status.targets.find((t) => t.name === 'mcp');
     assert.ok(mcpResult, 'health status must include mcp target');
     assert.equal(mcpResult.status, 'configured', 'orphan-only MCP drift must not report stale');
@@ -425,49 +492,45 @@ describe('agent hook sync targets', () => {
   it('health status reports stale for non-plugin managed MCP orphans', async () => {
     // Non-plugin orphans (managed MCPs removed from global config) should
     // surface as stale — they represent real drift, unlike plugin orphans.
-    //
-    // The orphan filter requires a valid global config at the startup root
-    // (filterOrphanIssues falls back to filtering ALL orphans when global
-    // is unreadable). Ensure a minimal global config exists for CI envs
-    // where .cat-cafe/ is not checked in.
-    const startupRoot = resolveStartupProjectRoot();
-    const globalCapsPath = join(startupRoot, '.cat-cafe', 'capabilities.json');
-    const globalCapsExisted = existsSync(globalCapsPath);
-    if (!globalCapsExisted) {
-      await mkdir(join(startupRoot, '.cat-cafe'), { recursive: true });
-      await writeFile(globalCapsPath, JSON.stringify({ version: 2, capabilities: [] }), 'utf-8');
-    }
-
-    const catCafeDir = join(projectRoot, '.cat-cafe');
-    const capPath = join(catCafeDir, 'capabilities.json');
-    await mkdir(catCafeDir, { recursive: true });
-    await writeFile(capPath, JSON.stringify({ version: 2, capabilities: [] }), 'utf-8');
-    await syncAgentHooks({ projectRoot, targetRoot, ownerAuthorized: true });
-    const synced = JSON.parse(await readFile(capPath, 'utf-8'));
+    const globalCatCafeDir = join(projectRoot, '.cat-cafe');
+    const projectCatCafeDir = join(capabilityProjectRoot, '.cat-cafe');
+    const projectCapabilitiesPath = join(projectCatCafeDir, 'capabilities.json');
+    await mkdir(globalCatCafeDir, { recursive: true });
+    await mkdir(projectCatCafeDir, { recursive: true });
+    await writeFile(
+      join(globalCatCafeDir, 'capabilities.json'),
+      JSON.stringify({ version: 2, capabilities: [] }),
+      'utf-8',
+    );
 
     // Inject a managed (non-plugin) orphan — source 'cat-cafe' but NO pluginId
     const managedOrphanId = `managed-orphan-${randomUUID().slice(0, 8)}`;
-    synced.capabilities.push({
-      type: 'mcp',
-      id: managedOrphanId,
-      source: 'cat-cafe',
-      enabled: true,
-      mcpServer: { command: 'echo', args: ['test'] },
-    });
-    await writeFile(capPath, JSON.stringify(synced, null, 2), 'utf-8');
+    await writeFile(
+      projectCapabilitiesPath,
+      JSON.stringify(
+        {
+          version: 2,
+          capabilities: [
+            {
+              type: 'mcp',
+              id: managedOrphanId,
+              source: 'cat-cafe',
+              enabled: true,
+              mcpServer: { command: 'echo', args: ['test'] },
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf-8',
+    );
 
-    try {
-      const status = await getAgentHookStatus({ projectRoot, targetRoot, ownerAuthorized: true });
-      const mcpResult = status.targets.find((t) => t.name === 'mcp');
-      assert.ok(mcpResult, 'health status must include mcp target');
-      assert.equal(mcpResult.status, 'stale', 'non-plugin managed orphan must report stale');
-      assert.equal(mcpResult.drifted, true, 'non-plugin managed orphan must report drifted');
-    } finally {
-      // Clean up global config if we created it (don't leave artifacts in repo root)
-      if (!globalCapsExisted) {
-        await rm(globalCapsPath, { force: true });
-      }
-    }
+    const status = await getAgentHookStatus({ projectRoot, targetRoot, capabilityProjectRoot, ownerAuthorized: true });
+    const mcpResult = status.targets.find((t) => t.name === 'mcp');
+    assert.ok(mcpResult, 'health status must include mcp target');
+    assert.equal(mcpResult.status, 'stale', 'non-plugin managed orphan must report stale');
+    assert.equal(mcpResult.drifted, true, 'non-plugin managed orphan must report drifted');
   });
 
   it('ownerAuthorized omitted defaults to fail-closed (no capability sync)', async () => {

--- a/packages/api/test/drift-check-initialization.test.js
+++ b/packages/api/test/drift-check-initialization.test.js
@@ -22,11 +22,14 @@ describe('/api/drift — project initialization boundary', () => {
   /** @type {string} */
   let projectRoot;
   let previousOwner;
+  let previousApiServerHost;
 
   beforeEach(async () => {
     projectRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-drift-check-'));
     previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    previousApiServerHost = process.env.API_SERVER_HOST;
     process.env.DEFAULT_OWNER_USER_ID = 'you';
+    delete process.env.API_SERVER_HOST;
     app = Fastify({ logger: false });
     app.addHook('preHandler', async (request) => {
       const raw = request.headers['x-test-session-user'];
@@ -43,6 +46,8 @@ describe('/api/drift — project initialization boundary', () => {
     await rm(projectRoot, { recursive: true, force: true });
     if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
     else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
+    if (previousApiServerHost === undefined) delete process.env.API_SERVER_HOST;
+    else process.env.API_SERVER_HOST = previousApiServerHost;
   });
 
   it('marks existing directories without .cat-cafe as uninitialized', async () => {
@@ -69,6 +74,49 @@ describe('/api/drift — project initialization boundary', () => {
 
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().result.initialized, true);
+  });
+
+  it('reports direct-local capability writes as allowed', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: { 'x-cat-cafe-user': 'you', host: 'localhost:3004', origin: 'http://localhost:3003' },
+      payload: { type: 'skill' },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.syncAllowed, true);
+  });
+
+  it('reports forwarded localhost requests as read-only', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: {
+        'x-cat-cafe-user': 'you',
+        host: 'localhost:3004',
+        origin: 'http://localhost:3003',
+        'x-forwarded-for': '127.0.0.1',
+      },
+      payload: { type: 'skill' },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.syncAllowed, false);
+  });
+
+  it('reports a non-loopback API bind as read-only', async () => {
+    process.env.API_SERVER_HOST = '0.0.0.0';
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: { 'x-cat-cafe-user': 'you', host: 'localhost:3004', origin: 'http://localhost:3003' },
+      payload: { type: 'mcp' },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.syncAllowed, false);
   });
 
   for (const type of ['skill', 'mcp']) {

--- a/packages/api/test/drift-check-initialization.test.js
+++ b/packages/api/test/drift-check-initialization.test.js
@@ -1,7 +1,8 @@
 // @ts-check
 
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, it } from 'node:test';
@@ -9,15 +10,30 @@ import Fastify from 'fastify';
 
 const { unifiedDriftRoutes } = await import('../dist/routes/drift.js');
 
-describe('/api/drift/check — project initialization metadata', () => {
+const AUTH_HEADERS = {
+  'x-test-session-user': 'you',
+  host: 'localhost:3004',
+  origin: 'http://localhost:3003',
+};
+
+describe('/api/drift — project initialization boundary', () => {
   /** @type {import('fastify').FastifyInstance} */
   let app;
   /** @type {string} */
   let projectRoot;
+  let previousOwner;
 
   beforeEach(async () => {
     projectRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-drift-check-'));
+    previousOwner = process.env.DEFAULT_OWNER_USER_ID;
+    process.env.DEFAULT_OWNER_USER_ID = 'you';
     app = Fastify({ logger: false });
+    app.addHook('preHandler', async (request) => {
+      const raw = request.headers['x-test-session-user'];
+      if (typeof raw === 'string' && raw.trim()) {
+        request.sessionUserId = raw.trim();
+      }
+    });
     await app.register(unifiedDriftRoutes);
     await app.ready();
   });
@@ -25,6 +41,8 @@ describe('/api/drift/check — project initialization metadata', () => {
   afterEach(async () => {
     await app?.close();
     await rm(projectRoot, { recursive: true, force: true });
+    if (previousOwner === undefined) delete process.env.DEFAULT_OWNER_USER_ID;
+    else process.env.DEFAULT_OWNER_USER_ID = previousOwner;
   });
 
   it('marks existing directories without .cat-cafe as uninitialized', async () => {
@@ -52,4 +70,33 @@ describe('/api/drift/check — project initialization metadata', () => {
     assert.equal(response.statusCode, 200);
     assert.equal(response.json().result.initialized, true);
   });
+
+  for (const type of ['skill', 'mcp']) {
+    it(`rejects ${type} resolution for an explicit uninitialized project without creating state`, async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/drift/resolve',
+        headers: AUTH_HEADERS,
+        payload: { type, action: 'sync', projectPath: projectRoot },
+      });
+
+      assert.equal(response.statusCode, 400);
+      assert.match(response.json().error, /Project not initialized|missing \.cat-cafe/);
+      assert.equal(existsSync(join(projectRoot, '.cat-cafe')), false);
+      assert.deepEqual(await readdir(projectRoot), []);
+    });
+
+    it(`keeps ${type} resolution available for an explicit initialized project`, async () => {
+      await mkdir(join(projectRoot, '.cat-cafe'));
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/api/drift/resolve',
+        headers: AUTH_HEADERS,
+        payload: { type, action: 'sync', projectPath: projectRoot },
+      });
+
+      assert.equal(response.statusCode, 200);
+    });
+  }
 });

--- a/packages/api/test/drift-check-initialization.test.js
+++ b/packages/api/test/drift-check-initialization.test.js
@@ -76,7 +76,7 @@ describe('/api/drift — project initialization boundary', () => {
     assert.equal(response.json().result.initialized, true);
   });
 
-  it('reports direct-local capability writes as allowed', async () => {
+  it('keeps direct-local reads without a session read-only', async () => {
     const response = await app.inject({
       method: 'POST',
       url: '/api/drift/check',
@@ -85,7 +85,35 @@ describe('/api/drift — project initialization boundary', () => {
     });
 
     assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.syncAllowed, false);
+  });
+
+  it('reports direct-local owner capability writes as allowed', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: AUTH_HEADERS,
+      payload: { type: 'skill' },
+    });
+
+    assert.equal(response.statusCode, 200);
     assert.equal(response.json().result.syncAllowed, true);
+  });
+
+  it('keeps direct-local non-owner reads read-only', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: {
+        'x-test-session-user': 'someone-else',
+        host: 'localhost:3004',
+        origin: 'http://localhost:3003',
+      },
+      payload: { type: 'skill' },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.syncAllowed, false);
   });
 
   it('reports forwarded localhost requests as read-only', async () => {

--- a/packages/api/test/drift-check-initialization.test.js
+++ b/packages/api/test/drift-check-initialization.test.js
@@ -1,0 +1,55 @@
+// @ts-check
+
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import Fastify from 'fastify';
+
+const { unifiedDriftRoutes } = await import('../dist/routes/drift.js');
+
+describe('/api/drift/check — project initialization metadata', () => {
+  /** @type {import('fastify').FastifyInstance} */
+  let app;
+  /** @type {string} */
+  let projectRoot;
+
+  beforeEach(async () => {
+    projectRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-drift-check-'));
+    app = Fastify({ logger: false });
+    await app.register(unifiedDriftRoutes);
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app?.close();
+    await rm(projectRoot, { recursive: true, force: true });
+  });
+
+  it('marks existing directories without .cat-cafe as uninitialized', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: { 'x-cat-cafe-user': 'you' },
+      payload: { type: 'skill', projectPath: projectRoot },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.initialized, false);
+  });
+
+  it('marks projects with .cat-cafe as initialized', async () => {
+    await mkdir(join(projectRoot, '.cat-cafe'));
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/drift/check',
+      headers: { 'x-cat-cafe-user': 'you' },
+      payload: { type: 'skill', projectPath: projectRoot },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().result.initialized, true);
+  });
+});

--- a/packages/api/test/skills-drift-route.test.js
+++ b/packages/api/test/skills-drift-route.test.js
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { lstat, mkdir, mkdtemp, realpath, rm, symlink } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, relative, resolve } from 'node:path';
 import { describe, it } from 'node:test';
@@ -47,6 +47,78 @@ function expectedSymlinkTarget(linkPath, sourcePath) {
 }
 
 describe('Skills Drift Route (F228)', () => {
+  it('accepts project links to the persistent workspace skill source in runtime mode', async () => {
+    const prevRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
+    const prevWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;
+    const runtimeRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+    const workspaceRoot = await realpath(await mkdtemp(join(tmpdir(), 'skills-drift-persistent-source-workspace-')));
+    const projectDir = await realpath(await mkdtemp(join(tmpdir(), 'skills-drift-persistent-source-project-')));
+    const skillName = 'anime-forge';
+    const persistentSkill = join(workspaceRoot, 'cat-cafe-skills', skillName);
+    process.env.CAT_CAFE_RUNTIME_ROOT = runtimeRoot;
+    process.env.CAT_CAFE_WORKSPACE_ROOT = workspaceRoot;
+
+    await mkdir(persistentSkill, { recursive: true });
+    await writeFile(join(workspaceRoot, 'cat-cafe-skills', 'manifest.yaml'), 'version: 1\n');
+    await writeFile(join(persistentSkill, 'SKILL.md'), '# Anime Forge\n');
+    await writeCapabilitiesConfig(workspaceRoot, {
+      version: 2,
+      capabilities: [
+        {
+          id: skillName,
+          type: 'skill',
+          enabled: true,
+          globalEnabled: true,
+          source: 'cat-cafe',
+          mountPaths: ['claude', 'codex', 'gemini', 'kimi'],
+        },
+      ],
+    });
+    await writeCapabilitiesConfig(projectDir, {
+      version: 2,
+      capabilities: [
+        {
+          id: skillName,
+          type: 'skill',
+          enabled: true,
+          source: 'cat-cafe',
+          mountPaths: ['claude', 'codex', 'gemini', 'kimi'],
+        },
+      ],
+    });
+    for (const provider of ['claude', 'codex', 'gemini', 'kimi']) {
+      const linkPath = join(projectDir, `.${provider}`, 'skills', skillName);
+      await mkdir(dirname(linkPath), { recursive: true });
+      await symlink(expectedSymlinkTarget(linkPath, persistentSkill), linkPath);
+    }
+
+    const app = await buildSkillsDriftApp({ mainProjectRoot: workspaceRoot });
+    try {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/api/skills/drift-check',
+        headers: { 'x-cat-cafe-user': 'default-user' },
+        payload: { projectPath: projectDir },
+      });
+
+      assert.equal(res.statusCode, 200, res.body);
+      const body = JSON.parse(res.body);
+      assert.equal(
+        body.result.issues.some((issue) => issue.skill === skillName),
+        false,
+        'a project link to the persistent workspace source must not be reported as conflict',
+      );
+    } finally {
+      if (prevRuntimeRoot === undefined) delete process.env.CAT_CAFE_RUNTIME_ROOT;
+      else process.env.CAT_CAFE_RUNTIME_ROOT = prevRuntimeRoot;
+      if (prevWorkspaceRoot === undefined) delete process.env.CAT_CAFE_WORKSPACE_ROOT;
+      else process.env.CAT_CAFE_WORKSPACE_ROOT = prevWorkspaceRoot;
+      await app.close();
+      await rm(workspaceRoot, { recursive: true, force: true });
+      await rm(projectDir, { recursive: true, force: true });
+    }
+  });
+
   it('POST /api/skills/drift-check reads runtime selections from the persistent workspace', async () => {
     const prevRuntimeRoot = process.env.CAT_CAFE_RUNTIME_ROOT;
     const prevWorkspaceRoot = process.env.CAT_CAFE_WORKSPACE_ROOT;

--- a/packages/web/src/components/AgentHookHealthNotice.tsx
+++ b/packages/web/src/components/AgentHookHealthNotice.tsx
@@ -125,6 +125,42 @@ function previewTargets(health: AgentHookStatusResponse | null): AgentHookTarget
     .slice(0, 5);
 }
 
+function canSyncAgentHooks(
+  health: AgentHookStatusResponse | null,
+  syncing: boolean,
+  currentStatus: AgentHookHealthStatus | 'syncing' | 'synced' | 'error',
+): boolean {
+  return health?.syncAllowed !== false && !syncing && currentStatus !== 'synced';
+}
+
+function shouldShowTargetStatus(health: AgentHookStatusResponse | null): boolean {
+  return health?.syncAllowed !== false || targetsFor(health).length > 0;
+}
+
+function AgentHookTargetStatusBadges({ health }: { health: AgentHookStatusResponse | null }) {
+  if (!shouldShowTargetStatus(health)) return null;
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-2 text-xs">
+      <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
+        Claude：{statusText(groupStatus(health, 'claude'))}
+      </span>
+      <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
+        Codex：{statusText(groupStatus(health, 'codex'))}
+      </span>
+      <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
+        Gemini：{statusText(groupStatus(health, 'gemini'))}
+      </span>
+      <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
+        Skills：{statusText(groupStatus(health, 'skills'))}
+      </span>
+      <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
+        MCP：{statusText(groupStatus(health, 'mcp'))}
+      </span>
+    </div>
+  );
+}
+
 export function AgentHookHealthNotice({
   health,
   error,
@@ -138,7 +174,7 @@ export function AgentHookHealthNotice({
   const currentStatus = error ? 'error' : syncing ? 'syncing' : synced ? 'synced' : health ? health.status : 'error';
   const tone = toneFor(currentStatus);
   const problematicTargets = previewTargets(health);
-  const canSync = !syncing && currentStatus !== 'synced';
+  const canSync = canSyncAgentHooks(health, syncing, currentStatus);
 
   return (
     <div data-testid="agent-hook-health-notice" className={`rounded-lg border p-3 ${tone.classes} ${className}`}>
@@ -148,7 +184,7 @@ export function AgentHookHealthNotice({
           <div className="flex flex-wrap items-start gap-2">
             <div className="min-w-0 flex-1">
               <p className="text-sm font-semibold">{tone.title}</p>
-              <p className="mt-1 text-xs opacity-85">{error ?? tone.body}</p>
+              <p className="mt-1 text-xs opacity-85">{error ?? health?.message ?? tone.body}</p>
             </div>
             {canSync && (
               <button
@@ -162,23 +198,7 @@ export function AgentHookHealthNotice({
             {syncing && <span className="text-xs font-medium">同步中...</span>}
           </div>
 
-          <div className="mt-2 flex flex-wrap gap-2 text-xs">
-            <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
-              Claude：{statusText(groupStatus(health, 'claude'))}
-            </span>
-            <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
-              Codex：{statusText(groupStatus(health, 'codex'))}
-            </span>
-            <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
-              Gemini：{statusText(groupStatus(health, 'gemini'))}
-            </span>
-            <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
-              Skills：{statusText(groupStatus(health, 'skills'))}
-            </span>
-            <span className="rounded-full border border-cafe-subtle bg-cafe-surface-elevated px-2 py-0.5 text-cafe-secondary">
-              MCP：{statusText(groupStatus(health, 'mcp'))}
-            </span>
-          </div>
+          <AgentHookTargetStatusBadges health={health} />
 
           {problematicTargets.length > 0 && (
             <details className="mt-2 text-xs">

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -83,6 +83,46 @@ interface ChatContainerProps {
   threadId: string;
 }
 
+interface ThreadDetailSyncPayload {
+  projectPath?: string;
+  bootcampState?: Thread['bootcampState'];
+  firstRunQuestState?: { phase: string; firstCatName?: string };
+}
+
+function syncThreadDetailToLocalState(
+  threadId: string,
+  thread: ThreadDetailSyncPayload,
+  setCurrentProject: (projectPath: string) => void,
+) {
+  const store = useChatStore.getState();
+  const local = store.threads.find((candidate) => candidate.id === threadId);
+  const projectPath =
+    typeof thread.projectPath === 'string' && thread.projectPath.trim().length > 0 ? thread.projectPath : null;
+
+  if (projectPath && projectPath !== local?.projectPath) {
+    useChatStore.setState((state) => ({
+      threads: state.threads.map((candidate) =>
+        candidate.id === threadId ? { ...candidate, projectPath } : candidate,
+      ),
+    }));
+  }
+  if (projectPath && store.currentThreadId === threadId) {
+    setCurrentProject(projectPath);
+  }
+  if (thread.bootcampState || local?.bootcampState) {
+    syncLocalBootcampState(threadId, thread.bootcampState);
+  }
+
+  const localQuest = (local as Record<string, unknown> | undefined)?.firstRunQuestState;
+  if (thread.firstRunQuestState || localQuest) {
+    useChatStore.setState((state) => ({
+      threads: state.threads.map((candidate) =>
+        candidate.id === threadId ? { ...candidate, firstRunQuestState: thread.firstRunQuestState } : candidate,
+      ),
+    }));
+  }
+}
+
 export function ChatContainer({ threadId }: ChatContainerProps) {
   const bottomChromeRef = useRef<HTMLDivElement | null>(null);
   const bottomChromeObserverRef = useRef<ResizeObserver | null>(null);
@@ -455,31 +495,13 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
   // thread ensures the store stays in sync.
   const syncThreadState = useCallback(() => {
     apiFetch(`/api/threads/${threadId}`)
-      .then((res) =>
-        res.ok
-          ? (res.json() as Promise<{
-              bootcampState?: Thread['bootcampState'];
-              firstRunQuestState?: { phase: string; firstCatName?: string };
-            }>)
-          : null,
-      )
+      .then((res) => (res.ok ? (res.json() as Promise<ThreadDetailSyncPayload>) : null))
       .then((thread) => {
         if (!thread) return;
-        const local = useChatStore.getState().threads.find((t) => t.id === threadId);
-        if (thread.bootcampState || local?.bootcampState) {
-          syncLocalBootcampState(threadId, thread.bootcampState);
-        }
-        const localQuest = (local as Record<string, unknown> | undefined)?.firstRunQuestState;
-        if (thread.firstRunQuestState || localQuest) {
-          useChatStore.setState((state) => ({
-            threads: state.threads.map((t) =>
-              t.id === threadId ? { ...t, firstRunQuestState: thread.firstRunQuestState } : t,
-            ),
-          }));
-        }
+        syncThreadDetailToLocalState(threadId, thread, setCurrentProject);
       })
       .catch(() => {});
-  }, [threadId]);
+  }, [threadId, setCurrentProject]);
 
   // Sync on invocation end (active → inactive transition)
   const prevInvocationRef = useRef(hasActiveInvocation);
@@ -997,7 +1019,8 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
                       onSyncAgentHooks={agentHookHealth.sync}
                       onComplete={() => {
                         setSetupDone(true);
-                        govRefetch();
+                        void govRefetch();
+                        void agentHookHealth.refresh();
                       }}
                     />
                   </div>

--- a/packages/web/src/components/ChatContainer.tsx
+++ b/packages/web/src/components/ChatContainer.tsx
@@ -493,15 +493,24 @@ export function ChatContainer({ threadId }: ChatContainerProps) {
   // MCP callbacks update Redis directly; the companion WebSocket `thread_updated`
   // may not reach this frontend (e.g. worktree port isolation). Re-fetching the
   // thread ensures the store stays in sync.
+  const threadDetailSyncGenerationRef = useRef(0);
   const syncThreadState = useCallback(() => {
+    const generation = ++threadDetailSyncGenerationRef.current;
     apiFetch(`/api/threads/${threadId}`)
       .then((res) => (res.ok ? (res.json() as Promise<ThreadDetailSyncPayload>) : null))
       .then((thread) => {
-        if (!thread) return;
+        if (!thread || generation !== threadDetailSyncGenerationRef.current) return;
         syncThreadDetailToLocalState(threadId, thread, setCurrentProject);
       })
       .catch(() => {});
   }, [threadId, setCurrentProject]);
+
+  useEffect(
+    () => () => {
+      threadDetailSyncGenerationRef.current += 1;
+    },
+    [threadId],
+  );
 
   // Sync on invocation end (active → inactive transition)
   const prevInvocationRef = useRef(hasActiveInvocation);

--- a/packages/web/src/components/McpConfigModal.tsx
+++ b/packages/web/src/components/McpConfigModal.tsx
@@ -21,6 +21,8 @@ export interface McpConfigModalProps {
   editId?: string;
   editData?: McpEditData;
   readOnly?: boolean;
+  /** Whether localhost-only probe and capability mutation actions are available. */
+  allowLocalActions?: boolean;
   tools?: McpTool[];
   onSaved: () => void;
   onClose: () => void;
@@ -84,10 +86,17 @@ async function readApiError(res: Response, fallback: string): Promise<string> {
   return data.error ?? `${fallback} (${res.status})`;
 }
 
-function modalSubtitle(readOnly: boolean, isEdit: boolean): string {
+function modalSubtitle(readOnly: boolean, isEdit: boolean, allowLocalActions: boolean): string {
+  if (readOnly && !allowLocalActions) {
+    return '远程访问为只读预览；本机探测与配置修改需在 localhost Hub 执行。';
+  }
   if (readOnly) return '托管 MCP 为只读预览，敏感值仅显示键名。';
   if (isEdit) return '敏感值已掩码，未改动的字段保留原值。';
   return '先预览将改动的 CLI 配置，再确认安装。';
+}
+
+function whenAllowed<T>(allowed: boolean, action: T): T | undefined {
+  return allowed ? action : undefined;
 }
 
 type ProbeConnectionStatus = 'connected' | 'disconnected' | 'timeout' | 'error' | 'unknown';
@@ -126,6 +135,7 @@ export function McpConfigModal({
   editId,
   editData,
   readOnly = false,
+  allowLocalActions = true,
   tools: initialTools,
   onSaved,
   onClose,
@@ -217,11 +227,11 @@ export function McpConfigModal({
   const mountProbed = useRef(false);
   useEffect(() => {
     if (mountProbed.current) return;
-    if (isEdit && editId && !initialTools) {
+    if (allowLocalActions && isEdit && editId && !initialTools) {
       mountProbed.current = true;
       void doProbe(projectPath ? { projectPath } : {});
     }
-  }, [doProbe, editId, initialTools, isEdit, projectPath]);
+  }, [allowLocalActions, doProbe, editId, initialTools, isEdit, projectPath]);
 
   // Sync externally provided tools (from parent's initial load).
   useEffect(() => {
@@ -288,7 +298,7 @@ export function McpConfigModal({
 
   // F249 §8.3: "恢复全局配置" — clear project override, restore to global config
   const [restoring, setRestoring] = useState(false);
-  const canRestoreGlobal = isEdit && !!projectPath;
+  const canRestoreGlobal = allowLocalActions && isEdit && !!projectPath;
   const handleRestoreGlobal = useCallback(async () => {
     if (!editId || !projectPath) return;
     setError(null);
@@ -321,7 +331,7 @@ export function McpConfigModal({
       <div className="relative flex max-h-[85vh] w-full max-w-[620px] flex-col overflow-hidden rounded-2xl bg-[var(--console-card-bg)] px-6 py-4 shadow-[0_24px_56px_rgba(43,33,26,0.14)]">
         <McpModalHeader
           title={readOnly ? id : isEdit ? `编辑 ${id}` : '新增 MCP'}
-          subtitle={modalSubtitle(readOnly, isEdit)}
+          subtitle={modalSubtitle(readOnly, isEdit, allowLocalActions)}
           onClose={onClose}
         />
         <div className="mt-3 flex-1 space-y-2.5 overflow-y-auto">
@@ -381,7 +391,7 @@ export function McpConfigModal({
             loading={probeLoading}
             connectionStatus={probeStatus}
             error={probeError}
-            onProbe={handleProbeTools}
+            onProbe={whenAllowed(allowLocalActions, handleProbeTools)}
           />
           <McpPreviewSection preview={preview} />
         </div>

--- a/packages/web/src/components/McpConfigModalPanels.tsx
+++ b/packages/web/src/components/McpConfigModalPanels.tsx
@@ -12,6 +12,10 @@ const STATUS_LABELS: Record<ConnectionStatus, { text: string; tone: string }> = 
   unknown: { text: '未探测', tone: 'text-cafe-muted' },
 };
 
+function emptyToolsMessage(canProbe: boolean): string {
+  return canProbe ? '未探测到工具（点击刷新按钮探测）' : '当前未提供工具探测结果';
+}
+
 export function McpToolsSection({
   tools,
   loading,
@@ -69,7 +73,7 @@ export function McpToolsSection({
           </div>
         ) : (
           <div className="rounded-xl bg-[var(--console-panel-bg)] px-3 py-2.5 text-xs text-cafe-muted">
-            未探测到工具（点击刷新按钮探测）
+            {emptyToolsMessage(Boolean(onProbe))}
           </div>
         )}
       </FormItem>

--- a/packages/web/src/components/__tests__/agent-hook-health-notice.test.tsx
+++ b/packages/web/src/components/__tests__/agent-hook-health-notice.test.tsx
@@ -34,6 +34,13 @@ const missingHealth: AgentHookStatusResponse = {
   ],
 };
 
+const remoteBlockedHealth: AgentHookStatusResponse = {
+  status: 'unsupported',
+  targets: [],
+  syncAllowed: false,
+  message: '为保护本机配置，一键同步仅支持 localhost Hub。',
+};
+
 describe('AgentHookHealthNotice', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -101,6 +108,15 @@ describe('AgentHookHealthNotice', () => {
     expect(html).toContain('MCP：未知');
     expect(html).not.toContain('Claude：正常');
     expect(html).not.toContain('Codex：正常');
+  });
+
+  it('explains a blocked remote check without offering sync', () => {
+    const html = renderToStaticMarkup(<AgentHookHealthNotice health={remoteBlockedHealth} onSync={() => {}} />);
+
+    expect(html).toContain('Agent 运行环境支持待确认');
+    expect(html).toContain('为保护本机配置，一键同步仅支持 localhost Hub。');
+    expect(html).not.toContain('<button');
+    expect(html).not.toContain('Claude：未知');
   });
 });
 

--- a/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
+++ b/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
@@ -1,0 +1,81 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { AllProjectsSyncBanner } from '../settings/AllProjectsSyncBanner';
+import { isDirectLocalHubHostname } from '../settings/useDriftSync';
+
+describe('isDirectLocalHubHostname', () => {
+  it.each(['localhost', '127.0.0.1', '127.2.3.4', '::1', '[::1]'])('accepts direct loopback host %s', (hostname) => {
+    expect(isDirectLocalHubHostname(hostname)).toBe(true);
+  });
+
+  it.each(['skycat.cpolar.top', '192.168.1.10', 'localhost.example.com'])('rejects remote host %s', (hostname) => {
+    expect(isDirectLocalHubHostname(hostname)).toBe(false);
+  });
+});
+
+describe('AllProjectsSyncBanner', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  it('renders remote capability drift as read-only without write controls', async () => {
+    const scope = {
+      key: '/workspace/traqen',
+      label: 'Traqen',
+      path: '/workspace/traqen',
+      issues: [{ id: 'browser-preview', issueType: 'conflict', message: '存在冲突' }],
+    };
+
+    await act(async () => {
+      root.render(
+        <AllProjectsSyncBanner
+          type="skill"
+          scopes={[scope]}
+          scopesWithIssues={[scope]}
+          syncing={false}
+          error={null}
+          canSync={false}
+          onSyncAll={() => undefined}
+          onSyncScope={() => undefined}
+        />,
+      );
+    });
+
+    expect(container.textContent).toContain('远程访问仅支持查看');
+
+    await act(async () => {
+      const detail = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('查看详情'),
+      );
+      detail?.click();
+    });
+
+    const dialog = document.body.querySelector('[role="dialog"]');
+    expect(dialog?.textContent).toContain('Traqen');
+    expect(dialog?.textContent).not.toContain('同步全部');
+    expect(Array.from(dialog?.querySelectorAll('button') ?? []).some((button) => button.textContent === '同步')).toBe(
+      false,
+    );
+  });
+});

--- a/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
+++ b/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
@@ -5,11 +5,17 @@ import { AllProjectsSyncBanner } from '../settings/AllProjectsSyncBanner';
 import { isDirectLocalHubHostname } from '../settings/useDriftSync';
 
 describe('isDirectLocalHubHostname', () => {
-  it.each(['localhost', '127.0.0.1', '127.2.3.4', '::1', '[::1]'])('accepts direct loopback host %s', (hostname) => {
+  it.each(['localhost', '127.0.0.1', '::1', '[::1]'])('accepts direct loopback host %s', (hostname) => {
     expect(isDirectLocalHubHostname(hostname)).toBe(true);
   });
 
-  it.each(['skycat.cpolar.top', '192.168.1.10', 'localhost.example.com'])('rejects remote host %s', (hostname) => {
+  it.each([
+    'skycat.cpolar.top',
+    '192.168.1.10',
+    'localhost.example.com',
+    '127.2.3.4',
+    '127.example.com',
+  ])('rejects remote host %s', (hostname) => {
     expect(isDirectLocalHubHostname(hostname)).toBe(false);
   });
 });

--- a/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
+++ b/packages/web/src/components/__tests__/all-projects-sync-banner.test.tsx
@@ -2,23 +2,6 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { AllProjectsSyncBanner } from '../settings/AllProjectsSyncBanner';
-import { isDirectLocalHubHostname } from '../settings/useDriftSync';
-
-describe('isDirectLocalHubHostname', () => {
-  it.each(['localhost', '127.0.0.1', '::1', '[::1]'])('accepts direct loopback host %s', (hostname) => {
-    expect(isDirectLocalHubHostname(hostname)).toBe(true);
-  });
-
-  it.each([
-    'skycat.cpolar.top',
-    '192.168.1.10',
-    'localhost.example.com',
-    '127.2.3.4',
-    '127.example.com',
-  ])('rejects remote host %s', (hostname) => {
-    expect(isDirectLocalHubHostname(hostname)).toBe(false);
-  });
-});
 
 describe('AllProjectsSyncBanner', () => {
   let container: HTMLDivElement;

--- a/packages/web/src/components/__tests__/chat-container-governance-refetch.test.ts
+++ b/packages/web/src/components/__tests__/chat-container-governance-refetch.test.ts
@@ -2,6 +2,7 @@ import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChatContainer } from '@/components/ChatContainer';
+import { apiFetch } from '@/utils/api-client';
 
 type StoreState = {
   messages: [];
@@ -20,6 +21,7 @@ type StoreState = {
   setTargetCats: ReturnType<typeof vi.fn>;
   clearCatStatuses: ReturnType<typeof vi.fn>;
   setCurrentThread: ReturnType<typeof vi.fn>;
+  currentThreadId: string;
   updateThreadTitle: ReturnType<typeof vi.fn>;
   setCurrentGame: ReturnType<typeof vi.fn>;
   currentGame: null;
@@ -56,6 +58,16 @@ type StoreState = {
 
 const mockGovRefetch = vi.fn();
 const mockUseAgentHookHealth = vi.fn();
+const mockAgentHookRefresh = vi.fn();
+
+let governanceStatus = {
+  ready: true,
+  needsBootstrap: false,
+  needsConfirmation: false,
+  isEmptyDir: false,
+  isGitRepo: true,
+  gitAvailable: true,
+};
 
 const staleAgentHookHealth = {
   status: 'missing',
@@ -88,6 +100,7 @@ const makeStoreState = (): StoreState => ({
   setTargetCats: vi.fn(),
   clearCatStatuses: vi.fn(),
   setCurrentThread: vi.fn(),
+  currentThreadId: 'thread-a',
   updateThreadTitle: vi.fn(),
   setCurrentGame: vi.fn(),
   currentGame: null,
@@ -139,6 +152,13 @@ vi.mock('@/stores/chatStore', () => {
   const hook = (selector?: (s: StoreState) => unknown) => {
     const state = storeState;
     return selector ? selector(state) : state;
+  };
+  hook.getState = () => storeState;
+  hook.setState = (update: Partial<StoreState> | ((state: StoreState) => Partial<StoreState>)) => {
+    storeState = {
+      ...storeState,
+      ...(typeof update === 'function' ? update(storeState) : update),
+    };
   };
   return { useChatStore: hook };
 });
@@ -229,14 +249,7 @@ vi.mock('@/hooks/usePreviewAutoOpen', () => ({ usePreviewAutoOpen: vi.fn() }));
 vi.mock('@/hooks/useWorkspaceNavigate', () => ({ useWorkspaceNavigate: vi.fn() }));
 vi.mock('@/hooks/useGovernanceStatus', () => ({
   useGovernanceStatus: () => ({
-    status: {
-      ready: true,
-      needsBootstrap: false,
-      needsConfirmation: false,
-      isEmptyDir: false,
-      isGitRepo: true,
-      gitAvailable: true,
-    },
+    status: governanceStatus,
     refetch: mockGovRefetch,
   }),
 }));
@@ -281,7 +294,10 @@ vi.mock('../WorkspacePanel', () => ({ WorkspacePanel: () => null }));
 vi.mock('../BootstrapOrchestrator', () => ({ BootstrapOrchestrator: () => null }));
 vi.mock('../BootcampListModal', () => ({ BootcampListModal: () => null }));
 vi.mock('@/components/HubListModal', () => ({ HubListModal: () => null }));
-vi.mock('@/components/ProjectSetupCard', () => ({ ProjectSetupCard: () => null }));
+vi.mock('@/components/ProjectSetupCard', () => ({
+  ProjectSetupCard: ({ onComplete }: { onComplete: () => void }) =>
+    React.createElement('button', { type: 'button', onClick: onComplete }, 'complete project setup'),
+}));
 vi.mock('@/components/game/GameOverlayConnector', () => ({ GameOverlayConnector: () => null }));
 vi.mock('@/components/icons/PawIcon', () => ({ PawIcon: () => null }));
 vi.mock('@/components/icons/BootcampIcon', () => ({ BootcampIcon: () => null }));
@@ -306,7 +322,19 @@ describe('ChatContainer governance refetch', () => {
     document.body.appendChild(container);
     root = createRoot(container);
     storeState = makeStoreState();
+    governanceStatus = {
+      ready: true,
+      needsBootstrap: false,
+      needsConfirmation: false,
+      isEmptyDir: false,
+      isGitRepo: true,
+      gitAvailable: true,
+    };
     mockGovRefetch.mockReset();
+    mockAgentHookRefresh.mockReset();
+    vi.mocked(apiFetch)
+      .mockReset()
+      .mockImplementation(async () => ({ ok: true, json: async () => ({ threads: [] }) }) as Response);
     mockUseAgentHookHealth.mockReset();
     mockUseAgentHookHealth.mockReturnValue({
       health: null,
@@ -314,6 +342,7 @@ describe('ChatContainer governance refetch', () => {
       syncing: false,
       synced: false,
       sync: vi.fn(),
+      refresh: mockAgentHookRefresh,
     });
   });
 
@@ -352,7 +381,50 @@ describe('ChatContainer governance refetch', () => {
       root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
     });
 
-    expect(mockUseAgentHookHealth).toHaveBeenCalledWith({ enabled: false });
+    expect(mockUseAgentHookHealth).toHaveBeenCalledWith({ enabled: false, projectPath: 'default' });
     expect(container.textContent).not.toContain('Agent 运行 Hook 需要同步');
+  });
+
+  it('refreshes governance and agent hook health after project setup completes', async () => {
+    governanceStatus = {
+      ...governanceStatus,
+      ready: false,
+      needsBootstrap: true,
+    };
+
+    await act(async () => {
+      root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
+    });
+
+    const completeButton = [...container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('complete project setup'),
+    );
+    if (!completeButton) throw new Error('Missing mocked project setup button');
+
+    await act(async () => {
+      completeButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mockGovRefetch).toHaveBeenCalledTimes(1);
+    expect(mockAgentHookRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebinds the active project when thread detail has a newer projectPath than the cached thread list', async () => {
+    const reboundProjectPath = '/tmp/rebound-project';
+    vi.mocked(apiFetch).mockImplementation(
+      async (path) =>
+        ({
+          ok: true,
+          json: async () =>
+            path === '/api/threads/thread-a' ? { id: 'thread-a', projectPath: reboundProjectPath } : { threads: [] },
+        }) as Response,
+    );
+
+    await act(async () => {
+      root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
+    });
+
+    expect(storeState.setCurrentProject).toHaveBeenCalledWith(reboundProjectPath);
+    expect(storeState.threads.find((thread) => thread.id === 'thread-a')?.projectPath).toBe(reboundProjectPath);
   });
 });

--- a/packages/web/src/components/__tests__/chat-container-governance-refetch.test.ts
+++ b/packages/web/src/components/__tests__/chat-container-governance-refetch.test.ts
@@ -427,4 +427,54 @@ describe('ChatContainer governance refetch', () => {
     expect(storeState.setCurrentProject).toHaveBeenCalledWith(reboundProjectPath);
     expect(storeState.threads.find((thread) => thread.id === 'thread-a')?.projectPath).toBe(reboundProjectPath);
   });
+
+  it('ignores an older thread detail response after a newer reconciliation succeeds', async () => {
+    type ThreadPayload = { id: string; projectPath: string };
+    let resolveOlder!: (value: ThreadPayload) => void;
+    let resolveNewer!: (value: ThreadPayload) => void;
+    const older = new Promise<ThreadPayload>((resolve) => {
+      resolveOlder = resolve;
+    });
+    const newer = new Promise<ThreadPayload>((resolve) => {
+      resolveNewer = resolve;
+    });
+    let threadReads = 0;
+    vi.mocked(apiFetch).mockImplementation(
+      async (path) =>
+        ({
+          ok: true,
+          json: () => {
+            if (path !== '/api/threads/thread-a') return Promise.resolve({ threads: [] });
+            threadReads += 1;
+            return threadReads === 1 ? older : newer;
+          },
+        }) as Response,
+    );
+
+    await act(async () => {
+      root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
+    });
+    storeState.hasActiveInvocation = true;
+    await act(async () => {
+      root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
+    });
+    storeState.hasActiveInvocation = false;
+    await act(async () => {
+      root.render(React.createElement(ChatContainer, { threadId: 'thread-a' }));
+    });
+
+    await act(async () => {
+      resolveNewer({ id: 'thread-a', projectPath: '/tmp/newer-project' });
+      await newer;
+    });
+    expect(storeState.threads.find((thread) => thread.id === 'thread-a')?.projectPath).toBe('/tmp/newer-project');
+
+    await act(async () => {
+      resolveOlder({ id: 'thread-a', projectPath: '/tmp/older-project' });
+      await older;
+    });
+
+    expect(storeState.threads.find((thread) => thread.id === 'thread-a')?.projectPath).toBe('/tmp/newer-project');
+    expect(storeState.setCurrentProject).not.toHaveBeenCalledWith('/tmp/older-project');
+  });
 });

--- a/packages/web/src/components/__tests__/mcp-manage-content.test.ts
+++ b/packages/web/src/components/__tests__/mcp-manage-content.test.ts
@@ -106,7 +106,17 @@ describe('McpManageContent', () => {
     root = createRoot(container);
     mockThreads = [];
     mockFetch.mockReset();
-    mockFetch.mockResolvedValue(ITEMS_RESPONSE);
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/drift/check') {
+        return {
+          ok: true,
+          json: async () => ({
+            result: { issues: [], driftHash: 'local-drift', syncAllowed: true },
+          }),
+        };
+      }
+      return ITEMS_RESPONSE;
+    });
   });
 
   afterEach(() => {
@@ -160,12 +170,7 @@ describe('McpManageContent', () => {
     expect(container.textContent).not.toContain('cross-cat-handoff');
   });
 
-  it('renders every MCP capability write control as read-only on remote hosts', async () => {
-    const originalLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...originalLocation, hostname: 'skycat.cpolar.top' },
-    });
+  it('renders every MCP capability write control as read-only when the server denies writes', async () => {
     mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input);
       if (url === '/api/drift/check') {
@@ -175,6 +180,7 @@ describe('McpManageContent', () => {
             result: {
               issues: [{ id: 'custom-mcp', issueType: 'missing-in-project', message: 'Needs sync' }],
               driftHash: 'remote-drift',
+              syncAllowed: false,
             },
           }),
         };
@@ -182,46 +188,37 @@ describe('McpManageContent', () => {
       return ITEMS_RESPONSE;
     });
 
-    try {
-      await renderContent();
-      await flushEffects();
+    await renderContent();
+    await flushEffects();
 
-      expect(container.textContent).not.toContain('同步系统配置');
-      expect(container.textContent).not.toContain('新增 MCP');
-      expect(container.querySelector('button[title="禁用"]')).toBeNull();
-      expect(container.querySelector('button[title="卸载此 MCP"]')).toBeNull();
+    expect(container.textContent).not.toContain('同步系统配置');
+    expect(container.textContent).not.toContain('新增 MCP');
+    expect(container.querySelector('button[title="禁用"]')).toBeNull();
+    expect(container.querySelector('button[title="卸载此 MCP"]')).toBeNull();
 
-      await act(async () => {
-        buttonByText('项目 MCP').click();
-      });
-      await flushEffects();
-      await act(async () => {
-        buttonByText('查看详情').click();
-      });
+    await act(async () => {
+      buttonByText('项目 MCP').click();
+    });
+    await flushEffects();
+    await act(async () => {
+      buttonByText('查看详情').click();
+    });
 
-      expect(document.body.querySelector('[role="dialog"]')?.textContent).not.toContain('立即同步');
+    expect(document.body.querySelector('[role="dialog"]')?.textContent).not.toContain('立即同步');
 
-      await act(async () => {
-        buttonByText('custom-mcp').click();
-      });
-      await flushEffects();
-      expect(document.body.querySelector('[data-testid="mcp-config-modal"]')).toBeTruthy();
-      expect(document.body.textContent).toContain('只读预览');
-      expect(document.body.textContent).not.toContain('保存');
-      expect(document.body.querySelector('button[title="探测工具列表"]')).toBeNull();
-      expect(document.body.textContent).not.toContain('点击刷新按钮探测');
-      expect(
-        mockFetch.mock.calls.some(
-          ([input]) => String(input).startsWith('/api/mcp/') && String(input).endsWith('/tools'),
-        ),
-      ).toBe(false);
-      expect(document.body.textContent).not.toContain('恢复全局配置');
-    } finally {
-      Object.defineProperty(window, 'location', {
-        configurable: true,
-        value: originalLocation,
-      });
-    }
+    await act(async () => {
+      buttonByText('custom-mcp').click();
+    });
+    await flushEffects();
+    expect(document.body.querySelector('[data-testid="mcp-config-modal"]')).toBeTruthy();
+    expect(document.body.textContent).toContain('只读预览');
+    expect(document.body.textContent).not.toContain('保存');
+    expect(document.body.querySelector('button[title="探测工具列表"]')).toBeNull();
+    expect(document.body.textContent).not.toContain('点击刷新按钮探测');
+    expect(
+      mockFetch.mock.calls.some(([input]) => String(input).startsWith('/api/mcp/') && String(input).endsWith('/tools')),
+    ).toBe(false);
+    expect(document.body.textContent).not.toContain('恢复全局配置');
   });
 
   it('uses the settings section header without duplicating MCP titles', async () => {
@@ -331,6 +328,14 @@ describe('McpManageContent', () => {
 
   it('shows configured-owner errors from MCP preview', async () => {
     mockFetch.mockImplementation(async (url: string) => {
+      if (url === '/api/drift/check') {
+        return {
+          ok: true,
+          json: async () => ({
+            result: { issues: [], driftHash: 'local-drift', syncAllowed: true },
+          }),
+        };
+      }
       if (url === '/api/capabilities/mcp/preview') {
         return {
           ok: false,
@@ -393,6 +398,7 @@ describe('McpManageContent', () => {
             result: {
               issues: [{ id: 'custom-mcp', issueType: 'missing-in-project', message: 'Needs sync' }],
               driftHash: `hash:${body.projectPath ?? 'global'}`,
+              syncAllowed: true,
             },
           }),
         };
@@ -434,7 +440,7 @@ describe('McpManageContent', () => {
   });
 
   it('renders plugin-owned MCP with normal controls but no delete button', async () => {
-    mockFetch.mockResolvedValue({
+    const pluginItemsResponse = {
       ok: true,
       json: async () => ({
         items: [
@@ -450,6 +456,17 @@ describe('McpManageContent', () => {
         projectPath: '/test/project',
         skillHealth: null,
       }),
+    };
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/drift/check') {
+        return {
+          ok: true,
+          json: async () => ({
+            result: { issues: [], driftHash: 'local-drift', syncAllowed: true },
+          }),
+        };
+      }
+      return pluginItemsResponse;
     });
 
     await renderContent();
@@ -474,7 +491,6 @@ describe('McpManageContent', () => {
     // Ad-hoc probe body would strip redacted env values (all MCP env is redacted
     // in API responses), breaking MCPs that conditionally register tools based
     // on env — e.g. protocol-server for plugin MCPs (F205 -32601 fix).
-    mockFetch.mockResolvedValue(ITEMS_RESPONSE);
     await renderContent();
 
     mockFetch.mockClear();

--- a/packages/web/src/components/__tests__/mcp-manage-content.test.ts
+++ b/packages/web/src/components/__tests__/mcp-manage-content.test.ts
@@ -204,9 +204,18 @@ describe('McpManageContent', () => {
       await act(async () => {
         buttonByText('custom-mcp').click();
       });
+      await flushEffects();
       expect(document.body.querySelector('[data-testid="mcp-config-modal"]')).toBeTruthy();
       expect(document.body.textContent).toContain('只读预览');
       expect(document.body.textContent).not.toContain('保存');
+      expect(document.body.querySelector('button[title="探测工具列表"]')).toBeNull();
+      expect(document.body.textContent).not.toContain('点击刷新按钮探测');
+      expect(
+        mockFetch.mock.calls.some(
+          ([input]) => String(input).startsWith('/api/mcp/') && String(input).endsWith('/tools'),
+        ),
+      ).toBe(false);
+      expect(document.body.textContent).not.toContain('恢复全局配置');
     } finally {
       Object.defineProperty(window, 'location', {
         configurable: true,
@@ -249,6 +258,26 @@ describe('McpManageContent', () => {
     expect(document.body.textContent).toContain('只读预览');
     expect(document.body.textContent).not.toContain('保存');
     expect(document.body.textContent).toContain('关闭');
+  });
+
+  it('keeps local project restore and probe actions available', async () => {
+    await renderContent();
+    await act(async () => {
+      buttonByText('项目 MCP').click();
+    });
+    await flushEffects();
+    mockFetch.mockClear();
+
+    await act(async () => {
+      buttonByText('custom-mcp').click();
+    });
+    await flushEffects();
+
+    expect(document.body.textContent).toContain('恢复全局配置');
+    expect(document.body.querySelector('button[title="探测工具列表"]')).toBeTruthy();
+    expect(
+      mockFetch.mock.calls.some(([input]) => String(input).startsWith('/api/mcp/') && String(input).endsWith('/tools')),
+    ).toBe(true);
   });
 
   it('opens plugin-owned MCP in readOnly modal (managed by plugin)', async () => {

--- a/packages/web/src/components/__tests__/mcp-manage-content.test.ts
+++ b/packages/web/src/components/__tests__/mcp-manage-content.test.ts
@@ -160,6 +160,61 @@ describe('McpManageContent', () => {
     expect(container.textContent).not.toContain('cross-cat-handoff');
   });
 
+  it('renders every MCP capability write control as read-only on remote hosts', async () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'skycat.cpolar.top' },
+    });
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === '/api/drift/check') {
+        return {
+          ok: true,
+          json: async () => ({
+            result: {
+              issues: [{ id: 'custom-mcp', issueType: 'missing-in-project', message: 'Needs sync' }],
+              driftHash: 'remote-drift',
+            },
+          }),
+        };
+      }
+      return ITEMS_RESPONSE;
+    });
+
+    try {
+      await renderContent();
+      await flushEffects();
+
+      expect(container.textContent).not.toContain('同步系统配置');
+      expect(container.textContent).not.toContain('新增 MCP');
+      expect(container.querySelector('button[title="禁用"]')).toBeNull();
+      expect(container.querySelector('button[title="卸载此 MCP"]')).toBeNull();
+
+      await act(async () => {
+        buttonByText('项目 MCP').click();
+      });
+      await flushEffects();
+      await act(async () => {
+        buttonByText('查看详情').click();
+      });
+
+      expect(document.body.querySelector('[role="dialog"]')?.textContent).not.toContain('立即同步');
+
+      await act(async () => {
+        buttonByText('custom-mcp').click();
+      });
+      expect(document.body.querySelector('[data-testid="mcp-config-modal"]')).toBeTruthy();
+      expect(document.body.textContent).toContain('只读预览');
+      expect(document.body.textContent).not.toContain('保存');
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
   it('uses the settings section header without duplicating MCP titles', async () => {
     await renderSettingsContent();
 

--- a/packages/web/src/components/__tests__/mcp-manage-content.test.ts
+++ b/packages/web/src/components/__tests__/mcp-manage-content.test.ts
@@ -277,6 +277,43 @@ describe('McpManageContent', () => {
     ).toBe(true);
   });
 
+  it('reacts when write permission resolves after an external MCP modal opens', async () => {
+    let resolveDrift!: (value: { result: { issues: never[]; driftHash: string; syncAllowed: boolean } }) => void;
+    const driftPayload = new Promise<{
+      result: { issues: never[]; driftHash: string; syncAllowed: boolean };
+    }>((resolve) => {
+      resolveDrift = resolve;
+    });
+    mockFetch.mockImplementation(async (input: RequestInfo | URL) => {
+      if (String(input) === '/api/drift/check') {
+        return {
+          ok: true,
+          json: () => driftPayload,
+        };
+      }
+      return ITEMS_RESPONSE;
+    });
+
+    await renderContent();
+    await flushEffects();
+    await act(async () => {
+      buttonByText('custom-mcp').click();
+    });
+
+    expect(document.body.textContent).toContain('只读预览');
+    expect(document.body.textContent).not.toContain('保存');
+
+    await act(async () => {
+      resolveDrift({
+        result: { issues: [], driftHash: 'local-drift', syncAllowed: true },
+      });
+      await driftPayload;
+    });
+    await flushEffects();
+
+    expect(document.body.textContent).toContain('保存');
+  });
+
   it('opens plugin-owned MCP in readOnly modal (managed by plugin)', async () => {
     await renderContent();
 

--- a/packages/web/src/components/__tests__/skills-content.test.tsx
+++ b/packages/web/src/components/__tests__/skills-content.test.tsx
@@ -125,9 +125,14 @@ const DEFAULT_CONFLICT_ISSUE = {
   message: 'claude 存在同名目录占用（立即同步会覆盖和清理已有内容，请先确认是否需要进行备份）',
 };
 
-function driftResponse(projectPath: string | undefined, issues: unknown[] = [], initialized = true): Response {
+function driftResponse(
+  projectPath: string | undefined,
+  issues: unknown[] = [],
+  initialized = true,
+  syncAllowed = true,
+): Response {
   return jsonResponse({
-    result: { issues, driftHash: `hash:${projectPath ?? 'global'}`, initialized },
+    result: { issues, driftHash: `hash:${projectPath ?? 'global'}`, initialized, syncAllowed },
     projectPath,
   });
 }
@@ -142,6 +147,7 @@ function mockBothApis(
   capOverride?: unknown,
   driftIssuesFor: (projectPath?: string) => unknown[] = defaultDriftIssues,
   driftInitializedFor: (projectPath?: string) => boolean = () => true,
+  driftSyncAllowedFor: (projectPath?: string) => boolean = () => true,
 ) {
   mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -159,7 +165,12 @@ function mockBothApis(
     if (url === '/api/drift/check') {
       const body = JSON.parse(String(init?.body ?? '{}')) as { type?: string; projectPath?: string };
       return Promise.resolve(
-        driftResponse(body.projectPath, driftIssuesFor(body.projectPath), driftInitializedFor(body.projectPath)),
+        driftResponse(
+          body.projectPath,
+          driftIssuesFor(body.projectPath),
+          driftInitializedFor(body.projectPath),
+          driftSyncAllowedFor(body.projectPath),
+        ),
       );
     }
     if (url === '/api/drift/resolve' && init?.method === 'POST') {
@@ -237,75 +248,69 @@ describe('SkillsContent', () => {
     expect(skillsList?.textContent).not.toContain('cross-cat-handoff');
   });
 
-  it('renders every Skill capability write control as read-only on remote hosts', async () => {
-    const originalLocation = window.location;
-    Object.defineProperty(window, 'location', {
-      configurable: true,
-      value: { ...originalLocation, hostname: 'skycat.cpolar.top' },
-    });
+  it('renders every Skill capability write control as read-only when the server denies writes', async () => {
     mockGetProjectPaths.mockReturnValue(['/workspace/project']);
-    mockBothApis(undefined, undefined, () => [DEFAULT_CONFLICT_ISSUE]);
+    mockBothApis(
+      undefined,
+      undefined,
+      () => [DEFAULT_CONFLICT_ISSUE],
+      () => true,
+      () => false,
+    );
 
-    try {
-      await render(React.createElement(SkillsContent));
+    await render(React.createElement(SkillsContent));
 
-      expect(container.querySelector('button[title="全局禁用"]')).toBeNull();
-      expect(container.querySelector('button[title="批量禁用当前筛选的 Skill"]')).toBeNull();
+    expect(container.querySelector('button[title="全局禁用"]')).toBeNull();
+    expect(container.querySelector('button[title="批量禁用当前筛选的 Skill"]')).toBeNull();
 
-      const defaultMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
-        button.textContent?.includes('全局默认 Mount Rules'),
+    const defaultMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('全局默认 Mount Rules'),
+    );
+    await act(async () => {
+      defaultMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+    expect(
+      Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
+        (input) => input.disabled,
+      ),
+    ).toBe(true);
+    expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === '添加')).toBe(
+      false,
+    );
+
+    const projectTab = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('项目 Skill'),
+    );
+    await act(async () => {
+      projectTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    const projectMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.startsWith('Mount Rules'),
+    );
+    await act(async () => {
+      projectMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+    expect(
+      Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
+        (input) => input.disabled,
+      ),
+    ).toBe(true);
+    await act(async () => {
+      const detail = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('查看详情'),
       );
-      await act(async () => {
-        defaultMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-      await flushEffects();
-      expect(
-        Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
-          (input) => input.disabled,
-        ),
-      ).toBe(true);
-      expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === '添加')).toBe(
-        false,
-      );
+      detail?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
 
-      const projectTab = Array.from(container.querySelectorAll('button')).find((button) =>
-        button.textContent?.includes('项目 Skill'),
-      );
-      await act(async () => {
-        projectTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-      await flushEffects();
-
-      const projectMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
-        button.textContent?.startsWith('Mount Rules'),
-      );
-      await act(async () => {
-        projectMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-      await flushEffects();
-      expect(
-        Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
-          (input) => input.disabled,
-        ),
-      ).toBe(true);
-      await act(async () => {
-        const detail = Array.from(container.querySelectorAll('button')).find((button) =>
-          button.textContent?.includes('查看详情'),
-        );
-        detail?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-
-      expect(
-        Array.from(document.body.querySelectorAll('[role="dialog"] button')).some(
-          (button) => button.textContent === '立即同步',
-        ),
-      ).toBe(false);
-    } finally {
-      Object.defineProperty(window, 'location', {
-        configurable: true,
-        value: originalLocation,
-      });
-    }
+    expect(
+      Array.from(document.body.querySelectorAll('[role="dialog"] button')).some(
+        (button) => button.textContent === '立即同步',
+      ),
+    ).toBe(false);
   });
 
   it('opens a read-only SKILL.md preview from the card', async () => {

--- a/packages/web/src/components/__tests__/skills-content.test.tsx
+++ b/packages/web/src/components/__tests__/skills-content.test.tsx
@@ -125,8 +125,11 @@ const DEFAULT_CONFLICT_ISSUE = {
   message: 'claude 存在同名目录占用（立即同步会覆盖和清理已有内容，请先确认是否需要进行备份）',
 };
 
-function driftResponse(projectPath: string | undefined, issues: unknown[] = []): Response {
-  return jsonResponse({ result: { issues, driftHash: `hash:${projectPath ?? 'global'}` }, projectPath });
+function driftResponse(projectPath: string | undefined, issues: unknown[] = [], initialized = true): Response {
+  return jsonResponse({
+    result: { issues, driftHash: `hash:${projectPath ?? 'global'}`, initialized },
+    projectPath,
+  });
 }
 
 /** Default drift routing: an anomaly in the global scope, projects clean. */
@@ -138,6 +141,7 @@ function mockBothApis(
   skillsOverride?: unknown,
   capOverride?: unknown,
   driftIssuesFor: (projectPath?: string) => unknown[] = defaultDriftIssues,
+  driftInitializedFor: (projectPath?: string) => boolean = () => true,
 ) {
   mockFetch.mockImplementation((input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -154,7 +158,9 @@ function mockBothApis(
     }
     if (url === '/api/drift/check') {
       const body = JSON.parse(String(init?.body ?? '{}')) as { type?: string; projectPath?: string };
-      return Promise.resolve(driftResponse(body.projectPath, driftIssuesFor(body.projectPath)));
+      return Promise.resolve(
+        driftResponse(body.projectPath, driftIssuesFor(body.projectPath), driftInitializedFor(body.projectPath)),
+      );
     }
     if (url === '/api/drift/resolve' && init?.method === 'POST') {
       return Promise.resolve(jsonResponse({ ok: true }));
@@ -176,6 +182,7 @@ describe('SkillsContent', () => {
     container = document.createElement('div');
     document.body.appendChild(container);
     root = createRoot(container);
+    mockGetProjectPaths.mockReturnValue([]);
     mockFetch.mockReset();
     mockBothApis();
   });
@@ -210,7 +217,7 @@ describe('SkillsContent', () => {
     expect(container.textContent).toContain('cross-cat-handoff');
     expect(container.textContent).toContain('browser-preview');
     expect(container.textContent).toContain('missing-browser:missing');
-    expect(container.textContent).toContain('检测到 1 处 Skill 异常');
+    expect(container.textContent).toContain('1 个作用域存在 Skill 待同步');
     expect(container.textContent).toContain('查看详情');
 
     const frontendFilter = Array.from(container.querySelectorAll('button')).find(
@@ -624,7 +631,7 @@ describe('SkillsContent', () => {
     const scopeTabs = container.querySelector('[data-testid="skills-scope-tabs"]');
     expect(scopeTabs?.textContent).toContain('全部 Skill');
     expect(scopeTabs?.textContent).toContain('项目 Skill');
-    expect(container.textContent).toContain('检测到 1 处 Skill 异常');
+    expect(container.textContent).toContain('1 个作用域存在 Skill 待同步');
     expect(container.textContent).toContain('查看详情');
 
     const skillsList = container.querySelector('[data-testid="skills-list"]');
@@ -981,7 +988,7 @@ describe('SkillsContent', () => {
     expect(driftScopes.has('global')).toBe(true);
     expect(driftScopes.has(projectA)).toBe(false);
     expect(driftScopes.has(projectB)).toBe(true);
-    expect(container.textContent).toContain('检测到 1 处 Skill 异常');
+    expect(container.textContent).toContain('1 个作用域存在 Skill 待同步');
 
     const detail = Array.from(container.querySelectorAll('button')).find((b) => b.textContent?.includes('查看详情'));
     await act(async () => {
@@ -989,7 +996,7 @@ describe('SkillsContent', () => {
     });
 
     const dialog = container.querySelector('[role="dialog"]');
-    expect(dialog?.textContent).toContain('项目 Skill 异常详情');
+    expect(dialog?.textContent).toContain('Skill 待同步详情');
     expect(String(dialog?.className)).toContain('fixed');
     expect(String(dialog?.className)).toContain('inset-0');
     // Only project-b scope (with the conflict) appears, showing the verbatim backend message.
@@ -1015,6 +1022,67 @@ describe('SkillsContent', () => {
     );
     expect(collapsedToggle?.getAttribute('aria-expanded')).toBe('false');
     expect(dialog?.textContent).not.toContain('存在同名目录占用');
+  });
+
+  it('"全部 Skill" excludes uninitialized historical project paths from anomalies and sync', async () => {
+    const mainProject = '/workspace/cat-cafe';
+    const staleProject = '/workspace/old-thread-project';
+    const initializedProject = '/workspace/traqen';
+    mockGetProjectPaths.mockReturnValue([mainProject, staleProject, initializedProject]);
+    mockBothApis(
+      skillsPayload,
+      {
+        ...capabilitiesPayload,
+        projectPath: mainProject,
+        knownProjectPaths: [mainProject, staleProject, initializedProject],
+      },
+      (projectPath) =>
+        projectPath === staleProject || projectPath === initializedProject ? [DEFAULT_CONFLICT_ISSUE] : [],
+      (projectPath) => projectPath !== staleProject,
+    );
+
+    await render(React.createElement(SkillsContent));
+    await flushEffects();
+    await flushEffects();
+
+    expect(container.textContent).toContain('1 个作用域存在 Skill 待同步');
+    expect(container.textContent).not.toContain('2 个作用域存在 Skill 待同步');
+
+    const detail = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('查看详情'),
+    );
+    await act(async () => {
+      detail?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog?.textContent).toContain('traqen');
+    expect(dialog?.textContent).not.toContain('old-thread-project');
+
+    mockFetch.mockClear();
+    const syncAll = Array.from(dialog?.querySelectorAll('button') ?? []).find((button) =>
+      button.textContent?.includes('同步全部'),
+    );
+    await act(async () => {
+      syncAll?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    const syncedProjectPaths = mockFetch.mock.calls
+      .filter(
+        (call: unknown[]) =>
+          String(call[0]) === '/api/drift/resolve' && (call[1] as { method?: string } | undefined)?.method === 'POST',
+      )
+      .map((call: unknown[]) => {
+        const body = JSON.parse(String((call[1] as { body?: string } | undefined)?.body ?? '{}')) as {
+          projectPath?: string;
+        };
+        return body.projectPath;
+      })
+      .filter(Boolean);
+    expect(syncedProjectPaths).toEqual([initializedProject]);
+
+    mockGetProjectPaths.mockReturnValue([]);
   });
 
   it('opens one unified issue dialog rendering backend project issues verbatim', async () => {

--- a/packages/web/src/components/__tests__/skills-content.test.tsx
+++ b/packages/web/src/components/__tests__/skills-content.test.tsx
@@ -165,6 +165,9 @@ function mockBothApis(
     if (url === '/api/drift/resolve' && init?.method === 'POST') {
       return Promise.resolve(jsonResponse({ ok: true }));
     }
+    if (url.startsWith('/api/mount-rules') && init?.method !== 'PUT') {
+      return Promise.resolve(jsonResponse(mountRulesPayload));
+    }
     return Promise.resolve(jsonResponse(skillsOverride ?? skillsPayload));
   });
 }
@@ -232,6 +235,77 @@ describe('SkillsContent', () => {
     const skillsList = container.querySelector('[data-testid="skills-list"]');
     expect(skillsList?.textContent).toContain('browser-preview');
     expect(skillsList?.textContent).not.toContain('cross-cat-handoff');
+  });
+
+  it('renders every Skill capability write control as read-only on remote hosts', async () => {
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, hostname: 'skycat.cpolar.top' },
+    });
+    mockGetProjectPaths.mockReturnValue(['/workspace/project']);
+    mockBothApis(undefined, undefined, () => [DEFAULT_CONFLICT_ISSUE]);
+
+    try {
+      await render(React.createElement(SkillsContent));
+
+      expect(container.querySelector('button[title="全局禁用"]')).toBeNull();
+      expect(container.querySelector('button[title="批量禁用当前筛选的 Skill"]')).toBeNull();
+
+      const defaultMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('全局默认 Mount Rules'),
+      );
+      await act(async () => {
+        defaultMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      await flushEffects();
+      expect(
+        Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
+          (input) => input.disabled,
+        ),
+      ).toBe(true);
+      expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent === '添加')).toBe(
+        false,
+      );
+
+      const projectTab = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.includes('项目 Skill'),
+      );
+      await act(async () => {
+        projectTab?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      await flushEffects();
+
+      const projectMountRules = Array.from(container.querySelectorAll('button')).find((button) =>
+        button.textContent?.startsWith('Mount Rules'),
+      );
+      await act(async () => {
+        projectMountRules?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+      await flushEffects();
+      expect(
+        Array.from(container.querySelectorAll<HTMLInputElement>('input[type="checkbox"]')).every(
+          (input) => input.disabled,
+        ),
+      ).toBe(true);
+      await act(async () => {
+        const detail = Array.from(container.querySelectorAll('button')).find((button) =>
+          button.textContent?.includes('查看详情'),
+        );
+        detail?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(
+        Array.from(document.body.querySelectorAll('[role="dialog"] button')).some(
+          (button) => button.textContent === '立即同步',
+        ),
+      ).toBe(false);
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
   });
 
   it('opens a read-only SKILL.md preview from the card', async () => {

--- a/packages/web/src/components/settings/AllProjectsSyncBanner.tsx
+++ b/packages/web/src/components/settings/AllProjectsSyncBanner.tsx
@@ -21,6 +21,7 @@ export function AllProjectsSyncBanner({
   scopesWithIssues,
   syncing,
   error,
+  canSync,
   onSyncAll,
   onSyncScope,
 }: {
@@ -30,6 +31,8 @@ export function AllProjectsSyncBanner({
   scopesWithIssues: ScopeIssues[];
   syncing: boolean;
   error: string | null;
+  /** Capability writes are intentionally limited to direct localhost Hub access. */
+  canSync: boolean;
   onSyncAll: () => void;
   onSyncScope?: (projectPath?: string) => void;
 }) {
@@ -48,7 +51,7 @@ export function AllProjectsSyncBanner({
     <div className="rounded-lg border border-conn-amber-ring bg-conn-amber-bg px-4 py-3">
       <div className="flex flex-wrap items-center gap-3">
         <p className="text-sm font-bold text-conn-amber-text">
-          检测到 {issueScopeCount} 处 {label} 异常
+          {issueScopeCount} 个作用域存在 {label} 待同步
         </p>
         <button
           type="button"
@@ -59,6 +62,9 @@ export function AllProjectsSyncBanner({
         </button>
       </div>
 
+      {!canSync && (
+        <p className="mt-1 text-xs text-cafe-muted">远程访问仅支持查看；同步需在 Mac Mini 的 localhost Hub 执行。</p>
+      )}
       {error && <p className="mt-1 text-xs text-conn-red-text">⚠ {error}</p>}
 
       {showDetail && (
@@ -66,6 +72,7 @@ export function AllProjectsSyncBanner({
           type={type}
           scopes={scopesWithIssues}
           syncing={syncing}
+          canSync={canSync}
           onClose={() => setShowDetail(false)}
           onSyncAll={onSyncAll}
           onSyncScope={onSyncScope}
@@ -79,6 +86,7 @@ function AllProjectsIssueDetailDialog({
   type,
   scopes,
   syncing,
+  canSync,
   onClose,
   onSyncAll,
   onSyncScope,
@@ -86,6 +94,7 @@ function AllProjectsIssueDetailDialog({
   type: DriftType;
   scopes: ScopeIssues[];
   syncing: boolean;
+  canSync: boolean;
   onClose: () => void;
   onSyncAll: () => void;
   onSyncScope?: (projectPath?: string) => void;
@@ -105,7 +114,7 @@ function AllProjectsIssueDetailDialog({
   return (
     <ModalOverlay onClose={onClose} maxWidthClass="max-w-2xl">
       <div className="flex shrink-0 items-center justify-between gap-3">
-        <h3 className="text-sm font-bold text-cafe">项目 {label} 异常详情</h3>
+        <h3 className="text-sm font-bold text-cafe">{label} 待同步详情</h3>
         <button
           type="button"
           aria-label="关闭"
@@ -134,7 +143,7 @@ function AllProjectsIssueDetailDialog({
                   {scope.label}
                   <span className="text-cafe-muted">（{scope.issues.length}）</span>
                 </button>
-                {onSyncScope && (
+                {canSync && onSyncScope && (
                   <button
                     type="button"
                     onClick={() => onSyncScope(scope.path)}
@@ -155,16 +164,18 @@ function AllProjectsIssueDetailDialog({
         })}
       </div>
 
-      <div className="mt-4 shrink-0">
-        <button
-          type="button"
-          onClick={onSyncAll}
-          disabled={syncing}
-          className="rounded-lg bg-cafe-accent px-3 py-1 text-xs font-semibold text-[var(--cafe-accent-foreground)] hover:bg-cafe-accent-hover disabled:opacity-40"
-        >
-          {syncing ? '同步中…' : '同步全部'}
-        </button>
-      </div>
+      {canSync && (
+        <div className="mt-4 shrink-0">
+          <button
+            type="button"
+            onClick={onSyncAll}
+            disabled={syncing}
+            className="rounded-lg bg-cafe-accent px-3 py-1 text-xs font-semibold text-[var(--cafe-accent-foreground)] hover:bg-cafe-accent-hover disabled:opacity-40"
+          >
+            {syncing ? '同步中…' : '同步全部'}
+          </button>
+        </div>
+      )}
     </ModalOverlay>
   );
 }

--- a/packages/web/src/components/settings/DriftBanner.tsx
+++ b/packages/web/src/components/settings/DriftBanner.tsx
@@ -163,6 +163,8 @@ export function DriftBanner({ type, projectPath, refreshToken = 0, canSync = tru
   }, [fetchDrift, refreshToken]);
 
   const sync = useCallback(async () => {
+    if (!canSync || drift?.initialized === false) return;
+
     // MCP-specific: confirm orphan removal before syncing
     if (type === 'mcp') {
       const orphans = (drift?.issues ?? []).filter((i) => i.issueType === 'project-orphan');
@@ -193,10 +195,12 @@ export function DriftBanner({ type, projectPath, refreshToken = 0, canSync = tru
     } finally {
       setBusy(false);
     }
-  }, [type, projectPath, fetchDrift, onResolved, drift]);
+  }, [type, projectPath, fetchDrift, onResolved, drift, canSync]);
 
   const label = driftTypeLabel(type);
   const issues = drift?.issues ?? [];
+  const initialized = drift?.initialized !== false;
+  const canResolve = canSync && initialized;
 
   if (loading && !drift && issues.length === 0) {
     return <p className="text-xs text-cafe-muted">{label} 配置检测中…</p>;
@@ -224,13 +228,16 @@ export function DriftBanner({ type, projectPath, refreshToken = 0, canSync = tru
       {!canSync && (
         <p className="mt-1 text-xs text-cafe-muted">远程访问仅支持查看；同步需在 Mac Mini 的 localhost Hub 执行。</p>
       )}
+      {canSync && !initialized && (
+        <p className="mt-1 text-xs text-cafe-muted">该历史项目尚未初始化；请先初始化项目后再同步。</p>
+      )}
       {error && <p className="mt-1 text-xs text-conn-red-text">⚠ {error}</p>}
       {showDetail && (
         <DriftIssueDetailDialog
           type={type}
           issues={issues}
           syncing={busy}
-          canSync={canSync}
+          canSync={canResolve}
           onSync={sync}
           onClose={() => setShowDetail(false)}
         />

--- a/packages/web/src/components/settings/DriftBanner.tsx
+++ b/packages/web/src/components/settings/DriftBanner.tsx
@@ -57,12 +57,14 @@ function DriftIssueDetailDialog({
   type,
   issues,
   syncing,
+  canSync,
   onSync,
   onClose,
 }: {
   type: DriftType;
   issues: DriftIssue[];
   syncing: boolean;
+  canSync: boolean;
   onSync: () => void;
   onClose: () => void;
 }) {
@@ -84,16 +86,18 @@ function DriftIssueDetailDialog({
         {issues.length > 0 ? <DriftIssueList issues={issues} /> : <p className="text-cafe-muted">暂无异常。</p>}
       </section>
 
-      <div className="mt-4 flex shrink-0 gap-2">
-        <button
-          type="button"
-          onClick={onSync}
-          disabled={syncing}
-          className="rounded-lg bg-cafe-accent px-3 py-1 text-xs font-semibold text-[var(--cafe-accent-foreground)] hover:bg-cafe-accent-hover disabled:opacity-40"
-        >
-          {syncing ? '同步中…' : '立即同步'}
-        </button>
-      </div>
+      {canSync && (
+        <div className="mt-4 flex shrink-0 gap-2">
+          <button
+            type="button"
+            onClick={onSync}
+            disabled={syncing}
+            className="rounded-lg bg-cafe-accent px-3 py-1 text-xs font-semibold text-[var(--cafe-accent-foreground)] hover:bg-cafe-accent-hover disabled:opacity-40"
+          >
+            {syncing ? '同步中…' : '立即同步'}
+          </button>
+        </div>
+      )}
     </ModalOverlay>
   );
 }
@@ -105,6 +109,8 @@ interface DriftBannerProps {
   type: DriftType;
   projectPath?: string;
   refreshToken?: number;
+  /** Capability writes are intentionally limited to direct localhost Hub access. */
+  canSync?: boolean;
   onResolved?: () => void | Promise<void>;
 }
 
@@ -112,7 +118,7 @@ interface DriftBannerProps {
  * Unified single-project drift banner — replaces both SkillsDriftBanner and
  * McpDriftBanner. Same endpoint, same UI, parameterized by `type`.
  */
-export function DriftBanner({ type, projectPath, refreshToken = 0, onResolved }: DriftBannerProps) {
+export function DriftBanner({ type, projectPath, refreshToken = 0, canSync = true, onResolved }: DriftBannerProps) {
   const [drift, setDrift] = useState<DriftCheckResult | null>(null);
   const [loading, setLoading] = useState(false);
   const [busy, setBusy] = useState(false);
@@ -215,12 +221,16 @@ export function DriftBanner({ type, projectPath, refreshToken = 0, onResolved }:
           查看详情
         </button>
       </div>
+      {!canSync && (
+        <p className="mt-1 text-xs text-cafe-muted">远程访问仅支持查看；同步需在 Mac Mini 的 localhost Hub 执行。</p>
+      )}
       {error && <p className="mt-1 text-xs text-conn-red-text">⚠ {error}</p>}
       {showDetail && (
         <DriftIssueDetailDialog
           type={type}
           issues={issues}
           syncing={busy}
+          canSync={canSync}
           onSync={sync}
           onClose={() => setShowDetail(false)}
         />

--- a/packages/web/src/components/settings/McpManageContent.tsx
+++ b/packages/web/src/components/settings/McpManageContent.tsx
@@ -122,7 +122,7 @@ export function McpManageContent() {
       setModal({
         editId: item.id,
         readOnly,
-        // Modal auto-probes on mount (McpConfigModal.handleProbeTools); no parent fetch needed.
+        // Local modal auto-probes on mount; remote read-only access must not trigger localhost-only probes.
         tools: undefined,
         editData: buildEditData(item),
       });
@@ -385,6 +385,7 @@ export function McpManageContent() {
           editId={modal.editId}
           editData={modal.editData}
           readOnly={modal.readOnly}
+          allowLocalActions={driftSync.canSync}
           tools={modal.tools}
           onSaved={handleSaved}
           onClose={() => setModal(null)}

--- a/packages/web/src/components/settings/McpManageContent.tsx
+++ b/packages/web/src/components/settings/McpManageContent.tsx
@@ -221,6 +221,7 @@ export function McpManageContent() {
           scopesWithIssues={driftSync.scopesWithIssues}
           syncing={driftSync.syncing}
           error={driftSync.syncAllError}
+          canSync={driftSync.canSync}
           onSyncAll={driftSync.handleSyncAllScopes}
           onSyncScope={driftSync.handleSyncScope}
         />

--- a/packages/web/src/components/settings/McpManageContent.tsx
+++ b/packages/web/src/components/settings/McpManageContent.tsx
@@ -116,16 +116,19 @@ export function McpManageContent() {
     enabled: activeTab === 'global' && !cap.loading,
   });
 
-  const handleCardClick = useCallback((item: CapabilityBoardItem) => {
-    const readOnly = item.source !== 'external' || !!item.pluginId;
-    setModal({
-      editId: item.id,
-      readOnly,
-      // Modal auto-probes on mount (McpConfigModal.handleProbeTools); no parent fetch needed.
-      tools: undefined,
-      editData: buildEditData(item),
-    });
-  }, []);
+  const handleCardClick = useCallback(
+    (item: CapabilityBoardItem) => {
+      const readOnly = !driftSync.canSync || item.source !== 'external' || !!item.pluginId;
+      setModal({
+        editId: item.id,
+        readOnly,
+        // Modal auto-probes on mount (McpConfigModal.handleProbeTools); no parent fetch needed.
+        tools: undefined,
+        editData: buildEditData(item),
+      });
+    },
+    [driftSync.canSync],
+  );
 
   const handleCreate = useCallback(() => setModal({}), []);
 
@@ -196,12 +199,14 @@ export function McpManageContent() {
           }
         }}
         actions={
-          <>
-            <SettingsSecondaryButton onClick={handleDiscover} disabled={discovering}>
-              {discovering ? '同步中…' : '同步系统配置'}
-            </SettingsSecondaryButton>
-            <SettingsPrimaryButton onClick={handleCreate}>新增 MCP</SettingsPrimaryButton>
-          </>
+          driftSync.canSync ? (
+            <>
+              <SettingsSecondaryButton onClick={handleDiscover} disabled={discovering}>
+                {discovering ? '同步中…' : '同步系统配置'}
+              </SettingsSecondaryButton>
+              <SettingsPrimaryButton onClick={handleCreate}>新增 MCP</SettingsPrimaryButton>
+            </>
+          ) : undefined
         }
       />
 
@@ -238,6 +243,7 @@ export function McpManageContent() {
             type="mcp"
             projectPath={cap.projectPath ?? undefined}
             refreshToken={refreshToken}
+            canSync={driftSync.canSync}
             onResolved={handleDriftResolved}
           />
         </>
@@ -273,7 +279,7 @@ export function McpManageContent() {
             </span>
           }
           title="暂无已安装的 MCP"
-          description="点击上方按钮手动新增 MCP 配置"
+          description={driftSync.canSync ? '点击上方按钮手动新增 MCP 配置' : '当前没有可查看的 MCP 配置'}
         />
       )}
 
@@ -313,51 +319,53 @@ export function McpManageContent() {
                 </>
               }
               actions={
-                <>
-                  <ToggleSwitch
-                    enabled={effectiveEnabled}
-                    busy={busy}
-                    disabled={false}
-                    title={effectiveEnabled ? '禁用' : '启用'}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      cap.handleToggle(item, !effectiveEnabled);
-                    }}
-                  />
-                  {cap.catFamilies.length > 0 && (
-                    <SettingsResourceIconButton
-                      onClick={() => setExpandedId(expanded ? null : item.id)}
-                      title="按猫开关"
-                      aria-label="按猫开关"
-                      className={expanded ? 'bg-[var(--console-hover-bg)] text-cafe-accent' : undefined}
-                    >
-                      <HubIcon name="users" className="h-4 w-4" />
-                    </SettingsResourceIconButton>
-                  )}
-                  {editable && (
-                    <SettingsResourceIconButton
-                      disabled={removing}
-                      onClick={async (event) => {
+                driftSync.canSync ? (
+                  <>
+                    <ToggleSwitch
+                      enabled={effectiveEnabled}
+                      busy={busy}
+                      disabled={false}
+                      title={effectiveEnabled ? '禁用' : '启用'}
+                      onClick={(event) => {
                         event.stopPropagation();
-                        const ok = await confirm({
-                          title: '卸载 MCP',
-                          message: `确认卸载 MCP "${item.id}"？配置将被移除，不可撤销。`,
-                          confirmLabel: '卸载',
-                          variant: 'danger',
-                        });
-                        if (ok) cap.handleRemoveMcp(item);
+                        cap.handleToggle(item, !effectiveEnabled);
                       }}
-                      title="卸载此 MCP"
-                      aria-label="卸载此 MCP"
-                      tone="danger"
-                    >
-                      <HubIcon name="trash" className="h-4 w-4" />
-                    </SettingsResourceIconButton>
-                  )}
-                </>
+                    />
+                    {cap.catFamilies.length > 0 && (
+                      <SettingsResourceIconButton
+                        onClick={() => setExpandedId(expanded ? null : item.id)}
+                        title="按猫开关"
+                        aria-label="按猫开关"
+                        className={expanded ? 'bg-[var(--console-hover-bg)] text-cafe-accent' : undefined}
+                      >
+                        <HubIcon name="users" className="h-4 w-4" />
+                      </SettingsResourceIconButton>
+                    )}
+                    {editable && (
+                      <SettingsResourceIconButton
+                        disabled={removing}
+                        onClick={async (event) => {
+                          event.stopPropagation();
+                          const ok = await confirm({
+                            title: '卸载 MCP',
+                            message: `确认卸载 MCP "${item.id}"？配置将被移除，不可撤销。`,
+                            confirmLabel: '卸载',
+                            variant: 'danger',
+                          });
+                          if (ok) cap.handleRemoveMcp(item);
+                        }}
+                        title="卸载此 MCP"
+                        aria-label="卸载此 MCP"
+                        tone="danger"
+                      >
+                        <HubIcon name="trash" className="h-4 w-4" />
+                      </SettingsResourceIconButton>
+                    )}
+                  </>
+                ) : undefined
               }
               expandedContent={
-                expanded ? (
+                driftSync.canSync && expanded ? (
                   <PerCatToggles
                     item={item}
                     catFamilies={cap.catFamilies}

--- a/packages/web/src/components/settings/McpManageContent.tsx
+++ b/packages/web/src/components/settings/McpManageContent.tsx
@@ -116,19 +116,16 @@ export function McpManageContent() {
     enabled: activeTab === 'global' && !cap.loading,
   });
 
-  const handleCardClick = useCallback(
-    (item: CapabilityBoardItem) => {
-      const readOnly = !driftSync.canSync || item.source !== 'external' || !!item.pluginId;
-      setModal({
-        editId: item.id,
-        readOnly,
-        // Local modal auto-probes on mount; remote read-only access must not trigger localhost-only probes.
-        tools: undefined,
-        editData: buildEditData(item),
-      });
-    },
-    [driftSync.canSync],
-  );
+  const handleCardClick = useCallback((item: CapabilityBoardItem) => {
+    const readOnly = item.source !== 'external' || !!item.pluginId;
+    setModal({
+      editId: item.id,
+      readOnly,
+      // Local modal auto-probes on mount; remote read-only access must not trigger localhost-only probes.
+      tools: undefined,
+      editData: buildEditData(item),
+    });
+  }, []);
 
   const handleCreate = useCallback(() => setModal({}), []);
 
@@ -384,7 +381,7 @@ export function McpManageContent() {
           projectPath={cap.projectPath ?? undefined}
           editId={modal.editId}
           editData={modal.editData}
-          readOnly={modal.readOnly}
+          readOnly={!driftSync.canSync || modal.readOnly}
           allowLocalActions={driftSync.canSync}
           tools={modal.tools}
           onSaved={handleSaved}

--- a/packages/web/src/components/settings/MountRulesPanel.tsx
+++ b/packages/web/src/components/settings/MountRulesPanel.tsx
@@ -31,10 +31,12 @@ interface MountRulesPanelProps {
   projectPath?: string;
   /** 'project' = per-project rules (default), 'default' = global defaultMountRules */
   scope?: 'project' | 'default';
+  /** Remote Hub sessions may inspect rules but cannot mutate them. */
+  readOnly?: boolean;
   onSaved?: () => void | Promise<void>;
 }
 
-export function MountRulesPanel({ projectPath, scope = 'project', onSaved }: MountRulesPanelProps) {
+export function MountRulesPanel({ projectPath, scope = 'project', readOnly = false, onSaved }: MountRulesPanelProps) {
   const [open, setOpen] = useState(false);
   const [rules, setRules] = useState<MountRules | null>(null);
   const [loading, setLoading] = useState(false);
@@ -179,7 +181,7 @@ export function MountRulesPanel({ projectPath, scope = 'project', onSaved }: Mou
                     <input
                       type="checkbox"
                       checked={rules.mountPoints[id].enabled}
-                      disabled={saving}
+                      disabled={saving || readOnly}
                       onChange={() => toggleStandard(id)}
                       className="h-4 w-4"
                     />
@@ -198,41 +200,45 @@ export function MountRulesPanel({ projectPath, scope = 'project', onSaved }: Mou
                   <div key={cp.alias} className="flex items-center gap-3 text-sm">
                     <span className="font-medium text-cafe">{cp.alias}</span>
                     <code className="flex-1 text-xs text-cafe-muted">{cp.path}</code>
-                    <button
-                      type="button"
-                      onClick={() => removeCustom(cp.alias)}
-                      disabled={saving}
-                      className="text-xs text-conn-red-text hover:underline"
-                    >
-                      移除
-                    </button>
+                    {!readOnly && (
+                      <button
+                        type="button"
+                        onClick={() => removeCustom(cp.alias)}
+                        disabled={saving}
+                        className="text-xs text-conn-red-text hover:underline"
+                      >
+                        移除
+                      </button>
+                    )}
                   </div>
                 ))}
               </div>
-              <div className="mt-2 flex items-center gap-2">
-                <input
-                  type="text"
-                  value={newAlias}
-                  onChange={(e) => setNewAlias(e.target.value)}
-                  placeholder="alias (e.g. opencode)"
-                  className="rounded-xl border border-[var(--console-border-soft)] bg-[var(--console-shell-bg)] px-2 py-1 text-xs"
-                />
-                <input
-                  type="text"
-                  value={newPath}
-                  onChange={(e) => setNewPath(e.target.value)}
-                  placeholder=".opencode/skills"
-                  className="flex-1 rounded-xl border border-[var(--console-border-soft)] bg-[var(--console-shell-bg)] px-2 py-1 text-xs"
-                />
-                <button
-                  type="button"
-                  onClick={addCustom}
-                  disabled={saving || !newAlias.trim() || !newPath.trim()}
-                  className="rounded-xl bg-[var(--console-active-bg)] px-3 py-1 text-xs font-semibold text-cafe-interactive disabled:opacity-40"
-                >
-                  添加
-                </button>
-              </div>
+              {!readOnly && (
+                <div className="mt-2 flex items-center gap-2">
+                  <input
+                    type="text"
+                    value={newAlias}
+                    onChange={(e) => setNewAlias(e.target.value)}
+                    placeholder="alias (e.g. opencode)"
+                    className="rounded-xl border border-[var(--console-border-soft)] bg-[var(--console-shell-bg)] px-2 py-1 text-xs"
+                  />
+                  <input
+                    type="text"
+                    value={newPath}
+                    onChange={(e) => setNewPath(e.target.value)}
+                    placeholder=".opencode/skills"
+                    className="flex-1 rounded-xl border border-[var(--console-border-soft)] bg-[var(--console-shell-bg)] px-2 py-1 text-xs"
+                  />
+                  <button
+                    type="button"
+                    onClick={addCustom}
+                    disabled={saving || !newAlias.trim() || !newPath.trim()}
+                    className="rounded-xl bg-[var(--console-active-bg)] px-3 py-1 text-xs font-semibold text-cafe-interactive disabled:opacity-40"
+                  >
+                    添加
+                  </button>
+                </div>
+              )}
             </>
           )}
         </div>

--- a/packages/web/src/components/settings/SkillsContent.tsx
+++ b/packages/web/src/components/settings/SkillsContent.tsx
@@ -216,6 +216,7 @@ export function SkillsContent() {
                 scopesWithIssues={sync.scopesWithIssues}
                 syncing={sync.syncing}
                 error={sync.syncAllError}
+                canSync={sync.canSync}
                 onSyncAll={sync.handleSyncAllScopes}
                 onSyncScope={sync.handleSyncScope}
               />

--- a/packages/web/src/components/settings/SkillsContent.tsx
+++ b/packages/web/src/components/settings/SkillsContent.tsx
@@ -188,13 +188,15 @@ export function SkillsContent() {
               controls.switchProject(path);
             }}
           />
-          <MountRulesPanel projectPath={selectedProjectPath} onSaved={handleMountRulesSaved} />
+          <MountRulesPanel projectPath={selectedProjectPath} readOnly={!sync.canSync} onSaved={handleMountRulesSaved} />
         </>
       )}
 
       {combinedError && <SettingsStatusStrip tone="error">{combinedError}</SettingsStatusStrip>}
 
-      {scope === SCOPE_ALL && <MountRulesPanel scope="default" onSaved={handleMountRulesSaved} />}
+      {scope === SCOPE_ALL && (
+        <MountRulesPanel scope="default" readOnly={!sync.canSync} onSaved={handleMountRulesSaved} />
+      )}
 
       {dataReady && (
         <SkillsFilterToolbar
@@ -226,11 +228,12 @@ export function SkillsContent() {
                 type="skill"
                 projectPath={selectedProjectPath}
                 refreshToken={driftRefreshToken}
+                canSync={sync.canSync}
                 onResolved={refreshSelectedSkills}
               />
             )}
           </div>
-          {filteredSkills.some((s) => s.controls) && (
+          {sync.canSync && filteredSkills.some((s) => s.controls) && (
             <SettingsResourceToggleSwitch
               enabled={batchEnabled}
               busy={controls.toggling === '__batch__'}
@@ -252,6 +255,7 @@ export function SkillsContent() {
             scope={scope}
             syncSummary={sync.skillProjectSync.get(skill.name)}
             toggling={controls.toggling}
+            canManage={sync.canSync}
             expandedMounts={expandedMounts}
             onPreview={() => setPreviewSkill(skill)}
             onToggle={handleToggle}

--- a/packages/web/src/components/settings/SkillsSubComponents.tsx
+++ b/packages/web/src/components/settings/SkillsSubComponents.tsx
@@ -20,6 +20,7 @@ export function SkillRow({
   scope,
   syncSummary,
   toggling,
+  canManage,
   expandedMounts,
   onPreview,
   onToggle,
@@ -30,6 +31,7 @@ export function SkillRow({
   scope: SkillScope;
   syncSummary?: SkillProjectSyncSummary;
   toggling: string | null;
+  canManage: boolean;
   expandedMounts: string | null;
   onPreview: () => void;
   onToggle: (skill: SettingsSkillItem, enabled: boolean) => void;
@@ -86,7 +88,7 @@ export function SkillRow({
         )
       }
       actions={
-        skill.controls ? (
+        canManage && skill.controls ? (
           <>
             <SettingsResourceToggleSwitch
               enabled={effectiveEnabled}
@@ -124,7 +126,7 @@ export function SkillRow({
               ))}
             </div>
           )}
-          {isMountExpanded && skill.controls && (
+          {canManage && isMountExpanded && skill.controls && (
             <PerMountPointToggles
               skillId={skill.id}
               scope={scope}

--- a/packages/web/src/components/settings/__tests__/SkillsDriftBanner.test.tsx
+++ b/packages/web/src/components/settings/__tests__/SkillsDriftBanner.test.tsx
@@ -11,7 +11,7 @@ vi.mock('../../../utils/api-client', () => ({
   apiFetch: (...args: unknown[]) => apiFetch(...args),
 }));
 
-function driftResponse(projectPath: string) {
+function driftResponse(projectPath: string, initialized = true) {
   return {
     result: {
       issues: [
@@ -23,6 +23,7 @@ function driftResponse(projectPath: string) {
         },
       ],
       driftHash: `hash-${projectPath}`,
+      initialized,
     },
   };
 }
@@ -98,6 +99,9 @@ describe('DriftBanner (skill)', () => {
     expect(dialog?.textContent).toContain('tdd');
     expect(dialog?.textContent).toContain('存在同名目录占用');
     expect(dialog?.textContent).toContain('立即同步会覆盖和清理已有内容，请先确认是否需要进行备份');
+    expect(
+      Array.from(dialog?.querySelectorAll('button') ?? []).some((button) => button.textContent === '立即同步'),
+    ).toBe(true);
   });
 
   it('closes the detail dialog when the backdrop is clicked', async () => {
@@ -117,5 +121,39 @@ describe('DriftBanner (skill)', () => {
     });
     await flush();
     expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('keeps an explicit uninitialized project read-only even on localhost', async () => {
+    apiFetch.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/drift/check') {
+        const body = JSON.parse(String(init?.body ?? '{}')) as { projectPath?: string };
+        return {
+          ok: true,
+          json: async () => driftResponse(body.projectPath ?? '', false),
+        };
+      }
+      throw new Error(`Unexpected apiFetch path: ${url}`);
+    });
+
+    act(() => {
+      root.render(<DriftBanner type="skill" projectPath="/tmp/uninitialized-project" />);
+    });
+    await flush();
+
+    expect(container.textContent).toContain('尚未初始化');
+    const detail = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('查看详情'),
+    );
+    act(() => {
+      detail?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+
+    const dialog = document.querySelector('[role="dialog"]');
+    const syncButton = Array.from(dialog?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent === '立即同步',
+    );
+    expect(syncButton).toBeUndefined();
+    expect(apiFetch).not.toHaveBeenCalledWith('/api/drift/resolve', expect.objectContaining({ method: 'POST' }));
   });
 });

--- a/packages/web/src/components/settings/__tests__/useDriftSync.test.tsx
+++ b/packages/web/src/components/settings/__tests__/useDriftSync.test.tsx
@@ -1,0 +1,117 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch } from '@/utils/api-client';
+import { useDriftSync } from '../useDriftSync';
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(),
+}));
+
+let latestResult: ReturnType<typeof useDriftSync> | null = null;
+
+function HookHost({ enabled }: { enabled: boolean }) {
+  latestResult = useDriftSync({
+    type: 'skill',
+    projectPaths: ['/workspace/project'],
+    resolvedProjectPath: '/workspace/main',
+    enabled,
+  });
+  return null;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((next, fail) => {
+    resolve = next;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+}
+
+function driftResponse(projectPath?: string) {
+  return new Response(
+    JSON.stringify({
+      result: { issues: [], driftHash: projectPath ?? 'global', syncAllowed: true },
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+}
+
+describe('useDriftSync write eligibility', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    latestResult = null;
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          result: { issues: [], driftHash: 'global', syncAllowed: true },
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('resolves server write eligibility even when full scope reports are disabled', async () => {
+    await act(async () => {
+      root.render(<HookHost enabled={false} />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(latestResult?.canSync).toBe(true);
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+    const [, init] = vi.mocked(apiFetch).mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toEqual({ type: 'skill' });
+  });
+
+  it('ignores an older authority failure after full reports succeed', async () => {
+    const olderAuthority = deferred<Response>();
+    let globalRequests = 0;
+    vi.mocked(apiFetch).mockImplementation((_input, init) => {
+      const body = JSON.parse(String(init?.body)) as { projectPath?: string };
+      if (!body.projectPath && globalRequests++ === 0) return olderAuthority.promise;
+      return Promise.resolve(driftResponse(body.projectPath));
+    });
+
+    await act(async () => {
+      root.render(<HookHost enabled={false} />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      root.render(<HookHost enabled />);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    expect(latestResult?.canSync).toBe(true);
+    expect(latestResult?.syncAllError).toBeNull();
+
+    await act(async () => {
+      olderAuthority.reject(new Error('stale authority request failed'));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(latestResult?.canSync).toBe(true);
+    expect(latestResult?.syncAllError).toBeNull();
+  });
+});

--- a/packages/web/src/components/settings/drift-types.ts
+++ b/packages/web/src/components/settings/drift-types.ts
@@ -35,6 +35,8 @@ export interface ScopeIssues {
 export interface DriftCheckResult {
   issues: DriftIssue[];
   driftHash: string;
+  /** False when a historical project path exists but has no .cat-cafe project state. */
+  initialized?: boolean;
 }
 
 /** Issue-type label map (covers both Skill and MCP issue types). */

--- a/packages/web/src/components/settings/drift-types.ts
+++ b/packages/web/src/components/settings/drift-types.ts
@@ -37,6 +37,8 @@ export interface DriftCheckResult {
   driftHash: string;
   /** False when a historical project path exists but has no .cat-cafe project state. */
   initialized?: boolean;
+  /** Server-authoritative locality decision for capability write surfaces. */
+  syncAllowed?: boolean;
 }
 
 /** Issue-type label map (covers both Skill and MCP issue types). */

--- a/packages/web/src/components/settings/useDriftSync.ts
+++ b/packages/web/src/components/settings/useDriftSync.ts
@@ -9,7 +9,7 @@ const subscribeToLocation = () => () => undefined;
 
 export function isDirectLocalHubHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
-  return normalized === 'localhost' || normalized === '::1' || normalized === '[::1]' || normalized.startsWith('127.');
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1' || normalized === '[::1]';
 }
 
 function getLocalHubSnapshot(): boolean {

--- a/packages/web/src/components/settings/useDriftSync.ts
+++ b/packages/web/src/components/settings/useDriftSync.ts
@@ -1,10 +1,20 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { apiFetch } from '@/utils/api-client';
 import type { DriftCheckResult, DriftIssue, DriftType, ScopeIssues } from './drift-types';
 
 const GLOBAL_SCOPE_KEY = 'global';
+const subscribeToLocation = () => () => undefined;
+
+export function isDirectLocalHubHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'localhost' || normalized === '::1' || normalized === '[::1]' || normalized.startsWith('127.');
+}
+
+function getLocalHubSnapshot(): boolean {
+  return typeof window !== 'undefined' && isDirectLocalHubHostname(window.location.hostname);
+}
 
 interface UseDriftSyncOptions {
   /** Capability type: 'skill' or 'mcp'. */
@@ -47,7 +57,7 @@ export function useDriftSync({
   // driftFor(undefined) → checkGlobal. Including it again would duplicate global
   // issues (mount-missing, unregistered) as project-level sync issues, making
   // every skill badge show "待同步" even when projects are correctly synced.
-  const projectPaths = useMemo(() => {
+  const candidateProjectPaths = useMemo(() => {
     const normalize = (p: string) => p.replace(/\/+$/, '');
     const resolvedNorm = resolvedProjectPath ? normalize(resolvedProjectPath) : null;
     const paths = new Set<string>();
@@ -58,7 +68,8 @@ export function useDriftSync({
     }
     return Array.from(paths);
   }, [rawProjectPaths, resolvedProjectPath]);
-  const projectPathsKey = projectPaths.join('\0');
+  const projectPathsKey = candidateProjectPaths.join('\0');
+  const canSync = useSyncExternalStore(subscribeToLocation, getLocalHubSnapshot, () => false);
 
   /** Call /api/drift/check for one scope. */
   const driftFor = useCallback(
@@ -118,6 +129,11 @@ export function useDriftSync({
     });
   }, [fetchScopeReports, projectPathsKey, enabled, refreshToken]);
 
+  const projectPaths = useMemo(
+    () => candidateProjectPaths.filter((path) => scopeDrift[path]?.initialized !== false),
+    [candidateProjectPaths, scopeDrift],
+  );
+
   /** Scope tree: global first, then each project. */
   const scopeIssues: ScopeIssues[] = useMemo(() => {
     const projectName = (path: string) => {
@@ -164,14 +180,14 @@ export function useDriftSync({
       setSyncAllError(null);
       try {
         await resolveScope('sync', projectPath);
-        await fetchScopeReports(projectPaths);
+        await fetchScopeReports(candidateProjectPaths);
       } catch (err) {
         setSyncAllError(err instanceof Error ? err.message : '同步失败');
       } finally {
         setSyncing(false);
       }
     },
-    [fetchScopeReports, projectPaths, resolveScope],
+    [candidateProjectPaths, fetchScopeReports, resolveScope],
   );
 
   const handleSyncAllScopes = useCallback(async () => {
@@ -183,17 +199,18 @@ export function useDriftSync({
       for (const path of projectPaths) {
         await resolveScope('sync', path);
       }
-      await fetchScopeReports(projectPaths);
+      await fetchScopeReports(candidateProjectPaths);
     } catch (err) {
       setSyncAllError(err instanceof Error ? err.message : '全部同步失败');
     } finally {
       setSyncing(false);
     }
-  }, [fetchScopeReports, projectPaths, resolveScope, type]);
+  }, [candidateProjectPaths, fetchScopeReports, projectPaths, resolveScope, type]);
 
   return {
     syncing,
     syncAllError,
+    canSync,
     projectPaths,
     projectConsistency,
     scopeIssues,

--- a/packages/web/src/components/settings/useDriftSync.ts
+++ b/packages/web/src/components/settings/useDriftSync.ts
@@ -1,20 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiFetch } from '@/utils/api-client';
 import type { DriftCheckResult, DriftIssue, DriftType, ScopeIssues } from './drift-types';
 
 const GLOBAL_SCOPE_KEY = 'global';
-const subscribeToLocation = () => () => undefined;
-
-export function isDirectLocalHubHostname(hostname: string): boolean {
-  const normalized = hostname.toLowerCase();
-  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1' || normalized === '[::1]';
-}
-
-function getLocalHubSnapshot(): boolean {
-  return typeof window !== 'undefined' && isDirectLocalHubHostname(window.location.hostname);
-}
 
 interface UseDriftSyncOptions {
   /** Capability type: 'skill' or 'mcp'. */
@@ -69,7 +59,7 @@ export function useDriftSync({
     return Array.from(paths);
   }, [rawProjectPaths, resolvedProjectPath]);
   const projectPathsKey = candidateProjectPaths.join('\0');
-  const canSync = useSyncExternalStore(subscribeToLocation, getLocalHubSnapshot, () => false);
+  const canSync = scopeDrift[GLOBAL_SCOPE_KEY]?.syncAllowed === true;
 
   /** Call /api/drift/check for one scope. */
   const driftFor = useCallback(

--- a/packages/web/src/components/settings/useDriftSync.ts
+++ b/packages/web/src/components/settings/useDriftSync.ts
@@ -15,7 +15,7 @@ interface UseDriftSyncOptions {
   resolvedProjectPath?: string;
   /** Increment to force re-fetch of scope reports. */
   refreshToken?: number;
-  /** Whether to fetch (only when scope = all-projects). */
+  /** Whether to fetch full cross-project reports (the global write gate is always resolved once). */
   enabled?: boolean;
 }
 
@@ -59,6 +59,7 @@ export function useDriftSync({
     return Array.from(paths);
   }, [rawProjectPaths, resolvedProjectPath]);
   const projectPathsKey = candidateProjectPaths.join('\0');
+  const hasResolvedWriteEligibility = scopeDrift[GLOBAL_SCOPE_KEY] !== undefined;
   const canSync = scopeDrift[GLOBAL_SCOPE_KEY]?.syncAllowed === true;
 
   /** Call /api/drift/check for one scope. */
@@ -81,30 +82,34 @@ export function useDriftSync({
     async (paths: string[]) => {
       const generation = ++reportsFetchGen.current;
       const isCurrent = () => reportsFetchGen.current === generation;
-      const [globalDrift, projectDrifts] = await Promise.all([
-        driftFor(undefined),
-        // Per-project: catch individually so one invalid/stale project doesn't
-        // kill the entire batch. A failed project shows as a synthetic issue
-        // instead of silently hiding all drift results.
-        Promise.all(
-          paths.map(async (path) => {
-            try {
-              return [path, await driftFor(path)] as const;
-            } catch (err) {
-              const label = path.split('/').pop() ?? path;
-              const msg = err instanceof Error ? err.message : '检测失败';
-              const failIssue: DriftIssue = {
-                id: '__check-failed',
-                issueType: 'check-failed',
-                message: `项目 ${label} 异常检测失败: ${msg}`,
-              };
-              return [path, { issues: [failIssue], driftHash: '' } as DriftCheckResult] as const;
-            }
-          }),
-        ),
-      ]);
-      if (!isCurrent()) return;
-      setScopeDrift({ [GLOBAL_SCOPE_KEY]: globalDrift, ...Object.fromEntries(projectDrifts) });
+      try {
+        const [globalDrift, projectDrifts] = await Promise.all([
+          driftFor(undefined),
+          // Per-project: catch individually so one invalid/stale project doesn't
+          // kill the entire batch. A failed project shows as a synthetic issue
+          // instead of silently hiding all drift results.
+          Promise.all(
+            paths.map(async (path) => {
+              try {
+                return [path, await driftFor(path)] as const;
+              } catch (err) {
+                const label = path.split('/').pop() ?? path;
+                const msg = err instanceof Error ? err.message : '检测失败';
+                const failIssue: DriftIssue = {
+                  id: '__check-failed',
+                  issueType: 'check-failed',
+                  message: `项目 ${label} 异常检测失败: ${msg}`,
+                };
+                return [path, { issues: [failIssue], driftHash: '' } as DriftCheckResult] as const;
+              }
+            }),
+          ),
+        ]);
+        if (!isCurrent()) return;
+        setScopeDrift({ [GLOBAL_SCOPE_KEY]: globalDrift, ...Object.fromEntries(projectDrifts) });
+      } catch (err) {
+        if (isCurrent()) throw err;
+      }
     },
     [driftFor],
   );
@@ -118,6 +123,17 @@ export function useDriftSync({
       setSyncAllError(err instanceof Error ? err.message : '跨项目状态加载失败');
     });
   }, [fetchScopeReports, projectPathsKey, enabled, refreshToken]);
+
+  // The active tab may disable full cross-project reports, but it must not
+  // disable the server-authoritative write gate. Fetch only the global scope
+  // until eligibility is known; project reports remain gated by `enabled`.
+  useEffect(() => {
+    if (enabled || hasResolvedWriteEligibility) return;
+    setSyncAllError(null);
+    void fetchScopeReports([]).catch((err) => {
+      setSyncAllError(err instanceof Error ? err.message : '写权限检测失败');
+    });
+  }, [enabled, fetchScopeReports, hasResolvedWriteEligibility]);
 
   const projectPaths = useMemo(
     () => candidateProjectPaths.filter((path) => scopeDrift[path]?.initialized !== false),

--- a/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
@@ -33,6 +33,13 @@ function Probe({ onStatus }: { onStatus: (status: string | null) => void }) {
   return null;
 }
 
+let latestResult: ReturnType<typeof useAgentHookHealth> | null = null;
+
+function ResultProbe() {
+  latestResult = useAgentHookHealth({ enabled: true, projectPath: '/workspace/project' });
+  return null;
+}
+
 describe('useAgentHookHealth', () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -49,6 +56,7 @@ describe('useAgentHookHealth', () => {
 
   beforeEach(() => {
     resetAgentHookHealthCacheForTests();
+    latestResult = null;
     vi.mocked(apiFetch).mockReset();
     vi.mocked(apiFetch).mockResolvedValue({
       ok: true,
@@ -85,5 +93,66 @@ describe('useAgentHookHealth', () => {
     expect(apiFetch).toHaveBeenCalledTimes(1);
     expect(apiFetch).toHaveBeenCalledWith('/api/agent-hooks/status');
     expect(statuses).toContain('configured');
+  });
+
+  it('surfaces an uninitialized project as a non-syncable health result', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Project not initialized (missing .cat-cafe/): /workspace/project' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(latestResult?.error).toBeNull();
+    expect(latestResult?.health).toMatchObject({
+      status: 'error',
+      targets: [],
+      syncAllowed: false,
+      message: 'Project not initialized (missing .cat-cafe/): /workspace/project',
+    });
+  });
+
+  it('surfaces remote host protection as unsupported and non-syncable', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'Agent hook health requires an explicit targetRoot or a local API host' }), {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(latestResult?.error).toBeNull();
+    expect(latestResult?.health).toMatchObject({
+      status: 'unsupported',
+      targets: [],
+      syncAllowed: false,
+      message: '为保护本机 Agent 配置，环境检测和一键同步仅支持通过 localhost Hub 操作。',
+    });
+  });
+
+  it('rejects malformed optional health metadata', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: 'configured', targets: [], syncAllowed: 'yes' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(latestResult?.health).toBeNull();
+    expect(latestResult?.error).toBe('agent hook status response is invalid');
   });
 });

--- a/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
@@ -25,6 +25,14 @@ function flushPromises() {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 function Probe({ onStatus }: { onStatus: (status: string | null) => void }) {
   const { health } = useAgentHookHealth({ enabled: true });
   useEffect(() => {
@@ -174,6 +182,117 @@ describe('useAgentHookHealth', () => {
 
     expect(apiFetch).toHaveBeenCalledTimes(2);
     expect(latestResult?.health?.status).toBe('configured');
+    expect(latestResult?.error).toBeNull();
+  });
+
+  it('forces a fresh status request after setup and ignores the older in-flight result', async () => {
+    const beforeSetup = deferred<Response>();
+    const afterSetup = deferred<Response>();
+    vi.mocked(apiFetch).mockReturnValueOnce(beforeSetup.promise).mockReturnValueOnce(afterSetup.promise);
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await Promise.resolve();
+    });
+    expect(apiFetch).toHaveBeenCalledTimes(1);
+
+    const refresh = latestResult?.refresh;
+    if (!refresh) throw new Error('Missing hook refresh action');
+    let refreshPromise = Promise.resolve();
+    act(() => {
+      refreshPromise = refresh();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      afterSetup.resolve(
+        new Response(JSON.stringify(configuredResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      await refreshPromise;
+    });
+    expect(latestResult?.health?.status).toBe('configured');
+
+    await act(async () => {
+      beforeSetup.resolve(
+        new Response(JSON.stringify({ error: 'Project not initialized (missing .cat-cafe/)' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      await flushPromises();
+    });
+
+    expect(latestResult?.health?.status).toBe('configured');
+    expect(latestResult?.error).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(latestResult?.health?.status).toBe('configured');
+  });
+
+  it('keeps a successful sync authoritative when an older status request finishes later', async () => {
+    const beforeSync = deferred<Response>();
+    const syncRequest = deferred<Response>();
+    vi.mocked(apiFetch).mockReturnValueOnce(beforeSync.promise).mockReturnValueOnce(syncRequest.promise);
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await Promise.resolve();
+    });
+
+    const sync = latestResult?.sync;
+    if (!sync) throw new Error('Missing hook sync action');
+    let syncPromise = Promise.resolve();
+    act(() => {
+      syncPromise = sync();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(apiFetch).toHaveBeenLastCalledWith('/api/agent-hooks/sync', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectPath: '/workspace/project' }),
+    });
+
+    await act(async () => {
+      syncRequest.resolve(
+        new Response(JSON.stringify(configuredResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      await syncPromise;
+    });
+    expect(latestResult?.health?.status).toBe('configured');
+    expect(latestResult?.synced).toBe(true);
+
+    await act(async () => {
+      beforeSync.resolve(
+        new Response(JSON.stringify({ error: 'Project not initialized (missing .cat-cafe/)' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      await flushPromises();
+    });
+
+    expect(latestResult?.health?.status).toBe('configured');
+    expect(latestResult?.synced).toBe(true);
     expect(latestResult?.error).toBeNull();
   });
 

--- a/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
+++ b/packages/web/src/hooks/__tests__/use-agent-hook-health.test.tsx
@@ -139,6 +139,44 @@ describe('useAgentHookHealth', () => {
     });
   });
 
+  it('does not cache transient client errors as permanent health', async () => {
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'Too many requests' }), {
+          status: 429,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify(configuredResponse), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(latestResult?.health).toBeNull();
+    expect(latestResult?.error).toBe('Too many requests');
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(<ResultProbe />);
+      await flushPromises();
+    });
+
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+    expect(latestResult?.health?.status).toBe('configured');
+    expect(latestResult?.error).toBeNull();
+  });
+
   it('rejects malformed optional health metadata', async () => {
     vi.mocked(apiFetch).mockResolvedValueOnce(
       new Response(JSON.stringify({ status: 'configured', targets: [], syncAllowed: 'yes' }), {

--- a/packages/web/src/hooks/__tests__/useAgentHookHealth-project-switch.test.ts
+++ b/packages/web/src/hooks/__tests__/useAgentHookHealth-project-switch.test.ts
@@ -126,4 +126,30 @@ describe('useAgentHookHealth project switch', () => {
     expect(lastResult?.health).toEqual(healthB);
     expect(lastResult?.loading).toBe(false);
   });
+
+  it('clears a successful sync confirmation when the project changes', async () => {
+    apiFetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify(healthA), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify(healthA), { status: 200 }));
+
+    await act(async () => {
+      root.render(React.createElement(HookHost, { projectPath: PROJECT_A }));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    const sync = lastResult?.sync;
+    if (!sync) throw new Error('Missing hook sync action');
+    await act(async () => {
+      await sync();
+    });
+    expect(lastResult?.synced).toBe(true);
+
+    const pendingB = new Promise<Response>(() => {});
+    apiFetchMock.mockReturnValueOnce(pendingB);
+    await act(async () => {
+      root.render(React.createElement(HookHost, { projectPath: PROJECT_B }));
+    });
+
+    expect(lastResult?.synced).toBe(false);
+  });
 });

--- a/packages/web/src/hooks/useAgentHookHealth.ts
+++ b/packages/web/src/hooks/useAgentHookHealth.ts
@@ -22,6 +22,8 @@ export interface AgentHookTargetHealth {
 export interface AgentHookStatusResponse {
   status: AgentHookHealthStatus;
   targets: AgentHookTargetHealth[];
+  syncAllowed?: boolean;
+  message?: string;
 }
 
 interface UseAgentHookHealthOptions {
@@ -47,12 +49,41 @@ let inFlightProjectPath: string | undefined;
 let inFlightStatus: Promise<AgentHookStatusResponse> | null = null;
 
 function isAgentHookStatusResponse(value: unknown): value is AgentHookStatusResponse {
+  const response = value as { status?: unknown; targets?: unknown; syncAllowed?: unknown; message?: unknown } | null;
   return (
-    !!value &&
-    typeof value === 'object' &&
-    typeof (value as { status?: unknown }).status === 'string' &&
-    Array.isArray((value as { targets?: unknown }).targets)
+    !!response &&
+    typeof response === 'object' &&
+    typeof response.status === 'string' &&
+    Array.isArray(response.targets) &&
+    (response.syncAllowed === undefined || typeof response.syncAllowed === 'boolean') &&
+    (response.message === undefined || typeof response.message === 'string')
   );
+}
+
+async function readApiErrorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const payload = (await response.json()) as { error?: unknown; message?: unknown };
+    if (typeof payload.error === 'string' && payload.error.trim()) return payload.error.trim();
+    if (typeof payload.message === 'string' && payload.message.trim()) return payload.message.trim();
+  } catch {
+    return fallback;
+  }
+  return fallback;
+}
+
+async function clientErrorHealth(response: Response): Promise<AgentHookStatusResponse | null> {
+  if (response.status < 400 || response.status >= 500) return null;
+
+  const serverMessage = await readApiErrorMessage(response, `agent hook status failed (${response.status})`);
+  return {
+    status: response.status === 403 ? 'unsupported' : 'error',
+    targets: [],
+    syncAllowed: false,
+    message:
+      response.status === 403
+        ? '为保护本机 Agent 配置，环境检测和一键同步仅支持通过 localhost Hub 操作。'
+        : serverMessage,
+  };
 }
 
 async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatusResponse> {
@@ -66,7 +97,11 @@ async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatu
   inFlightProjectPath = projectPath;
   inFlightStatus = apiFetch(url)
     .then(async (res) => {
-      if (!res.ok) throw new Error(`agent hook status failed (${res.status})`);
+      if (!res.ok) {
+        const blockedHealth = await clientErrorHealth(res);
+        if (blockedHealth) return blockedHealth;
+        throw new Error(await readApiErrorMessage(res, `agent hook status failed (${res.status})`));
+      }
       const status = await res.json();
       if (!isAgentHookStatusResponse(status)) throw new Error('agent hook status response is invalid');
       return status;
@@ -90,7 +125,7 @@ async function postAgentHookSync(projectPath?: string): Promise<AgentHookStatusR
     headers: projectPath ? { 'Content-Type': 'application/json' } : undefined,
     body: projectPath ? JSON.stringify({ projectPath }) : undefined,
   });
-  if (!res.ok) throw new Error(`agent hook sync failed (${res.status})`);
+  if (!res.ok) throw new Error(await readApiErrorMessage(res, `agent hook sync failed (${res.status})`));
   const status = await res.json();
   if (!isAgentHookStatusResponse(status)) throw new Error('agent hook sync response is invalid');
   cachedHealth = status;

--- a/packages/web/src/hooks/useAgentHookHealth.ts
+++ b/packages/web/src/hooks/useAgentHookHealth.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { apiFetch } from '../utils/api-client';
 
 export type AgentHookHealthStatus = 'configured' | 'missing' | 'stale' | 'unsupported' | 'error';
@@ -45,8 +45,12 @@ interface UseAgentHookHealthResult {
 let cachedHealth: AgentHookStatusResponse | null = null;
 let cachedProjectPath: string | undefined;
 let hasCachedHealth = false;
-let inFlightProjectPath: string | undefined;
-let inFlightStatus: Promise<AgentHookStatusResponse> | null = null;
+let requestGeneration = 0;
+let inFlightStatus: {
+  projectPath: string | undefined;
+  generation: number;
+  promise: Promise<AgentHookStatusResponse>;
+} | null = null;
 
 function isAgentHookStatusResponse(value: unknown): value is AgentHookStatusResponse {
   const response = value as { status?: unknown; targets?: unknown; syncAllowed?: unknown; message?: unknown } | null;
@@ -86,16 +90,30 @@ async function clientErrorHealth(response: Response): Promise<AgentHookStatusRes
   };
 }
 
-async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatusResponse> {
-  if (hasCachedHealth && cachedHealth && cachedProjectPath === projectPath) return cachedHealth;
-  if (inFlightStatus && inFlightProjectPath === projectPath) return inFlightStatus;
+function clearCachedHealth() {
+  cachedHealth = null;
+  cachedProjectPath = undefined;
+  hasCachedHealth = false;
+}
+
+function cacheHealthIfCurrent(generation: number, projectPath: string | undefined, status: AgentHookStatusResponse) {
+  if (generation !== requestGeneration) return;
+  cachedHealth = status;
+  cachedProjectPath = projectPath;
+  hasCachedHealth = true;
+}
+
+async function readAgentHookStatus(projectPath?: string, force = false): Promise<AgentHookStatusResponse> {
+  if (!force && hasCachedHealth && cachedHealth && cachedProjectPath === projectPath) return cachedHealth;
+  if (!force && inFlightStatus && inFlightStatus.projectPath === projectPath) return inFlightStatus.promise;
+  if (force) clearCachedHealth();
 
   const url = projectPath
     ? `/api/agent-hooks/status?projectPath=${encodeURIComponent(projectPath)}`
     : '/api/agent-hooks/status';
 
-  inFlightProjectPath = projectPath;
-  inFlightStatus = apiFetch(url)
+  const generation = ++requestGeneration;
+  const promise = apiFetch(url)
     .then(async (res) => {
       if (!res.ok) {
         const blockedHealth = await clientErrorHealth(res);
@@ -107,19 +125,21 @@ async function readAgentHookStatus(projectPath?: string): Promise<AgentHookStatu
       return status;
     })
     .then((status) => {
-      cachedHealth = status;
-      cachedProjectPath = projectPath;
-      hasCachedHealth = true;
+      cacheHealthIfCurrent(generation, projectPath, status);
       return status;
     })
     .finally(() => {
-      inFlightStatus = null;
+      if (inFlightStatus?.generation === generation) inFlightStatus = null;
     });
 
-  return inFlightStatus;
+  inFlightStatus = { projectPath, generation, promise };
+  return promise;
 }
 
 async function postAgentHookSync(projectPath?: string): Promise<AgentHookStatusResponse> {
+  clearCachedHealth();
+  const generation = ++requestGeneration;
+  inFlightStatus = null;
   const res = await apiFetch('/api/agent-hooks/sync', {
     method: 'POST',
     headers: projectPath ? { 'Content-Type': 'application/json' } : undefined,
@@ -128,9 +148,7 @@ async function postAgentHookSync(projectPath?: string): Promise<AgentHookStatusR
   if (!res.ok) throw new Error(await readApiErrorMessage(res, `agent hook sync failed (${res.status})`));
   const status = await res.json();
   if (!isAgentHookStatusResponse(status)) throw new Error('agent hook sync response is invalid');
-  cachedHealth = status;
-  cachedProjectPath = projectPath;
-  hasCachedHealth = true;
+  cacheHealthIfCurrent(generation, projectPath, status);
   return status;
 }
 
@@ -139,8 +157,8 @@ function errorMessage(error: unknown): string {
 }
 
 export function resetAgentHookHealthCacheForTests() {
-  cachedHealth = null;
-  hasCachedHealth = false;
+  clearCachedHealth();
+  requestGeneration += 1;
   inFlightStatus = null;
 }
 
@@ -155,64 +173,77 @@ export function useAgentHookHealth({
   const [syncing, setSyncing] = useState(false);
   const [synced, setSynced] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const operationGeneration = useRef(0);
 
-  const applyStatus = useCallback(async (readStatus: () => Promise<AgentHookStatusResponse>) => {
+  const applyStatus = useCallback(async (generation: number, readStatus: () => Promise<AgentHookStatusResponse>) => {
     try {
       const status = await readStatus();
+      if (operationGeneration.current !== generation) return null;
       setHealth(status);
       return status;
     } catch (err) {
-      setError(errorMessage(err));
+      if (operationGeneration.current === generation) setError(errorMessage(err));
       return null;
     }
   }, []);
 
   const refresh = useCallback(async () => {
+    const generation = ++operationGeneration.current;
     setLoading(true);
+    setSyncing(false);
+    setSynced(false);
     setError(null);
-    cachedHealth = null;
-    hasCachedHealth = false;
-    await applyStatus(() => readAgentHookStatus(projectPath));
-    setLoading(false);
+    await applyStatus(generation, () => readAgentHookStatus(projectPath, true));
+    if (operationGeneration.current === generation) {
+      setLoading(false);
+    }
   }, [applyStatus, projectPath]);
 
   const sync = useCallback(async () => {
+    const generation = ++operationGeneration.current;
+    setLoading(false);
     setSyncing(true);
     setSynced(false);
     setError(null);
-    const status = await applyStatus(() => postAgentHookSync(projectPath));
-    setSynced(status?.status === 'configured');
-    setSyncing(false);
+    const status = await applyStatus(generation, () => postAgentHookSync(projectPath));
+    if (operationGeneration.current === generation) {
+      setSynced(status?.status === 'configured');
+      setSyncing(false);
+    }
   }, [applyStatus, projectPath]);
 
   useEffect(() => {
-    if (!enabled) return;
-    let cancelled = false;
+    const generation = ++operationGeneration.current;
+    const cancelPendingOperation = () => {
+      operationGeneration.current += 1;
+    };
+    setSynced(false);
+    if (!enabled) return cancelPendingOperation;
 
     if (hasCachedHealth && cachedProjectPath === projectPath) {
       setHealth(cachedHealth);
-      return;
+      setLoading(false);
+      return cancelPendingOperation;
     }
 
     setLoading(true);
+    setSyncing(false);
     setError(null);
     setHealth(null);
     readAgentHookStatus(projectPath)
       .then(
         (status) => {
-          if (!cancelled) setHealth(status);
+          if (operationGeneration.current === generation) setHealth(status);
         },
         (err) => {
-          if (!cancelled) setError(errorMessage(err));
+          if (operationGeneration.current === generation) setError(errorMessage(err));
         },
       )
       .finally(() => {
-        if (!cancelled) setLoading(false);
+        if (operationGeneration.current === generation) setLoading(false);
       });
 
-    return () => {
-      cancelled = true;
-    };
+    return cancelPendingOperation;
   }, [enabled, projectPath]);
 
   return { health, loading, syncing, synced, error, refresh, sync };

--- a/packages/web/src/hooks/useAgentHookHealth.ts
+++ b/packages/web/src/hooks/useAgentHookHealth.ts
@@ -72,7 +72,7 @@ async function readApiErrorMessage(response: Response, fallback: string): Promis
 }
 
 async function clientErrorHealth(response: Response): Promise<AgentHookStatusResponse | null> {
-  if (response.status < 400 || response.status >= 500) return null;
+  if (response.status !== 400 && response.status !== 403) return null;
 
   const serverMessage = await readApiErrorMessage(response, `agent hook status failed (${response.status})`);
   return {

--- a/packages/web/src/lib/capability-tips.seed.json
+++ b/packages/web/src/lib/capability-tips.seed.json
@@ -823,6 +823,27 @@
     "owner": "opus"
   },
   {
+    "id": "capability-drift-remote-readonly",
+    "kind": "capability",
+    "sourceRef": {
+      "path": "packages/web/src/components/settings/AllProjectsSyncBanner.tsx",
+      "anchor": "远程访问仅支持查看"
+    },
+    "structureSource": {
+      "path": "packages/web/src/components/settings/AllProjectsSyncBanner.tsx",
+      "anchor": "AllProjectsSyncBanner"
+    },
+    "bodySource": {
+      "path": "packages/web/src/components/settings/AllProjectsSyncBanner.tsx",
+      "anchor": "localhost Hub"
+    },
+    "contexts": ["concierge_open", "feature_dev"],
+    "audience": ["cvo"],
+    "body": "通过 cpolar 远程打开 Skill / MCP 管理时，可以查看各项目的同步差异；涉及本机配置写入的同步操作，请回到 Mac Mini 的 localhost Hub 执行。",
+    "action": { "type": "open_concierge_draft", "label": "了解远程同步边界" },
+    "owner": "codex"
+  },
+  {
     "id": "feature-f273-desktop-in-app-update",
     "kind": "feature",
     "sourceRef": { "path": "docs/features/F273-desktop-in-app-update.md", "anchor": "User Journey" },

--- a/review-notes/2026-07-28-agent-hook-runtime-mcp-root-review-request.md
+++ b/review-notes/2026-07-28-agent-hook-runtime-mcp-root-review-request.md
@@ -1,0 +1,103 @@
+# Review Request: Agent Hook runtime MCP baseline
+
+Review-Target-ID: fix-agent-hook-health-cpolar
+Branch: fix/agent-hook-health-cpolar
+
+## What
+
+Agent Hook 的 MCP 健康检查和同步现在通过既有的 `redirectRuntimeProjectPath()` 边界，把一次性 runtime worktree 映射到持久 workspace。持久根不可用时，健康检查显式报错，能力同步 fail-closed。
+
+## Why
+
+运行中的 runtime capabilities 没有 MCP，而持久 workspace 保存全部配置。旧实现把 runtime 当成全局基线，误报 6 个核心 MCP 为 `project-orphan`，同步存在删除它们的风险。
+
+## Original Requirements
+
+> “我的项目上有很多skill与mcp，都涉及7类异常。同步问题，是否能帮我处理一下？”
+
+- 来源：`docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md`
+- **请对照上面的摘录判断交付物是否解决了 operator 的问题。**
+
+## Tradeoff
+
+不复制 runtime 配置、不新建第二套真相源，也不放宽 cpolar 远程写门禁。复用现有持久项目路径边界；根解析失败时宁可跳过能力同步，也不猜测或删除 MCP。
+
+## Architecture Ownership
+
+Architecture cell: capability synchronization boundary（F249；当前 ownership map 未单列该 cell）
+Map delta: none
+Why: 复用既有 persistent-project-path 边界，没有新增 Store / Queue / Router / Adapter / Dispatcher / Binding，也没有改变 owner 或 extension point。
+
+请 reviewer 检查：
+
+- diff 是否与 `Map delta: none` 一致；
+- 是否存在 runtime→workspace 越界或符号链接绕过；
+- 持久根缺失或 capabilities 无法解析时是否真正 fail-closed；
+- MCP 同步是否仍可能把 6 个核心 MCP 当作 orphan 删除。
+
+## Open Questions
+
+### 技术 OQ
+
+`resolveAgentHookGlobalRoot()` 是否应该继续作为 Agent Hook 内部边界导出，还是应直接测试更底层的 `redirectRuntimeProjectPath()`？当前导出用于锁住 Agent Hook 必须经过该边界的回归契约。
+
+### 价值 OQ
+
+无。
+
+## Next Action
+
+请对 commit `c96071e90` 以及本请求信组成的最终 HEAD 做独立安全审查，并给出带 P1/P2/P3 严重度的 APPROVE 或 REQUEST-CHANGES。
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/fix-agent-hook-health-cpolar/codex-peer`
+- Start Command: `pnpm review:start`
+- Ports: `web=3213`, `api=3214`
+
+### 沙盒 Bootstrap
+
+```bash
+unset NODE_ENV
+pnpm install --frozen-lockfile
+pnpm --filter @cat-cafe/shared build
+pnpm --filter @cat-cafe/api run build
+```
+
+## 自检证据
+
+### Spec 合规
+
+- 不放宽远程 localhost 门禁；
+- 不复制 `.cat-cafe/capabilities.json`；
+- 持久配置只读复查：48 Skills、11 MCPs、6 core MCPs；
+- 实际漂移：Skills `new=0, stale=0, conflicts=0`；MCP issues `0`；
+- 根目录媒体/设计工件闸门为空；无 UI delta，设计与浏览器门禁不适用；
+- Architecture map delta 为 none。
+
+### 测试结果
+
+```bash
+pnpm exec biome check packages/api/src/agent-hooks/health.ts \
+  packages/api/src/agent-hooks/index.ts packages/api/test/agent-hooks.test.js
+# clean
+
+pnpm --filter @cat-cafe/api build
+# exit 0
+
+pnpm --filter @cat-cafe/api exec node --test test/agent-hooks.test.js
+# 29 passed, 0 failed
+
+git diff --check
+# clean
+```
+
+完整 `pnpm --filter @cat-cafe/api test` 在此 worktree 退出 1；失败集中于隔离 checkout 缺少未纳入 Git 的 `.claude`/根文档/launchd 文件、宿主未安装 `tmux`，以及依赖本机全局 capability 环境的既有测试。本次相关 Agent Hook 套件 29/29 全绿，build/tsc/Biome 均通过。鉴于完整门禁在干净 worktree 中不可满足，本轮以定向高风险回归 + 实际持久配置只读验收 + 独立 review 作为替代证据。
+
+### 相关文档
+
+- Bug report: `docs/bug-report/agent-hook-runtime-mcp-root/bug-report.md`
+- Prior fix commit: `cf065e51a`
+- Code fix commit: `c96071e90`
+
+[砚砚/GPT-5.6🐾]

--- a/review-notes/2026-07-28-capability-drift-remote-review-request.md
+++ b/review-notes/2026-07-28-capability-drift-remote-review-request.md
@@ -1,0 +1,81 @@
+# Review Request: Capability drift remote false positives
+
+Review-Target-ID: fix-agent-hook-health-cpolar
+Branch: fix/agent-hook-health-cpolar
+Code commit: `976c22352`
+
+## What
+
+Skill / MCP drift checks now report whether a requested project scope is initialized. The web client keeps checking historical paths for visibility, but excludes paths without `.cat-cafe` from anomaly aggregation and sync targets. Through cpolar or another non-loopback hostname, drift remains readable while all write controls are hidden.
+
+## Why
+
+The operator's remote Settings page said “检测到 7 处 Skill 异常”. The number represented seven scopes, not seven Skill issues: six historical thread paths were no longer initialized projects and were each contributing 96 false-positive Skill issues. The remaining Traqen project had 192 genuine conflicts and has already been synchronized through the guarded local API.
+
+The previous UI also showed sync controls remotely even though the API correctly rejected those writes with 403. This change aligns the UI with that existing security boundary without weakening it.
+
+## Original Requirement
+
+> “我现在需要怎么才能解决这个异常显示？”
+
+Context: cpolar displayed “检测到 7 处 Skill 异常” and “Capability writes require direct localhost Hub access”.
+
+## Tradeoff
+
+Historical paths are still probed, so a project becomes visible again if `.cat-cafe` is restored. They are omitted only while the API explicitly reports `initialized: false`. The localhost classifier is deliberately strict: `localhost`, IPv6 loopback, and `127/8` are writable; tunneled or custom hostnames are read-only.
+
+## Architecture Ownership
+
+Architecture cell: capability synchronization boundary (F228 / F249)
+Map delta: none
+Why: this extends the existing drift response, hook, and banner. It adds no Store, Queue, Router, Adapter, Dispatcher, Binding, or new extension point.
+
+Please verify:
+
+- uninitialized historical paths cannot contribute issue counts or receive sync writes;
+- an absent `initialized` field remains backward compatible;
+- the browser hostname classifier does not treat cpolar/custom hosts as local;
+- remote write controls are absent while the existing API 403 guard remains authoritative;
+- the new wording distinguishes scope count from individual issue count.
+
+## Open Questions
+
+None blocking. The optional `initialized` field is intentional for rolling web/API deployment compatibility.
+
+## Next Action
+
+Review code commit `976c22352` plus this request note and return an APPROVE or REQUEST-CHANGES verdict with P1/P2/P3 severities.
+
+## Review Sandbox
+
+- Path: `/private/tmp/cat-cafe-review/fix-agent-hook-health-cpolar/{reviewer}`
+- Start command: `pnpm review:start`
+- Suggested ports: any non-reserved pair
+- Storage: memory only
+
+## Verification Evidence
+
+- TDD red states were observed for missing remote-readonly copy, incorrect aggregation, and missing API initialization metadata.
+- Web banner/hostname tests: 9/9 passed.
+- Skill aggregation and sync regressions: 4/4 passed.
+- MCP sync-all regression: 1/1 passed.
+- API drift suites: 18/18 passed.
+- API initialization metadata: 2/2 passed.
+- Web `tsc --noEmit`: passed.
+- API build and repository recursive build: passed.
+- `pnpm check`: passed.
+- `pnpm lint`: passed with pre-existing warnings only.
+- Capability-tip validation: passed.
+- `git diff --check`: clean.
+- Isolated memory-mode browser smoke test: Settings → Skill 管理 loaded with 0 console errors and rendered “✓ 全部 Skill 同步一致”.
+
+Full `pnpm test` is not green in this historical worktree. Failures are unrelated baseline/environment gaps: missing untracked `.claude` and root-document fixtures, absent `tmux`, and suites that depend on the host capability baseline. Relevant suites, builds, type checks, Biome checks, and browser smoke validation are green.
+
+## Dogfood State
+
+- `/Volumes/WorkSSD/projects/Traqen`: Skill drift 0 after guarded local sync.
+- 192/192 managed Skill links now point to the persistent runtime skill source.
+- Six historical paths without `.cat-cafe` were not modified.
+- Remote capability write guard remains closed.
+
+[砚砚/GPT-5.6🐾]


### PR DESCRIPTION
## Why

Agent hook setup failures were collapsed into a generic UI error, stale client-side authority could overwrite newer project state, and runtime deployments resolved capability/Skill truth from disposable checkouts. Those splits caused remote/local write controls to disagree with the API and caused valid Nalo `anime-forge` mounts to appear as destructive conflicts.

## What changed

- Reconcile canonical thread `projectPath` responses with latest-request-wins semantics.
- Map deterministic 400/403 Agent Hook responses to actionable health states; remote access remains read-only.
- Force post-setup Agent Hook refreshes to supersede older in-flight requests.
- Enforce the localhost/explicit-target authorization boundary before filesystem validation.
- Derive Drift `syncAllowed` from the same session + locality + owner gate used by the write endpoint.
- Derive open MCP modal mutability reactively from current server-authoritative permission.
- Redirect runtime-owned Skill sources to the persistent workspace, preserving valid Nalo provider links.
- Add regression coverage for stale responses, expired/non-owner sessions, modal permission races, runtime/workspace Skill roots, malformed metadata, and remote tunnel requests.

## Verification

Author-side evidence for exact HEAD `a4186539b17eeb14acc492fca479cb0d8f8edcb1`:

- Focused API regression suites: 23/23 passed.
- Focused Web regression suites: 21/21 passed.
- `pnpm check`: passed.
- `pnpm lint`: passed.
- `pnpm build`: passed.
- Isolated development acceptance (API 3172 / Web 5172): Nalo `anime-forge` issues = 0; remote/no-session state remained read-only.
- Full-suite residuals are not claimed green: the same Web 6 files / 20 failures are documented on the clean baseline; three existing tmux integration files require a tmux binary absent on this machine; `signal-fetcher-launchd-script.test.js` targets a script absent from both this HEAD and `origin/main`.

## Security

The localhost-only synchronization boundary remains fail-closed. Read endpoints stay available, while `syncAllowed` now matches the complete write gate. Remote requests still cannot learn arbitrary local path existence or write Agent/Skill/MCP configuration.

## Provenance

Implementation and verification above are author-side, AI-assisted evidence. Formal exact-HEAD maintainer/cloud review remains pending.
