### PR TITLE
fix(api): preserve Claude partial text lifecycle

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/claude-ndjson-parser.ts
@@ -198,6 +198,11 @@ export function transformClaudeEvent(
     const skipFinalText = Boolean(messageId && streamState.partialTextMessageIds.has(messageId));
     const content = message?.content;
     if (!Array.isArray(content)) return null;
+    const hasTextBlock = content.some((block) => {
+      if (typeof block !== 'object' || block === null) return false;
+      const candidate = block as Record<string, unknown>;
+      return candidate.type === 'text' && typeof candidate.text === 'string' && candidate.text.length > 0;
+    });
 
     // F230: Claude CLI can synthesize local assistant entries without an LLM
     // response. Keep that provider provenance structured here, before ordinary
@@ -252,7 +257,11 @@ export function transformClaudeEvent(
         messages.push(msg);
       }
     }
-    if (messageId && skipFinalText) {
+    // #1272: Claude can split one message ID across thinking/text/tool assistant
+    // envelopes. A thinking-only or tool-only envelope is not proof that the
+    // text-bearing final snapshot has arrived; clearing here makes that later
+    // snapshot look new and re-emits text already delivered by text_delta.
+    if (messageId && skipFinalText && hasTextBlock) {
       streamState.partialTextMessageIds.delete(messageId);
     }
     // #778: thinking-only final message — emit thinking as system_info so the
@@ -287,6 +296,13 @@ export function transformClaudeEvent(
       content: JSON.stringify({ type: 'rate_limit', catId, utilization, resetsAt }),
       timestamp: Date.now(),
     };
+  }
+
+  // #1272: result is the invocation terminal boundary. Clear any IDs that had
+  // partial text but no later text-bearing assistant envelope so state cannot
+  // leak into a subsequent invocation/session.
+  if (e.type === 'result') {
+    streamState.partialTextMessageIds.clear();
   }
 
   // result/error → error message (F045: include errorSubtype)

--- a/packages/api/test/claude-ndjson-parser.test.js
+++ b/packages/api/test/claude-ndjson-parser.test.js
@@ -544,3 +544,184 @@ test('assistant event with empty text block alongside tool_use → only tool_use
   assert.equal(result.length, 1, 'only tool_use, empty text filtered out');
   assert.equal(result[0].type, 'tool_use');
 });
+
+test('#1272: streamed text survives thinking-only envelope without final snapshot duplication', () => {
+  const state = makeStreamState();
+  const events = [
+    { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-thinking' } } },
+    {
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '只应出现一次。' } },
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-thinking',
+        content: [{ type: 'thinking', thinking: '继续分析' }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-thinking',
+        content: [{ type: 'text', text: '只应出现一次。' }],
+      },
+    },
+  ];
+
+  const output = events.flatMap((event) => {
+    const result = transformClaudeEvent(event, CAT, state);
+    if (result === null) return [];
+    return Array.isArray(result) ? result : [result];
+  });
+
+  assert.deepEqual(
+    output.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+    ['只应出现一次。'],
+  );
+  assert.equal(state.partialTextMessageIds.has('msg-1272-thinking'), false, 'text-bearing snapshot closes the ID');
+});
+
+test('#1272: tool-only envelope retains partial-text ID until the text-bearing snapshot', () => {
+  const state = makeStreamState();
+  const events = [
+    { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-tool' } } },
+    {
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '正文' } },
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-tool',
+        content: [{ type: 'tool_use', id: 'tool-1', name: 'Read', input: { path: 'README.md' } }],
+      },
+    },
+    {
+      type: 'assistant',
+      message: { id: 'msg-1272-tool', content: [{ type: 'text', text: '正文' }] },
+    },
+  ];
+
+  const output = events.flatMap((event) => {
+    const result = transformClaudeEvent(event, CAT, state);
+    if (result === null) return [];
+    return Array.isArray(result) ? result : [result];
+  });
+
+  assert.deepEqual(
+    output.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+    ['正文'],
+  );
+  assert.equal(output.filter((msg) => msg.type === 'tool_use').length, 1, 'tool event remains visible');
+  assert.equal(state.partialTextMessageIds.has('msg-1272-tool'), false);
+});
+
+test('#1272: empty text alongside a tool does not close the partial-text ID', () => {
+  const state = makeStreamState();
+  const events = [
+    { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-empty-text' } } },
+    {
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '正文' } },
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-empty-text',
+        content: [
+          { type: 'text', text: '' },
+          { type: 'tool_use', id: 'tool-empty', name: 'Read', input: { path: 'README.md' } },
+        ],
+      },
+    },
+    {
+      type: 'assistant',
+      message: { id: 'msg-1272-empty-text', content: [{ type: 'text', text: '正文' }] },
+    },
+  ];
+
+  const output = events.flatMap((event) => {
+    const result = transformClaudeEvent(event, CAT, state);
+    if (result === null) return [];
+    return Array.isArray(result) ? result : [result];
+  });
+
+  assert.deepEqual(
+    output.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+    ['正文'],
+  );
+  assert.equal(output.filter((msg) => msg.type === 'tool_use').length, 1);
+  assert.equal(state.partialTextMessageIds.has('msg-1272-empty-text'), false);
+});
+
+test('#1272: text-bearing snapshot closes the ID without hiding a later tool envelope', () => {
+  const state = makeStreamState();
+  const events = [
+    { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-text-tool' } } },
+    {
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '正文' } },
+    },
+    {
+      type: 'assistant',
+      message: { id: 'msg-1272-text-tool', content: [{ type: 'text', text: '正文' }] },
+    },
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-text-tool',
+        content: [{ type: 'tool_use', id: 'tool-after-text', name: 'Read', input: { path: 'README.md' } }],
+      },
+    },
+  ];
+
+  const output = events.flatMap((event) => {
+    const result = transformClaudeEvent(event, CAT, state);
+    if (result === null) return [];
+    return Array.isArray(result) ? result : [result];
+  });
+
+  assert.deepEqual(
+    output.filter((msg) => msg.type === 'text').map((msg) => msg.content),
+    ['正文'],
+  );
+  assert.equal(output.filter((msg) => msg.type === 'tool_use').length, 1);
+  assert.equal(state.partialTextMessageIds.has('msg-1272-text-tool'), false);
+});
+
+test('#1272: terminal result clears a partial-text ID left by a thinking-only message', () => {
+  const state = makeStreamState();
+  transformClaudeEvent(
+    { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-terminal' } } },
+    CAT,
+    state,
+  );
+  transformClaudeEvent(
+    {
+      type: 'stream_event',
+      event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'partial' } },
+    },
+    CAT,
+    state,
+  );
+  transformClaudeEvent(
+    {
+      type: 'assistant',
+      message: {
+        id: 'msg-1272-terminal',
+        content: [{ type: 'thinking', thinking: 'no final text follows' }],
+      },
+    },
+    CAT,
+    state,
+  );
+
+  assert.equal(
+    state.partialTextMessageIds.has('msg-1272-terminal'),
+    true,
+    'thinking-only envelope is not a proven text boundary',
+  );
+  transformClaudeEvent({ type: 'result', subtype: 'success' }, CAT, state);
+  assert.equal(state.partialTextMessageIds.size, 0, 'terminal result prevents cross-invocation state leakage');
+});

--- a/packages/api/test/issue-1272-claude-route-persistence.test.js
+++ b/packages/api/test/issue-1272-claude-route-persistence.test.js
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const CAT = 'opus';
+
+function createClaudeEventService(transformClaudeEvent) {
+  return {
+    async *invoke() {
+      const state = {
+        currentMessageId: undefined,
+        partialTextMessageIds: new Set(),
+        lastTurnInputTokens: undefined,
+        thinkingBuffer: '',
+      };
+      const events = [
+        { type: 'stream_event', event: { type: 'message_start', message: { id: 'msg-1272-route' } } },
+        {
+          type: 'stream_event',
+          event: { type: 'content_block_delta', delta: { type: 'text_delta', text: '持久化正文。' } },
+        },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-1272-route',
+            content: [{ type: 'thinking', thinking: 'thinking snapshot' }],
+          },
+        },
+        {
+          type: 'assistant',
+          message: {
+            id: 'msg-1272-route',
+            content: [{ type: 'text', text: '持久化正文。' }],
+          },
+        },
+        { type: 'result', subtype: 'success' },
+      ];
+      for (const event of events) {
+        const result = transformClaudeEvent(event, CAT, state);
+        if (result === null) continue;
+        for (const msg of Array.isArray(result) ? result : [result]) yield msg;
+      }
+      yield { type: 'done', catId: CAT, timestamp: Date.now() };
+    },
+  };
+}
+
+function createMockDeps(service, appendCalls) {
+  let messageSeq = 0;
+  const storedById = new Map();
+  return {
+    services: { [CAT]: service },
+    invocationDeps: {
+      registry: {
+        create: () => ({ invocationId: 'inv-1272-claude', callbackToken: 'tok-1272-claude' }),
+        verify: async () => ({ ok: false, reason: 'unknown_invocation' }),
+      },
+      sessionManager: {
+        get: async () => null,
+        getOrCreate: async () => ({}),
+        resolveWorkingDirectory: () => '/tmp/test',
+      },
+      threadStore: null,
+      apiUrl: 'http://127.0.0.1:3004',
+    },
+    messageStore: {
+      append: async (input) => {
+        const stored = { id: `msg-${++messageSeq}`, ...input, threadId: input.threadId ?? 'thread-1272' };
+        appendCalls.push(input);
+        storedById.set(stored.id, stored);
+        return stored;
+      },
+      getById: async (id) => storedById.get(id) ?? null,
+      getRecent: () => [],
+      getMentionsFor: () => [],
+      getRecentMentionsFor: () => [],
+    },
+  };
+}
+
+test('#1272: Claude live final text and refreshed persisted message contain one streamed body', async () => {
+  const { transformClaudeEvent } = await import(
+    '../dist/domains/cats/services/agents/providers/claude-ndjson-parser.js'
+  );
+  const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+  const appendCalls = [];
+  const deps = createMockDeps(createClaudeEventService(transformClaudeEvent), appendCalls);
+
+  const yielded = [];
+  for await (const msg of routeSerial(deps, [CAT], '排查重复回复', 'user-1272', 'thread-1272')) {
+    yielded.push(msg);
+  }
+
+  assert.equal(appendCalls.length, 1, 'route persists one cat message');
+  assert.equal(appendCalls[0].content, '持久化正文。');
+
+  const liveText = yielded
+    .filter((msg) => msg.type === 'text' && msg.catId === CAT)
+    .map((msg) => msg.content)
+    .join('');
+  assert.equal(liveText, '持久化正文。', 'live accumulated text contains no final-snapshot replay');
+
+  const refreshed = await deps.messageStore.getById('msg-1');
+  assert.equal(refreshed?.content, '持久化正文。', 'F5/read path returns exactly the stored parser output');
+});

--- a/review-notes/2026-08-03-issue-1272-claude-partial-text-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-claude-partial-text-review-request.md
@@ -1,0 +1,102 @@
+# Review Request: #1272 Claude partial-text lifecycle
+
+Review-Target-ID: `fix-1272-claude-partial-text-lifecycle`
+Branch: `fix/1272-claude-partial-text-lifecycle`
+Base: `origin/main@041190ca7aec0500ff84160db54bb78ce719661b`
+Reviewer: `@砚砚`
+
+## What
+
+- Retain a streamed message ID through thinking-only, tool-only, and empty-text assistant envelopes.
+- Clear the ID only after a non-empty text-bearing snapshot has been deliberately skipped, or at terminal `result`.
+- Add parser lifecycle and route/persistence regressions for thinking/text/tool envelope orderings and terminal cleanup.
+
+## Why
+
+The parser emitted `text_delta` immediately, then treated any same-ID assistant envelope as the final text boundary. A thinking-only envelope deleted the ID without carrying text; a later text snapshot was therefore emitted again and persisted as a duplicate full body.
+
+## Original Requirements
+
+> “按回复拆分PR来修复问题，用adaptive_development sop来修复”
+
+- Source: current collaboration thread; accepted bug contract and maintainer disposition: <https://github.com/zts212653/clowder-ai/issues/1272>.
+- Please judge the delivery against #1272's Claude lifecycle tests and its prohibition on frontend/full-text deduplication.
+
+## Tradeoff
+
+- The state machine uses structural proof (`non-empty text block` or terminal `result`), not timeout/heuristic cleanup.
+- Thinking/tool events remain visible. The change does not suppress legitimate final text when no partial delta exists.
+- No independent fresh-context pre-scan was claimed: this author session participated in implementation. The named peer review below remains the sole approval source.
+
+## Architecture Ownership
+
+Architecture cell: `bubble-pipeline`
+Map delta: `none`
+Why: this corrects an existing provider lifecycle state transition and persisted-text invariant; it adds no Store, Queue, Router, Adapter, Dispatcher, Binding, bubble identity, or write entrance.
+
+## Open Questions
+
+### Technical OQ
+
+1. Is a non-empty text block the right proof boundary, including `text + tool`, `empty text + tool`, and later tool-only envelopes?
+2. Does terminal `result` cleanup cover success/error without hiding error output or leaking IDs across invocations?
+3. Are the new ordering tests sufficient to prevent a future unconditional delete regression?
+
+### Value OQ
+
+None.
+
+## Next Action
+
+Please review the exact branch HEAD supplied in the current-thread handoff. Give every finding P1/P2/P3 and a clear disposition; if no P1/P2 remains, state `APPROVE` with the full SHA.
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/fix-1272-claude-partial-text-lifecycle/codex`
+- Checkout: detached exact SHA from handoff
+- Start Command: not needed; backend provider/parser tests only
+- Ports: none
+
+Bootstrap:
+
+```bash
+unset NODE_ENV
+pnpm install --frozen-lockfile
+pnpm --filter @cat-cafe/shared build
+pnpm --filter @cat-cafe/api run build
+```
+
+## Quality Gate Evidence
+
+- Spec: accepted #1272 maintainer comment at `main@041190ca7aec0500ff84160db54bb78ce719661b`; split delivery explicitly authorized.
+- Requirements: delta→thinking→text emits once; tool-only/empty-text envelopes retain the ID; text→tool keeps tool output; no-delta control remains; terminal cleanup prevents leakage; route persistence equals refreshed read.
+- Dogfood path: real built `transformClaudeEvent` → `routeSerial` → one `messageStore.append` → `getById`; live, stored, and refreshed text all contain one body.
+- Design: no UI changes; no matching `.pen` file.
+- Artifact hygiene: no root media/design artifacts.
+- Architecture scan: `Map delta: none`; no new architecture nouns or parallel ownership surface.
+- Public checkout does not export `check-hotfix-pattern`, `check-fallback-layers`, or `check:architecture-ownership`; these were reported unavailable, not claimed green. Manual diff scan found no fallback stack.
+
+Validation:
+
+```bash
+# focused provider/service/route chain
+node --import ./packages/api/test/helpers/setup-cat-registry.js --test \
+  packages/api/test/claude-ndjson-parser.test.js \
+  packages/api/test/claude-agent-service.test.js \
+  packages/api/test/f215-malformed-toolcall.test.js \
+  packages/api/test/bg-transcript-parity.test.js \
+  packages/api/test/issue-1272-claude-route-persistence.test.js
+# 120 passed, 0 failed
+
+pnpm --filter @cat-cafe/api run test:public
+# 16,762 tests; 16,731 pass; 0 fail; 31 skipped
+
+pnpm lint                    # exit 0; baseline web warnings only
+pnpm check                   # exit 0; terminal suite 75/75
+pnpm -r --if-present run build  # exit 0
+git diff --check             # exit 0
+```
+
+Generic `pnpm test` is not the canonical gate for this public sync shape: it ran 18,760 source tests and hit 77 failures from intentionally omitted source-only governance docs/scripts. `scripts/pre-merge-check.sh` explicitly resolves this checkout to `test:public`.
+
+[宪宪/gpt-5.6-sol🐾]


### PR DESCRIPTION
## Summary

- retain a streamed Claude message ID through thinking-only, tool-only, and empty-text assistant envelopes
- clear the ID only after a non-empty text-bearing snapshot is skipped or terminal `result` is reached
- add parser lifecycle and route/persistence regressions proving live, stored, and refreshed text contain one body

This is the Claude parser half of #1272. The Codex signature half is intentionally delivered in a separate PR, so this PR uses `Refs #1272` and does not close the umbrella issue by itself.

## Root cause

After `text_delta` emitted a body, any same-ID assistant envelope deleted `partialTextMessageIds`. A thinking-only envelope therefore cleared the ID before the later text-bearing snapshot, causing the full body to be emitted and persisted again.

## Validation

- focused provider/service/route chain: 120 passed, 0 failed
- public API suite: 16,762 tests; 16,731 passed; 0 failed; 31 skipped
- `pnpm lint`: exit 0
- `pnpm check`: 75/75 terminal suite, exit 0
- recursive build: exit 0
- `git diff --check`: exit 0

Independent formal review covered exact SHA `7f15c7e5b03eb8b0381e38e4041c2556ec947e5e`: APPROVE, P1=0 / P2=0 / P3=0. Reviewer additionally replayed four historical bad archives and four same-ID multi-text-block archives; emitted characters matched `text_delta`, assistant body replay was zero, and terminal ID state was empty.

Refs #1272

[宪宪/gpt-5.6-sol🐾]

## Risk assessment

- **Behavior**: medium — changes Claude same-ID partial-text lifecycle and prevents duplicate final snapshots while retaining tool/thinking envelopes.
- **Data**: affects future user-visible persisted message content; no schema migration, backfill, deletion, or production-data rewrite.
- **Security**: no authentication, authorization, secret, network, or trust-boundary change.
- **Contract**: internal Claude provider-event parsing only; no public API or external wire-contract change.
- **Irreversibility**: none — one squash commit is revertible; no destructive data operation.
- **Gate selection**: targeted parser/service/route persistence chain plus the full public CI matrix covers the affected behavior and storage path.