### PR TITLE
verdict(eval:a2a): 2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/attribution.json
@@ -1,0 +1,36 @@
+{
+  "verdictId": "2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix",
+  "featureId": "F167",
+  "evalSnapshotId": "eval-F167-2026-07-30",
+  "generatedAt": "2026-07-30T03:06:12.248Z",
+  "findings": [
+    {
+      "id": "AR-2026-07-30-001",
+      "relatedFeature": "F167",
+      "frictionSignal": {
+        "type": "observability-gap",
+        "severity": "medium",
+        "confidence": 0.9
+      },
+      "attribution": {
+        "primaryLayer": "environment_drift",
+        "pipelineOrHuman": "pipeline",
+        "evidence": [
+          {
+            "type": "telemetry-gap",
+            "anchor": "L1/streak_warn_count",
+            "excerpt": "No counter: OTel is disabled because TELEMETRY_HMAC_SALT is not configured; L1 activation frequency cannot be measured."
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "restore-telemetry",
+          "target": "L1/streak_warn_count",
+          "rationale": "Restore the telemetry initialization prerequisite before evaluating L1 rates."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/snapshots/2026-07-30T03-06-12-246Z-F167-eval.yaml",
+      "sha256": "f9aceccc80d3afa82c9685b8ac2cd6073e1e072a38d2f4ef41de95161130fc2b"
+    },
+    {
+      "path": "docs/harness-feedback/attributions/2026-07-30T03-06-12-248Z-F167-attribution.yaml",
+      "sha256": "d9535ae000335a2a11927982f1760d139e56f39c68c28f7dd49b199629f92d06"
+    }
+  ],
+  "generatedAt": "2026-07-30T03:06:12.248Z",
+  "generator": {
+    "name": "eval-a2a-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f192-e-pilot-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix",
+  "evalSnapshotId": "eval-F167-2026-07-30",
+  "featureId": "F167",
+  "generatedAt": "2026-07-30T03:06:12.246Z",
+  "window": {
+    "startMs": 1785380772246,
+    "endMs": 1785380772246,
+    "durationHours": 0
+  },
+  "counterWindow": {
+    "startMs": 1785307398230,
+    "endMs": 1785380772246,
+    "durationHours": 20.38167111111111
+  },
+  "components": [
+    {
+      "id": "L1",
+      "name": "WorklistRegistry (ping-pong breaker)",
+      "confidence": "no-data",
+      "activationCounts": {},
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix.md
+++ b/docs/harness-feedback/verdicts/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix.md
@@ -1,0 +1,30 @@
+---
+feature_ids: [F192, F167]
+topics: [harness-eval, eval-a2a, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: 2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix
+source_snapshot: "snapshot:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/snapshot"
+---
+
+# Live Verdict — 2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix
+
+- Verdict: `fix`
+- Phenomenon: F167 的 counter window 已覆盖 20.38 小时，但运行时明确因 TELEMETRY_HMAC_SALT 未配置而关闭 OTel，metrics、metrics history、traces、grounding samples 四个证据面均不可用；L1、C1、C2、route-serial、grounding-phase-o 五个组件全部为 no-data。Phase O 没有可解释的 mismatch 分布，不能把零样本当作健康。
+- Harness: F167/f167-runtime-eval-telemetry (A2A runtime eval telemetry and Phase O grounding evidence)
+- Owner ask: 修复 F167 telemetry 的部署/启动契约：由需要的人类配置面注入有效 TELEMETRY_HMAC_SALT，并让启动或 readiness 对缺失盐显式失败；恢复 metrics、metrics history、traces、grounding samples 四端点；同时让 daily f167-runtime-eval source adapter 在唤醒 eval 猫前自动生成 snapshots/attributions raw YAML，避免再次依赖人工重建。
+- Re-eval: 下一轮自动生成新的 F167 raw snapshot/attribution；四个 telemetry 端点均返回 200；counter_window.duration_hours >= 2；L1/C1/C2/route-serial/grounding-phase-o 均不再是 no-data；grounding.check_total 与 grounding.verdict_total 可读，若 mismatch_sample_count > 0 则附 recurring-pattern 复核。 at 2026-08-02T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/snapshot
+- attribution:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/AR-2026-07-30-001
+- metric:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/counterWindow.durationHours
+- metric:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/components.noDataCount
+- metric:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/attribution.openFindingCount
+- metadata:bundle/2026-07-30-eval-a2a-otel-salt-telemetry-gap-fix/provenance#sourceThreadId=thread_eval_a2a
+
+Counterarguments:
+- 进程 counter window 已超过 2 小时，说明分母口径修复本身有效；当前问题是计数器和存储根本未初始化，而不是短窗口噪声。
+- 新增第 7 个 observability gap 来自 Phase O 组件显式纳入，不能单凭 6→7 判定业务回归，因此趋势定为 flat。
+- readiness 的 Redis/SQLite 为 ready 不代表 eval harness 健康；eval:a2a 的证据契约明确依赖 telemetry 四个端点。


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: fix
Domain: eval:a2a
Phenomenon: F167 的 counter window 已覆盖 20.38 小时，但运行时明确因 TELEMETRY_HMAC_SALT 未配置而关闭 OTel，metrics、metrics history、traces、grounding samples 四个证据面均不可用；L1、C1、C2、route-serial、grounding-phase-o 五个组件全部为 no-data。Phase O 没有可解释的 mismatch 分布，不能把零样本当作健康。

Reviewed by: opus-47
Action: 修复 F167 telemetry 的部署/启动契约：由需要的人类配置面注入有效 TELEMETRY_HMAC_SALT，并让启动或 readiness 对缺失盐显式失败；恢复 metrics、metrics history、traces、grounding samples 四端点；同时让 daily f167-runtime-eval source adapter 在唤醒 eval 猫前自动生成 snapshots/attributions raw YAML，避免再次依赖人工重建。