### PR TITLE
fix(opencode): route account model aliases to upstream ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,16 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @cat-cafe/shared build
+      - run: pnpm --filter @cat-cafe/api build
+      - name: Install OpenCode behavior baseline
+        run: npm install --global opencode-ai@1.18.9
+      - name: Verify OpenCode model ID routing
+        run: >-
+          node --test
+          packages/api/test/opencode-model-id-ci-contract.test.js
+          packages/api/test/opencode-model-id-request.test.js
+        env:
+          REQUIRE_OPENCODE_MODEL_ID_TEST: '1'
       - run: pnpm --filter @cat-cafe/api run test:public
         env:
           GIT_AUTHOR_NAME: CI Runner

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -34,6 +34,15 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter @cat-cafe/shared build
       - run: pnpm --filter @cat-cafe/api build
+      - name: Install OpenCode behavior baseline
+        run: npm install --global opencode-ai@1.18.9
+      - name: Verify OpenCode model ID routing
+        run: >-
+          node --test
+          packages/api/test/opencode-model-id-ci-contract.test.js
+          packages/api/test/opencode-model-id-request.test.js
+        env:
+          REQUIRE_OPENCODE_MODEL_ID_TEST: '1'
       - name: Windows-relevant tests
         run: |
           node --test packages/api/test/cli-spawn-win.test.js

--- a/packages/api/src/config/account-resolver.ts
+++ b/packages/api/src/config/account-resolver.ts
@@ -29,6 +29,7 @@ export interface RuntimeProviderProfile {
   baseUrl?: string;
   apiKey?: string;
   models?: string[];
+  modelAliases?: Record<string, string>;
   /** F171: User-defined env vars for agent subprocess injection. */
   envVars?: Record<string, string>;
 }
@@ -263,6 +264,9 @@ function accountToRuntimeProfile(ref: string, account: AccountConfig, projectRoo
     ...(account.baseUrl ? { baseUrl: account.baseUrl } : {}),
     ...(apiKey ? { apiKey } : {}),
     ...(account.models && account.models.length > 0 ? { models: [...account.models] } : {}),
+    ...(account.modelAliases && Object.keys(account.modelAliases).length > 0
+      ? { modelAliases: { ...account.modelAliases } }
+      : {}),
     ...(account.envVars && Object.keys(account.envVars).length > 0 ? { envVars: { ...account.envVars } } : {}),
   };
 }

--- a/packages/api/src/config/catalog-accounts.ts
+++ b/packages/api/src/config/catalog-accounts.ts
@@ -117,17 +117,31 @@ function normalizeModels(models: readonly string[] | undefined): string[] | unde
   return normalized.length > 0 ? normalized.sort() : undefined;
 }
 
+function normalizeModelAliases(value: unknown): Record<string, string> | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const normalized = Object.entries(value as Record<string, unknown>)
+    .filter((entry): entry is [string, string] => typeof entry[1] === 'string')
+    .map(([key, upstreamId]) => [key.trim(), upstreamId.trim()] as const)
+    .filter(([key, upstreamId]) => key.length > 0 && upstreamId.length > 0)
+    .sort(([left], [right]) => left.localeCompare(right));
+  return normalized.length > 0 ? Object.fromEntries(normalized) : undefined;
+}
+
 function canonicalizeAccount(account: AccountConfig): {
   authType: 'oauth' | 'api_key';
   baseUrl?: string;
   displayName?: string;
   models?: string[];
+  modelAliases?: Record<string, string>;
 } {
   return {
     authType: account.authType,
     ...(normalizeBaseUrl(account.baseUrl) ? { baseUrl: normalizeBaseUrl(account.baseUrl) } : {}),
     ...(normalizeDisplayName(account.displayName) ? { displayName: normalizeDisplayName(account.displayName) } : {}),
     ...(normalizeModels(account.models) ? { models: normalizeModels(account.models) } : {}),
+    ...(normalizeModelAliases(account.modelAliases)
+      ? { modelAliases: normalizeModelAliases(account.modelAliases) }
+      : {}),
   };
 }
 
@@ -145,6 +159,11 @@ function describeAccountConflict(existing: AccountConfig, incoming: AccountConfi
   }
   if (JSON.stringify(current.models ?? []) !== JSON.stringify(next.models ?? [])) {
     diffs.push(`models ${JSON.stringify(current.models ?? [])} vs ${JSON.stringify(next.models ?? [])}`);
+  }
+  if (JSON.stringify(current.modelAliases ?? {}) !== JSON.stringify(next.modelAliases ?? {})) {
+    diffs.push(
+      `modelAliases ${JSON.stringify(current.modelAliases ?? {})} vs ${JSON.stringify(next.modelAliases ?? {})}`,
+    );
   }
 
   return diffs.join('; ');
@@ -294,12 +313,14 @@ function migrateLegacyFrom(
     const displayName = normalizeDisplayName(typeof p.displayName === 'string' ? p.displayName : undefined);
     const baseUrl = normalizeBaseUrl(typeof p.baseUrl === 'string' ? p.baseUrl : undefined);
     const models = normalizeModels(Array.isArray(p.models) ? p.models.map(String) : undefined);
+    const modelAliases = normalizeModelAliases(p.modelAliases);
     // clowder-ai#340: protocol not migrated — derived at runtime from well-known account IDs.
     const account: AccountConfig = {
       authType: inferLegacyAuthType(p),
       ...(displayName ? { displayName } : {}),
       ...(baseUrl ? { baseUrl } : {}),
       ...(models ? { models } : {}),
+      ...(modelAliases ? { modelAliases } : {}),
     };
     if (opts?.shouldImportAccount && !opts.shouldImportAccount(id, account)) continue;
     accounts[id] = account;

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -2020,6 +2020,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       const runtimeConfigOptions = {
         providerName: effectiveProviderName,
         models: rawModels,
+        ...(resolvedAccount.modelAliases ? { modelAliases: resolvedAccount.modelAliases } : {}),
         defaultModel: effectiveModel,
         apiType,
         hasBaseUrl: Boolean(resolvedAccount.baseUrl),

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-acp-spawn-config.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-acp-spawn-config.ts
@@ -14,6 +14,7 @@ export interface OpenCodeAcpSpawnAccount {
   apiKey?: string;
   baseUrl?: string;
   models?: readonly string[];
+  modelAliases?: Readonly<Record<string, string>>;
 }
 
 export interface OpenCodeAcpSpawnConfigOptions {
@@ -92,6 +93,7 @@ export async function prepareOpenCodeAcpSpawnConfig(
   const runtimeConfigOptions = {
     providerName: effective.providerName,
     models: account?.models?.length ? account.models : [effective.model],
+    ...(account?.modelAliases ? { modelAliases: account.modelAliases } : {}),
     defaultModel: effective.model,
     apiType: deriveOpenCodeApiType(effective.providerName),
     hasBaseUrl: Boolean(account?.baseUrl),

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -180,6 +180,21 @@ function stripOwnProviderPrefix(modelName: string, providerName: string): string
 }
 
 /**
+ * OpenCode model keys are local aliases, while the compatible API receives the
+ * upstream model id from the model's `name` field. Kimi Code publishes
+ * namespaced aliases but kitcoding expects the raw ids.
+ */
+const OPENCODE_UPSTREAM_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  'kimi-code/k3': 'kimi-k3',
+  'kimi-code/kimi-for-coding': 'kimi-k2.7-code',
+  'kimi-code/kimi-for-coding-highspeed': 'kimi-k3',
+};
+
+export function resolveOpenCodeUpstreamModel(modelName: string): string {
+  return OPENCODE_UPSTREAM_MODEL_ALIASES[modelName] ?? modelName;
+}
+
+/**
  * OpenCode treats certain provider names as built-in and forces its own SDK
  * handling (e.g. 'openai' → Responses API via sdk.responses()), ignoring the
  * npm adapter field.  Remap these names so the config's npm adapter is used.
@@ -229,7 +244,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
   const modelsToRegister = defaultModel ? [...models, defaultModel] : [...models];
   for (const rawModel of modelsToRegister) {
     const modelName = stripOwnProviderPrefix(rawModel, providerName);
-    modelsMap[modelName] = { name: modelName };
+    modelsMap[modelName] = { name: resolveOpenCodeUpstreamModel(modelName) };
   }
 
   let configDefaultModel = defaultModel;

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -16,7 +16,7 @@ interface OpenCodeConfigOptions {
 
 type OpenCodeProviderConfig = {
   npm?: string;
-  models?: Record<string, { name: string }>;
+  models?: Record<string, { id?: string; name: string }>;
   options: {
     apiKey?: string;
     baseURL?: string;
@@ -114,6 +114,7 @@ export function deriveOpenCodeApiType(providerName: string | undefined): OpenCod
 export interface OpenCodeRuntimeConfigOptions {
   providerName: string;
   models: readonly string[];
+  modelAliases?: Readonly<Record<string, string>>;
   defaultModel?: string;
   apiType?: OpenCodeApiType;
   hasBaseUrl?: boolean;
@@ -157,6 +158,7 @@ export interface OpenCodeRuntimeConfigDebugSummary {
     {
       npm?: string;
       modelKeys: string[];
+      modelMappings: Record<string, string>;
       hasBaseUrl: boolean;
       apiKeySource: string;
       baseUrlSource?: string;
@@ -177,21 +179,6 @@ export function parseOpenCodeModel(model: string): { providerName: string; model
 function stripOwnProviderPrefix(modelName: string, providerName: string): string {
   const prefix = `${providerName}/`;
   return modelName.startsWith(prefix) ? modelName.slice(prefix.length) : modelName;
-}
-
-/**
- * OpenCode model keys are local aliases, while the compatible API receives the
- * upstream model id from the model's `name` field. Kimi Code publishes
- * namespaced aliases but kitcoding expects the raw ids.
- */
-const OPENCODE_UPSTREAM_MODEL_ALIASES: Readonly<Record<string, string>> = {
-  'kimi-code/k3': 'kimi-k3',
-  'kimi-code/kimi-for-coding': 'kimi-k2.7-code',
-  'kimi-code/kimi-for-coding-highspeed': 'kimi-k3',
-};
-
-export function resolveOpenCodeUpstreamModel(modelName: string): string {
-  return OPENCODE_UPSTREAM_MODEL_ALIASES[modelName] ?? modelName;
 }
 
 /**
@@ -224,6 +211,7 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
   const {
     providerName,
     models,
+    modelAliases,
     defaultModel,
     apiType = 'openai',
     hasBaseUrl = false,
@@ -240,11 +228,15 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
 
   const configName = safeProviderName(providerName);
 
-  const modelsMap: Record<string, { name: string }> = {};
+  const modelsMap: Record<string, { id?: string; name: string }> = {};
   const modelsToRegister = defaultModel ? [...models, defaultModel] : [...models];
   for (const rawModel of modelsToRegister) {
     const modelName = stripOwnProviderPrefix(rawModel, providerName);
-    modelsMap[modelName] = { name: resolveOpenCodeUpstreamModel(modelName) };
+    const upstreamId = modelAliases?.[modelName]?.trim();
+    modelsMap[modelName] = {
+      ...(upstreamId ? { id: upstreamId } : {}),
+      name: modelName,
+    };
   }
 
   let configDefaultModel = defaultModel;
@@ -320,6 +312,11 @@ export function summarizeOpenCodeRuntimeConfigForDebug(
         {
           npm: providerConfig.npm,
           modelKeys: Object.keys(providerConfig.models ?? {}).sort(),
+          modelMappings: Object.fromEntries(
+            Object.entries(providerConfig.models ?? {})
+              .sort(([left], [right]) => left.localeCompare(right))
+              .map(([modelKey, modelConfig]) => [modelKey, modelConfig.id ?? modelKey]),
+          ),
           hasBaseUrl: Boolean(providerConfig.options.baseURL),
           apiKeySource: summarizeEnvPlaceholder(providerConfig.options.apiKey) ?? '(unset)',
           ...(providerConfig.options.baseURL

--- a/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/opencode-config-template.ts
@@ -232,7 +232,9 @@ export function generateOpenCodeRuntimeConfig(options: OpenCodeRuntimeConfigOpti
   const modelsToRegister = defaultModel ? [...models, defaultModel] : [...models];
   for (const rawModel of modelsToRegister) {
     const modelName = stripOwnProviderPrefix(rawModel, providerName);
-    const upstreamId = modelAliases?.[modelName]?.trim();
+    const configuredAlias =
+      modelAliases && Object.hasOwn(modelAliases, modelName) ? modelAliases[modelName] : undefined;
+    const upstreamId = typeof configuredAlias === 'string' ? configuredAlias.trim() : undefined;
     modelsMap[modelName] = {
       ...(upstreamId ? { id: upstreamId } : {}),
       name: modelName,

--- a/packages/api/src/routes/accounts.ts
+++ b/packages/api/src/routes/accounts.ts
@@ -54,6 +54,9 @@ function accountToView(id: string, account: AccountConfig, apiKeyPresent: boolea
     ...(clientId ? { clientId } : {}),
     ...(account.baseUrl ? { baseUrl: account.baseUrl } : {}),
     models: account.models ? [...account.models] : [],
+    ...(account.modelAliases && Object.keys(account.modelAliases).length > 0
+      ? { modelAliases: { ...account.modelAliases } }
+      : {}),
     hasApiKey: apiKeyPresent,
     mode: account.authType === 'api_key' ? ('api_key' as const) : ('subscription' as const),
     ...(account.envVars && Object.keys(account.envVars).length > 0 ? { envVars: { ...account.envVars } } : {}),
@@ -122,6 +125,27 @@ const envVarsSchema = z
     }
     return Object.keys(filtered).length > 0 ? filtered : undefined;
   });
+const modelAliasKeySchema = z.string().refine((key) => key.trim().length > 0, 'model alias key cannot be blank');
+const modelAliasesSchema = z
+  .record(modelAliasKeySchema, z.string().trim().min(1))
+  .superRefine((aliases, ctx) => {
+    const normalizedKeys = new Set<string>();
+    for (const key of Object.keys(aliases)) {
+      const normalizedKey = key.trim();
+      if (normalizedKeys.has(normalizedKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [key],
+          message: 'model alias keys must be unique after trimming',
+        });
+      }
+      normalizedKeys.add(normalizedKey);
+    }
+  })
+  .transform((aliases) =>
+    Object.fromEntries(Object.entries(aliases).map(([key, upstreamId]) => [key.trim(), upstreamId])),
+  )
+  .optional();
 
 const authTypeEnum = z.enum(['oauth', 'api_key']);
 const modeEnum = z.enum(['subscription', 'api_key']);
@@ -155,6 +179,7 @@ const createBodySchema = z
           .pipe(z.string().min(1)),
       )
       .optional(),
+    modelAliases: modelAliasesSchema,
     /** F171: User-defined env vars injected into agent subprocess. */
     envVars: envVarsSchema,
   })
@@ -189,6 +214,7 @@ const updateBodySchema = z.object({
         .pipe(z.string().min(1)),
     )
     .optional(),
+  modelAliases: modelAliasesSchema,
   /** F171: User-defined env vars injected into agent subprocess. */
   envVars: envVarsSchema,
 });
@@ -279,6 +305,7 @@ export const accountsRoutes: FastifyPluginAsync = async (app) => {
         ...(body.clientId ? { clientId: body.clientId } : {}),
         ...(body.baseUrl ? { baseUrl: body.baseUrl } : {}),
         ...(body.models ? { models: body.models } : {}),
+        ...(body.modelAliases && Object.keys(body.modelAliases).length > 0 ? { modelAliases: body.modelAliases } : {}),
         ...((body.displayName ?? body.name) ? { displayName: body.displayName ?? body.name } : {}),
         ...(body.envVars && Object.keys(body.envVars).length > 0 ? { envVars: body.envVars } : {}),
       };
@@ -348,6 +375,13 @@ export const accountsRoutes: FastifyPluginAsync = async (app) => {
           ? { models: parsed.data.models }
           : existing.models
             ? { models: [...existing.models] }
+            : {}),
+        ...('modelAliases' in parsed.data
+          ? parsed.data.modelAliases && Object.keys(parsed.data.modelAliases).length > 0
+            ? { modelAliases: parsed.data.modelAliases }
+            : {}
+          : existing.modelAliases && Object.keys(existing.modelAliases).length > 0
+            ? { modelAliases: { ...existing.modelAliases } }
             : {}),
         ...('envVars' in parsed.data
           ? parsed.data.envVars && Object.keys(parsed.data.envVars).length > 0

--- a/packages/api/test/account-resolver.test.js
+++ b/packages/api/test/account-resolver.test.js
@@ -79,6 +79,7 @@ describe('account-resolver (4b unified runtime resolution)', () => {
         authType: 'api_key',
         baseUrl: 'https://open.bigmodel.cn/api/paas/v4',
         models: ['glm-5'],
+        modelAliases: { 'glm-5': 'upstream-glm-5' },
         displayName: 'My GLM',
       },
     });
@@ -94,6 +95,7 @@ describe('account-resolver (4b unified runtime resolution)', () => {
     assert.equal(profile.baseUrl, 'https://open.bigmodel.cn/api/paas/v4');
     assert.equal(profile.apiKey, 'glm-xxx');
     assert.deepEqual(profile.models, ['glm-5']);
+    assert.deepEqual(profile.modelAliases, { 'glm-5': 'upstream-glm-5' });
   });
 
   it('resolveByAccountRef returns builtin-style profile for oauth accounts', async () => {

--- a/packages/api/test/accounts-route.test.js
+++ b/packages/api/test/accounts-route.test.js
@@ -124,12 +124,16 @@ describe('accounts routes', () => {
           baseUrl: 'https://api.route.dev',
           apiKey: 'sk-route',
           models: ['claude-opus-4-6'],
+          modelAliases: { 'claude-opus-4-6': 'claude-opus-4-6-20260101' },
         }),
       });
       assert.equal(createRes.statusCode, 200);
       const created = createRes.json();
       assert.equal(created.profile.authType, 'api_key');
       assert.equal(created.profile.hasApiKey, true);
+      assert.deepEqual(created.profile.modelAliases, {
+        'claude-opus-4-6': 'claude-opus-4-6-20260101',
+      });
 
       const listRes = await app.inject({
         method: 'GET',
@@ -144,6 +148,91 @@ describe('accounts routes', () => {
       const listed = list.providers.find((p) => p.id === created.profile.id);
       assert.ok(listed, 'created profile should appear in list');
       assert.equal(listed.hasApiKey, true);
+      assert.deepEqual(listed.modelAliases, {
+        'claude-opus-4-6': 'claude-opus-4-6-20260101',
+      });
+    } finally {
+      restoreGlobalRoot();
+      await rm(projectDir, { recursive: true, force: true });
+      await app.close();
+    }
+  });
+
+  it('PATCH /api/accounts/:id updates and clears model aliases', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { accountsRoutes } = await import('../dist/routes/accounts.js');
+    const app = Fastify();
+    await app.register(accountsRoutes);
+    await app.ready();
+
+    const projectDir = await makeTmpDir('model-aliases');
+    setGlobalRoot(projectDir);
+    try {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/accounts',
+        headers: { ...AUTH_HEADERS, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          projectPath: projectDir,
+          displayName: 'Aliased Models',
+          authType: 'api_key',
+          modelAliases: { 'kimi-code/k3': 'kimi-k3' },
+        }),
+      });
+      assert.equal(createRes.statusCode, 200);
+      const profileId = createRes.json().profile.id;
+
+      const updateRes = await app.inject({
+        method: 'PATCH',
+        url: `/api/accounts/${profileId}`,
+        headers: { ...AUTH_HEADERS, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          projectPath: projectDir,
+          modelAliases: { 'kimi-code/kimi-for-coding': 'kimi-k2.7-code' },
+        }),
+      });
+      assert.equal(updateRes.statusCode, 200);
+      assert.deepEqual(updateRes.json().profile.modelAliases, {
+        'kimi-code/kimi-for-coding': 'kimi-k2.7-code',
+      });
+
+      const clearRes = await app.inject({
+        method: 'PATCH',
+        url: `/api/accounts/${profileId}`,
+        headers: { ...AUTH_HEADERS, 'content-type': 'application/json' },
+        payload: JSON.stringify({ projectPath: projectDir, modelAliases: {} }),
+      });
+      assert.equal(clearRes.statusCode, 200);
+      assert.equal(clearRes.json().profile.modelAliases, undefined);
+    } finally {
+      restoreGlobalRoot();
+      await rm(projectDir, { recursive: true, force: true });
+      await app.close();
+    }
+  });
+
+  it('rejects blank model alias ids', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { accountsRoutes } = await import('../dist/routes/accounts.js');
+    const app = Fastify();
+    await app.register(accountsRoutes);
+    await app.ready();
+
+    const projectDir = await makeTmpDir('invalid-model-alias');
+    setGlobalRoot(projectDir);
+    try {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/accounts',
+        headers: { ...AUTH_HEADERS, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          projectPath: projectDir,
+          displayName: 'Invalid Alias',
+          authType: 'api_key',
+          modelAliases: { 'kimi-code/k3': '   ' },
+        }),
+      });
+      assert.equal(createRes.statusCode, 400);
     } finally {
       restoreGlobalRoot();
       await rm(projectDir, { recursive: true, force: true });
@@ -153,6 +242,35 @@ describe('accounts routes', () => {
 
   // clowder-ai#340: POST /api/accounts/:id/test route removed — incomplete feature with no frontend entry.
   // Probe/heuristic protocol inference deleted alongside.
+
+  it('rejects model alias keys that collide after trimming', async () => {
+    const Fastify = (await import('fastify')).default;
+    const { accountsRoutes } = await import('../dist/routes/accounts.js');
+    const app = Fastify();
+    await app.register(accountsRoutes);
+    await app.ready();
+
+    const projectDir = await makeTmpDir('duplicate-model-alias');
+    setGlobalRoot(projectDir);
+    try {
+      const createRes = await app.inject({
+        method: 'POST',
+        url: '/api/accounts',
+        headers: { ...AUTH_HEADERS, 'content-type': 'application/json' },
+        payload: JSON.stringify({
+          projectPath: projectDir,
+          displayName: 'Duplicate Alias',
+          authType: 'api_key',
+          modelAliases: { 'kimi-code/k3': 'kimi-k3', ' kimi-code/k3 ': 'different-id' },
+        }),
+      });
+      assert.equal(createRes.statusCode, 400);
+    } finally {
+      restoreGlobalRoot();
+      await rm(projectDir, { recursive: true, force: true });
+      await app.close();
+    }
+  });
 
   it('rejects blank profile name in create request', async () => {
     const Fastify = (await import('fastify')).default;

--- a/packages/api/test/catalog-accounts.test.js
+++ b/packages/api/test/catalog-accounts.test.js
@@ -323,7 +323,13 @@ describe('global accounts (clowder-ai#340)', () => {
         anthropic: {
           activeProfileId: 'my-proxy',
           profiles: [
-            { id: 'my-proxy', displayName: 'My Proxy', authType: 'api_key', baseUrl: 'https://proxy.example/v1' },
+            {
+              id: 'my-proxy',
+              displayName: 'My Proxy',
+              authType: 'api_key',
+              baseUrl: 'https://proxy.example/v1',
+              modelAliases: { 'kimi-code/k3': 'kimi-k3' },
+            },
             { id: 'team-key', displayName: 'Team Key', authType: 'api_key' },
           ],
         },
@@ -353,6 +359,7 @@ describe('global accounts (clowder-ai#340)', () => {
     assert.equal(result['my-proxy'].authType, 'api_key');
     assert.equal(result['my-proxy'].displayName, 'My Proxy');
     assert.equal(result['my-proxy'].baseUrl, 'https://proxy.example/v1');
+    assert.deepEqual(result['my-proxy'].modelAliases, { 'kimi-code/k3': 'kimi-k3' });
     assert.ok(result['team-key'], 'team-key account should exist');
     assert.equal(result['team-key'].authType, 'api_key');
     // Must NOT create an "anthropic" shell account from the parent key
@@ -430,6 +437,51 @@ describe('global accounts (clowder-ai#340)', () => {
     const credRaw = await readFile(join(globalRoot, '.cat-cafe', 'credentials.json'), 'utf-8');
     const creds = JSON.parse(credRaw);
     assert.equal(creds['my-custom'].apiKey, 'sk-retry-key', 'credential must be imported on retry');
+  });
+
+  it('treats different model aliases as a legacy account conflict', async () => {
+    const { readCatalogAccounts, resetMigrationState, writeCatalogAccount } = await import(
+      '../dist/config/catalog-accounts.js'
+    );
+    resetMigrationState();
+
+    writeCatalogAccount(projectRoot, 'shared', {
+      authType: 'api_key',
+      baseUrl: 'https://proxy.example/v1',
+      models: ['kimi-code/k3'],
+      modelAliases: { 'kimi-code/k3': 'kimi-k3' },
+    });
+    resetMigrationState();
+
+    await writeFile(
+      join(projectRoot, '.cat-cafe', 'provider-profiles.json'),
+      JSON.stringify({
+        version: 2,
+        providers: [
+          {
+            id: 'shared',
+            authType: 'api_key',
+            baseUrl: 'https://proxy.example/v1',
+            models: ['kimi-code/k3'],
+            modelAliases: { 'kimi-code/k3': 'different-upstream-id' },
+          },
+        ],
+      }),
+      'utf-8',
+    );
+    await writeFile(
+      join(projectRoot, '.cat-cafe', 'provider-profiles.secrets.local.json'),
+      JSON.stringify({ profiles: { shared: { apiKey: 'sk-wrong-source' } } }),
+      'utf-8',
+    );
+
+    const result = readCatalogAccounts(projectRoot);
+    assert.deepEqual(result.shared.modelAliases, { 'kimi-code/k3': 'kimi-k3' });
+    const credentialPath = join(globalRoot, '.cat-cafe', 'credentials.json');
+    if (existsSync(credentialPath)) {
+      const credentials = JSON.parse(await readFile(credentialPath, 'utf-8'));
+      assert.equal(credentials.shared, undefined);
+    }
   });
 
   it('skips legacy secret when colliding with pre-existing global OAuth account', async () => {

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -5855,6 +5855,10 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
       models: ['maas/glm-5'],
       setActive: false,
     });
+    const accountsPath = join(root, '.cat-cafe', 'accounts.json');
+    const accounts = JSON.parse(await readFile(accountsPath, 'utf-8'));
+    accounts[customProfile.id].modelAliases = { 'glm-5': 'upstream-glm-5' };
+    await writeFile(accountsPath, `${JSON.stringify(accounts, null, 2)}\n`, 'utf-8');
 
     const registrySnapshot = catRegistry.getAllConfigs();
     const originalConfig = catRegistry.tryGet('opencode')?.config;
@@ -5914,7 +5918,9 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(callbackEnv.CAT_CAFE_OC_BASE_URL, 'https://maas.example/v1');
     assert.equal(seenRuntimeConfig?.model, 'maas/glm-5');
     assert.equal(seenRuntimeConfig?.provider?.maas?.npm, '@ai-sdk/openai-compatible');
-    assert.deepStrictEqual(seenRuntimeConfig?.provider?.maas?.models, { 'glm-5': { name: 'glm-5' } });
+    assert.deepStrictEqual(seenRuntimeConfig?.provider?.maas?.models, {
+      'glm-5': { id: 'upstream-glm-5', name: 'glm-5' },
+    });
     await assert.rejects(readFile(seenConfigPath, 'utf-8'));
   });
 

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -13,6 +13,7 @@ import {
   OC_API_KEY_ENV,
   OC_BASE_URL_ENV,
   parseOpenCodeModel,
+  resolveOpenCodeUpstreamModel,
   summarizeOpenCodeRuntimeConfigForDebug,
 } from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
 import {
@@ -222,6 +223,20 @@ describe('parseOpenCodeModel', () => {
   });
 });
 
+describe('resolveOpenCodeUpstreamModel', () => {
+  test('maps Kimi Code aliases to upstream model ids', () => {
+    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/k3'), 'kimi-k3');
+    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/kimi-for-coding'), 'kimi-k2.7-code');
+    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/kimi-for-coding-highspeed'), 'kimi-k3');
+  });
+
+  test('keeps upstream and unknown model ids unchanged', () => {
+    assert.equal(resolveOpenCodeUpstreamModel('kimi-k3'), 'kimi-k3');
+    assert.equal(resolveOpenCodeUpstreamModel('gemini-3.1-pro'), 'gemini-3.1-pro');
+    assert.equal(resolveOpenCodeUpstreamModel('vendor/custom-model'), 'vendor/custom-model');
+  });
+});
+
 describe('deriveOpenCodeApiType', () => {
   test('derives apiType solely from providerName', () => {
     const scenarios = [
@@ -359,6 +374,21 @@ describe('generateOpenCodeRuntimeConfig', () => {
     assert.equal(config.provider.maas.npm, '@ai-sdk/openai-compatible');
     assert.equal(config.provider.maas.options.baseURL, `{env:${OC_BASE_URL_ENV}}`);
     assert.equal(config.provider.maas.options.apiKey, `{env:${OC_API_KEY_ENV}}`);
+  });
+
+  test('maps Kimi aliases only in the upstream model name', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'kimi',
+      models: ['kimi-code/k3'],
+      defaultModel: 'kimi/kimi-code/k3',
+      apiType: 'openai',
+      hasBaseUrl: true,
+    });
+
+    assert.equal(config.model, 'kimi/kimi-code/k3');
+    assert.deepStrictEqual(config.provider.kimi.models, {
+      'kimi-code/k3': { name: 'kimi-k3' },
+    });
   });
 
   test('apiType maps to correct npm adapters', () => {

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -401,6 +401,19 @@ describe('generateOpenCodeRuntimeConfig', () => {
     });
   });
 
+  test('keeps prototype-named local models on identity routing without inherited aliases', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'vendor',
+      models: ['toString', 'constructor'],
+      modelAliases: { configured: 'upstream-configured' },
+    });
+
+    assert.deepStrictEqual(config.provider.vendor.models, {
+      toString: { name: 'toString' },
+      constructor: { name: 'constructor' },
+    });
+  });
+
   test('apiType maps to correct npm adapters', () => {
     const cases = [
       { apiType: 'openai', expectedNpm: '@ai-sdk/openai-compatible' },

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -13,7 +13,6 @@ import {
   OC_API_KEY_ENV,
   OC_BASE_URL_ENV,
   parseOpenCodeModel,
-  resolveOpenCodeUpstreamModel,
   summarizeOpenCodeRuntimeConfigForDebug,
 } from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
 import {
@@ -223,20 +222,6 @@ describe('parseOpenCodeModel', () => {
   });
 });
 
-describe('resolveOpenCodeUpstreamModel', () => {
-  test('maps Kimi Code aliases to upstream model ids', () => {
-    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/k3'), 'kimi-k3');
-    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/kimi-for-coding'), 'kimi-k2.7-code');
-    assert.equal(resolveOpenCodeUpstreamModel('kimi-code/kimi-for-coding-highspeed'), 'kimi-k3');
-  });
-
-  test('keeps upstream and unknown model ids unchanged', () => {
-    assert.equal(resolveOpenCodeUpstreamModel('kimi-k3'), 'kimi-k3');
-    assert.equal(resolveOpenCodeUpstreamModel('gemini-3.1-pro'), 'gemini-3.1-pro');
-    assert.equal(resolveOpenCodeUpstreamModel('vendor/custom-model'), 'vendor/custom-model');
-  });
-});
-
 describe('deriveOpenCodeApiType', () => {
   test('derives apiType solely from providerName', () => {
     const scenarios = [
@@ -283,6 +268,7 @@ describe('prepareOpenCodeAcpSpawnConfig', () => {
           apiKey: 'sk-test-secret',
           baseUrl: 'https://proxy.example/v1',
           models: ['claude-opus-4-6'],
+          modelAliases: { 'claude-opus-4-6': 'claude-opus-4-6-20260101' },
         },
       });
 
@@ -296,7 +282,17 @@ describe('prepareOpenCodeAcpSpawnConfig', () => {
       assert.equal(config.small_model, 'anthropic/claude-opus-4-6');
       assert.equal(config.provider.anthropic.options.apiKey, `{env:${OC_API_KEY_ENV}}`);
       assert.equal(config.provider.anthropic.options.baseURL, `{env:${OC_BASE_URL_ENV}}`);
+      assert.deepEqual(config.provider.anthropic.models, {
+        'claude-opus-4-6': { id: 'claude-opus-4-6-20260101', name: 'claude-opus-4-6' },
+      });
+      assert.deepEqual(prepared.runtimeConfigSummary.providerSummary.anthropic.modelMappings, {
+        'claude-opus-4-6': 'claude-opus-4-6-20260101',
+      });
       assert.ok(!JSON.stringify(config).includes('sk-test-secret'), 'runtime config must not write secrets');
+      assert.ok(
+        !JSON.stringify(prepared.runtimeConfigSummary).includes('sk-test-secret'),
+        'debug summary must not include secrets',
+      );
     } finally {
       rmSync(projectRoot, { recursive: true, force: true });
     }
@@ -376,18 +372,32 @@ describe('generateOpenCodeRuntimeConfig', () => {
     assert.equal(config.provider.maas.options.apiKey, `{env:${OC_API_KEY_ENV}}`);
   });
 
-  test('maps Kimi aliases only in the upstream model name', () => {
+  test('uses account model aliases as upstream ids while preserving local keys', () => {
     const config = generateOpenCodeRuntimeConfig({
       providerName: 'kimi',
       models: ['kimi-code/k3'],
       defaultModel: 'kimi/kimi-code/k3',
       apiType: 'openai',
       hasBaseUrl: true,
+      modelAliases: { 'kimi-code/k3': 'kimi-k3' },
     });
 
     assert.equal(config.model, 'kimi/kimi-code/k3');
     assert.deepStrictEqual(config.provider.kimi.models, {
-      'kimi-code/k3': { name: 'kimi-k3' },
+      'kimi-code/k3': { id: 'kimi-k3', name: 'kimi-code/k3' },
+    });
+  });
+
+  test('keeps unknown models on identity routing without guessing aliases', () => {
+    const config = generateOpenCodeRuntimeConfig({
+      providerName: 'vendor',
+      models: ['vendor/custom-model'],
+      defaultModel: 'vendor/custom-model',
+      apiType: 'openai',
+    });
+
+    assert.deepStrictEqual(config.provider.vendor.models, {
+      'custom-model': { name: 'custom-model' },
     });
   });
 
@@ -642,6 +652,7 @@ describe('generateOpenCodeRuntimeConfig', () => {
       defaultModel: 'anthropic/minimax-m2.7',
       apiType: 'anthropic',
       hasBaseUrl: true,
+      modelAliases: { 'minimax-m2.7': 'upstream-minimax-m2.7' },
     });
 
     assert.equal(summary.model, 'anthropic/minimax-m2.7');
@@ -651,6 +662,10 @@ describe('generateOpenCodeRuntimeConfig', () => {
       anthropic: {
         npm: '@ai-sdk/anthropic',
         modelKeys: ['minimax-m2.7', 'minimax-text-01'],
+        modelMappings: {
+          'minimax-m2.7': 'upstream-minimax-m2.7',
+          'minimax-text-01': 'minimax-text-01',
+        },
         hasBaseUrl: true,
         apiKeySource: `env:${OC_API_KEY_ENV}`,
         baseUrlSource: `env:${OC_BASE_URL_ENV}`,

--- a/packages/api/test/opencode-model-id-ci-contract.test.js
+++ b/packages/api/test/opencode-model-id-ci-contract.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+import { parse } from 'yaml';
+
+const requiredVersion = '1.18.9';
+
+for (const [workflow, jobName] of [
+  ['ci.yml', 'test'],
+  ['windows-smoke.yml', 'test-windows'],
+]) {
+  test(`${workflow} installs and requires the exact OpenCode behavior baseline`, () => {
+    const document = parse(readFileSync(new URL(`../../../.github/workflows/${workflow}`, import.meta.url), 'utf8'));
+    const steps = document.jobs[jobName].steps;
+    const installIndex = steps.findIndex((step) => step.run === `npm install --global opencode-ai@${requiredVersion}`);
+    const buildIndex = steps.findIndex((step) => step.run === 'pnpm --filter @cat-cafe/api build');
+    const behaviorIndex = steps.findIndex((step) =>
+      step.run?.includes('packages/api/test/opencode-model-id-request.test.js'),
+    );
+
+    assert.ok(buildIndex >= 0, 'the API must be built before its compiled config generator is imported');
+    assert.ok(installIndex >= 0, `OpenCode ${requiredVersion} must be installed`);
+    assert.ok(behaviorIndex >= 0, 'the OpenCode behavior test must run');
+    assert.match(steps[behaviorIndex].run, /opencode-model-id-ci-contract\.test\.js/);
+    assert.equal(steps[behaviorIndex].env.REQUIRE_OPENCODE_MODEL_ID_TEST, '1');
+    assert.ok(buildIndex < behaviorIndex, 'the API must be built before the behavior test');
+    assert.ok(installIndex < behaviorIndex, 'the exact OpenCode version must be installed before the behavior test');
+    if (workflow === 'ci.yml') {
+      const publicSuiteIndex = steps.findIndex((step) => step.run?.includes('test:public'));
+      assert.ok(
+        behaviorIndex < publicSuiteIndex,
+        'the behavior gate must run even when an independent public-suite baseline fails',
+      );
+    }
+  });
+}

--- a/packages/api/test/opencode-model-id-request.test.js
+++ b/packages/api/test/opencode-model-id-request.test.js
@@ -1,0 +1,189 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import {
+  generateOpenCodeRuntimeConfig,
+  OC_API_KEY_ENV,
+  OC_BASE_URL_ENV,
+} from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
+
+const requiredOpenCodeVersion = '1.18.9';
+
+function resolveOpenCodeExecutable() {
+  if (process.platform !== 'win32') return 'opencode';
+  const result = spawnSync('where.exe', ['opencode.cmd'], { encoding: 'utf8' });
+  if (result.status !== 0) return null;
+  const commandShim = result.stdout
+    .split(/\r?\n/)
+    .map((value) => value.trim())
+    .find(Boolean);
+  if (!commandShim) return null;
+  const executable = join(dirname(commandShim), 'node_modules', 'opencode-ai', 'bin', 'opencode.exe');
+  return existsSync(executable) ? executable : null;
+}
+
+const openCodeExecutable = resolveOpenCodeExecutable();
+const openCodeVersion = installedOpenCodeVersion();
+
+function installedOpenCodeVersion() {
+  if (!openCodeExecutable) return null;
+  const result = spawnSync(openCodeExecutable, ['--version'], {
+    encoding: 'utf8',
+  });
+  return result.status === 0 ? result.stdout.trim() : null;
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve(server.address()));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function startOpenCode(args, options) {
+  const child = spawn(openCodeExecutable, args, {
+    ...options,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  const completed = new Promise((resolve, reject) => {
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', (error) => {
+      reject(error);
+    });
+    child.once('close', (code, signal) => {
+      resolve({ code, signal, stdout, stderr });
+    });
+  });
+  return { child, completed, output: () => ({ stdout, stderr }) };
+}
+
+function timeoutAfter(milliseconds, message) {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(typeof message === 'function' ? message() : message)), milliseconds).unref();
+  });
+}
+
+test(
+  'OpenCode v1.18.9 sends the configured upstream model id',
+  { skip: openCodeVersion === null, timeout: 40_000 },
+  async () => {
+    assert.equal(
+      openCodeVersion,
+      requiredOpenCodeVersion,
+      'OpenCode schema baseline changed; revalidate model id routing',
+    );
+    const tempRoot = mkdtempSync(join(tmpdir(), 'cat-cafe-opencode-model-id-'));
+    const gitInit = spawnSync('git', ['init', '--quiet', tempRoot], { encoding: 'utf8' });
+    assert.equal(gitInit.status, 0, gitInit.stderr);
+    let openCodeProcess;
+    let captureResolve;
+    const captured = new Promise((resolve) => {
+      captureResolve = resolve;
+    });
+    const server = createServer((request, response) => {
+      let body = '';
+      request.setEncoding('utf8');
+      request.on('data', (chunk) => {
+        body += chunk;
+      });
+      request.on('end', () => {
+        const capturedRequest = {
+          method: request.method,
+          url: request.url,
+          body: JSON.parse(body),
+        };
+        captureResolve(capturedRequest);
+        response.writeHead(503, { 'content-type': 'application/json', connection: 'close' });
+        response.end(JSON.stringify({ error: { message: 'request captured' } }));
+      });
+    });
+
+    try {
+      const address = await listen(server);
+      assert.equal(typeof address, 'object');
+      const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+      const config = generateOpenCodeRuntimeConfig({
+        providerName: 'kitcoding',
+        models: ['kitcoding/kimi-code/k3'],
+        defaultModel: 'kitcoding/kimi-code/k3',
+        apiType: 'openai',
+        hasBaseUrl: true,
+        modelAliases: { 'kimi-code/k3': 'kimi-k3' },
+      });
+      const configPath = join(tempRoot, 'opencode.json');
+      writeFileSync(configPath, JSON.stringify(config), 'utf8');
+
+      openCodeProcess = startOpenCode(
+        [
+          'run',
+          '--pure',
+          '--print-logs',
+          '--log-level',
+          'DEBUG',
+          '--format',
+          'json',
+          '--model',
+          'kitcoding/kimi-code/k3',
+          'Reply with OK only.',
+        ],
+        {
+          cwd: tempRoot,
+          env: {
+            ...process.env,
+            XDG_CONFIG_HOME: join(tempRoot, 'xdg'),
+            XDG_DATA_HOME: join(tempRoot, 'data'),
+            XDG_STATE_HOME: join(tempRoot, 'state'),
+            XDG_CACHE_HOME: join(tempRoot, 'cache'),
+            OPENCODE_CONFIG: configPath,
+            [OC_API_KEY_ENV]: 'test-key',
+            [OC_BASE_URL_ENV]: baseUrl,
+          },
+        },
+      );
+      const outcome = await Promise.race([
+        captured.then((request) => ({ request })),
+        openCodeProcess.completed.then((result) => ({ result })),
+        timeoutAfter(20_000, () => `OpenCode did not send a request: ${JSON.stringify(openCodeProcess.output())}`),
+      ]);
+      assert.ok(
+        outcome.request,
+        `OpenCode exited before sending a request: ${JSON.stringify(outcome.result ?? openCodeProcess.output())}`,
+      );
+      const capturedRequest = outcome.request;
+
+      assert.equal(capturedRequest.method, 'POST');
+      assert.equal(capturedRequest.url, '/v1/chat/completions');
+      assert.equal(capturedRequest.body.model, 'kimi-k3');
+    } finally {
+      if (openCodeProcess?.child.exitCode === null) openCodeProcess.child.kill();
+      if (openCodeProcess) {
+        await Promise.race([
+          openCodeProcess.completed,
+          timeoutAfter(5_000, 'OpenCode did not terminate after capture'),
+        ]);
+      }
+      server.closeAllConnections?.();
+      await close(server);
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  },
+);

--- a/packages/api/test/opencode-model-id-request.test.js
+++ b/packages/api/test/opencode-model-id-request.test.js
@@ -12,6 +12,7 @@ import {
 } from '../dist/domains/cats/services/agents/providers/opencode-config-template.js';
 
 const requiredOpenCodeVersion = '1.18.9';
+const requireOpenCode = process.env.REQUIRE_OPENCODE_MODEL_ID_TEST === '1';
 
 function resolveOpenCodeExecutable() {
   if (process.platform !== 'win32') return 'opencode';
@@ -28,6 +29,15 @@ function resolveOpenCodeExecutable() {
 
 const openCodeExecutable = resolveOpenCodeExecutable();
 const openCodeVersion = installedOpenCodeVersion();
+
+if (requireOpenCode) {
+  assert.ok(openCodeExecutable, `OpenCode ${requiredOpenCodeVersion} is required for this test`);
+  assert.equal(
+    openCodeVersion,
+    requiredOpenCodeVersion,
+    'OpenCode schema baseline changed; revalidate model id routing',
+  );
+}
 
 function installedOpenCodeVersion() {
   if (!openCodeExecutable) return null;
@@ -51,12 +61,22 @@ function close(server) {
 }
 
 function startOpenCode(args, options) {
-  const child = spawn(openCodeExecutable, args, {
-    ...options,
+  const { executable = openCodeExecutable, ...spawnOptions } = options;
+  const child = spawn(executable, args, {
+    detached: process.platform !== 'win32',
+    ...spawnOptions,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   let stdout = '';
   let stderr = '';
+  const exited = new Promise((resolve) => {
+    child.once('error', (error) => {
+      resolve({ code: null, signal: null, error });
+    });
+    child.once('exit', (code, signal) => {
+      resolve({ code, signal });
+    });
+  });
   const completed = new Promise((resolve, reject) => {
     child.stdout.setEncoding('utf8');
     child.stderr.setEncoding('utf8');
@@ -73,7 +93,7 @@ function startOpenCode(args, options) {
       resolve({ code, signal, stdout, stderr });
     });
   });
-  return { child, completed, output: () => ({ stdout, stderr }) };
+  return { child, exited, completed, output: () => ({ stdout, stderr }) };
 }
 
 function timeoutAfter(milliseconds, message) {
@@ -81,6 +101,108 @@ function timeoutAfter(milliseconds, message) {
     setTimeout(() => reject(new Error(typeof message === 'function' ? message() : message)), milliseconds).unref();
   });
 }
+
+function processIsRunning(child) {
+  return child.exitCode === null && child.signalCode === null;
+}
+
+async function terminateWindowsProcessTree(child, exited) {
+  const result = spawnSync('taskkill.exe', ['/pid', String(child.pid), '/T', '/F'], {
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.status === 0 || !processIsRunning(child)) return;
+
+  const exitedDuringTaskkill = await Promise.race([
+    exited.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 100)),
+  ]);
+  if (!exitedDuringTaskkill) {
+    throw new Error(`taskkill failed for OpenCode process ${child.pid}: ${result.stderr || result.stdout}`);
+  }
+}
+
+async function terminatePosixProcessGroup(child, exited) {
+  try {
+    process.kill(-child.pid, 'SIGTERM');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+  const exitedAfterTerm = await Promise.race([
+    exited.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 1_000)),
+  ]);
+  if (exitedAfterTerm) return;
+
+  try {
+    process.kill(-child.pid, 'SIGKILL');
+  } catch (error) {
+    if (error?.code !== 'ESRCH') throw error;
+  }
+}
+
+async function terminateOpenCodeProcess(processHandle) {
+  const { child, exited, completed } = processHandle;
+
+  if (processIsRunning(child)) {
+    if (process.platform === 'win32') {
+      await terminateWindowsProcessTree(child, exited);
+    } else {
+      await terminatePosixProcessGroup(child, exited);
+    }
+  }
+
+  await Promise.race([exited, timeoutAfter(5_000, `OpenCode process tree ${child.pid} did not exit`)]);
+  child.stdout.destroy();
+  child.stderr.destroy();
+
+  return Promise.race([completed, timeoutAfter(5_000, `OpenCode process tree ${child.pid} did not close its stdio`)]);
+}
+
+function waitForReportedPid(processHandle) {
+  let poll;
+  const reported = new Promise((resolve) => {
+    poll = setInterval(() => {
+      const pid = Number.parseInt(processHandle.output().stdout.trim(), 10);
+      if (Number.isInteger(pid)) resolve(pid);
+    }, 10);
+  });
+  return Promise.race([reported, timeoutAfter(5_000, 'test process did not report its child pid')]).finally(() =>
+    clearInterval(poll),
+  );
+}
+
+function bestEffortKill(pid) {
+  try {
+    process.kill(pid, 'SIGKILL');
+  } catch {
+    // Preserve the original test failure if cleanup races with process exit.
+  }
+}
+
+test('terminates an OpenCode process tree after request capture', async () => {
+  const childScript = [
+    "const { spawn } = require('node:child_process');",
+    "const child = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });",
+    'console.log(child.pid);',
+    'setInterval(() => {}, 1000);',
+  ].join('');
+  const processHandle = startOpenCode(['-e', childScript], {
+    executable: process.execPath,
+  });
+  let descendantPid;
+
+  try {
+    descendantPid = await waitForReportedPid(processHandle);
+    await terminateOpenCodeProcess(processHandle);
+    const result = await Promise.race([processHandle.completed, timeoutAfter(5_000, 'test process did not terminate')]);
+    assert.notEqual(result.signal ?? result.code, null);
+    assert.throws(() => process.kill(descendantPid, 0), { code: 'ESRCH' });
+  } finally {
+    if (processHandle.child.exitCode === null) bestEffortKill(processHandle.child.pid);
+    if (descendantPid) bestEffortKill(descendantPid);
+  }
+});
 
 test(
   'OpenCode v1.18.9 sends the configured upstream model id',
@@ -174,13 +296,7 @@ test(
       assert.equal(capturedRequest.url, '/v1/chat/completions');
       assert.equal(capturedRequest.body.model, 'kimi-k3');
     } finally {
-      if (openCodeProcess?.child.exitCode === null) openCodeProcess.child.kill();
-      if (openCodeProcess) {
-        await Promise.race([
-          openCodeProcess.completed,
-          timeoutAfter(5_000, 'OpenCode did not terminate after capture'),
-        ]);
-      }
+      if (openCodeProcess) await terminateOpenCodeProcess(openCodeProcess);
       server.closeAllConnections?.();
       await close(server);
       rmSync(tempRoot, { recursive: true, force: true });

--- a/packages/shared/src/types/cat-breed.ts
+++ b/packages/shared/src/types/cat-breed.ts
@@ -233,6 +233,7 @@ export interface AccountConfig {
   readonly clientId?: string;
   readonly baseUrl?: string;
   readonly models?: readonly string[];
+  readonly modelAliases?: Readonly<Record<string, string>>;
   readonly displayName?: string;
   /** F171: User-defined env vars injected into agent subprocess.
    *  Keys starting with CAT_CAFE_ are reserved and cannot be overridden. */

--- a/packages/web/src/components/hub-accounts.types.ts
+++ b/packages/web/src/components/hub-accounts.types.ts
@@ -15,6 +15,7 @@ export interface ProfileItem {
   clientId?: BuiltinAccountClient;
   baseUrl?: string;
   models?: string[];
+  modelAliases?: Record<string, string>;
   modelOverride?: string | null;
   oauthLikeClient?: string;
   /** F171: User-defined env vars injected into agent subprocess. */

--- a/review-notes/2026-07-31-issue-1252-opencode-model-alias-review-request.md
+++ b/review-notes/2026-07-31-issue-1252-opencode-model-alias-review-request.md
@@ -1,0 +1,134 @@
+# Review Request: #1252 OpenCode 本地模型键与上游 ID 映射
+
+Review-Target-ID: fix-opencode-kimi-model-alias
+Branch: fix/opencode-kimi-model-alias
+Implementation-SHA: 233f825e0c72e004626eb190ba42be49c0c984ca
+PR: https://github.com/zts212653/clowder-ai/pull/1233
+
+`Implementation-SHA` 是已验证的实现 HEAD。若本 review packet 作为后续文档提交进入 PR，正式 verdict 仍须核对当时的实际 PR HEAD，并确认代码差异除 review packet 外未变化。
+
+## What
+
+为账户配置新增 `modelAliases`，把 OpenCode 的稳定本地模型键映射到 endpoint-specific 上游模型 ID。映射贯穿账户 REST、legacy migration、account resolver、ACP spawn 和普通 invocation；OpenCode 配置使用 `{ id: upstreamId, name: localKey }`，未配置映射时保持恒等路由。Debug summary 新增 local key → upstream ID 映射，但不包含凭据。
+
+## Why
+
+OpenCode `1.18.9` 将 `provider.<id>.models` 的 map key 用作本地选择键，真正发送给 SDK 的模型 ID 来自条目 `id`；`name` 只负责展示。旧实现只改 `name`，因此选择 `kimi/kimi-code/k3` 时仍向 OpenAI-compatible endpoint 发送 `model: kimi-code/k3`。
+
+## Original Requirements
+
+来源：[Issue #1252](https://github.com/zts212653/clowder-ai/issues/1252)，已获 maintainer `WELCOME / accepted bug`。
+
+> 1. `models` 中的键保持为用户选择、session 恢复和 telemetry 使用的稳定本地键。
+> 2. OpenCode 自定义 provider 的模型条目使用 `id` 传递上游请求 ID。
+> 3. `name` 仅用于展示，不承担路由语义。
+> 4. 未配置映射时使用恒等映射，不做字符串猜测。
+> 5. 映射由对应账户/provider profile owner 维护；通用 generator 不维护跨 provider 硬编码 alias 表。
+> 6. 验收必须启动真实 OpenCode 进程、捕获请求体并断言实际 `model`，不能只检查生成 JSON。
+> 7. Debug summary 同时展示 local key 与 upstream ID，且不得泄漏 API key。
+
+请 reviewer 对照以上原始契约判断，而不只检查类型与单元测试是否通过。
+
+## Tradeoff
+
+我们没有建立全局 provider alias catalog，也没有按模型名做猜测。代价是第三方 endpoint 的账户 owner 必须显式维护映射；收益是通用 generator 不持有会漂移的第三方知识，未知模型继续恒等路由，现有本地模型键与 session 绑定保持稳定。
+
+## Architecture Ownership
+
+Architecture cell: `identity-session`（`identity-agent` 的账户/运行时配置边界）
+Map delta: none
+Why: 本变更扩展既有账户配置与 provider adapter 数据流，没有新增 Store、Queue、Router、Dispatcher、Binding 或新的 ownership 边界。
+
+请 reviewer 检查 diff 是否与 `Map delta: none` 一致，并确认 `modelAliases` 没有形成第二份全局配置真相源。
+
+## Invariant Matrix
+
+| Invariant | 断言 | 证据 |
+| --- | --- | --- |
+| INV-1 | 本地模型键在账户、成员选择与 OpenCode `model` 选择路径中保持不变 | config template、invocation 回归 |
+| INV-2 | 只有账户级映射决定上游 `id`；未配置时恒等路由 | generator 单测、catalog/resolver 回归 |
+| INV-3 | ACP 与普通 invocation 使用同一映射契约 | ACP config 与 invocation 定向测试 |
+| INV-4 | REST create/list/update/clear 与 legacy migration 不丢映射 | accounts route、catalog tests |
+| INV-5 | Debug summary 展示映射但不包含 API key | config summary assertions |
+| INV-6 | OpenCode `1.18.9` 的真实请求体发送 `model: kimi-k3` | `opencode-model-id-request.test.js` |
+
+## Dogfood-Your-Slice
+
+Scope verdict: 必做，已完成。
+
+端到端路径：生成账户映射配置 → 启动真实 OpenCode `1.18.9` 子进程 → 指向随机端口本地假 OpenAI-compatible server → 捕获 `POST /v1/chat/completions`。
+
+捕获结果：本地选择仍为 `kitcoding/kimi-code/k3`，请求体 `model` 为 `kimi-k3`。假服务故意返回 503，仅用于在无真实凭据条件下终止请求；测试不把 kitcoding 原始 503 根因当作已独立复核事实。
+
+## Open Questions
+
+### Technical OQ
+
+1. `modelAliases` 的 trim、空值拒绝和 trim 后重复键检测是否覆盖了所有 canonical 冲突路径？
+2. REST、legacy migration、ACP pool 与普通 invocation 是否存在遗漏的账户复制/序列化边界？
+3. OpenCode schema 版本变化时，`1.18.9` 精确版本断言是否能足够早地阻止静默漂移？
+4. Debug summary 的 `modelMappings` 是否在所有路径都只包含模型标识，不可能带入凭据或 endpoint secret？
+
+### Value OQ
+
+None.
+
+## Fresh-Context Findings
+
+Agent: Archimedes（fresh-context scan）
+SHA scanned: `233f825e0`
+结果：0 remaining findings；FC-2/FC-3 已修复，FC-1 经源码真相源复核后驳回。
+
+Fresh-context scan 只负责 finding generation，不构成正式放行。
+
+## Quality-Gate Evidence
+
+检查 worktree：`G:\AIwork\clowder-ai\cat-cafe-opencode-kimi-fix`
+
+### Fresh targeted tests
+
+```text
+accounts-route.test.js                         17 passed, 0 failed
+account-resolver.test.js                       20 passed, 0 failed
+catalog aliases/migration pattern              2 passed, 0 failed
+OpenCode ACP/config alias pattern               4 passed, 0 failed
+invoke-single-cat alias propagation             1 passed, 0 failed
+real OpenCode 1.18.9 request capture            1 passed, 0 failed
+Total                                           45 passed, 0 failed
+```
+
+### Build / lint / formatting
+
+```text
+pnpm --filter @cat-cafe/api run build          exit 0
+pnpm --filter @cat-cafe/shared lint             exit 0
+pnpm --filter @cat-cafe/api lint                exit 0
+pnpm --filter @cat-cafe/web lint                exit 0（既有 warnings）
+pnpm -r --if-present run build                  exit 0
+```
+
+本地 Windows checkout 的 Biome 对 CRLF 工作树按整文件报格式差异，未自动改写；GitHub exact HEAD `233f825e0` 的 `Lint` check 为 SUCCESS。`Test (Windows)`、`Build`、`Directory Size Guard` 同样为 SUCCESS；发请求时 `Test (Public)` 仍在运行，由 PR tracking 事件驱动继续跟踪。
+
+完整大文件合并运行会触发该 checkout 已知的 HOME 串扰与 Windows 路径断言基线；本轮按仓库隔离约定逐组运行新增契约，45 项均绿。根目录媒体/设计工件检查为空，无匹配 `.pen`。
+
+`scripts/check-hotfix-pattern.mjs`、`scripts/check-fallback-layers.mjs` 与 `check:architecture-ownership` 在此上游 checkout 不存在。人工 diff 审计未发现同文件新增三层 fallback，也未新增架构 ownership primitive。
+
+## Review Focus
+
+1. 账户配置的 source-of-truth 与所有传播边界是否完整。
+2. local key / display name / upstream ID 三者是否始终分离。
+3. legacy migration 与 canonical conflict 是否可能静默覆盖映射。
+4. 真实 OpenCode 进程测试是否足以证明请求语义，而非只证明 JSON 形状。
+5. Debug summary 与日志是否保持凭据安全。
+
+## Next Action
+
+请对当前 PR exact HEAD 做独立跨家族 review，在 PR conversation 以 logical review comment 给出明确 `APPROVE` 或 `REQUEST-CHANGES`，覆盖 HEAD SHA，并将每个 finding 标为 P1/P2/P3。不要使用 `gh pr review --approve`，因为 author/reviewer 共用 GitHub login。
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/fix-opencode-kimi-model-alias/opus`
+- Start command: `pnpm review:start`
+- Ports: 由 review launcher 分配；不得占用 runtime `3003/3004`。
+
+[砚砚/GPT-5.6 Sol🐾]


### PR DESCRIPTION
## 根因
OpenCode `1.18.9` 将 `provider.<id>.models` 的 map key 作为稳定本地选择键；真正发送给上游 SDK 的模型 ID 来自条目的 `id`，`name` 只用于展示。旧实现仅改写 `name`，因此本地选择 `kimi-code/k3` 时仍向 OpenAI-compatible endpoint 发送错误的 `model: kimi-code/k3`。

## 契约
- 本地 model key 保持稳定，避免破坏成员配置与路由。
- `modelAliases` 由对应账户/provider profile 持有，映射本地 key → endpoint-specific upstream ID。
- 未配置映射时恒等路由；通用 OpenCode generator 不维护 Kimi/第三方 endpoint 的全局硬编码表。
- Debug summary 展示 local key → upstream ID，但不包含 API key。

## 修复
- 为账户类型、REST create/list/update/clear、legacy migration 与 canonical conflict 增加 `modelAliases`。
- 通过 account resolver 将映射贯穿 OpenCode ACP pool 与普通 invocation。
- 生成 `{ id: upstreamId, name: localKey }`；未知模型保持 `{ name: localKey }`。
- Debug summary 增加 `modelMappings`。
- 拒绝空 upstream ID、空 key，以及 trim 后冲突的 alias key。
- 删除 generator 内的 Kimi 全局 alias 表。

账户 owner 可通过 `POST/PATCH /api/accounts` 配置，例如：

```json
{
  modelAliases: {
    kimi-code/k3: kimi-k3
  }
}
```

## 验证
Implementation HEAD: `233f825e0`
Review packet HEAD: `8d5f3bccd`

- `pnpm --filter @cat-cafe/api build`
- OpenCode `1.18.9` 真实子进程 + 随机端口假 OpenAI-compatible server：捕获 `POST /v1/chat/completions`，断言请求体 `model === kimi-k3`
- Accounts routes：17 passed
- Account resolver：20 passed
- OpenCode ACP/config contract：6 passed
- Legacy alias migration/conflict：2 passed
- 普通 invocation 回归：1 passed
- `shared` / `api` / `web` lint 均 exit 0
- `pnpm -r --if-present run build` exit 0
- 定向 Biome：14 files clean
- Fresh-context scan：0 remaining findings（2 resolved，1 dismissed with source-of-truth rationale）

Fixes #1252