### PR TITLE
chore(gates): reconcile public baseline registries

### DIFF
--- a/.dir-exceptions.json
+++ b/.dir-exceptions.json
@@ -3,71 +3,64 @@
     {
       "path": "packages/api/src/domains/cats/services/agents/routing",
       "owner": "opus-48",
-      "reason": "Routing 25 files（agent routing + artifact-tracking + F232 thread-artifacts-aggregator）。与 invocation(25)/providers(32) 同属 agents 子域债务，ADR-010 该子拆分但 scope 不含 F232。F232 加 aggregator 顶过 25 线，time-bound 豁免待 routing 子拆分（记 F23 Phase 2）。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 26 files. Agent routing and artifact tracking remain one unsplit agents subdomain; F23 Phase 2 owns the boundary split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     },
     {
       "path": "packages/api/src/routes",
       "owner": "opus",
-      "reason": "Routes 按功能已分文件（147 files），ADR-010 重构 scope 不含 routes，需要按 HTTP verb / domain 重新评估子拆分边界。THIRD-ROUND unblock（首轮 a4e81b8791 续期到 2026-06-01, 二轮到 2026-06-30）。Follow-up split plan 记在 F23 § Phase 2 follow-up。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 200 files. Routes need a domain/HTTP-boundary split rather than file shuffling; F23 Phase 2 owns the split plan.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     },
     {
       "path": "packages/api/src/config",
       "owner": "opus",
-      "reason": "Config 38 files（cat-budgets/cat-config/env 等独立配置项）。需要先做 config 域 audit 再确定子拆分边界。THIRD-ROUND unblock（首轮 a4e81b8791 续期到 2026-06-01, 二轮到 2026-06-30）。Follow-up split plan 记在 F23 § Phase 2 follow-up。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 42 files. Config needs a domain audit before choosing stable subdirectories; F23 Phase 2 owns that split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     },
     {
       "path": "packages/api/src/domains/cats/services/agents/invocation",
       "owner": "opus",
-      "reason": "Invocation 控制面 25 files；按 queue/registry/tracker/progress/reconciliation/delivery/auth 子域拆分。THIRD-ROUND unblock（首轮 4136847b10 砚砚 2026-05-18 续期到 2026-06-01, 二轮到 2026-06-30）。Follow-up split plan 记在 F23 § Phase 2 follow-up。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 27 files. Invocation should split by queue/registry/tracker/progress/reconciliation/delivery/auth; F23 Phase 2 owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     },
     {
       "path": "packages/api/src/domains/cats/services/agents/providers",
       "owner": "opus",
-      "reason": "Agent providers 32 files；按 agents/event-transforms/carriers/image/configs 子域拆分。THIRD-ROUND unblock（首轮 4136847b10 砚砚 2026-05-18 续期到 2026-06-01, 二轮到 2026-06-30）。Follow-up split plan 记在 F23 § Phase 2 follow-up。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 42 files. Providers should split by agents/event transforms/carriers/image/config; F23 Phase 2 owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     },
     {
       "path": "packages/api/src/domains/cats/services/stores/ports",
       "owner": "codex",
-      "reason": "F231 Phase C 新增 ProfileUpdateProposalStore port 后，stores/ports 达到 25 files；当前 store port 集中目录仍是既有模式，Phase C scope 不做跨 store-port 拆分。需在 F23/F231 follow-up 中按 proposal/profile/session 等子域拆分 ports。THIRD-ROUND unblock（二轮到 2026-06-30）。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 28 files. Store ports remain centralized and need proposal/profile/session subdomains; F231/F23 follow-up owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F231/F23-followup"
     },
     {
       "path": "packages/api/src/domains/memory",
       "owner": "gpt52",
-      "reason": "Memory 域现有 72 个非 index.ts 文件，职责已横跨 indexing/query/governance/library；THIRD-ROUND unblock（首轮续期到 2026-06-15, 二轮到 2026-06-30），继续按真实边界拆子目录。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 95 files. Memory spans indexing/query/governance/library and needs boundary-led subdirectories; F102 owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F102"
     },
     {
       "path": "packages/api/src/utils",
       "owner": "codex",
-      "reason": "API utils 31 files；按 cli/process/media/paths/network/parsing/skills 子域拆分（详见 F23 § Phase 2）。THIRD-ROUND unblock（首轮 4136847b10 砚砚 2026-05-18 续期到 2026-06-01, 二轮到 2026-06-30）。Follow-up split plan 记在 F23 § Phase 2 follow-up。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 40 files. Utils should split by cli/process/media/paths/network/parsing/skills; F23 Phase 2 owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
-    },
-    {
-      "path": "packages/api/src/infrastructure/harness-eval",
-      "owner": "opus",
-      "reason": "F192 socio-technical harness eval 当前 29 .ts（Phase F capability-wakeup 一批 eval-capability-wakeup-* 加入超 error=25）；THIRD-ROUND unblock（首轮续期到 2026-06-15, 二轮到 2026-06-30），后续按 capability-wakeup / a2a / domain / hub 子域拆分。详见 F192 feat doc Known Debt + GitHub issue。",
-      "expiresAt": "2026-07-31",
-      "ticket": "F192"
     },
     {
       "path": "packages/api/src/domains/cats/services/stores/redis",
       "owner": "opus",
-      "reason": "F235 RedisCommunityIssueDraftStore 加入后 redis/ 达 25 files；与 ports/(26) 同源——每个 store port 一个 Redis impl。需在 F23 follow-up 中按 proposal/community/session 子域拆分。THIRD-ROUND unblock（二轮到 2026-06-30）。",
-      "expiresAt": "2026-07-31",
+      "reason": "2026-08-02 public-target recount: 29 files. Redis implementations should split with their proposal/community/session domains; F23 Phase 2 owns the split.",
+      "expiresAt": "2026-08-31",
       "ticket": "F23-followup"
     }
   ]

--- a/packages/api/config/public-test-exclusions.json
+++ b/packages/api/config/public-test-exclusions.json
@@ -8,16 +8,7 @@
       "reason": "Redis isolation and persistence tests are internal harness coverage, not part of the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
-    },
-    {
-      "id": "concurrent-fault-drill",
-      "match": "concurrent-fault-drill",
-      "category": "flaky_or_perf",
-      "reason": "Fault-drill stress coverage is too heavy for the public gate and stays in internal validation.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "task-progress-store",
@@ -26,7 +17,7 @@
       "reason": "Task progress store behavior depends on internal persistence surfaces not exported to the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "session-strategy-phase3",
@@ -35,7 +26,7 @@
       "reason": "Phase 3 session strategy assertions cover internal rollout behavior outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "signal-article-store",
@@ -44,16 +35,7 @@
       "reason": "Signal article store cases exercise source-only data plumbing not guaranteed in the public export.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
-    },
-    {
-      "id": "persistence-fault-drill",
-      "match": "persistence-fault-drill",
-      "category": "flaky_or_perf",
-      "reason": "Persistence fault drills are heavyweight stress scenarios reserved for internal validation.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "cursor-store-atomicity",
@@ -62,7 +44,7 @@
       "reason": "Atomic cursor store checks cover internal durability mechanics not enforced by the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "workflow-sop-store",
@@ -71,7 +53,7 @@
       "reason": "Workflow SOP store tests rely on internal governance persistence surfaces excluded from the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "codex-agent-service",
@@ -80,7 +62,7 @@
       "reason": "Codex agent runtime service tests depend on internal carrier/harness wiring outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "kimi-agent-service",
@@ -89,7 +71,7 @@
       "reason": "Kimi agent service coverage is internal runtime behavior, not public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "claude-settings-hooks",
@@ -98,7 +80,7 @@
       "reason": "Claude settings hook assertions depend on private runtime fixtures unavailable in public export.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "game-store",
@@ -107,7 +89,7 @@
       "reason": "Game store tests rely on non-exported local fixtures and are kept out of the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "memory-tests",
@@ -116,7 +98,7 @@
       "reason": "Memory package tests cover internal recall/index behavior outside the public gate promise.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "cross-cat-context",
@@ -125,7 +107,7 @@
       "reason": "Cross-cat context routing is internal collaboration harness behavior, not public gate surface.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "thread-wiring",
@@ -134,7 +116,7 @@
       "reason": "Thread wiring assertions cover internal callback plumbing outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "integration-wiring",
@@ -143,7 +125,7 @@
       "reason": "Integration wiring checks depend on internal connection topology not exported to public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "shared-state-wiring",
@@ -152,7 +134,7 @@
       "reason": "Shared-state wiring is internal runtime glue not part of the public gate guarantee.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "signal-fetcher-launchd",
@@ -161,7 +143,7 @@
       "reason": "launchd-specific signal fetcher coverage depends on private macOS fixtures and stays internal.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "reflection-capsule-m3",
@@ -170,7 +152,7 @@
       "reason": "Reflection capsule M3 tests cover internal memory/harness behavior outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "workspace-project-context",
@@ -179,7 +161,7 @@
       "reason": "Workspace project context assertions depend on source-only repo structure and local project wiring.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "projects-setup",
@@ -188,7 +170,7 @@
       "reason": "Project setup tests cover internal bootstrap flows not guaranteed in the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "projects-mkdir",
@@ -197,7 +179,7 @@
       "reason": "Project directory creation coverage depends on source-only filesystem conventions.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "governance-status",
@@ -206,7 +188,7 @@
       "reason": "Governance status assertions are source-owned workflow coverage, not public gate behavior.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "governance-pack",
@@ -215,7 +197,7 @@
       "reason": "Governance pack assertions validate source-only sync content and are intentionally excluded from public gate.",
       "owner": "@zts212653",
       "introducedBy": "069d0f0fb",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "pack-integration",
@@ -224,7 +206,7 @@
       "reason": "Pack integration coverage exercises internal source packaging rules outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "project-setup-flow",
@@ -233,16 +215,7 @@
       "reason": "Project setup flow behavior is internal bootstrap coverage, not public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
-    },
-    {
-      "id": "process-liveness-probe",
-      "match": "process-liveness-probe\\.test",
-      "category": "flaky_or_perf",
-      "reason": "Process liveness probe timing is too contention-sensitive for the public gate.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "expedition-bootstrap",
@@ -251,7 +224,7 @@
       "reason": "Expedition bootstrap coverage depends on source-owned harness flows not exported publicly.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "rules-route",
@@ -260,7 +233,7 @@
       "reason": "Rules route assertions depend on source-only rule artifacts stripped from public export.",
       "owner": "@zts212653",
       "introducedBy": "4243948da",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "root-md-slim",
@@ -269,7 +242,7 @@
       "reason": "Root markdown slim tests rely on source-specific Chinese anchors not preserved in public export.",
       "owner": "@zts212653",
       "introducedBy": "7a300704a",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "audit-cc-system-prompt",
@@ -278,7 +251,7 @@
       "reason": "System prompt audit depends on internal L0 prompt assets not shipped in public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "f188-cold-start-fixtures",
@@ -287,7 +260,7 @@
       "reason": "F188 cold-start fixture coverage depends on internal fixture files absent from public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "f188-harness-consistency",
@@ -296,7 +269,7 @@
       "reason": "F188 harness consistency checks rely on internal fixtures and remain source-only.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "orphan-chrome-cleaner",
@@ -305,25 +278,16 @@
       "reason": "Orphan Chrome cleaner assertions are sensitive to local path sanitization and private fixtures.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "capabilities-route",
       "match": "capabilities-route\\.test",
       "category": "product_regression",
-      "reason": "Managed MCP path realignment currently fails in public gate and must be tracked as a real product regression.",
+      "reason": "Public target e0c11043d still fails managed-capability lifecycle assertions; track the fix in https://github.com/zts212653/clowder-ai/issues/1049.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-07-31"
-    },
-    {
-      "id": "antigravity-run-command-executor",
-      "match": "antigravity-run-command-executor\\.test",
-      "category": "flaky_or_perf",
-      "reason": "Antigravity run-command executor timing is unstable on CI and remains out of the public gate until hardened.",
-      "owner": "@zts212653",
-      "introducedBy": "0340783c6",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-08"
     },
     {
       "id": "f203-phase-i-opencode-l0",
@@ -332,7 +296,7 @@
       "reason": "F203 opencode L0 coverage depends on internal runtime files not exported publicly.",
       "owner": "@zts212653",
       "introducedBy": "9c4f26fde",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "f236-cc-anchor-hook",
@@ -341,7 +305,7 @@
       "reason": "F236 cc anchor hook coverage imports the source-only root .claude hook implementation that is not part of the public export.",
       "owner": "@zts212653",
       "introducedBy": "68dd499d9",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "github-schedule-factories",
@@ -350,7 +314,7 @@
       "reason": "GitHub schedule factory assertions are source-owned public-sync governance coverage, not runtime gate behavior.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "harness-eval-hub-read-model",
@@ -359,7 +323,7 @@
       "reason": "Eval hub read-model coverage exercises source-owned harness governance surfaces outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     },
     {
       "id": "harness-eval-merge-gate-provenance-contract",
@@ -368,7 +332,7 @@
       "reason": "Merge-gate provenance contract tests are source-owned governance coverage, not public runtime behavior.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-07-31"
+      "expiresOn": "2026-08-31"
     }
   ]
 }

--- a/packages/api/test/public-test-exclusions.test.js
+++ b/packages/api/test/public-test-exclusions.test.js
@@ -9,13 +9,11 @@ const packageRoot = resolve(__dirname, '..');
 const registryPath = resolve(packageRoot, 'config/public-test-exclusions.json');
 const resolverModuleUrl = pathToFileURL(resolve(packageRoot, 'scripts/resolve-public-test-files.mjs')).href;
 
-const LEGACY_EXCLUSIONS = [
+const RECONCILED_EXCLUSIONS = [
   'redis-',
-  'concurrent-fault-drill',
   'task-progress-store',
   'session-strategy-phase3',
   'signal-article-store',
-  'persistence-fault-drill',
   'cursor-store-atomicity',
   'workflow-sop-store',
   'codex-agent-service',
@@ -37,7 +35,6 @@ const LEGACY_EXCLUSIONS = [
   'governance-pack\\.test',
   'pack-integration\\.test',
   'project-setup-flow\\.test',
-  'process-liveness-probe\\.test',
   'expedition-bootstrap\\.test',
   'rules-route\\.test',
   'root-md-slim\\.test',
@@ -46,7 +43,6 @@ const LEGACY_EXCLUSIONS = [
   'f188-harness-consistency\\.test',
   'orphan-chrome-cleaner\\.test',
   'capabilities-route\\.test',
-  'antigravity-run-command-executor\\.test',
   'f203-phase-i-opencode-l0\\.test',
   'f236-cc-anchor-hook\\.test',
   'github-schedule-factories\\.test',
@@ -71,12 +67,12 @@ async function listTestFiles(rootDir, relDir = '') {
   return files.sort();
 }
 
-function applyLegacySelection(files) {
-  const patterns = LEGACY_EXCLUSIONS.map((value) => new RegExp(value));
+function applyReconciledSelection(files) {
+  const patterns = RECONCILED_EXCLUSIONS.map((value) => new RegExp(value));
   return files.filter((file) => patterns.every((pattern) => !pattern.test(file))).sort();
 }
 
-test('registry preserves metadata for active legacy exclusions and drops stale ones', async () => {
+test('registry preserves metadata for reconciled exclusions and drops retired ones', async () => {
   const { loadPublicTestExclusions } = await import(resolverModuleUrl);
   const registry = await loadPublicTestExclusions({ configPath: registryPath });
 
@@ -98,15 +94,15 @@ test('registry preserves metadata for active legacy exclusions and drops stale o
       category: 'source_only',
       owner: '@zts212653',
       introducedBy: '069d0f0fb',
-      expiresOn: '2026-07-31',
+      expiresOn: '2026-08-31',
     },
   );
 });
 
-test('resolver preserves legacy public test file selection parity', async () => {
+test('resolver preserves the reconciled public test file selection', async () => {
   const { resolvePublicTestFiles } = await import(resolverModuleUrl);
   const allTestFiles = await listTestFiles(resolve(packageRoot, 'test'));
-  const expected = applyLegacySelection(allTestFiles);
+  const expected = applyReconciledSelection(allTestFiles);
 
   const resolved = await resolvePublicTestFiles({
     packageRoot,


### PR DESCRIPTION
## Summary

- Retire four expired flaky_or_perf exclusions that are green on the public export surface.
- Keep the capabilities-route product regression on a short issue-bound TTL.
- Refresh only the public directory exceptions that still exceed the enforced threshold.

## Boundary

Exactly three governance and test files. No source-only import, broad sync, blanket override, runtime activation, or external-author branch mutation.

## Why now

The expired registries fail closed before unrelated contributor tests can run. Public PR #1266 has landed at b8e1a969ddc8adf508d7f435617c711093b95a14, so this branch is rebased on the current public main.

## Validation

- Exact HEAD: 83e5e0808005d7367541370556bad93a20e4cd52
- Full public pnpm gate: PASS; tests, lint, and check all green; 775s
- Combined train proof with #1266 plus this repair: PASS at 41c869e0d3b50f5c8872e91a95567bd3579745a0; 777s
- Diff remains exactly three files: .dir-exceptions.json, public-test-exclusions.json, and its resolver test.

## Rollback

One squash commit reverts the registry reconciliation. If the public source surface regresses, restore only the affected exclusion with fresh evidence and a bounded TTL.