### PR TITLE
fix(web): direction-aware bottom-follow anchor — streaming can no longer strand the thread viewport blank

### DIFF
--- a/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
+++ b/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { resolveScrollAnchor } from '../useChatHistory';
+
+// Container geometry used across cases: viewport 600, content 1000 → bottom is scrollTop 400.
+const AT_BOTTOM = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
+const MID = { scrollTop: 200, scrollHeight: 1000, clientHeight: 600 };
+
+describe('resolveScrollAnchor (streaming bottom-anchor stability)', () => {
+  it('reports bottom when within the near-bottom threshold', () => {
+    expect(resolveScrollAnchor({ ...AT_BOTTOM, prevTop: null, prevAnchor: null })).toBe('bottom');
+  });
+
+  it('keeps bottom while streaming grows content below (scrollTop flat, height increases)', () => {
+    // User was pinned at bottom; a bubble streams in and grows scrollHeight while scrollTop
+    // stays put. The viewport is momentarily NOT within 24px of the new bottom — but the user
+    // never scrolled up, so we must not demote to offset (that is the blank-thread bug).
+    const anchor = resolveScrollAnchor({
+      scrollTop: 400,
+      scrollHeight: 1400,
+      clientHeight: 600,
+      prevTop: 400,
+      prevAnchor: 'bottom',
+    });
+    expect(anchor).toBe('bottom');
+  });
+
+  it('keeps bottom during a downward programmatic scroll (scrollTop increasing, not yet at bottom)', () => {
+    // Mid smooth-scroll-to-bottom frame: scrollTop is increasing toward the target.
+    const anchor = resolveScrollAnchor({
+      scrollTop: 350,
+      scrollHeight: 1200,
+      clientHeight: 600,
+      prevTop: 300,
+      prevAnchor: 'bottom',
+    });
+    expect(anchor).toBe('bottom');
+  });
+
+  it('demotes to offset only when the user scrolls up away from bottom', () => {
+    const anchor = resolveScrollAnchor({
+      scrollTop: 200,
+      scrollHeight: 1000,
+      clientHeight: 600,
+      prevTop: 400,
+      prevAnchor: 'bottom',
+    });
+    expect(anchor).toBe('offset');
+  });
+
+  it('ignores sub-threshold jitter/reflow nudges (tiny scrollTop decrease keeps prior anchor)', () => {
+    const anchor = resolveScrollAnchor({
+      scrollTop: 398,
+      scrollHeight: 1000,
+      clientHeight: 600,
+      prevTop: 400,
+      prevAnchor: 'bottom',
+    });
+    expect(anchor).toBe('bottom');
+  });
+
+  it('preserves an existing offset anchor when the user has not returned to bottom', () => {
+    expect(resolveScrollAnchor({ ...MID, prevTop: 200, prevAnchor: 'offset' })).toBe('offset');
+  });
+
+  it('re-anchors to bottom once an offset reader scrolls back down into the threshold', () => {
+    expect(resolveScrollAnchor({ ...AT_BOTTOM, prevTop: 200, prevAnchor: 'offset' })).toBe('bottom');
+  });
+
+  it('defaults an unseen mid-scroll position to offset (no prior state)', () => {
+    expect(resolveScrollAnchor({ ...MID, prevTop: null, prevAnchor: null })).toBe('offset');
+  });
+});

--- a/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
+++ b/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
@@ -10,57 +10,66 @@ describe('resolveScrollAnchor (streaming bottom-anchor stability)', () => {
       name: 'within the near-bottom threshold → bottom',
       el: geom(400),
       prev: null,
+      userScrolledUp: false,
       expected: 'bottom',
     },
     {
       name: 'streaming grows content below (scrollTop flat, height increases) keeps bottom',
       el: geom(400, 1400),
       prev: { top: 400, anchor: 'bottom' as const },
+      userScrolledUp: false,
       expected: 'bottom',
     },
     {
       name: 'downward programmatic scroll frame (scrollTop increasing, not yet at bottom) keeps bottom',
       el: geom(350, 1200),
       prev: { top: 300, anchor: 'bottom' as const },
+      userScrolledUp: false,
       expected: 'bottom',
     },
     {
       name: 'user scroll-up away from bottom demotes to offset',
       el: geom(200),
       prev: { top: 400, anchor: 'bottom' as const },
+      userScrolledUp: true,
       expected: 'offset',
     },
     {
-      name: 'sub-threshold jitter (2px up, outside near-bottom band) keeps bottom',
+      name: 'programmatic 2px upward correction outside near-bottom band keeps bottom',
       el: geom(198, 1400),
       prev: { top: 200, anchor: 'bottom' as const },
+      userScrolledUp: false,
       expected: 'bottom',
     },
     {
-      name: 'scroll-up just past the intent threshold demotes to offset',
-      el: geom(195, 1400),
+      name: '2px upward movement with explicit user input demotes to offset',
+      el: geom(198, 1400),
       prev: { top: 200, anchor: 'bottom' as const },
+      userScrolledUp: true,
       expected: 'offset',
     },
     {
       name: 'existing offset reader who has not returned to bottom stays offset',
       el: geom(200),
       prev: { top: 200, anchor: 'offset' as const },
+      userScrolledUp: false,
       expected: 'offset',
     },
     {
       name: 'offset reader scrolling back into the threshold re-anchors to bottom',
       el: geom(400),
       prev: { top: 200, anchor: 'offset' as const },
+      userScrolledUp: false,
       expected: 'bottom',
     },
     {
       name: 'unseen mid-scroll position with no prior state defaults to offset',
       el: geom(200),
       prev: null,
+      userScrolledUp: false,
       expected: 'offset',
     },
-  ])('$name', ({ el, prev, expected }) => {
-    expect(resolveScrollAnchor(el, prev)).toBe(expected);
+  ])('$name', ({ el, prev, userScrolledUp, expected }) => {
+    expect(resolveScrollAnchor(el, prev, userScrolledUp)).toBe(expected);
   });
 });

--- a/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
+++ b/packages/web/src/hooks/__tests__/resolveScrollAnchor.test.ts
@@ -1,72 +1,66 @@
 import { describe, expect, it } from 'vitest';
 import { resolveScrollAnchor } from '../useChatHistory';
 
-// Container geometry used across cases: viewport 600, content 1000 → bottom is scrollTop 400.
-const AT_BOTTOM = { scrollTop: 400, scrollHeight: 1000, clientHeight: 600 };
-const MID = { scrollTop: 200, scrollHeight: 1000, clientHeight: 600 };
+// Viewport 600 / content 1000 → bottom is scrollTop 400 (near-bottom band: ≥ 376).
+const geom = (scrollTop: number, scrollHeight = 1000) => ({ scrollTop, scrollHeight, clientHeight: 600 });
 
 describe('resolveScrollAnchor (streaming bottom-anchor stability)', () => {
-  it('reports bottom when within the near-bottom threshold', () => {
-    expect(resolveScrollAnchor({ ...AT_BOTTOM, prevTop: null, prevAnchor: null })).toBe('bottom');
-  });
-
-  it('keeps bottom while streaming grows content below (scrollTop flat, height increases)', () => {
-    // User was pinned at bottom; a bubble streams in and grows scrollHeight while scrollTop
-    // stays put. The viewport is momentarily NOT within 24px of the new bottom — but the user
-    // never scrolled up, so we must not demote to offset (that is the blank-thread bug).
-    const anchor = resolveScrollAnchor({
-      scrollTop: 400,
-      scrollHeight: 1400,
-      clientHeight: 600,
-      prevTop: 400,
-      prevAnchor: 'bottom',
-    });
-    expect(anchor).toBe('bottom');
-  });
-
-  it('keeps bottom during a downward programmatic scroll (scrollTop increasing, not yet at bottom)', () => {
-    // Mid smooth-scroll-to-bottom frame: scrollTop is increasing toward the target.
-    const anchor = resolveScrollAnchor({
-      scrollTop: 350,
-      scrollHeight: 1200,
-      clientHeight: 600,
-      prevTop: 300,
-      prevAnchor: 'bottom',
-    });
-    expect(anchor).toBe('bottom');
-  });
-
-  it('demotes to offset only when the user scrolls up away from bottom', () => {
-    const anchor = resolveScrollAnchor({
-      scrollTop: 200,
-      scrollHeight: 1000,
-      clientHeight: 600,
-      prevTop: 400,
-      prevAnchor: 'bottom',
-    });
-    expect(anchor).toBe('offset');
-  });
-
-  it('ignores sub-threshold jitter/reflow nudges (tiny scrollTop decrease keeps prior anchor)', () => {
-    const anchor = resolveScrollAnchor({
-      scrollTop: 398,
-      scrollHeight: 1000,
-      clientHeight: 600,
-      prevTop: 400,
-      prevAnchor: 'bottom',
-    });
-    expect(anchor).toBe('bottom');
-  });
-
-  it('preserves an existing offset anchor when the user has not returned to bottom', () => {
-    expect(resolveScrollAnchor({ ...MID, prevTop: 200, prevAnchor: 'offset' })).toBe('offset');
-  });
-
-  it('re-anchors to bottom once an offset reader scrolls back down into the threshold', () => {
-    expect(resolveScrollAnchor({ ...AT_BOTTOM, prevTop: 200, prevAnchor: 'offset' })).toBe('bottom');
-  });
-
-  it('defaults an unseen mid-scroll position to offset (no prior state)', () => {
-    expect(resolveScrollAnchor({ ...MID, prevTop: null, prevAnchor: null })).toBe('offset');
+  it.each([
+    {
+      name: 'within the near-bottom threshold → bottom',
+      el: geom(400),
+      prev: null,
+      expected: 'bottom',
+    },
+    {
+      name: 'streaming grows content below (scrollTop flat, height increases) keeps bottom',
+      el: geom(400, 1400),
+      prev: { top: 400, anchor: 'bottom' as const },
+      expected: 'bottom',
+    },
+    {
+      name: 'downward programmatic scroll frame (scrollTop increasing, not yet at bottom) keeps bottom',
+      el: geom(350, 1200),
+      prev: { top: 300, anchor: 'bottom' as const },
+      expected: 'bottom',
+    },
+    {
+      name: 'user scroll-up away from bottom demotes to offset',
+      el: geom(200),
+      prev: { top: 400, anchor: 'bottom' as const },
+      expected: 'offset',
+    },
+    {
+      name: 'sub-threshold jitter (2px up, outside near-bottom band) keeps bottom',
+      el: geom(198, 1400),
+      prev: { top: 200, anchor: 'bottom' as const },
+      expected: 'bottom',
+    },
+    {
+      name: 'scroll-up just past the intent threshold demotes to offset',
+      el: geom(195, 1400),
+      prev: { top: 200, anchor: 'bottom' as const },
+      expected: 'offset',
+    },
+    {
+      name: 'existing offset reader who has not returned to bottom stays offset',
+      el: geom(200),
+      prev: { top: 200, anchor: 'offset' as const },
+      expected: 'offset',
+    },
+    {
+      name: 'offset reader scrolling back into the threshold re-anchors to bottom',
+      el: geom(400),
+      prev: { top: 200, anchor: 'offset' as const },
+      expected: 'bottom',
+    },
+    {
+      name: 'unseen mid-scroll position with no prior state defaults to offset',
+      el: geom(200),
+      prev: null,
+      expected: 'offset',
+    },
+  ])('$name', ({ el, prev, expected }) => {
+    expect(resolveScrollAnchor(el, prev)).toBe(expected);
   });
 });

--- a/packages/web/src/hooks/__tests__/useChatHistory-scroll-memory.test.ts
+++ b/packages/web/src/hooks/__tests__/useChatHistory-scroll-memory.test.ts
@@ -291,6 +291,63 @@ describe('useChatHistory scroll memory (#27)', () => {
     expect(scrollTop.get()).toBe(500);
   });
 
+  it('keeps following when smooth-scroll intermediate frames fire scroll events (#1234)', async () => {
+    const threadId = 'thread-append-smooth-frames';
+    const messages = [makeMsg('m1', 1), makeMsg('m2', 2)];
+
+    useChatStore.setState({
+      currentThreadId: threadId,
+      messages,
+      hasMore: false,
+      isLoadingHistory: false,
+      threadStates: {
+        [threadId]: makeThreadState(messages),
+      },
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HookHost, { threadId }));
+    });
+
+    const scrollEl = capturedHook!.scrollContainerRef.current!;
+    const scrollTop = defineMutableNumberProp(scrollEl, 'scrollTop', 400);
+    defineMutableNumberProp(scrollEl, 'clientHeight', 600);
+    const scrollHeight = defineMutableNumberProp(scrollEl, 'scrollHeight', 1000);
+    const endEl = capturedHook!.messagesEndRef.current!;
+    const scrollIntoView = vi.fn();
+    endEl.scrollIntoView = scrollIntoView;
+
+    rafCallbacks.clear();
+
+    // User is pinned at bottom (1000 - 600 - 400 = 0).
+    act(() => {
+      capturedHook?.handleScroll();
+    });
+
+    // A streaming append grows the content; the smooth follow has not caught up yet, so the
+    // next scroll event observes a downward-moving scrollTop that is far from the new bottom.
+    scrollHeight.set(1600);
+    act(() => {
+      useChatStore.setState({
+        messages: [...messages, makeMsg('m3', 3)],
+      });
+    });
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    scrollTop.set(500); // intermediate smooth frame: moving down, still 500px above the bottom
+    act(() => {
+      capturedHook?.handleScroll();
+    });
+
+    // The transient not-at-bottom frame must not demote the anchor: the next append still follows.
+    act(() => {
+      useChatStore.setState({
+        messages: [...messages, makeMsg('m3', 3), makeMsg('m4', 4)],
+      });
+    });
+    expect(scrollIntoView).toHaveBeenCalledTimes(2);
+  });
+
   it('keeps bottom anchor on layout-change events when the user is pinned to bottom', async () => {
     const threadId = 'thread-layout-bottom';
     const messages = [makeMsg('m1', 1), makeMsg('m2', 2)];

--- a/packages/web/src/hooks/__tests__/useChatHistory-scroll-memory.test.ts
+++ b/packages/web/src/hooks/__tests__/useChatHistory-scroll-memory.test.ts
@@ -291,6 +291,99 @@ describe('useChatHistory scroll memory (#27)', () => {
     expect(scrollTop.get()).toBe(500);
   });
 
+  it('leaves bottom follow after repeated small user scroll-up inputs', async () => {
+    const threadId = 'thread-small-user-scrolls';
+    const messages = [makeMsg('m1', 1), makeMsg('m2', 2)];
+
+    useChatStore.setState({
+      currentThreadId: threadId,
+      messages,
+      hasMore: false,
+      isLoadingHistory: false,
+      threadStates: {
+        [threadId]: makeThreadState(messages),
+      },
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HookHost, { threadId }));
+    });
+
+    const scrollEl = capturedHook!.scrollContainerRef.current!;
+    const scrollTop = defineMutableNumberProp(scrollEl, 'scrollTop', 400);
+    defineMutableNumberProp(scrollEl, 'clientHeight', 600);
+    const scrollHeight = defineMutableNumberProp(scrollEl, 'scrollHeight', 1000);
+    const endEl = capturedHook!.messagesEndRef.current!;
+    endEl.scrollIntoView = vi.fn();
+
+    rafCallbacks.clear();
+    act(() => {
+      capturedHook?.handleScroll();
+    });
+
+    scrollHeight.set(1400);
+    for (const top of [398, 396, 394, 392, 390]) {
+      act(() => {
+        scrollEl.dispatchEvent(new WheelEvent('wheel', { deltaY: -2 }));
+        scrollTop.set(top);
+        capturedHook?.handleScroll();
+      });
+    }
+
+    act(() => {
+      useChatStore.setState({
+        messages: [...messages, makeMsg('m3', 3)],
+      });
+    });
+
+    expect(endEl.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('keeps bottom follow across a layout-driven upward scroll correction', async () => {
+    const threadId = 'thread-layout-upward-correction';
+    const messages = [makeMsg('m1', 1), makeMsg('m2', 2)];
+
+    useChatStore.setState({
+      currentThreadId: threadId,
+      messages,
+      hasMore: false,
+      isLoadingHistory: false,
+      threadStates: {
+        [threadId]: makeThreadState(messages),
+      },
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HookHost, { threadId }));
+    });
+
+    const scrollEl = capturedHook!.scrollContainerRef.current!;
+    const scrollTop = defineMutableNumberProp(scrollEl, 'scrollTop', 500);
+    defineMutableNumberProp(scrollEl, 'clientHeight', 600);
+    const scrollHeight = defineMutableNumberProp(scrollEl, 'scrollHeight', 1100);
+    const endEl = capturedHook!.messagesEndRef.current!;
+    endEl.scrollIntoView = vi.fn();
+
+    rafCallbacks.clear();
+    act(() => {
+      capturedHook?.handleScroll();
+    });
+
+    scrollHeight.set(1400);
+    scrollTop.set(450);
+    act(() => {
+      capturedHook?.handleScroll();
+    });
+
+    act(() => {
+      useChatStore.setState({
+        messages: [...messages, makeMsg('m3', 3)],
+      });
+    });
+
+    expect(endEl.scrollIntoView).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps following when smooth-scroll intermediate frames fire scroll events (#1234)', async () => {
     const threadId = 'thread-append-smooth-frames';
     const messages = [makeMsg('m1', 1), makeMsg('m2', 2)];

--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -44,9 +44,6 @@ type SavedScrollState = {
 const scrollPositionsByThread = new Map<string, SavedScrollState>();
 const taskCacheByThread = new Map<string, TaskItem[]>();
 const SCROLL_BOTTOM_THRESHOLD_PX = 24;
-// A real user scroll-up moves scrollTop by tens of px per event; sub-pixel jitter and browser
-// scroll-anchoring nudges stay under this margin and must not demote the bottom anchor.
-const SCROLL_UP_INTENT_PX = 4;
 const MAX_RESTORE_FRAMES = 90;
 const CHAT_LAYOUT_CHANGED_EVENT = 'catcafe:chat-layout-changed';
 
@@ -74,28 +71,26 @@ function isNearBottom(el: { scrollTop: number; scrollHeight: number; clientHeigh
 }
 
 /**
- * Decide the bottom-follow anchor from a scroll observation, direction-aware: only a real
- * scroll-up (scrollTop decreasing past SCROLL_UP_INTENT_PX) demotes 'bottom' → 'offset'. Smooth
- * follow animations and streaming content growth never decrease scrollTop, so their transient
- * not-at-bottom frames can no longer break the follow (clowder-ai#1234). Programmatic up-scrolls
- * (teleport / cross-post jumps) demote like a user scroll-up — those readers are being taken
- * away from the bottom on purpose.
+ * Decide the bottom-follow anchor from a scroll observation. Geometry alone cannot distinguish
+ * user scrolling from smooth-follow or layout corrections, so leaving bottom follow requires an
+ * explicit upward-input signal. Intentional message jumps set the saved anchor to offset directly.
  *
  * Exported for unit testing — see __tests__/resolveScrollAnchor.test.ts.
  */
 export function resolveScrollAnchor(
   el: { scrollTop: number; scrollHeight: number; clientHeight: number },
   prev: SavedScrollState | null,
+  userScrolledUp = false,
 ): SavedScrollState['anchor'] {
   if (isNearBottom(el)) return 'bottom';
   if (prev?.anchor !== 'bottom') return 'offset';
-  return el.scrollTop < prev.top - SCROLL_UP_INTENT_PX ? 'offset' : 'bottom';
+  return userScrolledUp && el.scrollTop < prev.top ? 'offset' : 'bottom';
 }
 
-function rememberScrollState(threadId: string, el: HTMLElement) {
+function rememberScrollState(threadId: string, el: HTMLElement, userScrolledUp = false) {
   scrollPositionsByThread.set(threadId, {
     top: el.scrollTop,
-    anchor: resolveScrollAnchor(el, scrollPositionsByThread.get(threadId) ?? null),
+    anchor: resolveScrollAnchor(el, scrollPositionsByThread.get(threadId) ?? null, userScrolledUp),
   });
 }
 
@@ -767,6 +762,7 @@ export function useChatHistory(threadId: string) {
   const prevCountRef = useRef(0);
   const scrollSnapshotRef = useRef<number | null>(null);
   const restoreFrameRef = useRef<number | null>(null);
+  const userScrollUpRef = useRef(false);
 
   // Track loading guard per-thread to prevent double-fetch
   const loadingRef = useRef(false);
@@ -864,6 +860,13 @@ export function useChatHistory(threadId: string) {
           return;
         }
         if (scrollToMessage(messageId)) {
+          const el = scrollContainerRef.current;
+          if (el) {
+            scrollPositionsByThread.set(scheduledForThread, {
+              top: el.scrollTop,
+              anchor: 'offset',
+            });
+          }
           restoreFrameRef.current = null;
           return;
         }
@@ -1745,6 +1748,77 @@ export function useChatHistory(threadId: string) {
     };
   }, [followBottomAnchor]);
 
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+
+    let touchY: number | null = null;
+    let pointerY: number | null = null;
+    const markUpwardIntent = () => {
+      userScrollUpRef.current = true;
+    };
+    const handleWheel = (event: WheelEvent) => {
+      if (event.deltaY < 0) markUpwardIntent();
+    };
+    const handleTouchStart = (event: TouchEvent) => {
+      touchY = event.touches[0]?.clientY ?? null;
+    };
+    const handleTouchMove = (event: TouchEvent) => {
+      const nextY = event.touches[0]?.clientY ?? null;
+      if (touchY !== null && nextY !== null && nextY > touchY) markUpwardIntent();
+      touchY = nextY;
+    };
+    const handlePointerDown = (event: PointerEvent) => {
+      pointerY = event.clientY;
+    };
+    const handlePointerMove = (event: PointerEvent) => {
+      if (pointerY !== null && event.clientY < pointerY) markUpwardIntent();
+      pointerY = event.clientY;
+    };
+    const clearPointer = () => {
+      pointerY = null;
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      if (
+        event.defaultPrevented ||
+        (target instanceof HTMLElement &&
+          (target.isContentEditable || target.matches('input, textarea, select, [role="textbox"]')))
+      ) {
+        return;
+      }
+      if (
+        event.key === 'ArrowUp' ||
+        event.key === 'PageUp' ||
+        event.key === 'Home' ||
+        (event.key === ' ' && event.shiftKey)
+      ) {
+        markUpwardIntent();
+      }
+    };
+
+    el.addEventListener('wheel', handleWheel, { passive: true });
+    el.addEventListener('touchstart', handleTouchStart, { passive: true });
+    el.addEventListener('touchmove', handleTouchMove, { passive: true });
+    el.addEventListener('touchend', clearPointer, { passive: true });
+    el.addEventListener('pointerdown', handlePointerDown, { passive: true });
+    el.addEventListener('pointermove', handlePointerMove, { passive: true });
+    el.addEventListener('pointerup', clearPointer, { passive: true });
+    el.addEventListener('pointercancel', clearPointer, { passive: true });
+    window.addEventListener('keydown', handleKeyDown);
+    return () => {
+      el.removeEventListener('wheel', handleWheel);
+      el.removeEventListener('touchstart', handleTouchStart);
+      el.removeEventListener('touchmove', handleTouchMove);
+      el.removeEventListener('touchend', clearPointer);
+      el.removeEventListener('pointerdown', handlePointerDown);
+      el.removeEventListener('pointermove', handlePointerMove);
+      el.removeEventListener('pointerup', clearPointer);
+      el.removeEventListener('pointercancel', clearPointer);
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, []);
+
   // Load more when scrolled to top + clowder-ai#27 continuous scroll save
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -1754,7 +1828,8 @@ export function useChatHistory(threadId: string) {
     // Guard: don't save during store swap (DOM content may not match threadId,
     // and browser may fire scroll events with scrollTop=0 during content swap).
     if (useChatStore.getState().currentThreadId === threadIdRef.current) {
-      rememberScrollState(threadIdRef.current, el);
+      rememberScrollState(threadIdRef.current, el, userScrollUpRef.current);
+      userScrollUpRef.current = false;
     }
 
     if (!hasMore || isLoadingHistory) return;

--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -44,9 +44,8 @@ type SavedScrollState = {
 const scrollPositionsByThread = new Map<string, SavedScrollState>();
 const taskCacheByThread = new Map<string, TaskItem[]>();
 const SCROLL_BOTTOM_THRESHOLD_PX = 24;
-// A genuine user scroll-up moves scrollTop by tens of px; sub-pixel layout jitter and
-// browser scroll-anchoring nudges are much smaller. Only a decrease past this margin counts
-// as "the user chose to leave the bottom".
+// A real user scroll-up moves scrollTop by tens of px per event; sub-pixel jitter and browser
+// scroll-anchoring nudges stay under this margin and must not demote the bottom anchor.
 const SCROLL_UP_INTENT_PX = 4;
 const MAX_RESTORE_FRAMES = 90;
 const CHAT_LAYOUT_CHANGED_EVENT = 'catcafe:chat-layout-changed';
@@ -70,45 +69,33 @@ export function deriveQueueHydrationTargetCats({
   return activeCatIds;
 }
 
+function isNearBottom(el: { scrollTop: number; scrollHeight: number; clientHeight: number }): boolean {
+  return el.scrollHeight - el.clientHeight - el.scrollTop <= SCROLL_BOTTOM_THRESHOLD_PX;
+}
+
 /**
- * Decide the bottom-follow anchor from a scroll observation, direction-aware.
+ * Decide the bottom-follow anchor from a scroll observation, direction-aware: only a real
+ * scroll-up (scrollTop decreasing past SCROLL_UP_INTENT_PX) demotes 'bottom' → 'offset'. Smooth
+ * follow animations and streaming content growth never decrease scrollTop, so their transient
+ * not-at-bottom frames can no longer break the follow (clowder-ai#1234). Programmatic up-scrolls
+ * (teleport / cross-post jumps) demote like a user scroll-up — those readers are being taken
+ * away from the bottom on purpose.
  *
- * The old rule ("near bottom ? bottom : offset") flipped to `offset` on any frame where the
- * viewport was not within the threshold — including the transient frames a smooth scroll-to-bottom
- * or a streaming height increase produces. Once flipped, both the append follow and
- * `followBottomAnchor` give up permanently, freezing scrollTop in a low-content region and leaving
- * the thread visually blank during streaming (clowder-ai#1234).
- *
- * Fix: demote a bottom anchor to `offset` ONLY when the user scrolls UP (scrollTop decreases past
- * SCROLL_UP_INTENT_PX). Programmatic downward scrolls and content growth move scrollTop down or
- * grow scrollHeight — never up — so they can no longer break the follow. Returning into the
- * near-bottom band always re-anchors to `bottom`.
+ * Exported for unit testing — see __tests__/resolveScrollAnchor.test.ts.
  */
-export function resolveScrollAnchor(params: {
-  scrollTop: number;
-  scrollHeight: number;
-  clientHeight: number;
-  prevTop: number | null;
-  prevAnchor: 'bottom' | 'offset' | null;
-}): 'bottom' | 'offset' {
-  const { scrollTop, scrollHeight, clientHeight, prevTop, prevAnchor } = params;
-  if (scrollHeight - clientHeight - scrollTop <= SCROLL_BOTTOM_THRESHOLD_PX) return 'bottom';
-  const scrolledUp = prevTop !== null && scrollTop < prevTop - SCROLL_UP_INTENT_PX;
-  if (scrolledUp) return 'offset';
-  return prevAnchor ?? 'offset';
+export function resolveScrollAnchor(
+  el: { scrollTop: number; scrollHeight: number; clientHeight: number },
+  prev: SavedScrollState | null,
+): SavedScrollState['anchor'] {
+  if (isNearBottom(el)) return 'bottom';
+  if (prev?.anchor !== 'bottom') return 'offset';
+  return el.scrollTop < prev.top - SCROLL_UP_INTENT_PX ? 'offset' : 'bottom';
 }
 
 function rememberScrollState(threadId: string, el: HTMLElement) {
-  const prev = scrollPositionsByThread.get(threadId);
   scrollPositionsByThread.set(threadId, {
     top: el.scrollTop,
-    anchor: resolveScrollAnchor({
-      scrollTop: el.scrollTop,
-      scrollHeight: el.scrollHeight,
-      clientHeight: el.clientHeight,
-      prevTop: prev?.top ?? null,
-      prevAnchor: prev?.anchor ?? null,
-    }),
+    anchor: resolveScrollAnchor(el, scrollPositionsByThread.get(threadId) ?? null),
   });
 }
 

--- a/packages/web/src/hooks/useChatHistory.ts
+++ b/packages/web/src/hooks/useChatHistory.ts
@@ -44,6 +44,10 @@ type SavedScrollState = {
 const scrollPositionsByThread = new Map<string, SavedScrollState>();
 const taskCacheByThread = new Map<string, TaskItem[]>();
 const SCROLL_BOTTOM_THRESHOLD_PX = 24;
+// A genuine user scroll-up moves scrollTop by tens of px; sub-pixel layout jitter and
+// browser scroll-anchoring nudges are much smaller. Only a decrease past this margin counts
+// as "the user chose to leave the bottom".
+const SCROLL_UP_INTENT_PX = 4;
 const MAX_RESTORE_FRAMES = 90;
 const CHAT_LAYOUT_CHANGED_EVENT = 'catcafe:chat-layout-changed';
 
@@ -66,14 +70,45 @@ export function deriveQueueHydrationTargetCats({
   return activeCatIds;
 }
 
-function isNearBottom(el: HTMLElement): boolean {
-  return el.scrollHeight - el.clientHeight - el.scrollTop <= SCROLL_BOTTOM_THRESHOLD_PX;
+/**
+ * Decide the bottom-follow anchor from a scroll observation, direction-aware.
+ *
+ * The old rule ("near bottom ? bottom : offset") flipped to `offset` on any frame where the
+ * viewport was not within the threshold — including the transient frames a smooth scroll-to-bottom
+ * or a streaming height increase produces. Once flipped, both the append follow and
+ * `followBottomAnchor` give up permanently, freezing scrollTop in a low-content region and leaving
+ * the thread visually blank during streaming (clowder-ai#1234).
+ *
+ * Fix: demote a bottom anchor to `offset` ONLY when the user scrolls UP (scrollTop decreases past
+ * SCROLL_UP_INTENT_PX). Programmatic downward scrolls and content growth move scrollTop down or
+ * grow scrollHeight — never up — so they can no longer break the follow. Returning into the
+ * near-bottom band always re-anchors to `bottom`.
+ */
+export function resolveScrollAnchor(params: {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  prevTop: number | null;
+  prevAnchor: 'bottom' | 'offset' | null;
+}): 'bottom' | 'offset' {
+  const { scrollTop, scrollHeight, clientHeight, prevTop, prevAnchor } = params;
+  if (scrollHeight - clientHeight - scrollTop <= SCROLL_BOTTOM_THRESHOLD_PX) return 'bottom';
+  const scrolledUp = prevTop !== null && scrollTop < prevTop - SCROLL_UP_INTENT_PX;
+  if (scrolledUp) return 'offset';
+  return prevAnchor ?? 'offset';
 }
 
 function rememberScrollState(threadId: string, el: HTMLElement) {
+  const prev = scrollPositionsByThread.get(threadId);
   scrollPositionsByThread.set(threadId, {
     top: el.scrollTop,
-    anchor: isNearBottom(el) ? 'bottom' : 'offset',
+    anchor: resolveScrollAnchor({
+      scrollTop: el.scrollTop,
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      prevTop: prev?.top ?? null,
+      prevAnchor: prev?.anchor ?? null,
+    }),
   });
 }
 


### PR DESCRIPTION
## 问题

Fixes #1234

多只猫流式执行中打开或刷新 thread 页面时，消息 DOM 已渲染，但滚动锚点可能在 smooth-scroll 中间帧或 CLI/thinking 布局变化时从 `bottom` 错误翻成 `offset`。折叠后视口会停在低内容区，呈现大面积空白。

## 根因

旧逻辑只用“当前是否位于底部 24px 内”推断用户意图。这个几何条件无法区分：

- 用户主动上滑去读历史；
- `scrollIntoView({ behavior: 'smooth' })` 的中间帧；
- streaming、CLI/thinking 展开/折叠引起的程序性布局修正。

一旦程序性滚动把 anchor 误记成 `offset`，append-follow 与 layout-follow 都会停止。

## 修复

`resolveScrollAnchor` 只在收到明确的用户向上输入后，才把 `bottom` 降级为 `offset`：

- wheel、touch、pointer 和键盘向上导航先记录一次用户意图，下一次 scroll 消费该意图；
- 没有用户输入的 smooth-scroll 中间帧、内容增长与 layout collapse 保持 `bottom`；
- 多次很小的真实上滑也能立即退出 bottom-follow，不依赖逐事件像素阈值；
- 已在读历史的 `offset` 用户不会被 append 拉回；滑回底部后重新吸底；
- cross-post/teleport 等显式消息跳转继续保存为 `offset`。

这次 maintainer fixup 移除了逐事件 `4px` 魔法阈值，以输入来源作为意图边界。

## 测试

- `resolveScrollAnchor.test.ts`：9 个纯函数契约用例；
- `useChatHistory-scroll-memory.test.ts`：8 个 hook 时序用例，包括连续小位移真实上滑和 layout-driven 向上修正；
- 聚焦回归：17/17 通过；
- Web 全量：6044/6048 通过；剩余 4 个失败在相同 `origin/main` 上逐项复现，均为既有 F232/adaptive-pass-ball 基线，与本 PR 三个文件无交集；
- Web lint / targeted Biome / `git diff --check` 通过；
- `pnpm gate`：最终结果以 fresh HEAD 的 gate/CI 记录为准。

## 手工验证

1. 在 thread 底部保持流式 append：消息持续跟随；
2. streaming 过程中展开/折叠 CLI/thinking：布局修正不会丢失 bottom anchor；
3. 连续轻微向上滚动：立即退出吸底并可阅读历史；
4. 滑回底部：后续 append 重新跟随。

## 风险评估（五轴）

- 行为：高。改动直接影响用户可见的滚动跟随，因此用两条先红后绿回归、17 个聚焦用例、完整 gate 与 GitHub CI 守门。
- 数据：无。未修改消息、thread 或用户状态的持久化格式与写入路径。
- 安全：无。未触及鉴权、输入信任边界、凭据或外部执行。
- 契约：低。仅收窄 Web 内部 hook 的滚动锚点判定；没有公开 API、跨包类型或协议变化。
- 不可逆：代码可通过单次回滚撤销；第三方 PR merge 另由 accepted issue、exact HEAD、非作者 review、CI 与授权 guard 守门。

[小太阳·砚砚/GPT-5.6 Sol🐾]
