### PR TITLE
verdict(eval:a2a): 2026-08-01-eval-a2a-source-adapter-stalled-build

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/attribution.json
@@ -1,0 +1,61 @@
+{
+  "verdictId": "2026-08-01-eval-a2a-source-adapter-stalled-build",
+  "featureId": "F167",
+  "evalSnapshotId": "eval-F167-2026-08-01",
+  "generatedAt": "2026-08-01T03:07:39.296Z",
+  "findings": [
+    {
+      "id": "AR-2026-08-01-001",
+      "relatedFeature": "F167",
+      "frictionSignal": {
+        "type": "daily_source_artifact_missing",
+        "severity": "high",
+        "confidence": 0.98
+      },
+      "attribution": {
+        "primaryLayer": "execution_gap",
+        "pipelineOrHuman": "pipeline",
+        "evidence": [
+          {
+            "type": "schedule-ledger",
+            "anchor": "source-adapter/missing_source_pair_count",
+            "excerpt": "Four eval:a2a cycles were delivered on 2026-07-28, 2026-07-29, 2026-07-31, and 2026-08-01; all invocation contexts had empty trendRefs/verdictRefs and the live harness root had zero snapshot/attribution source pairs."
+          },
+          {
+            "type": "code-path",
+            "anchor": "source-adapter/scheduled_cycle_count",
+            "excerpt": "eval-domain-daily builds the eval invocation with trendRefs=[] and verdictRefs=[] and contains no f167-runtime-eval source-adapter call before invoking the eval cat."
+          },
+          {
+            "type": "counter-window",
+            "anchor": "source-adapter/counter_window.duration_hours",
+            "excerpt": "Live process-info exposes counter_window.duration_hours=36.170368095405, so counter-derived confidence is not downgraded; the runtime telemetry requested by the 2026-06-30 verdict is now reachable."
+          },
+          {
+            "type": "trace-metadata",
+            "anchor": "route-serial/route.error_count",
+            "excerpt": "The current trace window contains two route spans and both failed with Unknown cat ID: opus-47; route.total_cats_invoked remained 0."
+          },
+          {
+            "type": "grounding-shadow",
+            "anchor": "grounding-phase-o/grounding.check_total",
+            "excerpt": "Grounding counters and the sample endpoint are wired, but check_total=0, verdict_total=0, mismatch_sample_count=0 and stored samples=0; this is no-observation data, not evidence for a healthy mismatch distribution or fail-closed escalation."
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "build-source-adapter",
+          "target": "F192/eval-domain-daily",
+          "rationale": "Run the existing telemetry adapter, F167 snapshot generator, attribution generator, and YAML serializer before eval-cat invocation; pass the generated source basenames into the invocation context and keep the source pair in the live gitignored harness root for publish_verdict."
+        },
+        {
+          "action": "repair-eval-cat-registry",
+          "target": "F192/eval-domains",
+          "rationale": "Replace disabled/unregistered opus-47 evalCat and ownerCatId entries with an active catalog cat so scheduled invocations and actionable handoffs do not route into Unknown cat ID failures."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-08-01-eval-a2a-source-adapter-stalled-build",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/snapshots/2026-08-01T03-07-39-296Z-F167-eval.yaml",
+      "sha256": "bd6b167db8fc0427f7098537928e3767bd16b0ecbef22fbf421839748081705d"
+    },
+    {
+      "path": "docs/harness-feedback/attributions/2026-08-01T03-07-39-296Z-F167-attribution.yaml",
+      "sha256": "69064b2056ae32b6c47cab6caaa3dcb90e38bfbe80e0fe81e8cf47a4417fd669"
+    }
+  ],
+  "generatedAt": "2026-08-01T03:07:39.296Z",
+  "generator": {
+    "name": "eval-a2a-live-verdict",
+    "version": "1"
+  },
+  "sanitizeRulesVersion": "f192-e-pilot-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-01-eval-a2a-source-adapter-stalled-build/snapshot.json
@@ -1,0 +1,63 @@
+{
+  "verdictId": "2026-08-01-eval-a2a-source-adapter-stalled-build",
+  "evalSnapshotId": "eval-F167-2026-08-01",
+  "featureId": "F167",
+  "generatedAt": "2026-08-01T03:07:39.296Z",
+  "window": {
+    "startMs": 1785553200866,
+    "endMs": 1785553200882,
+    "durationHours": 0.000004444444444444444
+  },
+  "counterWindow": {
+    "startMs": 1785423445939,
+    "endMs": 1785553659264,
+    "durationHours": 36.170368095405
+  },
+  "components": [
+    {
+      "id": "route-serial",
+      "name": "route-serial (A2A handoff routing)",
+      "confidence": "high",
+      "activationCounts": {
+        "inline_action.checked": 2,
+        "route.span_count": 2,
+        "route.total_cats_invoked": 0
+      },
+      "frictionCounts": {
+        "route.error_count": 2
+      }
+    },
+    {
+      "id": "grounding-phase-o",
+      "name": "claim grounding (Phase O shadow)",
+      "confidence": "medium",
+      "activationCounts": {
+        "grounding.check_total": 0,
+        "grounding.verdict_total": 0,
+        "grounding.resolver_total": 0,
+        "grounding.cache_hit_total": 0,
+        "grounding.sample_count": 0,
+        "grounding.mismatch_sample_count": 0
+      },
+      "frictionCounts": {
+        "grounding.budget_exhausted_total": 0
+      }
+    },
+    {
+      "id": "source-adapter",
+      "name": "f167-runtime-eval daily source adapter",
+      "confidence": "high",
+      "activationCounts": {
+        "scheduled_cycle_count": 4,
+        "delivered_cycle_count": 4,
+        "source_pair_count": 0,
+        "verdict_count": 0,
+        "counter_window.duration_hours": 36.170368095405,
+        "legacy_scheduled_task_count": 0
+      },
+      "frictionCounts": {
+        "missing_source_pair_count": 4
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-01-eval-a2a-source-adapter-stalled-build.md
+++ b/docs/harness-feedback/verdicts/2026-08-01-eval-a2a-source-adapter-stalled-build.md
@@ -1,0 +1,36 @@
+---
+feature_ids: [F192, F167]
+topics: [harness-eval, eval-a2a, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:a2a
+packet_id: 2026-08-01-eval-a2a-source-adapter-stalled-build
+source_snapshot: "snapshot:bundle/2026-08-01-eval-a2a-source-adapter-stalled-build/snapshot"
+---
+
+# Live Verdict — 2026-08-01-eval-a2a-source-adapter-stalled-build
+
+- Verdict: `build`
+- Phenomenon: Live F167 metrics, history, traces, process-info, and grounding endpoints are now reachable with a 36.17h counter window, but four delivered eval:a2a cycles since 2026-07-28 produced no automatic snapshot/attribution source pair or verdict. The same window also shows two of two route spans failing on the stale opus-47 cat ID, while grounding shadow telemetry has zero observations and cannot support fail-closed escalation.
+- Harness: F167/f167-runtime-eval-source-adapter (F167 daily runtime eval source adapter)
+- Owner ask: Build the eval:a2a source-adapter stage into eval-domain-daily: collect live telemetry, generate and persist the sanitized F167 snapshot/attribution pair, pass their basenames into the invocation context, and validate publish from a git-backed repo. In the same ownership cell, replace stale opus-47 evalCat/ownerCatId registry entries with an active cat.
+- Re-eval: The next scheduled eval:a2a cycle automatically creates one matched snapshot/attribution source pair before cat invocation, supplies both basenames in context, publishes a clean evidence PR from a git-backed repo, records no Unknown cat ID route failure, and reports grounding counters/samples or an explicit no-stateful-call observation without treating zero mismatches as healthy distribution evidence. at 2026-08-02T03:00:00Z
+
+Evidence:
+- snapshot:bundle/2026-08-01-eval-a2a-source-adapter-stalled-build/snapshot
+- attribution:bundle/2026-08-01-eval-a2a-source-adapter-stalled-build/AR-2026-08-01-001
+- metric:counter_window.duration_hours=36.170368095405
+- metric:scheduled_cycle_count=4
+- metric:source_pair_count=0
+- metric:grounding.check_total=0
+- metric:grounding.verdict_total=0
+- metric:grounding.mismatch_sample_count=0
+- metric:route.error_count=2
+- metric:route.total_cats_invoked=0
+- metric:legacy_scheduled_task_count=0
+- trace:metadata/thread_eval_a2a/2026-08-01T03:00:00Z/route-spans-2
+
+Counterarguments:
+- The A2A behavioral counters themselves are quiet and show no L1/C1/C2 friction in the available 5.99h history, so this is a source-pipeline build finding rather than evidence that those guards are malfunctioning.
+- The two opus-47 trace errors were emitted by sibling eval-domain routes and are secondary evidence of registry drift, not the sole cause of eval:a2a source generation failure.
+- A manually produced source pair can unblock this publication once, but it does not satisfy the daily harness contract or day-over-day persistence requirement.


### PR DESCRIPTION
Verdict published via cat_cafe_publish_verdict MCP tool.

Verdict: build
Domain: eval:a2a
Source thread: thread_eval_a2a
Published commit: 99ae1a915a30060c0d3c6f2da078f7f088340081

Phenomenon: Live F167 metrics, history, traces, process-info, and grounding endpoints are reachable with a 36.17h counter window, but four delivered eval:a2a cycles since 2026-07-28 produced no automatic snapshot/attribution source pair or verdict. Two of two route spans also fail on stale cat ID opus-47. Grounding shadow telemetry has zero observations and cannot support fail-closed escalation.

Owner: opus / F192
Action: Build the eval:a2a source-adapter stage into eval-domain-daily: collect live telemetry, generate and persist the sanitized F167 snapshot/attribution pair, pass their basenames into the invocation context, validate publish from a git-backed repo, and replace stale opus-47 registry entries with an active cat.

Traceability note: the current installed publisher generated provenance.json without the promised sourceThreadId field; this PR body preserves the source thread explicitly.