### PR TITLE
fix(routing): preserve first-pass output across remedials

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -216,21 +216,13 @@ function emitBallInvocationHeartbeat(
     .catch((err) => log.warn({ threadId, invocationId, catId, err }, 'invocation.heartbeat ingest failed'));
 }
 const routeSerialTracer = trace.getTracer('cat-cafe-api', '0.1.0');
-const ROUTE_ONLY_REMEDIAL_TEXT_RE =
-  /^@[\p{L}\p{N}_.-]+(?:[\s,.:;!?()[\]{}<>，。！？、：；（）【】《》「」『』〈〉]+)?$/u;
 
-function stripMarkdownRoutePrefix(line: string): string {
-  return line.replace(/^(?:[-*+]\s+|>\s*|\d+[.)]\s+)/, '').trim();
-}
-
-function normalizeRouteOnlyRemedialText(text: string): string | null {
-  const lines = text
+function normalizeRemedialRoutingText(text: string): string {
+  return text
     .trim()
     .split(/\r?\n/)
-    .map((line) => stripMarkdownRoutePrefix(line))
-    .filter((line) => line.length > 0);
-  if (lines.length !== 1) return null;
-  return ROUTE_ONLY_REMEDIAL_TEXT_RE.test(lines[0]) ? lines[0] : null;
+    .map((line) => line.replace(/^(?:[-*+]\s+|>\s*|\d+[.)]\s+)/, '').trim())
+    .join('\n');
 }
 
 function collectStructuredTargetCatsFromInput(input: unknown): string[] {
@@ -1909,24 +1901,25 @@ export async function* routeSerial(
         const remedialSanitized = sanitizeInjectedContent(textContent);
         const remedialExtracted = extractRichFromText(remedialSanitized);
         const remedialCleanText = remedialExtracted.cleanText;
-        const remedialRouteOnlyContent = remedialCleanText ? normalizeRouteOnlyRemedialText(remedialCleanText) : null;
-        const remedialIsRouteOnly = remedialRouteOnlyContent !== null;
-        // Route-only remedial text (`@cat` / `@co-creator`) is an exit patch, not a replacement artifact.
-        // Use it for routing validation, but keep first-pass visible content so F5/history hydration
-        // does not replace generated work with a bare route outlet.
         const preservesOriginalVisibleContent =
-          (!remedialCleanText || remedialIsRouteOnly) && originalStoredContentBeforeRemedial.length > 0;
+          originalStoredContentBeforeRemedial.length > 0 ||
+          originalRichBlocksBeforeRemedial.length > 0 ||
+          originalToolEventsBeforeRemedial.length > 0;
         visibleContentInvocationIdOverride = preservesOriginalVisibleContent
           ? originalVisibleInvocationIdBeforeRemedial
           : undefined;
         const remedialStoredContent = preservesOriginalVisibleContent
           ? originalStoredContentBeforeRemedial
           : remedialCleanText;
-        const remedialRoutingContent = remedialRouteOnlyContent ?? (remedialCleanText || remedialStoredContent);
-        const baseRichBlocks = !remedialCleanText || remedialIsRouteOnly ? originalRichBlocksBeforeRemedial : [];
-        let remedialAllRichBlocks = [...baseRichBlocks, ...remedialExtracted.blocks, ...streamRichBlocks];
-        // Replacement text becomes a new persisted message and discards invalid first-pass evidence.
-        // Exit-only remedials keep the original visible content, so preserve original tool evidence too.
+        const remedialRoutingContent = remedialCleanText
+          ? normalizeRemedialRoutingText(remedialCleanText)
+          : remedialStoredContent;
+        let remedialAllRichBlocks = preservesOriginalVisibleContent
+          ? originalRichBlocksBeforeRemedial
+          : [...remedialExtracted.blocks, ...streamRichBlocks];
+        // A remedial invocation is a synthetic control turn. Once the first pass produced visible
+        // text, rich output, or tool evidence, the remedial may supply routing evidence but cannot
+        // replace that user-visible result.
         if (preservesOriginalVisibleContent && originalToolEventsBeforeRemedial.length > 0) {
           const remedialToolEvents = [...collectedToolEvents];
           collectedToolEvents.splice(
@@ -1937,7 +1930,7 @@ export async function* routeSerial(
           );
         }
         textContent = remedialStoredContent;
-        if (preservesOriginalVisibleContent && originalDeferredVoiceTextChunksBeforeRemedial.length > 0) {
+        if (preservesOriginalVisibleContent) {
           resetDeferredVoice();
           deferredVoiceInvocationId = originalDeferredVoiceInvocationIdBeforeRemedial;
           deferredVoiceTextChunks.push(...originalDeferredVoiceTextChunksBeforeRemedial);
@@ -1969,8 +1962,12 @@ export async function* routeSerial(
             return false;
           }
         };
-        const visibleRemedialSourceStreamEvents = remedialIsRouteOnly
-          ? remedialStreamEvents.filter((event) => event.type !== 'text')
+        const visibleRemedialSourceStreamEvents = preservesOriginalVisibleContent
+          ? remedialStreamEvents.filter(
+              (event) =>
+                event.type !== 'text' &&
+                !(event.type === 'system_info' && event.content && isUserFacingSystemInfoContent(event.content)),
+            )
           : remedialStreamEvents;
         const visibleRemedialEvidenceStreamEvents: AgentMessage[] = [];
         const remedialLifecycleStreamEvents: AgentMessage[] = [];
@@ -2002,8 +1999,8 @@ export async function* routeSerial(
           a2aMentions: remedialA2aMentions,
           hasCoCreatorLineStartMention: remedialHasCoCreatorLineStartMention,
           hasLocalCoCreatorLineStartMention: remedialHasLocalCoCreatorLineStartMention,
-          // Exit-only remedials validate preserved content instead of replacing it; replay the visible
-          // text and routing-exit evidence before the remedial boundary can replace that turn.
+          // Synthetic remedials validate preserved content instead of replacing it; replay the
+          // first-pass text and routing evidence before the remedial lifecycle boundary.
           streamEvents: preservesOriginalVisibleContent
             ? [
                 ...originalVisibleStreamEventsForRemedialTurn,
@@ -3213,11 +3210,15 @@ export async function* routeSerial(
                 ...(noTextBlocks.length > 0 ? { rich: { v: 1 as const, blocks: noTextBlocks } } : {}),
                 // F194 Phase Z9 AC-Z25 (KD-28): always stamp turnInvocationId
                 // (= ownInvocationId, else parent fallback).
-                ...((options.parentInvocationId ?? ownInvocationId)
+                ...((options.parentInvocationId ?? visibleContentInvocationIdOverride ?? ownInvocationId)
                   ? {
                       stream: {
-                        invocationId: (options.parentInvocationId ?? ownInvocationId) as string,
-                        turnInvocationId: (ownInvocationId ?? options.parentInvocationId) as string,
+                        invocationId: (options.parentInvocationId ??
+                          visibleContentInvocationIdOverride ??
+                          ownInvocationId) as string,
+                        turnInvocationId: (visibleContentInvocationIdOverride ??
+                          ownInvocationId ??
+                          options.parentInvocationId) as string,
                       },
                     }
                   : {}),

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1062,6 +1062,7 @@ export async function* routeSerial(
       // F22 R2 P1-1: Capture own invocationId from stream (not getLatestId)
       let ownInvocationId: string | undefined;
       let visibleContentInvocationIdOverride: string | undefined;
+      let preservedFirstPassVisibleContent = false;
       // F111 Phase B: Streaming TTS chunker for real-time voice (voiceMode only)
       let voiceChunker: StreamingTtsChunker | undefined;
       let deferredVoiceInvocationId: string | undefined;
@@ -1905,6 +1906,7 @@ export async function* routeSerial(
           originalStoredContentBeforeRemedial.length > 0 ||
           originalRichBlocksBeforeRemedial.length > 0 ||
           originalToolEventsBeforeRemedial.length > 0;
+        preservedFirstPassVisibleContent = preservesOriginalVisibleContent;
         visibleContentInvocationIdOverride = preservesOriginalVisibleContent
           ? originalVisibleInvocationIdBeforeRemedial
           : undefined;
@@ -2495,8 +2497,11 @@ export async function* routeSerial(
           (storedContent ? detectUserMention(storedContent) : false) || localCvoHasCoCreatorLineStartMention,
         );
 
-        // #573: skip stream store only when callback confirmed persistence (not just invocation)
+        // #573: a confirmed callback owns its canonical callback message. A synthetic remedial
+        // callback does not, however, own the completed first-pass result that the guard preserved;
+        // store that result separately so F5/history matches the live replay.
         const callbackAlreadyStored = callbackPostConfirmed;
+        const callbackDeduplicatesStreamStore = callbackAlreadyStored && !preservedFirstPassVisibleContent;
 
         // Store with actual mentions — degrade on failure to ensure done reaches frontend
         // (缅因猫 review P1-2: Redis failure must not block done yield)
@@ -2559,7 +2564,7 @@ export async function* routeSerial(
             }
           }
 
-          if (!callbackAlreadyStored) {
+          if (!callbackDeduplicatesStreamStore) {
             const storedMsg = await deps.messageStore.append({
               userId,
               catId,

--- a/packages/api/test/route-serial-routing-guard-remedial.test.js
+++ b/packages/api/test/route-serial-routing-guard-remedial.test.js
@@ -4,8 +4,8 @@
  * Pure decision coverage lives in `routing-guard-remedial.test.js`. This suite
  * locks the route-serial side effect: codex-family cats that cannot use native
  * Stop hooks get one inline remedial invoke when they end without a routing
- * exit. Exit-only remedials route the original visible content instead of
- * replacing it with a bare outlet.
+ * exit. Synthetic remedials route the original visible evidence instead of
+ * replacing it with a shorter control response.
  */
 
 import assert from 'node:assert/strict';
@@ -156,7 +156,7 @@ async function loadRealRoster() {
 
 async function runRoute(service, threadId, extraServices = {}, mockOptions = {}) {
   return withCatRegistryLock(async () => {
-    const { thinkingMode = 'play', ...depsOptions } = mockOptions;
+    const { thinkingMode = 'play', routeOptions = {}, ...depsOptions } = mockOptions;
     const original = catRegistry.getAllConfigs();
     await loadRealRoster();
     const appended = [];
@@ -167,6 +167,7 @@ async function runRoute(service, threadId, extraServices = {}, mockOptions = {})
       const yielded = [];
       for await (const msg of routeSerial(deps, ['codex'], 'guard test', 'user1', threadId, {
         thinkingMode,
+        ...routeOptions,
       })) {
         yielded.push(msg);
       }
@@ -227,6 +228,39 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
       yieldedTextEvents[0]?.invocationId,
       done?.invocationId,
       'route-only remedial must not retag original visible text as the remedial turn',
+    );
+  });
+
+  test('action-bearing co-creator remedial cannot replace completed first-pass content', async () => {
+    const service = createSequenceService('codex', [
+      'I completed the investigation and documented the verified root cause.',
+      '@co-creator 请确认方案方向；认可后再进入立项与实现拆分。',
+    ]);
+
+    const { appended, calls, yielded } = await runRoute(service, 'thread-routing-guard-action-remedial');
+
+    assert.equal(calls.length, 2, 'first-pass no-exit text should trigger exactly one remedial invoke');
+    const codexMessages = appended.filter((m) => m.catId === 'codex' && m.origin === 'stream');
+    assert.equal(codexMessages.length, 1);
+    assert.equal(
+      codexMessages[0].content,
+      'I completed the investigation and documented the verified root cause.',
+      'synthetic remedial prose must not replace completed first-pass content',
+    );
+    assert.equal(codexMessages[0].mentionsUser, true);
+    assert.deepEqual(codexMessages[0].extra?.stream, {
+      invocationId: 'outer-inv-1',
+      turnInvocationId: 'outer-inv-1',
+    });
+    assert.deepEqual(
+      yielded.filter((m) => m.type === 'text').map((m) => [m.content, m.invocationId]),
+      [['I completed the investigation and documented the verified root cause.', 'outer-inv-1']],
+      'live output must retain only the first-pass text and identity',
+    );
+    assert.equal(
+      appended.find((m) => m.source?.connector === 'routing-guard-failure'),
+      undefined,
+      'action-bearing co-creator remedial is still a valid routing exit',
     );
   });
 
@@ -359,7 +393,10 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
   });
 
   test('remedial line-start cat mention flows through existing A2A worklist enqueue', async () => {
-    const codexService = createSequenceService('codex', ['I will keep going from here.', '@opus']);
+    const codexService = createSequenceService('codex', [
+      'I will keep going from here.',
+      '@opus 请继续处理这个已经完成首轮分析的任务。',
+    ]);
     const opusService = createSequenceService('opus', ['ack from opus'], { needsGuard: false });
 
     const { appended, calls } = await runRoute(codexService, 'thread-routing-guard-1b', { opus: opusService });
@@ -427,7 +464,7 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
     );
   });
 
-  test('tool-only no-text initial output still gets the remedial guard instead of silent completion', async () => {
+  test('tool-only no-text first pass is preserved when remedial routing includes action prose', async () => {
     const service = createSequenceService('codex', [
       [
         {
@@ -436,7 +473,7 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
           toolInput: { q: 'thread opus' },
         },
       ],
-      '@co-creator',
+      '@co-creator 请确认后续方向。',
     ]);
 
     const { appended, calls, yielded } = await runRoute(service, 'thread-routing-guard-1d');
@@ -451,12 +488,73 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
           return false;
         }
       }),
-      false,
-      'guarded tool-only turns should be remediated, not surfaced as silent_completion',
+      true,
+      'a preserved tool-only first pass should retain its normal silent-completion surface',
     );
     const codexMessages = appended.filter((m) => m.catId === 'codex' && m.origin === 'stream');
     assert.equal(codexMessages.length, 1);
-    assert.equal(codexMessages[0].content, '@co-creator');
+    assert.equal(codexMessages[0].content, '');
+    assert.deepEqual(
+      codexMessages[0].toolEvents?.map((event) => [event.type, event.toolName ?? null]),
+      [['tool_use', 'cat_cafe_search_evidence']],
+      'synthetic remedial prose must not replace or discard first-pass tool evidence',
+    );
+    assert.deepEqual(codexMessages[0].extra?.stream, {
+      invocationId: 'outer-inv-1',
+      turnInvocationId: 'outer-inv-1',
+    });
+    assert.deepEqual(
+      yielded.filter((m) => m.type === 'text').map((m) => m.content),
+      [],
+      'synthetic remedial prose must stay out of the live stream when first-pass tool evidence exists',
+    );
+  });
+
+  test('rich-only first pass is preserved when remedial routing includes action prose', async () => {
+    const richBlock = {
+      id: 'first-pass-rich-only',
+      kind: 'card',
+      v: 1,
+      title: 'Completed first-pass artifact',
+      bodyMarkdown: 'This card is the first-pass result.',
+    };
+    const service = createSequenceService('codex', [
+      [
+        {
+          type: 'system_info',
+          content: JSON.stringify({ type: 'rich_block', block: richBlock }),
+        },
+      ],
+      '@co-creator 请确认后续方向。',
+    ]);
+    const persistenceContext = {};
+
+    const { appended, calls, yielded } = await runRoute(
+      service,
+      'thread-routing-guard-rich-only-action-remedial',
+      {},
+      { routeOptions: { persistenceContext } },
+    );
+
+    assert.equal(calls.length, 2);
+    const codexMessages = appended.filter((m) => m.catId === 'codex' && m.origin === 'stream');
+    assert.equal(codexMessages.length, 1);
+    assert.equal(codexMessages[0].content, '');
+    assert.deepEqual(codexMessages[0].extra?.rich?.blocks, [richBlock]);
+    assert.deepEqual(
+      persistenceContext.richBlocks,
+      [richBlock],
+      'outbound persistence must retain the first-pass rich evidence',
+    );
+    assert.deepEqual(codexMessages[0].extra?.stream, {
+      invocationId: 'outer-inv-1',
+      turnInvocationId: 'outer-inv-1',
+    });
+    assert.deepEqual(
+      yielded.filter((m) => m.type === 'text').map((m) => m.content),
+      [],
+      'synthetic remedial prose must stay out of the live stream when first-pass rich evidence exists',
+    );
   });
 
   test('confirmed callback post with line-start cat mention counts as the routing exit', async () => {
@@ -884,9 +982,9 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
     );
   });
 
-  test('voice-mode route-only remediation speaks the validated first-pass text', async () => {
+  test('voice-mode action-bearing remediation speaks the validated first-pass text', async () => {
     await installFakeStreamingTtsRegistry();
-    const service = createSequenceService('codex', ['Invalid first-pass response.', '@co-creator']);
+    const service = createSequenceService('codex', ['Invalid first-pass response.', '@co-creator 请确认后续方向。']);
     const socketEvents = [];
 
     const { calls } = await runRoute(service, 'thread-routing-guard-voice', {}, { voiceMode: true, socketEvents });
@@ -899,9 +997,9 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
       'voice TTS must follow the same validated visible text as live/persistence',
     );
     assert.equal(
-      spokenChunks.includes('@co-creator'),
+      spokenChunks.includes('@co-creator 请确认后续方向。'),
       false,
-      'route-only remedial text must not be synthesized as user-visible speech',
+      'synthetic remedial prose must not be synthesized as user-visible speech',
     );
   });
 

--- a/packages/api/test/route-serial-routing-guard-remedial.test.js
+++ b/packages/api/test/route-serial-routing-guard-remedial.test.js
@@ -264,6 +264,48 @@ describe('F177 Phase H — route-serial routing guard remedial invoke', () => {
     );
   });
 
+  test('confirmed remedial callback preserves the completed first pass alongside the handoff', async () => {
+    const codexService = createSequenceService('codex', [
+      'I completed the investigation and documented the verified root cause.',
+      [
+        {
+          type: 'tool_use',
+          toolName: 'cat_cafe_post_message',
+          toolInput: { content: '@opus\n\nPlease continue from the completed investigation.' },
+        },
+        {
+          type: 'tool_result',
+          toolName: 'cat_cafe_post_message',
+          content: JSON.stringify({
+            status: 'ok',
+            messageId: 'msg-remedial-callback',
+            threadId: 'thread-routing-guard-remedial-callback',
+          }),
+        },
+      ],
+    ]);
+    const opusService = createSequenceService('opus', ['ack from opus'], { needsGuard: false });
+
+    const { appended, calls, yielded } = await runRoute(codexService, 'thread-routing-guard-remedial-callback', {
+      opus: opusService,
+    });
+
+    assert.equal(calls.length, 2, 'the first-pass no-exit text should trigger one remedial invocation');
+    assert.equal(opusService.calls.length, 1, 'the confirmed remedial callback must still route to opus');
+    const codexMessages = appended.filter((m) => m.catId === 'codex' && m.origin === 'stream');
+    assert.equal(codexMessages.length, 1, 'the callback message must not deduplicate the completed first pass');
+    assert.equal(codexMessages[0].content, 'I completed the investigation and documented the verified root cause.');
+    assert.deepEqual(codexMessages[0].extra?.stream, {
+      invocationId: 'outer-inv-1',
+      turnInvocationId: 'outer-inv-1',
+    });
+    assert.deepEqual(
+      yielded.filter((m) => m.type === 'text' && m.catId === 'codex').map((m) => [m.content, m.invocationId]),
+      [['I completed the investigation and documented the verified root cause.', 'outer-inv-1']],
+      'live output and persistence must retain the same first-pass content and identity',
+    );
+  });
+
   test('guarded first pass streams lifecycle and tool events while withholding invalid text', async () => {
     const service = createSequenceService('codex', [
       [


### PR DESCRIPTION
## Summary

- Treat routing-guard remedial invocations as synthetic control turns once the first pass has produced text, rich output, or tool evidence.
- Preserve the first-pass persisted/live/voice content and invocation identity while still using action-bearing remedial mentions for routing.
- When a remedial `cat_cafe_post_message` callback is confirmed, persist the preserved first pass beside the callback action instead of incorrectly deduplicating it.
- Add route-level regressions for the exact action-bearing co-creator overwrite, cat handoff, confirmed callback handoff, tool-only, rich-only, and voice paths.

## Why

The existing public implementation classified only bare line-start cat/co-creator mentions as route-only. An action-bearing synthetic remedial therefore replaced a completed first-pass response with shorter control prose. Visibility should be decided by first-pass evidence, not by matching remedial wording.

A confirmed callback owns its canonical action message, but it cannot deduplicate the completed first-pass evidence that the guard intentionally preserves for live output and F5 history.

Fixes #1255.

## Validation

- Initial RED: the exact issue sample persisted remedial action text instead of the completed first-pass response; the expanded matrix produced 5 expected failures.
- Reviewer P1 RED: a completed first pass followed by a confirmed remedial callback persisted zero first-pass stream messages.
- GREEN: API build plus focused routing-guard suites, 36/36; the callback regression verifies original content and invocation identity survive while the handoff still routes.
- `pnpm check`: PASS after the reviewer repair.
- `pnpm lint`: PASS after the reviewer repair.
- Literal API public-test command: not green on the accepted base. It reaches the pre-existing `messages-parallel-slot-release.test.js` failures and then hangs because the failed assertions never release their deferred gates.
- Pristine `origin/main` at `211ced8ab68663f65e2e52395e6c42bfb82677b3` reproduces that file identically (0/2) and, with only that deadlocking file excluded, reports 16,650/16,693 passing, 15 failing, 28 skipped.
- The adjacent A2A tracker is order-sensitive on both feature and pristine base. The callback-pushed path passed 3/3 targeted feature runs; pristine passed 2/3. Shared full-file failures are therefore recorded as accepted-base noise rather than fixed in #1255.

## Scope and invalidators

- No runtime activation or restart.
- PR #1209 currently touches the same source file for system-warning persistence in different hunks. If it lands first, this PR must rebase and rerun the focused suites; its nearby no-text persistence hunk invalidates stale merge-tree evidence.
- This change does not port the private structured custody implementation wholesale and adds no phrase-specific remedial regex.

## Risk routing

- Behavior: medium — changes which completed turn is visible and durable after a synthetic remedial control turn.
- Data: medium — preserves an existing first-pass message beside a confirmed callback; no schema change, migration, deletion, or rewrite of existing records.
- Security: unchanged — no auth, token, callback verification, secret, or trust-boundary change.
- Contract: medium — aligns live replay, F5/history persistence, voice output, and invocation identity on the same first-pass evidence.
- Irreversibility: low — one squash commit, no runtime activation, external dependency, production-data mutation, or destructive operation.
- Independent source: stateful local peer review on exact HEAD; cloud review was not selected because the risk is a repository-specific routing/persistence state transition with direct route-level coverage, not a context-blind security or external API boundary.
- Gate: focused RED/GREEN + API build + `pnpm check` + lint + exact-HEAD GitHub Build/Lint/Windows/Public tests. The pristine accepted-base local public-suite exception is documented above and is not represented as green evidence.
