### PR TITLE
fix(web): unblock member creation when accounts are empty

### DIFF
--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { CatData } from '@/hooks/useCatData';
 import { apiFetch } from '@/utils/api-client';
 import type { ConfigData } from './config-viewer-types';
 import type { TemplateCard } from './first-run-quest/TemplateStep';
-import type { AccountsResponse, ProfileItem } from './hub-accounts.types';
+import type { AccountsResponse, BuiltinAccountClient, ProfileItem } from './hub-accounts.types';
 import { uploadAvatarAsset, uploadRefAudioAsset } from './hub-cat-editor.client';
 import {
   autoSlug,
@@ -33,6 +33,7 @@ import { AccountSection, IdentitySection, RoutingSection } from './hub-cat-edito
 import { AdvancedRuntimeSection } from './hub-cat-editor-advanced';
 import { PersistenceBanner } from './hub-cat-editor-fields';
 import type { CatStrategyEntry } from './hub-strategy-types';
+import { UnifiedAuthModal } from './UnifiedAuthModal';
 import { useConfirm } from './useConfirm';
 
 interface HubCatEditorProps {
@@ -68,6 +69,8 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
   const [codexSettingsBaseline, setCodexSettingsBaseline] = useState<CodexRuntimeSettings | null>(null);
   const [templates, setTemplates] = useState<TemplateCard[]>([]);
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>('custom');
+  const [showAuthModal, setShowAuthModal] = useState(false);
+  const pendingProfileIdRef = useRef<string | null>(null);
 
   const availableProfiles = useMemo(() => filterAccounts(form.clientId, profiles), [form.clientId, profiles]);
   const selectedProfile = useMemo(
@@ -104,6 +107,8 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
     setCodexSettingsBaseline(null);
     setSelectedTemplateId('custom');
     setHasUnsavedChanges(false);
+    setShowAuthModal(false);
+    pendingProfileIdRef.current = null;
   }, [open, cat, draft]);
 
   // Re-fetch profiles when Provider Profiles page creates/saves/deletes an account.
@@ -146,7 +151,20 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
         return (await res.json()) as AccountsResponse;
       })
       .then((body) => {
-        if (!cancelled) setProfiles(body.providers);
+        if (cancelled) return;
+        setProfiles(body.providers);
+        const pendingProfileId = pendingProfileIdRef.current;
+        if (!pendingProfileId) return;
+        const createdProfile = body.providers.find((profile) => profile.id === pendingProfileId);
+        if (!createdProfile) return;
+        pendingProfileIdRef.current = null;
+        setHasUnsavedChanges(true);
+        setForm((prev) => ({
+          ...prev,
+          accountRef: createdProfile.id,
+          defaultModel: createdProfile.models?.[0] ?? '',
+          provider: '',
+        }));
       })
       .catch((err) => {
         if (!cancelled) setError(err instanceof Error ? err.message : '账号配置加载失败');
@@ -279,7 +297,11 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
 
   if (!open) return null;
 
-  const saveBlockedByProfileBinding = false;
+  const createAccountClient: BuiltinAccountClient | undefined =
+    form.clientId === 'antigravity' || form.clientId === 'catagent' ? undefined : form.clientId;
+  const hasEmptyCreatableAccounts =
+    !cat && !loadingProfiles && createAccountClient !== undefined && availableProfiles.length === 0;
+  const saveBlockedByProfileBinding = hasEmptyCreatableAccounts;
 
   const patchForm = (patch: Partial<HubCatEditorFormState>) => {
     setHasUnsavedChanges(true);
@@ -546,7 +568,9 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
   return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-[var(--console-overlay-medium)] px-4 backdrop-blur-sm"
-      onClick={requestClose}
+      onClick={(event) => {
+        if (event.target === event.currentTarget) void requestClose();
+      }}
       data-bootcamp-host="cat-editor-modal"
     >
       <div
@@ -573,6 +597,11 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
         </div>
 
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-7 py-5">
+          {!cat ? (
+            <p className="rounded-[14px] bg-[var(--console-field-bg)] px-4 py-3 text-xs font-semibold text-cafe-secondary">
+              首次安装默认只启用一个品种；可在成员管理继续添加其他成员。
+            </p>
+          ) : null}
           {!cat && templates.length > 0 && (
             <section
               data-guide-id="add-member.template-picker"
@@ -626,11 +655,28 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
             hasError={fieldErrors.account}
             modelOptions={modelOptions}
             availableProfiles={availableProfiles}
-            loadingProfiles={loadingProfiles}
+            loadingProfiles={hasEmptyCreatableAccounts ? true : loadingProfiles}
             effectiveCodexCarrier={cat?.codexCarrier ?? null}
             codexLocalCapable={cat ? cat.cli != null : true}
             onChange={patchForm}
           />
+          {hasEmptyCreatableAccounts ? (
+            <section
+              aria-label="认证账号空状态"
+              className="rounded-[18px] border border-[var(--console-border-soft)] bg-[var(--console-card-bg)] p-[18px]"
+            >
+              <p className="text-xs leading-5 text-cafe-secondary">
+                当前没有可用的认证账号。先新建或登录账号，再继续选择模型并保存成员。
+              </p>
+              <button
+                type="button"
+                onClick={() => setShowAuthModal(true)}
+                className="mt-2 rounded-lg bg-cafe-accent px-3 py-1.5 text-xs font-semibold text-[var(--cafe-surface)] transition hover:bg-cafe-accent-hover"
+              >
+                新建 / 登录账号
+              </button>
+            </section>
+          ) : null}
           <RoutingSection
             form={form}
             hasError={fieldErrors.routing}
@@ -667,6 +713,16 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
           </button>
         </div>
       </div>
+      <UnifiedAuthModal
+        open={showAuthModal && createAccountClient !== undefined}
+        initialClientId={createAccountClient}
+        onClose={() => setShowAuthModal(false)}
+        onCreated={(profileId) => {
+          pendingProfileIdRef.current = profileId;
+          setShowAuthModal(false);
+          setProfilesVersion((version) => version + 1);
+        }}
+      />
     </div>,
     document.body,
   );

--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -298,7 +298,7 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
   if (!open) return null;
 
   const createAccountClient: BuiltinAccountClient | undefined =
-    form.clientId === 'antigravity' || form.clientId === 'catagent' ? undefined : form.clientId;
+    form.clientId === 'antigravity' ? undefined : form.clientId === 'catagent' ? 'anthropic' : form.clientId;
   const hasEmptyCreatableAccounts =
     !cat && !loadingProfiles && createAccountClient !== undefined && availableProfiles.length === 0;
   const saveBlockedByProfileBinding = hasEmptyCreatableAccounts;

--- a/packages/web/src/components/__tests__/hub-cat-editor-account-empty-state.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor-account-empty-state.test.tsx
@@ -1,0 +1,179 @@
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { apiFetch } from '@/utils/api-client';
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(() => Promise.resolve(new Response('{}', { status: 200 }))),
+}));
+
+vi.mock('@/components/useConfirm', () => ({
+  useConfirm: () => vi.fn(() => Promise.resolve(true)),
+}));
+
+import { HubCatEditor } from '@/components/HubCatEditor';
+import type { ProfileItem } from '@/components/hub-accounts.types';
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function profileItem(
+  input: Omit<ProfileItem, 'kind' | 'builtin'> & Partial<Pick<ProfileItem, 'kind' | 'builtin'>>,
+): ProfileItem {
+  const builtin = input.builtin === undefined ? input.authType === 'oauth' : input.builtin;
+  const kind = input.kind === undefined ? (builtin ? 'builtin' : 'api_key') : input.kind;
+  return { ...input, builtin, kind };
+}
+
+async function flushEffects() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function changeField(
+  element: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement,
+  value: string,
+  eventType: 'input' | 'change' = 'input',
+) {
+  await act(async () => {
+    const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value');
+    descriptor?.set?.call(element, value);
+    element.dispatchEvent(new Event(eventType, { bubbles: true }));
+  });
+}
+
+function queryField<T extends HTMLElement>(selector: string): T {
+  const element = document.body.querySelector(selector);
+  if (!element) throw new Error(`Missing element: ${selector}`);
+  return element as T;
+}
+
+describe('HubCatEditor zero-account onboarding', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    (globalThis as { React?: typeof React }).React = React;
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete (globalThis as { React?: typeof React }).React;
+    delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockApiFetch.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  it('creates authentication from the empty state and continues saving the member', async () => {
+    const onSaved = vi.fn(() => Promise.resolve());
+    let accountCreated = false;
+    const createdProfile = profileItem({
+      id: 'claude-oauth',
+      provider: 'claude-oauth',
+      displayName: 'Claude Login',
+      name: 'Claude Login',
+      authType: 'oauth',
+      mode: 'subscription',
+      models: ['claude-sonnet-4-6'],
+      hasApiKey: false,
+      createdAt: '2026-07-29T00:00:00.000Z',
+      updatedAt: '2026-07-29T00:00:00.000Z',
+    });
+    const responses = new Map<string, () => Promise<Response>>([
+      [
+        '/api/accounts:POST',
+        () => {
+          accountCreated = true;
+          return Promise.resolve(jsonResponse({ profile: { id: createdProfile.id } }, 201));
+        },
+      ],
+      [
+        '/api/accounts:GET',
+        () =>
+          Promise.resolve(
+            jsonResponse({
+              projectPath: '/tmp/project',
+              activeProfileId: accountCreated ? createdProfile.id : null,
+              providers: accountCreated ? [createdProfile] : [],
+            }),
+          ),
+      ],
+      ['/api/cats:POST', () => Promise.resolve(jsonResponse({ cat: { id: 'first-partner' } }, 201))],
+      ['/api/cat-templates:GET', () => Promise.resolve(jsonResponse({ templates: [] }))],
+    ]);
+    mockApiFetch.mockImplementation((path: string, init?: RequestInit) => {
+      const key = `${path}:${init?.method === undefined ? 'GET' : init.method}`;
+      const response = responses.get(key);
+      if (!response) throw new Error(`Unexpected apiFetch request: ${key}`);
+      return response();
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HubCatEditor, { open: true, onClose: vi.fn(), onSaved }));
+    });
+    await flushEffects();
+
+    expect(document.body.textContent).toContain('当前没有可用的认证账号');
+    expect(document.body.textContent).toContain('首次安装默认只启用一个品种');
+    expect(queryField<HTMLSelectElement>('select[aria-label="认证信息"]').disabled).toBe(true);
+
+    const createAccountButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === '新建 / 登录账号',
+    );
+    expect(createAccountButton).toBeTruthy();
+    await act(async () => {
+      createAccountButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    await changeField(queryField('input[placeholder="例如: my-claude-account"]'), 'Claude Login');
+    const authSaveButton = queryField<HTMLButtonElement>('button[data-guide-id="accounts.create-submit"]');
+    await act(async () => {
+      authSaveButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+    await flushEffects();
+
+    expect(document.body.textContent).toContain('添加成员');
+    expect(document.body.textContent).not.toContain('添加账户认证');
+    const accountSelect = queryField<HTMLSelectElement>('select[aria-label="认证信息"]');
+    expect(accountSelect.value).toBe('claude-oauth');
+    expect(queryField<HTMLInputElement>('input[aria-label="Model"]').value).toBe('claude-sonnet-4-6');
+
+    await changeField(queryField('input[aria-label="Name"]'), '第一只伙伴猫');
+    await changeField(queryField('input[aria-label="Description"]'), '陪我一起完成任务');
+    await changeField(queryField('textarea[aria-label="Aliases"]'), '@first-partner');
+
+    const memberSaveButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === '保存',
+    );
+    await act(async () => {
+      memberSaveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    const postCall = mockApiFetch.mock.calls.find(([path]) => path === '/api/cats');
+    expect(postCall).toBeTruthy();
+    const payload = JSON.parse(String(postCall?.[1]?.body));
+    expect(payload.accountRef).toBe('claude-oauth');
+    expect(payload.defaultModel).toBe('claude-sonnet-4-6');
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/__tests__/hub-cat-editor-account-empty-state.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor-account-empty-state.test.tsx
@@ -82,6 +82,46 @@ describe('HubCatEditor zero-account onboarding', () => {
     vi.clearAllMocks();
   });
 
+  it('offers the Anthropic account flow when CatAgent has no account', async () => {
+    mockApiFetch.mockImplementation((path: string, init?: RequestInit) => {
+      const method = init?.method ?? 'GET';
+      if (path === '/api/accounts' && method === 'GET') {
+        return Promise.resolve(
+          jsonResponse({
+            projectPath: '/tmp/project',
+            activeProfileId: null,
+            providers: [],
+          }),
+        );
+      }
+      if (path === '/api/cat-templates' && method === 'GET') {
+        return Promise.resolve(jsonResponse({ templates: [] }));
+      }
+      throw new Error(`Unexpected apiFetch request: ${path}:${method}`);
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HubCatEditor, { open: true, onClose: vi.fn(), onSaved: vi.fn() }));
+    });
+    await flushEffects();
+
+    await changeField(queryField<HTMLSelectElement>('select[aria-label="Client"]'), 'catagent', 'change');
+    await flushEffects();
+
+    expect(document.body.textContent).toContain('当前没有可用的认证账号');
+    const createAccountButton = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === '新建 / 登录账号',
+    );
+    expect(createAccountButton).toBeTruthy();
+
+    await act(async () => {
+      createAccountButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const authDetails = queryField<HTMLElement>('[data-guide-id="accounts.create-details"]');
+    expect(authDetails.textContent).toContain('Claude');
+  });
+
   it('creates authentication from the empty state and continues saving the member', async () => {
     const onSaved = vi.fn(() => Promise.resolve());
     let accountCreated = false;


### PR DESCRIPTION
## PR Type

- [x] 🐛 **Patch** — Bug fix, typo, test gap (no Feature Doc needed)
- [ ] ✨ **Feature** — New capability or behavior change (requires Feature Doc)
- [ ] 📋 **Protocol** — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Fixes #1229
Refs #1228
Refs #1230

## Feature Doc (Feature PRs only)

N/A — patch.

## What

Clean installations could leave the member editor with an empty required authentication select and no way forward. This patch:

- shows an actionable empty state for supported clients when no saved accounts exist;
- opens the existing account login/creation flow without closing the member editor;
- refreshes the account list after creation, selects the new account and its first model, then lets the user save the member;
- blocks submission while the required provider binding is missing;
- explains that first installation enables one breed by default and additional members can be added in member management;
- adds a platform-independent UI regression covering the Windows/Codex empty-account report.

Only `HubCatEditor.tsx` and one new focused regression file are synchronized. Existing public changes in the account section and broader editor tests are preserved.

## Why

Affected users had a valid CLI login but no persisted Clowder account, so `/api/accounts` returned an empty list. The UI exposed only a dead placeholder and could send an invalid member request that surfaced an internal provider-binding error.

The runtime fallback and authentication contract are unchanged. The editor now guides users through the existing supported account flow and prevents the invalid request at the UI boundary.

## Tradeoff

The empty state reuses the current `UnifiedAuthModal` instead of seeding credentials, enabling every breed, or adding a second authentication path. While empty, the existing select remains disabled and may retain its loading placeholder; the adjacent explicit empty-state copy provides the user-facing explanation.

Risk axes:

- Behavior: yes — repairs the clean-install member-creation path.
- Data: no schema, migration, or persistence-shape change.
- Security: auth-adjacent UI only; no credential validation or auth API change.
- Contract: no exported API, event, or runtime resolver change.
- Irreversible: none.

## Test Evidence

```text
pnpm -C packages/web exec vitest run \
  src/components/__tests__/hub-cat-editor-account-empty-state.test.tsx \
  src/components/__tests__/hub-cat-editor.test.tsx
# PASS: 2 files, 61 tests

pnpm -C packages/web exec tsc --noEmit
# PASS

pnpm check
# PASS

pnpm lint
# PASS (existing warnings only)

git diff --check main...HEAD
# PASS
```

`pnpm -C packages/api run test:public` was started on current `main` but cannot produce a terminal result because the unchanged `messages-parallel-slot-release.test.js` waits for a deferred gate only after its blocking `app.inject()` returns, while the public runner disables test timeouts. The run was stopped after the exact baseline hang was identified; this PR does not touch that test or the API package. GitHub CI remains the authoritative clean-environment gate for the PR.

## AC Checklist (Patch)

- [x] Zero-account editor shows a clear empty state and account login/creation action.
- [x] Created account is refreshed, selected, and usable to save the first member.
- [x] Missing required provider binding blocks submission.
- [x] Default-one-breed guidance is visible without seeding all breeds.
- [x] No credentials are fabricated and runtime synthetic fallback remains untouched.

[小太阳·砚砚/GPT-5.6 Sol🐾]
