### PR TITLE
verdict(eval:a2a): 2026-07-31-eval-a2a-stale-source-contract-fix

### DIFF
--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/attribution.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/attribution.json
@@ -1,0 +1,36 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-stale-source-contract-fix",
+  "featureId": "F167",
+  "evalSnapshotId": "eval-F167-2026-07-30",
+  "generatedAt": "2026-07-30T03:06:12.248Z",
+  "findings": [
+    {
+      "id": "AR-2026-07-30-001",
+      "relatedFeature": "F167",
+      "frictionSignal": {
+        "type": "observability-gap",
+        "severity": "medium",
+        "confidence": 0.9
+      },
+      "attribution": {
+        "primaryLayer": "environment_drift",
+        "pipelineOrHuman": "pipeline",
+        "evidence": [
+          {
+            "type": "telemetry-gap",
+            "anchor": "L1/streak_warn_count",
+            "excerpt": "No counter: OTel is disabled because TELEMETRY_HMAC_SALT is not configured; L1 activation frequency cannot be measured."
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "restore-telemetry",
+          "target": "L1/streak_warn_count",
+          "rationale": "Restore the telemetry initialization prerequisite before evaluating L1 rates."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/provenance.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-stale-source-contract-fix",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/snapshots/2026-07-30T03-06-12-246Z-F167-eval.yaml",
+      "sha256": "f9aceccc80d3afa82c9685b8ac2cd6073e1e072a38d2f4ef41de95161130fc2b"
+    },
+    {
+      "path": "docs/harness-feedback/attributions/2026-07-30T03-06-12-248Z-F167-attribution.yaml",
+      "sha256": "d9535ae000335a2a11927982f1760d139e56f39c68c28f7dd49b199629f92d06"
+    }
+  ],
+  "generatedAt": "2026-07-30T03:06:12.248Z",
+  "generator": {
+    "name": "eval-a2a-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f192-e-pilot-v1"
+}

--- a/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-07-31-eval-a2a-stale-source-contract-fix/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-07-31-eval-a2a-stale-source-contract-fix",
+  "evalSnapshotId": "eval-F167-2026-07-30",
+  "featureId": "F167",
+  "generatedAt": "2026-07-30T03:06:12.246Z",
+  "window": {
+    "startMs": 1785380772246,
+    "endMs": 1785380772246,
+    "durationHours": 0
+  },
+  "counterWindow": {
+    "startMs": 1785307398230,
+    "endMs": 1785380772246,
+    "durationHours": 20.38167111111111
+  },
+  "components": [
+    {
+      "id": "L1",
+      "name": "WorklistRegistry (ping-pong breaker)",
+      "confidence": "no-data",
+      "activationCounts": {},
+      "frictionCounts": {}
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-07-31-eval-a2a-stale-source-contract-fix.md
+++ b/docs/harness-feedback/verdicts/2026-07-31-eval-a2a-stale-source-contract-fix.md
@@ -1,0 +1,32 @@
+---
+feature_ids: [F192, F167]
+topics: [harness-eval, eval-a2a, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: 2026-07-31-eval-a2a-stale-source-contract-fix
+source_snapshot: "snapshot:bundle/2026-07-31-eval-a2a-stale-source-contract-fix/snapshot"
+---
+
+# Live Verdict — 2026-07-31-eval-a2a-stale-source-contract-fix
+
+- Verdict: `fix`
+- Phenomenon: 截至 2026-07-31 03:10 UTC，daily eval:a2a 没有生成 7/31 source pair；最新 snapshot 已约 24.06 小时，虽有 20.38 小时的 counter window，L1 仍为 no-data。昨日 maintainer 在另一运行时核验到 OTel/Prometheus 正常，因此当前证据支持的是 source capture 与目标 runtime 身份/认证未闭合，而不是再次断言 TELEMETRY_HMAC_SALT 未配置。
+- Harness: F167/f167-runtime-eval-source-adapter (A2A daily runtime evidence capture)
+- Owner ask: 修复 eval:a2a source-capture 契约：在唤醒 eval 猫前完成当日 snapshot/attribution 生成并附带 sourceRefs；artifact 记录目标 runtime identity、baseUrl 与 auth mode；精确区分 401/503/盐缺失/盐无效；Phase O 明确区分零 stateful 调用与采集失败。补回归测试覆盖“无当日 source pair 仍唤醒”和跨 runtime 状态误归因。
+- Re-eval: 下一次 daily eval 在唤醒时已附带生成时间不超过 1 小时的成对 sourceRefs，artifact 可定位唯一 runtime/auth 边界；L1 可读取两个计数字段或给出可验证的零值，grounding-phase-o 能报告 check/verdict/mismatch 分布或明确记录零 stateful 调用，不再返回不可归因 no-data。 at 2026-08-01T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-07-31-eval-a2a-stale-source-contract-fix/snapshot
+- attribution:bundle/2026-07-31-eval-a2a-stale-source-contract-fix/AR-2026-07-30-001
+- metric:source_age_hours
+- metric:new_source_pairs
+- metric:l1_counter_fields_present
+- metric:counter_window_hours
+- metric:grounding_phase_o_no_data
+- L1/streak_warn_count
+
+Counterarguments:
+- 旧 source 在业务无活动时未必失真，但 daily verdict 的新鲜度与 runtime identity 必须可验证；当前两者都不满足。
+- 昨日 maintainer 证明某个 runtime 的 telemetry 健康，这不否定本 finding，反而证明 eval source 与被核验 runtime 之间存在身份分歧。
+- counter_window 超过 2 小时，只能说明计数分母稳定；当计数读取失败时不能据此推断 harness 健康或不健康。


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: fix
Domain: eval:a2a
Phenomenon: 截至 2026-07-31 03:10 UTC，daily eval:a2a 没有生成 7/31 source pair；最新 snapshot 已约 24.06 小时，虽有 20.38 小时的 counter window，L1 仍为 no-data。昨日 maintainer 在另一运行时核验到 OTel/Prometheus 正常，因此当前证据支持的是 source capture 与目标 runtime 身份/认证未闭合，而不是再次断言 TELEMETRY_HMAC_SALT 未配置。

Reviewed by: opus-47
Action: 修复 eval:a2a source-capture 契约：在唤醒 eval 猫前完成当日 snapshot/attribution 生成并附带 sourceRefs；artifact 记录目标 runtime identity、baseUrl 与 auth mode；精确区分 401/503/盐缺失/盐无效；Phase O 明确区分零 stateful 调用与采集失败。补回归测试覆盖“无当日 source pair 仍唤醒”和跨 runtime 状态误归因。