### PR TITLE
fix(windows): fail closed when Redis is unavailable

### DIFF
--- a/scripts/start-dev-profile-isolation.test.mjs
+++ b/scripts/start-dev-profile-isolation.test.mjs
@@ -539,6 +539,73 @@ describe('cross-platform pnpm-start profile propagation (#421)', () => {
     );
   });
 
+  it('start-windows.ps1 fails closed when an external Redis URL is unreachable', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    assert.match(
+      ps1,
+      /function Stop-RedisStartup\s*\{[\s\S]*?Get-Job -Name "redis-bootstrap"[\s\S]*?Stop-Job[\s\S]*?Remove-Job[\s\S]*?install\.ps1[\s\S]*?REDIS_URL[\s\S]*?-Memory[\s\S]*?exit 1[\s\S]*?\}/,
+      'the shared failure path must clean the bootstrap job, explain both persistent-storage repairs, and exit non-zero',
+    );
+
+    assert.match(
+      ps1,
+      /Stop-RedisStartup\s+-Reason\s+"Redis is not reachable at \$safeConfiguredRedisUrl\."/,
+      'an unreachable external REDIS_URL must stop startup instead of selecting memory storage',
+    );
+    assert.ok(
+      ps1.lastIndexOf('Stop-RedisStartup -Reason') < ps1.indexOf('Start-Job -Name "api"'),
+      'every Redis failure path must run before API startup',
+    );
+  });
+
+  it('start-windows.ps1 fails closed when managed Redis does not start', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    assert.match(
+      ps1,
+      /Stop-RedisStartup\s+-Reason\s+"Managed Redis failed to start on port \$RedisPort\. Check \$redisLogFile for details\."/,
+      'a failed managed Redis start must stop startup before the API and web jobs are created',
+    );
+  });
+
+  it('start-windows.ps1 fails closed when no Redis binary is installed', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    assert.match(
+      ps1,
+      /Stop-RedisStartup\s+-Reason\s+"Redis is not installed\."/,
+      'a missing Redis binary must stop startup instead of silently choosing volatile storage',
+    );
+  });
+
+  it('start-windows.ps1 fails closed on an unexpected Redis bootstrap exception', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+
+    assert.match(
+      ps1,
+      /catch\s*\{[\s\S]*?Write-InstallerExceptionDetails\s+-Context\s+"Redis start"[\s\S]*?Stop-RedisStartup\s+-Reason\s+"Redis bootstrap failed\."/,
+      'an unexpected Redis bootstrap exception must stop startup after printing its diagnostic details',
+    );
+  });
+
+  it('start-windows.ps1 enables volatile storage only for explicit -Memory mode', () => {
+    const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
+    const assignments = ps1.match(/\$env:MEMORY_STORE\s*=\s*["']1["']/g) ?? [];
+
+    assert.equal(assignments.length, 1, 'the launcher must have exactly one MEMORY_STORE opt-in');
+    assert.match(
+      ps1,
+      /if\s*\(\$Memory\)\s*\{[\s\S]*?Remove-Item Env:REDIS_URL[\s\S]*?\$env:MEMORY_STORE\s*=\s*["']1["'][\s\S]*?\}/,
+      'MEMORY_STORE=1 must be scoped to the explicit -Memory switch',
+    );
+    assert.doesNotMatch(
+      ps1,
+      /\$useRedis\s*=\s*\$false/,
+      'Redis failure branches must not converge on an implicit memory fallback',
+    );
+  });
+
   it('start-windows.ps1 reapplies profile defaults inside Start-Job after .env reload', () => {
     const ps1 = readFileSync(resolve(ROOT, 'scripts/start-windows.ps1'), 'utf8');
 

--- a/scripts/start-dev.sh
+++ b/scripts/start-dev.sh
@@ -1115,7 +1115,7 @@ configure_mcp_server_path() {
 }
 
 # 检查/启动 Redis
-# USE_REDIS=true (默认): 尝试启动 Redis, 失败则回退内存
+# USE_REDIS=true (默认): 尝试启动 Redis, 失败则拒绝启动
 # USE_REDIS=false (--memory): 跳过 Redis, 强制内存存储
 setup_storage() {
     if [ "$USE_REDIS" = false ]; then

--- a/scripts/start-windows.ps1
+++ b/scripts/start-windows.ps1
@@ -35,6 +35,19 @@ function Write-Ok    { param([string]$msg) Write-Host "  [OK] $msg" -ForegroundC
 function Write-Warn  { param([string]$msg) Write-Host "  [!!] $msg" -ForegroundColor Yellow }
 function Write-Err   { param([string]$msg) Write-Host "  [ERR] $msg" -ForegroundColor Red }
 
+function Stop-RedisStartup {
+    param([string]$Reason)
+    $bootstrapJob = Get-Job -Name "redis-bootstrap" -ErrorAction SilentlyContinue
+    if ($bootstrapJob) {
+        Stop-Job -Job $bootstrapJob -ErrorAction SilentlyContinue
+        Remove-Job -Job $bootstrapJob -Force -ErrorAction SilentlyContinue
+    }
+    Write-Err $Reason
+    Write-Err "Persistent storage is required. Run .\scripts\install.ps1 to install Redis, or fix REDIS_URL."
+    Write-Err "To deliberately use volatile storage, restart with -Memory (all data will be lost on restart)."
+    exit 1
+}
+
 # -- Resolve project root ------------------------------------
 $ScriptPath = if ($PSCommandPath) { $PSCommandPath } elseif ($MyInvocation.MyCommand.Path) { $MyInvocation.MyCommand.Path } else { $null }
 if (-not $ScriptPath) {
@@ -321,15 +334,21 @@ $configuredIsManagedRedis = $configuredRedisUrl -and (Test-LocalRedisUrl -RedisU
 $useExternalRedis = $useRedis -and $configuredRedisUrl -and -not $configuredIsManagedRedis
 $safeConfiguredRedisUrl = Get-RedactedRedisUrl -RedisUrl $configuredRedisUrl
 
+if ($Memory) {
+    Write-Warn "Memory mode - data will be lost on restart"
+    Remove-Item Env:REDIS_URL -ErrorAction SilentlyContinue
+    $env:MEMORY_STORE = "1"
+} else {
+    Remove-Item Env:MEMORY_STORE -ErrorAction SilentlyContinue
+}
+
 if ($useRedis) {
     if ($configuredRedisUrl -and (Test-RedisReachable -RedisUrl $configuredRedisUrl)) {
         # A configured reachable Redis endpoint can be used without redis-cli.
         Write-Ok "Redis reachable at $safeConfiguredRedisUrl"
         $env:REDIS_URL = $configuredRedisUrl
     } elseif ($useExternalRedis) {
-        Write-Warn "Redis not reachable at $safeConfiguredRedisUrl - falling back to memory storage"
-        Write-Warn "Check your REDIS_URL or use -Memory to skip Redis."
-        $useRedis = $false
+        Stop-RedisStartup -Reason "Redis is not reachable at $safeConfiguredRedisUrl."
     } else {
         # No reachable configured Redis endpoint; manage Redis on $RedisPort.
         $localUrl = "redis://localhost:$RedisPort"
@@ -400,30 +419,20 @@ if ($useRedis) {
                         }
                         $startedRedis = $true
                     } else {
-                        Write-Warn "Redis start failed - falling back to memory storage"
-                        $useRedis = $false
+                        Stop-RedisStartup -Reason "Managed Redis failed to start on port $RedisPort. Check $redisLogFile for details."
                     }
                 } else {
-                    Write-Warn "Redis not installed - using memory storage"
-                    Write-Warn "Run .\\scripts\\install.ps1 again to fetch the project-local Redis bundle into .cat-cafe/redis/windows."
-                    $useRedis = $false
+                    Stop-RedisStartup -Reason "Redis is not installed."
                 }
             } catch {
                 if ($_.Exception -and $_.Exception.Message -like "Redis port $RedisPort is in use by a non-Clowder process") {
                     throw
                 }
-                Write-Warn "Redis start failed - using memory storage"
                 Write-InstallerExceptionDetails -Context "Redis start" -ErrorRecord $_
-                $useRedis = $false
+                Stop-RedisStartup -Reason "Redis bootstrap failed."
             }
         }
     }
-}
-
-if (-not $useRedis) {
-    Write-Warn "Memory mode - data will be lost on restart"
-    Remove-Item Env:REDIS_URL -ErrorAction SilentlyContinue
-    $env:MEMORY_STORE = "1"
 }
 
 try {


### PR DESCRIPTION
## What

- Make `scripts/start-windows.ps1` fail closed on unreachable external Redis, managed Redis startup failure, a missing Redis binary, and unexpected bootstrap exceptions.
- Keep volatile storage available only through explicit `-Memory` and clean up the managed bootstrap job before exiting.
- Add five Windows launcher regression cases and correct the stale Unix launcher comment without changing Unix behavior.

## Why

The Windows launcher previously synthesized `MEMORY_STORE=1` after Redis failures. That turned a storage failure into an unauthorized volatile startup, so a restart could erase all user-visible threads and messages with no recovery path.

Fixes #1250

## Original Requirements

- Source: #1250 maintainer triage and accepted fix boundary.
- Without explicit `-Memory`, every canonical Windows Redis failure must exit non-zero before API/Web startup.
- The launcher must not synthesize `MEMORY_STORE=1`; errors must identify remediation and preserve explicit memory mode.
- Cover unreachable external Redis, missing binary, managed startup failure, generic exception, and explicit memory mode without touching user Redis.
- Reviewer request: verify the delivered launcher behavior matches this accepted boundary.

## Plan / ADR

- Plan: focused hotfix per #1250 accepted boundary; no new architecture cell or ADR.
- Architecture cell: existing Windows launcher storage bootstrap.
- Map delta: none.
- Why: this removes an unauthorized fallback inside the existing launcher boundary.

## Tips Contribution

- [ ] Added/updated capability tips.
- [ ] Existing tip sourceRef covers this change.
- [x] `tips_exempt`: P0 startup data-safety correction; it changes failure behavior rather than adding a discoverable capability.

## Tradeoff

Startup now stops when persistence is unavailable instead of keeping the UI available with volatile state. Users can still deliberately choose `-Memory`, but data loss is no longer an implicit fallback. Unix behavior and the API storage guard remain unchanged.

## Test Evidence

- `pnpm check:start-profile-isolation` — 41 passed, 0 failed; includes the five new Windows cases.
- PowerShell AST parse — passed.
- `pnpm -r --if-present run build` — passed.
- `pnpm -r exec bash -lc 'if command -v tsc >/dev/null 2>&1; then tsc --noEmit; fi'` — passed.
- `pnpm --filter @cat-cafe/web lint` — passed with pre-existing warnings only.
- `pnpm biome check . --diagnostic-level=error` — 4512 files checked, no errors.
- Windows public-suite runner is blocked before test loading by the unchanged upstream harness (`Argument list too long`); the exact failure reproduces on clean `upstream/main` `211ced8a`.
- GitHub Linux CI is required to complete the canonical public-suite gate before merge.

## Open Questions

- Confirm all fail-closed exits precede API/Web job creation and the shared failure helper always reaps `redis-bootstrap`.
- Confirm no path other than explicit `-Memory` assigns `MEMORY_STORE=1`.

---

**本地 Review**: [x] opus-4-8 reviewed commit `2521c7fd1` and reported 0 blocking findings.
**云端 Review**: [ ] Trigger after PR creation.

<!-- 猫猫签名（纯文本）: 砚砚 / GPT-5.6 Sol -->