### PR TITLE
fix(api): finalize one Codex signature per message

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -12,7 +12,8 @@
  *   item.completed (agent_message) → text
  *   item.completed (command_execution) → tool_result
  *   item.completed (file_change) → tool_use
- *   turn.started / turn.completed / 其余 item 事件 → 跳过
+ *   turn.started / 其余 item 事件 → 跳过
+ *   turn.completed → exactly one runtime-canonical final signature
  */
 
 import { createHash } from 'node:crypto';
@@ -20,7 +21,7 @@ import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join, parse, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { type CatId, createCatId, resolveCliEffortOverride } from '@cat-cafe/shared';
+import { type CatId, catRegistry, createCatId, resolveCliEffortOverride } from '@cat-cafe/shared';
 import { parse as parseToml } from 'smol-toml';
 import {
   resolveBinaryRoot,
@@ -324,6 +325,9 @@ function toTomlString(value: string): string {
   });
   return `"${escaped}"`;
 }
+
+const CODEX_SIGNATURE_BOUNDARY_INSTRUCTION =
+  'Codex output boundary: do not append the cat signature to commentary/progress messages; append it exactly once, only at the end of the final response.';
 
 /** Build the structured Codex reasoning-effort config argument. */
 export function buildCodexReasoningArgs(effortLevel: string): string[] {
@@ -932,7 +936,9 @@ export class CodexAgentService implements AgentService {
   ): Promise<{ value: string } | { error: string; metadata: MessageMetadata }> {
     try {
       const compiledL0 = await this.l0CompilerFn({ catId: this.catId as string, userId });
-      return { value: compiledL0 };
+      const separator = compiledL0.endsWith('\n') ? '\n' : '\n\n';
+      const providerInstructions = `${compiledL0}${separator}${CODEX_SIGNATURE_BOUNDARY_INSTRUCTION}`;
+      return { value: providerInstructions };
     } catch (err) {
       return {
         error: `L0 compile failed for ${this.catId as string}: ${(err as Error).message}`,
@@ -1439,7 +1445,17 @@ export class CodexAgentService implements AgentService {
       // bookkeeping is duplicate + drift-prone. Codex 0.98+ recovery quirks
       // (compaction retry, turn.failed then new turn.started + turn.completed)
       // are handled canonically at spawn layer via localFinalTerminal tracking.
-      const codexStreamState: CodexStreamState = { hadPriorTextTurn: false };
+      const catConfig = catRegistry.tryGet(this.catId as string)?.config;
+      const signatureIdentity = catConfig?.nickname?.trim() || catConfig?.displayName?.trim();
+      const codexStreamState: CodexStreamState = {
+        hadPriorTextTurn: false,
+        ...(signatureIdentity
+          ? {
+              signatureIdentity,
+              canonicalSignature: `[${signatureIdentity}/${effectiveModel}🐾]`,
+            }
+          : {}),
+      };
 
       for await (const event of events) {
         if (pooledSessionInUse && pooledCredentialEnv && isCodexThreadStartedEvent(event)) {

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -30,8 +30,9 @@ interface StrippedTurnSignature {
   signature?: string;
 }
 
-const BARE_LIST_SIGNATURE_PREFIX_RE = /^[ \t]{0,3}(?:[-+*]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?$/u;
-const BLOCKQUOTE_SIGNATURE_PREFIX_RE = /^[ \t]{0,3}(?:(?:[-+*]|\d+[.)])[ \t]+)*>[ \t]*/u;
+const MARKDOWN_CONTAINER_ONLY_PREFIX_RE =
+  /^[ \t]{0,3}(?:(?:(?:[-+*]|\d{1,9}[.)])[ \t]+)|(?:>[ \t]*))+(?:\[[ xX]\][ \t]+)?$/u;
+const FENCE_RUN_RE = /(`{3,}|~{3,})/u;
 
 const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/[^[\]\n]+🐾\])`?[ \t]*$/u;
 
@@ -41,17 +42,62 @@ function isOwnSignatureIdentity(candidate: string, expected: string): boolean {
   return normalizedCandidate === normalizedExpected || normalizedCandidate.endsWith(`·${normalizedExpected}`);
 }
 
+interface MarkdownFence {
+  marker: '`' | '~';
+  length: number;
+  continuationIndent: number;
+}
+
+interface MarkdownFenceLine extends MarkdownFence {
+  suffix: string;
+}
+
+function isAllowedFencePrefix(prefix: string, openFence: MarkdownFence | undefined, isContainer: boolean): boolean {
+  if (!openFence) return (/^ *$/u.test(prefix) && prefix.length <= 3) || isContainer;
+  if (prefix.includes('>') && isContainer) return true;
+  if (!/^ *$/u.test(prefix)) return false;
+  if (openFence.continuationIndent === 0) return prefix.length <= 3;
+  return prefix.length >= openFence.continuationIndent && prefix.length <= openFence.continuationIndent + 3;
+}
+
+function parseMarkdownFenceLine(line: string, openFence?: MarkdownFence): MarkdownFenceLine | undefined {
+  const match = FENCE_RUN_RE.exec(line);
+  if (!match || match.index === undefined) return undefined;
+
+  const prefix = line.slice(0, match.index);
+  const isContainerPrefix = MARKDOWN_CONTAINER_ONLY_PREFIX_RE.test(prefix);
+  if (!isAllowedFencePrefix(prefix, openFence, isContainerPrefix)) return undefined;
+
+  const run = match[0];
+  const marker = run[0];
+  if (marker !== '`' && marker !== '~') return undefined;
+  return {
+    marker,
+    length: run.length,
+    continuationIndent: isContainerPrefix ? prefix.length : 0,
+    suffix: line.slice(match.index + run.length),
+  };
+}
+
 function isInsideFencedCode(text: string, candidateIndex: number): boolean {
-  let openFence: '```' | '~~~' | undefined;
+  let openFence: MarkdownFence | undefined;
   const prefixLines = text.slice(0, candidateIndex).split(/\r?\n/);
   for (const line of prefixLines) {
-    const trimmed = line.trimStart();
     if (!openFence) {
-      if (trimmed.startsWith('```')) openFence = '```';
-      else if (trimmed.startsWith('~~~')) openFence = '~~~';
+      const opening = parseMarkdownFenceLine(line);
+      if (!opening || (opening.marker === '`' && opening.suffix.includes('`'))) continue;
+      openFence = opening;
       continue;
     }
-    if (trimmed.startsWith(openFence)) openFence = undefined;
+
+    const closing = parseMarkdownFenceLine(line, openFence);
+    if (
+      closing?.marker === openFence.marker &&
+      closing.length >= openFence.length &&
+      /^[ \t]*$/u.test(closing.suffix)
+    ) {
+      openFence = undefined;
+    }
   }
   return openFence !== undefined;
 }
@@ -59,9 +105,9 @@ function isInsideFencedCode(text: string, candidateIndex: number): boolean {
 function isMarkdownSignatureSampleContext(text: string, candidateIndex: number): boolean {
   const lineStart = text.lastIndexOf('\n', Math.max(0, candidateIndex - 1)) + 1;
   const linePrefix = text.slice(lineStart, candidateIndex);
-  if (BLOCKQUOTE_SIGNATURE_PREFIX_RE.test(linePrefix)) return true;
+  if (MARKDOWN_CONTAINER_ONLY_PREFIX_RE.test(linePrefix)) return true;
   if (/^(?: {4,}| {0,3}\t)/u.test(linePrefix)) return true;
-  return BARE_LIST_SIGNATURE_PREFIX_RE.test(linePrefix);
+  return false;
 }
 
 /**

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -34,12 +34,39 @@ const MARKDOWN_CONTAINER_ONLY_PREFIX_RE =
   /^[ \t]{0,3}(?:(?:(?:[-+*]|\d{1,9}[.)])[ \t]+)|(?:>[ \t]*))+(?:\[[ xX]\][ \t]+)?$/u;
 const FENCE_RUN_RE = /(`{3,}|~{3,})/u;
 
-const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/[^[\]\n]+🐾\])`?[ \t]*$/u;
+const PAW_SIGNATURE_RE = /^\[([^[\]/\n]+)\/([^[\]\n]+)🐾\]$/u;
+const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/([^[\]\n]+)🐾\])`?[ \t]*$/u;
 
 function isOwnSignatureIdentity(candidate: string, expected: string): boolean {
   const normalizedCandidate = candidate.trim();
   const normalizedExpected = expected.trim();
   return normalizedCandidate === normalizedExpected || normalizedCandidate.endsWith(`·${normalizedExpected}`);
+}
+
+function normalizeSignatureModel(model: string): string {
+  return model
+    .normalize('NFKC')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/gu, '');
+}
+
+function isCanonicalOwnSignature(
+  candidateIdentity: string,
+  candidateModel: string,
+  expectedIdentity: string,
+  canonicalSignature: string | undefined,
+): boolean {
+  if (!isOwnSignatureIdentity(candidateIdentity, expectedIdentity)) return false;
+  if (!canonicalSignature) return false;
+
+  const canonical = PAW_SIGNATURE_RE.exec(canonicalSignature.trim());
+  const canonicalIdentity = canonical?.[1];
+  const canonicalModel = canonical?.[2];
+  if (!canonicalIdentity || !canonicalModel || !isOwnSignatureIdentity(canonicalIdentity, expectedIdentity)) {
+    return false;
+  }
+  return normalizeSignatureModel(candidateModel) === normalizeSignatureModel(canonicalModel);
 }
 
 interface MarkdownFence {
@@ -111,16 +138,28 @@ function isMarkdownSignatureSampleContext(text: string, candidateIndex: number):
 }
 
 /**
- * Remove only this cat's signature when it is the terminal token of one complete
- * Codex `agent_message` turn. Quoted/fenced examples and teammate signatures are
- * content, not transport decoration, and must survive finalization.
+ * Remove only this cat's runtime-canonical signature when it is the terminal token
+ * of one complete Codex `agent_message` turn. Same-cat signatures for other models,
+ * quoted/fenced examples, and teammate signatures are content, not transport
+ * decoration, and must survive finalization.
  */
-function stripOwnTrailingTurnSignature(text: string, signatureIdentity: string | undefined): StrippedTurnSignature {
+function stripOwnTrailingTurnSignature(
+  text: string,
+  signatureIdentity: string | undefined,
+  canonicalSignature: string | undefined,
+): StrippedTurnSignature {
   if (!signatureIdentity) return { content: text };
   const match = TRAILING_PAW_SIGNATURE_RE.exec(text);
   if (!match || match.index === undefined) return { content: text };
   const candidateIdentity = match[2];
-  if (!candidateIdentity || !isOwnSignatureIdentity(candidateIdentity, signatureIdentity)) return { content: text };
+  const candidateModel = match[3];
+  if (
+    !candidateIdentity ||
+    !candidateModel ||
+    !isCanonicalOwnSignature(candidateIdentity, candidateModel, signatureIdentity, canonicalSignature)
+  ) {
+    return { content: text };
+  }
 
   if (isMarkdownSignatureSampleContext(text, match.index) || isInsideFencedCode(text, match.index)) {
     return { content: text };
@@ -263,7 +302,7 @@ export function transformCodexEvent(
   const item = e.item as Record<string, unknown> | undefined;
 
   if (item?.type === 'agent_message' && typeof item.text === 'string' && item.text.trim().length > 0) {
-    const stripped = stripOwnTrailingTurnSignature(item.text, state?.signatureIdentity);
+    const stripped = stripOwnTrailingTurnSignature(item.text, state?.signatureIdentity, state?.canonicalSignature);
     if (state && stripped.signature) state.observedSignature = stripped.signature;
     if (stripped.content.trim().length === 0) return null;
     const prefix = state?.hadPriorTextTurn ? '\n\n' : '';

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -31,6 +31,7 @@ interface StrippedTurnSignature {
 }
 
 const BARE_LIST_SIGNATURE_PREFIX_RE = /^[ \t]{0,3}(?:[-+*]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?$/u;
+const BLOCKQUOTE_SIGNATURE_PREFIX_RE = /^[ \t]{0,3}(?:(?:[-+*]|\d+[.)])[ \t]+)*>[ \t]*/u;
 
 const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/[^[\]\n]+🐾\])`?[ \t]*$/u;
 
@@ -58,8 +59,8 @@ function isInsideFencedCode(text: string, candidateIndex: number): boolean {
 function isMarkdownSignatureSampleContext(text: string, candidateIndex: number): boolean {
   const lineStart = text.lastIndexOf('\n', Math.max(0, candidateIndex - 1)) + 1;
   const linePrefix = text.slice(lineStart, candidateIndex);
-  if (/^[ \t]*>/u.test(linePrefix)) return true;
-  if (/^(?: {4,}|\t)/u.test(linePrefix)) return true;
+  if (BLOCKQUOTE_SIGNATURE_PREFIX_RE.test(linePrefix)) return true;
+  if (/^(?: {4,}| {0,3}\t)/u.test(linePrefix)) return true;
   return BARE_LIST_SIGNATURE_PREFIX_RE.test(linePrefix);
 }
 

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -30,6 +30,8 @@ interface StrippedTurnSignature {
   signature?: string;
 }
 
+const BARE_LIST_SIGNATURE_PREFIX_RE = /^[ \t]{0,3}(?:[-+*]|\d+[.)])[ \t]+(?:\[[ xX]\][ \t]+)?$/u;
+
 const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/[^[\]\n]+🐾\])`?[ \t]*$/u;
 
 function isOwnSignatureIdentity(candidate: string, expected: string): boolean {
@@ -53,6 +55,14 @@ function isInsideFencedCode(text: string, candidateIndex: number): boolean {
   return openFence !== undefined;
 }
 
+function isMarkdownSignatureSampleContext(text: string, candidateIndex: number): boolean {
+  const lineStart = text.lastIndexOf('\n', Math.max(0, candidateIndex - 1)) + 1;
+  const linePrefix = text.slice(lineStart, candidateIndex);
+  if (/^[ \t]*>/u.test(linePrefix)) return true;
+  if (/^(?: {4,}|\t)/u.test(linePrefix)) return true;
+  return BARE_LIST_SIGNATURE_PREFIX_RE.test(linePrefix);
+}
+
 /**
  * Remove only this cat's signature when it is the terminal token of one complete
  * Codex `agent_message` turn. Quoted/fenced examples and teammate signatures are
@@ -65,9 +75,9 @@ function stripOwnTrailingTurnSignature(text: string, signatureIdentity: string |
   const candidateIdentity = match[2];
   if (!candidateIdentity || !isOwnSignatureIdentity(candidateIdentity, signatureIdentity)) return { content: text };
 
-  const lineStart = text.lastIndexOf('\n', Math.max(0, match.index - 1)) + 1;
-  const linePrefix = text.slice(lineStart, match.index).trimStart();
-  if (linePrefix.startsWith('>') || isInsideFencedCode(text, match.index)) return { content: text };
+  if (isMarkdownSignatureSampleContext(text, match.index) || isInsideFencedCode(text, match.index)) {
+    return { content: text };
+  }
 
   return {
     content: text.slice(0, match.index).trimEnd(),

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -16,6 +16,63 @@ const MAX_BASE64_LENGTH = 5 * 1024 * 1024;
  */
 export interface CodexStreamState {
   hadPriorTextTurn: boolean;
+  /** Cat nickname/display name used to distinguish this cat's signature from quoted teammate signatures. */
+  signatureIdentity?: string;
+  /** Runtime-derived signature appended once when Codex reports `turn.completed`. */
+  canonicalSignature?: string;
+  /** Latest provider-authored own signature, used only when runtime config cannot provide one. */
+  observedSignature?: string;
+  finalSignatureEmitted?: boolean;
+}
+
+interface StrippedTurnSignature {
+  content: string;
+  signature?: string;
+}
+
+const TRAILING_PAW_SIGNATURE_RE = /`?(\[([^[\]/\n]+)\/[^[\]\n]+🐾\])`?[ \t]*$/u;
+
+function isOwnSignatureIdentity(candidate: string, expected: string): boolean {
+  const normalizedCandidate = candidate.trim();
+  const normalizedExpected = expected.trim();
+  return normalizedCandidate === normalizedExpected || normalizedCandidate.endsWith(`·${normalizedExpected}`);
+}
+
+function isInsideFencedCode(text: string, candidateIndex: number): boolean {
+  let openFence: '```' | '~~~' | undefined;
+  const prefixLines = text.slice(0, candidateIndex).split(/\r?\n/);
+  for (const line of prefixLines) {
+    const trimmed = line.trimStart();
+    if (!openFence) {
+      if (trimmed.startsWith('```')) openFence = '```';
+      else if (trimmed.startsWith('~~~')) openFence = '~~~';
+      continue;
+    }
+    if (trimmed.startsWith(openFence)) openFence = undefined;
+  }
+  return openFence !== undefined;
+}
+
+/**
+ * Remove only this cat's signature when it is the terminal token of one complete
+ * Codex `agent_message` turn. Quoted/fenced examples and teammate signatures are
+ * content, not transport decoration, and must survive finalization.
+ */
+function stripOwnTrailingTurnSignature(text: string, signatureIdentity: string | undefined): StrippedTurnSignature {
+  if (!signatureIdentity) return { content: text };
+  const match = TRAILING_PAW_SIGNATURE_RE.exec(text);
+  if (!match || match.index === undefined) return { content: text };
+  const candidateIdentity = match[2];
+  if (!candidateIdentity || !isOwnSignatureIdentity(candidateIdentity, signatureIdentity)) return { content: text };
+
+  const lineStart = text.lastIndexOf('\n', Math.max(0, match.index - 1)) + 1;
+  const linePrefix = text.slice(lineStart, match.index).trimStart();
+  if (linePrefix.startsWith('>') || isInsideFencedCode(text, match.index)) return { content: text };
+
+  return {
+    content: text.slice(0, match.index).trimEnd(),
+    signature: match[1],
+  };
 }
 
 export interface CodexEventTransformOptions {
@@ -131,17 +188,33 @@ export function transformCodexEvent(
     return null;
   }
 
+  if (e.type === 'turn.completed') {
+    if ((!state?.hadPriorTextTurn && !state?.observedSignature) || state.finalSignatureEmitted) return null;
+    const signature = state.canonicalSignature ?? state.observedSignature;
+    if (!signature) return null;
+    state.finalSignatureEmitted = true;
+    return {
+      type: 'text',
+      catId,
+      content: `\n\n${signature}`,
+      timestamp: Date.now(),
+    };
+  }
+
   if (e.type !== 'item.completed') return null;
 
   const item = e.item as Record<string, unknown> | undefined;
 
   if (item?.type === 'agent_message' && typeof item.text === 'string' && item.text.trim().length > 0) {
+    const stripped = stripOwnTrailingTurnSignature(item.text, state?.signatureIdentity);
+    if (state && stripped.signature) state.observedSignature = stripped.signature;
+    if (stripped.content.trim().length === 0) return null;
     const prefix = state?.hadPriorTextTurn ? '\n\n' : '';
     if (state) state.hadPriorTextTurn = true;
     return {
       type: 'text',
       catId,
-      content: prefix + item.text,
+      content: prefix + stripped.content,
       timestamp: Date.now(),
     };
   }

--- a/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/codex-event-transform.ts
@@ -32,6 +32,7 @@ interface StrippedTurnSignature {
 
 const MARKDOWN_CONTAINER_ONLY_PREFIX_RE =
   /^[ \t]{0,3}(?:(?:(?:[-+*]|\d{1,9}[.)])[ \t]+)|(?:>[ \t]*))+(?:\[[ xX]\][ \t]+)?$/u;
+const MARKDOWN_LEADING_CONTAINER_RE = /^[ \t]{0,3}(?:(?:(?:[-+*]|\d{1,9}[.)])[ \t]+)|(?:>[ \t]*))+/u;
 const FENCE_RUN_RE = /(`{3,}|~{3,})/u;
 
 const PAW_SIGNATURE_RE = /^\[([^[\]/\n]+)\/([^[\]\n]+)🐾\]$/u;
@@ -133,6 +134,8 @@ function isMarkdownSignatureSampleContext(text: string, candidateIndex: number):
   const lineStart = text.lastIndexOf('\n', Math.max(0, candidateIndex - 1)) + 1;
   const linePrefix = text.slice(lineStart, candidateIndex);
   if (MARKDOWN_CONTAINER_ONLY_PREFIX_RE.test(linePrefix)) return true;
+  const leadingContainers = MARKDOWN_LEADING_CONTAINER_RE.exec(linePrefix);
+  if (leadingContainers?.[0].includes('>')) return true;
   if (/^(?: {4,}| {0,3}\t)/u.test(linePrefix)) return true;
   return false;
 }

--- a/packages/api/test/codex-agent-service-l0.test.js
+++ b/packages/api/test/codex-agent-service-l0.test.js
@@ -123,7 +123,8 @@ test('Task 4: codex argv carries -c developer_instructions=<compiled L0>', async
 
   const args = spawnFn.mock.calls[0].arguments[1];
   assert.ok(args.includes('--config'), 'argv must include --config');
-  assertCompiledL0Preserved(args, 'DEV-L0-BODY');
+  const developerInstructions = assertCompiledL0Preserved(args, 'DEV-L0-BODY');
+  assert.match(developerInstructions, /do not append the cat signature to commentary\/progress messages/);
 });
 
 test('P0 security: prompt 正文走 stdin 不进 argv（ps -o command= 跨进程泄露防护）', async () => {

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -319,13 +319,15 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
 
     const msgs = await promise;
 
-    assert.equal(msgs.length, 3);
+    assert.equal(msgs.length, 4);
     assert.equal(msgs[0].type, 'session_init');
     assert.equal(msgs[0].sessionId, 'thread-abc');
     assert.equal(msgs[0].catId, 'codex');
     assert.equal(msgs[1].type, 'text');
     assert.equal(msgs[1].content, 'Hello from Codex!');
-    assert.equal(msgs[2].type, 'done');
+    assert.equal(msgs[2].type, 'text');
+    assert.equal(msgs[2].content, '\n\n[砚砚/gpt-5.3-codex🐾]');
+    assert.equal(msgs[3].type, 'done');
   });
 
   test('uses exec resume when sessionId is provided', async () => {
@@ -2426,6 +2428,33 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     assert.equal(textMsgs[1].content, '\n\nSecond message');
   });
 
+  test('#1272: service strips per-message signatures and emits one runtime-canonical signature', async () => {
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn, model: 'gpt-5.6-sol' });
+
+    const promise = collect(service.invoke('Signed multi-turn'));
+    emitCodexEvents(proc, [
+      { type: 'thread.started', thread_id: 'thread-1272-signed' },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-1', type: 'agent_message', text: '第一段。 `[砚砚/GPT-5.6 Sol🐾]`' },
+      },
+      {
+        type: 'item.completed',
+        item: { id: 'msg-2', type: 'agent_message', text: '第二段。\n\n[砚砚/GPT-5.6 Sol🐾]' },
+      },
+      { type: 'turn.completed', usage: { input_tokens: 10, output_tokens: 20 } },
+    ]);
+
+    const msgs = await promise;
+    const textMsgs = msgs.filter((msg) => msg.type === 'text');
+    assert.deepEqual(
+      textMsgs.map((msg) => msg.content),
+      ['第一段。', '\n\n第二段。', '\n\n[砚砚/gpt-5.6-sol🐾]'],
+    );
+  });
+
   test('separates multi-turn text with paragraph breaks (turn newline fix)', async () => {
     const proc = createMockProcess();
     const spawnFn = createMockSpawnFn(proc);
@@ -2993,7 +3022,7 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
-  test('ignores turn.started and turn.completed control events', async () => {
+  test('ignores turn.started/unknown controls and uses turn.completed only to finalize the signature', async () => {
     const proc = createMockProcess();
     const spawnFn = createMockSpawnFn(proc);
     const service = new CodexAgentService({ l0CompilerFn: fakeL0Compiler, spawnFn });
@@ -3013,12 +3042,14 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     ]);
 
     const msgs = await promise;
-    // Only session_init, text, done — all control/unknown events skipped
-    assert.equal(msgs.length, 3);
+    // turn.completed remains non-UI control except for the one deterministic final signature chunk.
+    assert.equal(msgs.length, 4);
     assert.equal(msgs[0].type, 'session_init');
     assert.equal(msgs[1].type, 'text');
     assert.equal(msgs[1].content, 'Hello');
-    assert.equal(msgs[2].type, 'done');
+    assert.equal(msgs[2].type, 'text');
+    assert.equal(msgs[2].content, '\n\n[砚砚/gpt-5.3-codex🐾]');
+    assert.equal(msgs[3].type, 'done');
   });
 
   test('maps command execution lifecycle into tool_use and tool_result', async () => {

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -608,15 +608,15 @@ test('#1272: Codex finalization preserves quoted, fenced, and other-cat signatur
   };
   const textWithExamples = [
     '引用保持：',
-    '> [砚砚/example-model🐾]',
+    '> [砚砚/GPT-5.6 Sol🐾]',
     '',
     '```text',
-    '[砚砚/example-model🐾]',
+    '[砚砚/GPT-5.6 Sol🐾]',
     '```',
     '',
     '另一只猫：[宪宪/claude-opus-4-8🐾]',
     '',
-    '[砚砚/raw-model-name🐾]',
+    '[砚砚/GPT-5.6 Sol🐾]',
   ].join('\n');
 
   const first = transformCodexEvent(
@@ -635,10 +635,10 @@ test('#1272: Codex finalization preserves quoted, fenced, and other-cat signatur
     text,
     [
       '引用保持：',
-      '> [砚砚/example-model🐾]',
+      '> [砚砚/GPT-5.6 Sol🐾]',
       '',
       '```text',
-      '[砚砚/example-model🐾]',
+      '[砚砚/GPT-5.6 Sol🐾]',
       '```',
       '',
       '另一只猫：[宪宪/claude-opus-4-8🐾]',
@@ -673,7 +673,7 @@ test('#1272: a signature-only provider turn still finalizes to one canonical sig
     canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
   };
   const body = transformCodexEvent(
-    { type: 'item.completed', item: { type: 'agent_message', text: '[砚砚/raw-model🐾]' } },
+    { type: 'item.completed', item: { type: 'agent_message', text: '[砚砚/GPT-5.6 Sol🐾]' } },
     CAT,
     state,
   );
@@ -727,17 +727,41 @@ test('#1272: terminal teammate and legacy signatures remain content beside one c
   );
 });
 
+test('#1272 cloud P1: non-canonical same-cat signature samples remain user content', () => {
+  const samples = [
+    '> 引用签名：[砚砚/example-model🐾]',
+    '- 示例签名：[砚砚/example-model🐾]',
+    '正文签名样例：[砚砚/example-model🐾]',
+  ];
+
+  for (const sample of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      { type: 'item.completed', item: { type: 'agent_message', text: sample } },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
+});
+
 test('#1272 review P2: indented code and bare list signature samples remain content', () => {
   const samples = [
-    '缩进代码：\n\n    [砚砚/example-model🐾]',
-    '制表符代码：\n\n\t[砚砚/example-model🐾]',
-    '一空格加制表符代码：\n\n \t[砚砚/example-model🐾]',
-    '三空格加制表符代码：\n\n   \t[砚砚/example-model🐾]',
-    '无序列表：\n\n- `[砚砚/example-model🐾]`',
-    '有序列表：\n\n1. [砚砚/example-model🐾]',
-    '任务列表：\n\n- [ ] [砚砚/example-model🐾]',
-    '列表内引用：\n\n- > [砚砚/example-model🐾]',
-    '有序列表内引用：\n\n1. > `[砚砚/example-model🐾]`',
+    '缩进代码：\n\n    [砚砚/GPT-5.6 Sol🐾]',
+    '制表符代码：\n\n\t[砚砚/GPT-5.6 Sol🐾]',
+    '一空格加制表符代码：\n\n \t[砚砚/GPT-5.6 Sol🐾]',
+    '三空格加制表符代码：\n\n   \t[砚砚/GPT-5.6 Sol🐾]',
+    '无序列表：\n\n- `[砚砚/GPT-5.6 Sol🐾]`',
+    '有序列表：\n\n1. [砚砚/GPT-5.6 Sol🐾]',
+    '任务列表：\n\n- [ ] [砚砚/GPT-5.6 Sol🐾]',
+    '列表内引用：\n\n- > [砚砚/GPT-5.6 Sol🐾]',
+    '有序列表内引用：\n\n1. > `[砚砚/GPT-5.6 Sol🐾]`',
   ];
 
   for (const sample of samples) {
@@ -766,7 +790,7 @@ test('#1272 review P2 negative control: list progress still strips its own termi
   const body = transformCodexEvent(
     {
       type: 'item.completed',
-      item: { type: 'agent_message', text: '- 正在检查。 `[砚砚/raw-model🐾]`' },
+      item: { type: 'agent_message', text: '- 正在检查。 `[砚砚/GPT-5.6 Sol🐾]`' },
     },
     CAT,
     state,
@@ -778,13 +802,13 @@ test('#1272 review P2 negative control: list progress still strips its own termi
 
 test('#1272 cloud P1: open fences and nested bare lists preserve terminal signature samples', () => {
   const samples = [
-    '反引号伪关闭：\n\n```text\n```not-a-close\n[砚砚/example-model🐾]',
-    '较短反引号：\n\n````text\n```\n[砚砚/example-model🐾]',
-    '较短波浪线：\n\n~~~~text\n~~~\n[砚砚/example-model🐾]',
-    '不同 closing marker：\n\n```text\n~~~\n[砚砚/example-model🐾]',
-    '嵌套无序列表：\n\n- - [砚砚/example-model🐾]',
-    '嵌套有序任务列表：\n\n1. - [ ] `[砚砚/example-model🐾]`',
-    '列表内开放 fence：\n\n- ````text\n  ```not-a-close\n  [砚砚/example-model🐾]',
+    '反引号伪关闭：\n\n```text\n```not-a-close\n[砚砚/GPT-5.6 Sol🐾]',
+    '较短反引号：\n\n````text\n```\n[砚砚/GPT-5.6 Sol🐾]',
+    '较短波浪线：\n\n~~~~text\n~~~\n[砚砚/GPT-5.6 Sol🐾]',
+    '不同 closing marker：\n\n```text\n~~~\n[砚砚/GPT-5.6 Sol🐾]',
+    '嵌套无序列表：\n\n- - [砚砚/GPT-5.6 Sol🐾]',
+    '嵌套有序任务列表：\n\n1. - [ ] `[砚砚/GPT-5.6 Sol🐾]`',
+    '列表内开放 fence：\n\n- ````text\n  ```not-a-close\n  [砚砚/GPT-5.6 Sol🐾]',
   ];
 
   for (const sample of samples) {
@@ -821,7 +845,7 @@ test('#1272 cloud P1 negative control: legal fence closes before a decorative si
     const body = transformCodexEvent(
       {
         type: 'item.completed',
-        item: { type: 'agent_message', text: `${sample}\n[砚砚/raw-model🐾]` },
+        item: { type: 'agent_message', text: `${sample}\n[砚砚/GPT-5.6 Sol🐾]` },
       },
       CAT,
       state,

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -776,6 +776,62 @@ test('#1272 review P2 negative control: list progress still strips its own termi
   assert.equal(`${body?.content}${done?.content}`, '- 正在检查。\n\n[砚砚/gpt-5.6-sol🐾]');
 });
 
+test('#1272 cloud P1: open fences and nested bare lists preserve terminal signature samples', () => {
+  const samples = [
+    '反引号伪关闭：\n\n```text\n```not-a-close\n[砚砚/example-model🐾]',
+    '较短反引号：\n\n````text\n```\n[砚砚/example-model🐾]',
+    '较短波浪线：\n\n~~~~text\n~~~\n[砚砚/example-model🐾]',
+    '不同 closing marker：\n\n```text\n~~~\n[砚砚/example-model🐾]',
+    '嵌套无序列表：\n\n- - [砚砚/example-model🐾]',
+    '嵌套有序任务列表：\n\n1. - [ ] `[砚砚/example-model🐾]`',
+    '列表内开放 fence：\n\n- ````text\n  ```not-a-close\n  [砚砚/example-model🐾]',
+  ];
+
+  for (const sample of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      { type: 'item.completed', item: { type: 'agent_message', text: sample } },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
+});
+
+test('#1272 cloud P1 negative control: legal fence closes before a decorative signature', () => {
+  const samples = [
+    '````text\n正文\n`````',
+    '- ````text\n  正文\n  ````',
+    '~~~~text\n正文\n~~~~',
+    '```invalid`info\n正文',
+  ];
+
+  for (const sample of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      {
+        type: 'item.completed',
+        item: { type: 'agent_message', text: `${sample}\n[砚砚/raw-model🐾]` },
+      },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
+});
+
 test('mcp_tool_call mixed valid/invalid images → only valid included', () => {
   const event = {
     type: 'item.completed',

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -731,9 +731,13 @@ test('#1272 review P2: indented code and bare list signature samples remain cont
   const samples = [
     '缩进代码：\n\n    [砚砚/example-model🐾]',
     '制表符代码：\n\n\t[砚砚/example-model🐾]',
+    '一空格加制表符代码：\n\n \t[砚砚/example-model🐾]',
+    '三空格加制表符代码：\n\n   \t[砚砚/example-model🐾]',
     '无序列表：\n\n- `[砚砚/example-model🐾]`',
     '有序列表：\n\n1. [砚砚/example-model🐾]',
     '任务列表：\n\n- [ ] [砚砚/example-model🐾]',
+    '列表内引用：\n\n- > [砚砚/example-model🐾]',
+    '有序列表内引用：\n\n1. > `[砚砚/example-model🐾]`',
   ];
 
   for (const sample of samples) {
@@ -751,6 +755,25 @@ test('#1272 review P2: indented code and bare list signature samples remain cont
 
     assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
   }
+});
+
+test('#1272 review P2 negative control: list progress still strips its own terminal signature', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const body = transformCodexEvent(
+    {
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '- 正在检查。 `[砚砚/raw-model🐾]`' },
+    },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+  assert.equal(`${body?.content}${done?.content}`, '- 正在检查。\n\n[砚砚/gpt-5.6-sol🐾]');
 });
 
 test('mcp_tool_call mixed valid/invalid images → only valid included', () => {

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -727,6 +727,32 @@ test('#1272: terminal teammate and legacy signatures remain content beside one c
   );
 });
 
+test('#1272 review P2: indented code and bare list signature samples remain content', () => {
+  const samples = [
+    '缩进代码：\n\n    [砚砚/example-model🐾]',
+    '制表符代码：\n\n\t[砚砚/example-model🐾]',
+    '无序列表：\n\n- `[砚砚/example-model🐾]`',
+    '有序列表：\n\n1. [砚砚/example-model🐾]',
+    '任务列表：\n\n- [ ] [砚砚/example-model🐾]',
+  ];
+
+  for (const sample of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      { type: 'item.completed', item: { type: 'agent_message', text: sample } },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
+});
+
 test('mcp_tool_call mixed valid/invalid images → only valid included', () => {
   const event = {
     type: 'item.completed',

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -751,6 +751,33 @@ test('#1272 cloud P1: non-canonical same-cat signature samples remain user conte
   }
 });
 
+test('#1272 cloud P1: canonical signature samples remain content inside prose blockquotes', () => {
+  const samples = [
+    '> 引用签名：[砚砚/GPT-5.6 Sol🐾]',
+    '- > 引用签名：[砚砚/GPT-5.6 Sol🐾]',
+    '1. > 有序列表引用：[砚砚/GPT-5.6 Sol🐾]',
+    '> > 嵌套引用：[砚砚/GPT-5.6 Sol🐾]',
+    '> - 引用内列表：[砚砚/GPT-5.6 Sol🐾]',
+    '- - > 嵌套列表引用：[砚砚/GPT-5.6 Sol🐾]',
+  ];
+
+  for (const sample of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      { type: 'item.completed', item: { type: 'agent_message', text: sample } },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${sample}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
+});
+
 test('#1272 review P2: indented code and bare list signature samples remain content', () => {
   const samples = [
     '缩进代码：\n\n    [砚砚/GPT-5.6 Sol🐾]',
@@ -781,23 +808,28 @@ test('#1272 review P2: indented code and bare list signature samples remain cont
   }
 });
 
-test('#1272 review P2 negative control: list progress still strips its own terminal signature', () => {
-  const state = {
-    hadPriorTextTurn: false,
-    signatureIdentity: '砚砚',
-    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
-  };
-  const body = transformCodexEvent(
-    {
-      type: 'item.completed',
-      item: { type: 'agent_message', text: '- 正在检查。 `[砚砚/GPT-5.6 Sol🐾]`' },
-    },
-    CAT,
-    state,
-  );
-  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+test('#1272 review P2 negative control: ordinary prose/list progress still strips its own terminal signature', () => {
+  const samples = [
+    ['- 正在检查。 `[砚砚/GPT-5.6 Sol🐾]`', '- 正在检查。'],
+    ['正文比较 A > B。 `[砚砚/GPT-5.6 Sol🐾]`', '正文比较 A > B。'],
+    ['- 正文比较 A > B。 `[砚砚/GPT-5.6 Sol🐾]`', '- 正文比较 A > B。'],
+  ];
 
-  assert.equal(`${body?.content}${done?.content}`, '- 正在检查。\n\n[砚砚/gpt-5.6-sol🐾]');
+  for (const [sample, expectedBody] of samples) {
+    const state = {
+      hadPriorTextTurn: false,
+      signatureIdentity: '砚砚',
+      canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+    };
+    const body = transformCodexEvent(
+      { type: 'item.completed', item: { type: 'agent_message', text: sample } },
+      CAT,
+      state,
+    );
+    const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+    assert.equal(`${body?.content}${done?.content}`, `${expectedBody}\n\n[砚砚/gpt-5.6-sol🐾]`);
+  }
 });
 
 test('#1272 cloud P1: open fences and nested bare lists preserve terminal signature samples', () => {

--- a/packages/api/test/codex-event-transform.test.js
+++ b/packages/api/test/codex-event-transform.test.js
@@ -569,6 +569,164 @@ test('item.completed agent_message with empty text after prior turn → null (no
   assert.equal(msg, null, 'empty text after prior turn should not produce newline content');
 });
 
+test('#1272: completed Codex turns keep all prose but emit one canonical final signature', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const events = [
+    {
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '第一段进度。 `[砚砚/GPT-5.6 Sol🐾]`' },
+    },
+    {
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '第二段进度。\n\n[砚砚/gpt-5.6-sol🐾]' },
+    },
+    { type: 'turn.completed', usage: {} },
+  ];
+
+  const text = events
+    .flatMap((event) => {
+      const result = transformCodexEvent(event, CAT, state);
+      if (result === null) return [];
+      return Array.isArray(result) ? result : [result];
+    })
+    .filter((msg) => msg.type === 'text')
+    .map((msg) => msg.content)
+    .join('');
+
+  assert.equal(text, '第一段进度。\n\n第二段进度。\n\n[砚砚/gpt-5.6-sol🐾]');
+});
+
+test('#1272: Codex finalization preserves quoted, fenced, and other-cat signature-like text', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const textWithExamples = [
+    '引用保持：',
+    '> [砚砚/example-model🐾]',
+    '',
+    '```text',
+    '[砚砚/example-model🐾]',
+    '```',
+    '',
+    '另一只猫：[宪宪/claude-opus-4-8🐾]',
+    '',
+    '[砚砚/raw-model-name🐾]',
+  ].join('\n');
+
+  const first = transformCodexEvent(
+    { type: 'item.completed', item: { type: 'agent_message', text: textWithExamples } },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+  const text = [first, done]
+    .flatMap((result) => (result === null ? [] : Array.isArray(result) ? result : [result]))
+    .filter((msg) => msg.type === 'text')
+    .map((msg) => msg.content)
+    .join('');
+
+  assert.equal(
+    text,
+    [
+      '引用保持：',
+      '> [砚砚/example-model🐾]',
+      '',
+      '```text',
+      '[砚砚/example-model🐾]',
+      '```',
+      '',
+      '另一只猫：[宪宪/claude-opus-4-8🐾]',
+      '',
+      '[砚砚/gpt-5.6-sol🐾]',
+    ].join('\n'),
+  );
+});
+
+test('#1272: unsigned Codex content receives one canonical signature at turn completion', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const body = transformCodexEvent(
+    { type: 'item.completed', item: { type: 'agent_message', text: '只有正文。' } },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+  assert.equal(body?.content, '只有正文。');
+  assert.equal(done?.type, 'text');
+  assert.equal(done?.content, '\n\n[砚砚/gpt-5.6-sol🐾]');
+});
+
+test('#1272: a signature-only provider turn still finalizes to one canonical signature', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const body = transformCodexEvent(
+    { type: 'item.completed', item: { type: 'agent_message', text: '[砚砚/raw-model🐾]' } },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+  assert.equal(body, null);
+  assert.equal(done?.content, '\n\n[砚砚/gpt-5.6-sol🐾]');
+});
+
+test('#1272: one already-canonical Codex turn is byte-stable after finalization', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const original = '单回合正文。\n\n[砚砚/gpt-5.6-sol🐾]';
+  const body = transformCodexEvent(
+    { type: 'item.completed', item: { type: 'agent_message', text: original } },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+  assert.equal(`${body?.content}${done?.content}`, original);
+});
+
+test('#1272: terminal teammate and legacy signatures remain content beside one canonical signature', () => {
+  const state = {
+    hadPriorTextTurn: false,
+    signatureIdentity: '砚砚',
+    canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+  };
+  const teammate = transformCodexEvent(
+    {
+      type: 'item.completed',
+      item: { type: 'agent_message', text: '引用另一只猫的签名： [宪宪/claude-opus-4-8🐾]' },
+    },
+    CAT,
+    state,
+  );
+  const legacy = transformCodexEvent(
+    { type: 'item.completed', item: { type: 'agent_message', text: '保留 legacy： [砚砚/Codex]' } },
+    CAT,
+    state,
+  );
+  const done = transformCodexEvent({ type: 'turn.completed', usage: {} }, CAT, state);
+
+  assert.equal(
+    `${teammate?.content}${legacy?.content}${done?.content}`,
+    '引用另一只猫的签名： [宪宪/claude-opus-4-8🐾]\n\n保留 legacy： [砚砚/Codex]\n\n[砚砚/gpt-5.6-sol🐾]',
+  );
+});
+
 test('mcp_tool_call mixed valid/invalid images → only valid included', () => {
   const event = {
     type: 'item.completed',

--- a/packages/api/test/issue-1272-codex-route-persistence.test.js
+++ b/packages/api/test/issue-1272-codex-route-persistence.test.js
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+const CAT = 'codex';
+
+function createCodexEventService(transformCodexEvent) {
+  return {
+    async *invoke() {
+      const state = {
+        hadPriorTextTurn: false,
+        signatureIdentity: '砚砚',
+        canonicalSignature: '[砚砚/gpt-5.6-sol🐾]',
+      };
+      const events = [
+        ...Array.from({ length: 16 }, (_, index) => ({
+          type: 'item.completed',
+          item: {
+            type: 'agent_message',
+            text: `第 ${index + 1} 段不同进度。 \`[砚砚/gpt-5.6-sol🐾]\``,
+          },
+        })),
+        { type: 'turn.completed', usage: {} },
+      ];
+      for (const event of events) {
+        const result = transformCodexEvent(event, CAT, state);
+        if (result === null) continue;
+        for (const msg of Array.isArray(result) ? result : [result]) yield msg;
+      }
+      yield { type: 'done', catId: CAT, timestamp: Date.now() };
+    },
+  };
+}
+
+function createMockDeps(service, appendCalls) {
+  let messageSeq = 0;
+  const storedById = new Map();
+  return {
+    services: { [CAT]: service },
+    invocationDeps: {
+      registry: {
+        create: () => ({ invocationId: 'inv-1272-codex', callbackToken: 'tok-1272-codex' }),
+        verify: async () => ({ ok: false, reason: 'unknown_invocation' }),
+      },
+      sessionManager: {
+        get: async () => null,
+        getOrCreate: async () => ({}),
+        resolveWorkingDirectory: () => '/tmp/test',
+      },
+      threadStore: null,
+      apiUrl: 'http://127.0.0.1:3004',
+    },
+    messageStore: {
+      append: async (input) => {
+        const stored = { id: `msg-${++messageSeq}`, ...input, threadId: input.threadId ?? 'thread-1272' };
+        appendCalls.push(input);
+        storedById.set(stored.id, stored);
+        return stored;
+      },
+      getById: async (id) => storedById.get(id) ?? null,
+      getRecent: () => [],
+      getMentionsFor: () => [],
+      getRecentMentionsFor: () => [],
+    },
+  };
+}
+
+test('#1272: Codex live final text and refreshed persisted message contain one signature', async () => {
+  const { transformCodexEvent } = await import(
+    '../dist/domains/cats/services/agents/providers/codex-event-transform.js'
+  );
+  const { routeSerial } = await import('../dist/domains/cats/services/agents/routing/route-serial.js');
+  const appendCalls = [];
+  const deps = createMockDeps(createCodexEventService(transformCodexEvent), appendCalls);
+
+  const yielded = [];
+  for await (const msg of routeSerial(deps, [CAT], '排查重复回复', 'user-1272', 'thread-1272')) {
+    yielded.push(msg);
+  }
+
+  assert.equal(appendCalls.length, 1, 'route persists one cat message');
+  const expected = `${Array.from({ length: 16 }, (_, index) => `第 ${index + 1} 段不同进度。`).join(
+    '\n\n',
+  )}\n\n[砚砚/gpt-5.6-sol🐾]`;
+  assert.equal(appendCalls[0].content, expected);
+
+  const liveText = yielded
+    .filter((msg) => msg.type === 'text' && msg.catId === CAT)
+    .map((msg) => msg.content)
+    .join('');
+  assert.equal(liveText, expected, 'live accumulated content matches the finalized message');
+
+  const refreshed = await deps.messageStore.getById('msg-1');
+  assert.equal(refreshed?.content, expected, 'F5/read path returns exactly the stored finalized content');
+});

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -1,0 +1,102 @@
+# Review Request: #1272 Codex persisted-message signature finalization
+
+Review-Target-ID: `fix-1272-codex-signature-finalization`
+Branch: `fix/1272-codex-signature-finalization`
+Base: `origin/main@041190ca7aec0500ff84160db54bb78ce719661b`
+Reviewer: `@砚砚`
+
+## What
+
+- Preserve every Codex `agent_message` body while stripping only this cat's terminal paw signature from each provider turn.
+- Emit one runtime-derived canonical `[nickname/effectiveModel🐾]` signature at `turn.completed`.
+- Tighten Codex developer instructions so commentary/progress turns do not sign themselves.
+- Add provider, service-wiring, prompt-carrier, and 16-turn route/persistence regressions.
+
+## Why
+
+Codex emits multiple complete progress/final text turns, while `route-serial` appends them into one persisted message. L0 made each provider turn independently sign itself, so one refreshed bubble could contain 3–16 signatures even though no event was replayed.
+
+## Original Requirements
+
+> “按回复拆分PR来修复问题，用adaptive_development sop来修复”
+
+- Source: current collaboration thread; accepted bug contract and maintainer disposition: <https://github.com/zts212653/clowder-ai/issues/1272>.
+- Please judge the delivery against #1272's Codex acceptance tests and its prohibition on general prose/full-text deduplication.
+
+## Tradeoff
+
+- Finalization is append-only at the provider turn boundary; it does not switch live text aggregation to replace mode or scan/deduplicate arbitrary prose.
+- Only the current cat's terminal paw signature is stripped. Quoted/fenced examples, teammate signatures, and legacy un-pawed shapes remain content; one canonical current-cat signature is then appended.
+- No independent fresh-context pre-scan was claimed: this author session participated in implementation. The named peer review below remains the sole approval source.
+
+## Architecture Ownership
+
+Architecture cell: `bubble-pipeline`
+Map delta: `none`
+Why: this narrows an existing provider finalization boundary and persisted-text invariant; it adds no Store, Queue, Router, Adapter, Dispatcher, Binding, bubble identity, or write entrance.
+
+## Open Questions
+
+### Technical OQ
+
+1. Is terminal-signature recognition narrow enough for inline/backtick progress tails while preserving quoted, fenced, teammate, and legacy content?
+2. Is `turn.completed` the correct one-shot boundary for a canonical signature across success, usage capture, and signature-only provider output?
+3. Does deriving identity from runtime `catRegistry` and model from `effectiveModel` preserve per-cat/model override correctness?
+
+### Value OQ
+
+None.
+
+## Next Action
+
+Please review the exact branch HEAD supplied in the current-thread handoff. Give every finding P1/P2/P3 and a clear disposition; if no P1/P2 remains, state `APPROVE` with the full SHA.
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`
+- Checkout: detached exact SHA from handoff
+- Start Command: not needed; backend provider/parser tests only
+- Ports: none
+
+Bootstrap:
+
+```bash
+unset NODE_ENV
+pnpm install --frozen-lockfile
+pnpm --filter @cat-cafe/shared build
+pnpm --filter @cat-cafe/api run build
+```
+
+## Quality Gate Evidence
+
+- Spec: accepted #1272 maintainer comment at `main@041190ca7aec0500ff84160db54bb78ce719661b`; split delivery explicitly authorized.
+- Requirements: all 16 distinct bodies retained; one canonical final signature; single-turn byte stability; quoted/fenced/teammate/legacy preservation; route persistence equals refreshed read.
+- Dogfood path: real built `transformCodexEvent` → `routeSerial` → one `messageStore.append` → `getById`, using 16 distinct signed provider turns; live, stored, and refreshed text are identical.
+- Design: no UI changes; no matching `.pen` file.
+- Artifact hygiene: no root media/design artifacts.
+- Architecture scan: `Map delta: none`; no new architecture nouns or parallel ownership surface.
+- Public checkout does not export `check-hotfix-pattern`, `check-fallback-layers`, or `check:architecture-ownership`; these were reported unavailable, not claimed green. Manual diff scan found no fallback stack.
+
+Validation:
+
+```bash
+# focused provider/service/route chain
+node --import ./packages/api/test/helpers/setup-cat-registry.js --test \
+  packages/api/test/codex-event-transform.test.js \
+  packages/api/test/codex-agent-service.test.js \
+  packages/api/test/codex-agent-service-l0.test.js \
+  packages/api/test/issue-1272-codex-route-persistence.test.js
+# 113 passed, 0 failed
+
+pnpm --filter @cat-cafe/api run test:public
+# 16,763 tests; 16,732 pass; 0 fail; 31 skipped
+
+pnpm lint                    # exit 0; baseline web warnings only
+pnpm check                   # exit 0; terminal suite 75/75
+pnpm -r --if-present run build  # exit 0
+git diff --check             # exit 0
+```
+
+Generic `pnpm test` is not the canonical gate for this public sync shape: it ran 18,761 source tests and hit 82 failures from intentionally omitted source-only governance docs/scripts. `scripts/pre-merge-check.sh` explicitly resolves this checkout to `test:public`.
+
+[宪宪/gpt-5.6-sol🐾]

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -57,6 +57,13 @@ Please review the exact branch HEAD supplied in the current-thread handoff. Give
 - Red→Green: the new structure-preservation test failed on the indented-code sample (`42 pass / 1 fail`) before the fix and passes after it in the 114-test focused chain.
 - P3 disposition: no abnormal-termination fallback was added. Without a proven `turn.completed` boundary, appending a signature would also alter timeout/error/cancel reply semantics; #1272 does not define that failure-state contract. This remains a disclosed non-blocking risk rather than an unverified fallback layer.
 
+## Review Round 2 Repair
+
+- P2 fixed: CommonMark indented-code prefixes containing one to three spaces followed by a Tab are preserved, as are signature samples inside list-contained blockquotes such as `- >` and `1. >`.
+- Forced same-type sweep: plain/list-contained blockquotes, fenced code, four-space/pure-Tab/mixed-space-Tab indented code, and bare unordered/ordered/task-list samples all remain content. A signature after actual list prose remains decorative and is still stripped.
+- Red→Green: the expanded structure-preservation test failed before the fix (`43 pass / 1 fail`), while its list-prose negative control already passed. After the fix, the complete focused provider/service/route chain passes `115 / 115`.
+- P3 disposition is unchanged from Round 1; no abnormal-termination semantics were added.
+
 ## Review Sandbox
 
 - Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`
@@ -92,7 +99,7 @@ node --import ./packages/api/test/helpers/setup-cat-registry.js --test \
   packages/api/test/codex-agent-service.test.js \
   packages/api/test/codex-agent-service-l0.test.js \
   packages/api/test/issue-1272-codex-route-persistence.test.js
-# 114 passed, 0 failed
+# 115 passed, 0 failed
 
 pnpm --filter @cat-cafe/api run test:public
 # 16,763 tests; 16,732 pass; 0 fail; 31 skipped

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -51,6 +51,12 @@ None.
 
 Please review the exact branch HEAD supplied in the current-thread handoff. Give every finding P1/P2/P3 and a clear disposition; if no P1/P2 remains, state `APPROVE` with the full SHA.
 
+## Review Round 1 Repair
+
+- P2 fixed: terminal own-signature samples inside four-space/Tab indented code and bare unordered, ordered, or task-list items are now preserved as content. The finalizer still strips a signature after actual prose, so the 16-turn progress path remains unchanged.
+- Red→Green: the new structure-preservation test failed on the indented-code sample (`42 pass / 1 fail`) before the fix and passes after it in the 114-test focused chain.
+- P3 disposition: no abnormal-termination fallback was added. Without a proven `turn.completed` boundary, appending a signature would also alter timeout/error/cancel reply semantics; #1272 does not define that failure-state contract. This remains a disclosed non-blocking risk rather than an unverified fallback layer.
+
 ## Review Sandbox
 
 - Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`
@@ -86,7 +92,7 @@ node --import ./packages/api/test/helpers/setup-cat-registry.js --test \
   packages/api/test/codex-agent-service.test.js \
   packages/api/test/codex-agent-service-l0.test.js \
   packages/api/test/issue-1272-codex-route-persistence.test.js
-# 113 passed, 0 failed
+# 114 passed, 0 failed
 
 pnpm --filter @cat-cafe/api run test:public
 # 16,763 tests; 16,732 pass; 0 fail; 31 skipped

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -64,6 +64,14 @@ Please review the exact branch HEAD supplied in the current-thread handoff. Give
 - Red→Green: the expanded structure-preservation test failed before the fix (`43 pass / 1 fail`), while its list-prose negative control already passed. After the fix, the complete focused provider/service/route chain passes `115 / 115`.
 - P3 disposition is unchanged from Round 1; no abnormal-termination semantics were added.
 
+## Cloud Review P1 Repair
+
+- Verified against exact reviewed SHA `3a028e8b18cb9ce7bbd71b16d9bd6bb159836636`: a fence line with trailing text, a shorter same-character run, and a nested bare-list signature sample all lost user-visible content.
+- Red→Green: the cloud reproductions plus the same-family legal-close negative control failed before the fix (`44 pass / 2 fail`). The final focused provider/service/route chain passes `117 / 117`.
+- Failure-mode audit invariant: an open fence closes only on the same marker character, with a run at least as long as the opener and a whitespace-only suffix. The sweep covers backtick/tilde markers, shorter/different/invalid closers, longer legal closers, nested-list continuation indentation, invalid backtick info strings, nested bare lists, and the existing prose/list decoration negatives.
+- Coordinate correction: the prior `startsWith` toggling and separate one-marker list regexes were replaced by one explicit fence-state scanner plus one container-only prefix invariant. No Markdown dependency or fallback stack was added. The public checkout does not export `check-fallback-layers`; manual analysis found one fence state and zero fallback layers.
+- P3 disposition is unchanged from Round 1; no abnormal-termination semantics were added.
+
 ## Review Sandbox
 
 - Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`
@@ -99,7 +107,7 @@ node --import ./packages/api/test/helpers/setup-cat-registry.js --test \
   packages/api/test/codex-agent-service.test.js \
   packages/api/test/codex-agent-service-l0.test.js \
   packages/api/test/issue-1272-codex-route-persistence.test.js
-# 115 passed, 0 failed
+# 117 passed, 0 failed
 
 pnpm --filter @cat-cafe/api run test:public
 # 16,763 tests; 16,732 pass; 0 fail; 31 skipped

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -72,6 +72,41 @@ Please review the exact branch HEAD supplied in the current-thread handoff. Give
 - Coordinate correction: the prior `startsWith` toggling and separate one-marker list regexes were replaced by one explicit fence-state scanner plus one container-only prefix invariant. No Markdown dependency or fallback stack was added. The public checkout does not export `check-fallback-layers`; manual analysis found one fence state and zero fallback layers.
 - P3 disposition is unchanged from Round 1; no abnormal-termination semantics were added.
 
+## Review Round 4 Repair
+
+- Reviewed-state grounding: the outstanding P1 was verified against reviewed SHA
+  `6b536631ccecae51c7b49f32782dbdb90680b810`. The branch was then fast-forwarded to
+  GitHub's signed merge SHA `050b52d0d989567b1b61584e012946c0bdf8591c` (base
+  `f30e20c289313649b657ae80b7847b34d73edaa3`); none of the six #1272 implementation
+  or regression paths changed in that merge.
+- P1 fixed: terminal same-cat signatures are transport decoration only when both the
+  identity and normalized model match the runtime canonical signature. A sample for
+  another model is user content even when it shares the current cat's nickname.
+- State invariant:
+
+  | Terminal shape | Finalizer result |
+  | --- | --- |
+  | Another cat's signature | Preserve |
+  | Current identity, non-canonical model | Preserve |
+  | Runtime-canonical signature in quote/list/fence/indented code | Preserve |
+  | Runtime-canonical signature after ordinary prose/list progress | Strip |
+  | `turn.completed` after retained body content | Append one runtime canonical signature |
+
+- Red→Green: the exact quoted and list samples from the P1 plus a plain-body companion
+  failed before the fix (`49 / 50` pass). The provider transform file now passes
+  `50 / 50`, and the provider/service/L0/route-persistence chain passes `133 / 133`.
+- Failure-mode audit: this is a coordinate correction from nickname-only matching to
+  runtime canonical identity+model matching. It adds no prose keyword detector and no
+  additional Markdown/context fallback. `check-fallback-layers` still reports the
+  historical whole-PR `+9` count in this file; Round 4 adds no fallback branch beyond
+  fail-closed canonical availability/parsing.
+- Gate evidence on this rebased checkout: API build, `pnpm check`, Biome (zero errors;
+  two pre-existing complexity warnings), and `git diff --check` pass. The public suite
+  ran 19,410 tests with 19,368 pass, 0 fail, 9 cancelled, and 33 skipped; cancellation
+  came from the test sandbox lacking Git author identity before its setup commit. The
+  sole affected file was rerun with process-local author/committer variables and passes
+  `9 / 9` with 0 cancelled.
+
 ## Review Sandbox
 
 - Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`

--- a/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
+++ b/review-notes/2026-08-03-issue-1272-codex-signature-finalization-review-request.md
@@ -107,6 +107,41 @@ Please review the exact branch HEAD supplied in the current-thread handoff. Give
   sole affected file was rerun with process-local author/committer variables and passes
   `9 / 9` with 0 cancelled.
 
+## Review Round 5 Repair
+
+- Reviewed-state grounding: P1 review `4857388252` is bound to exact SHA
+  `110d3bfa39639274946e551bab33ec8e7c7b107e`. Both reported inputs reproduced locally:
+  the canonical sample was removed from `> 引用签名：…` and `- > 引用签名：…`.
+- Three gates: the accepted #1272 contract explicitly preserves quoted signature-like
+  content; the failure is isolated to the container-only prefix test; and ordinary
+  prose/list progress remains the feature-path negative control.
+- P1 fixed: signature context now parses the structural container sequence at the start
+  of the candidate line. A canonical terminal sample is preserved when that sequence
+  enters a blockquote, even when prose follows the `>` marker. An arbitrary `>` later in
+  ordinary prose or list progress does not establish blockquote context.
+- R2+ failure-mode audit: repeated findings in this classifier made a same-family sweep
+  mandatory. The contract edge is now explicit:
+
+  | Candidate line | Result |
+  | --- | --- |
+  | Plain, list-contained, nested, or list-inside blockquote with prose | Preserve |
+  | Ordinary prose/list progress containing an inline `>` | Strip runtime-canonical tail |
+  | Same-cat non-canonical model or another cat | Preserve |
+  | Runtime-canonical tail outside protected Markdown context | Strip, then append one canonical at completion |
+
+  The regression sweep covers plain, unordered/ordered/nested list-contained, nested
+  blockquotes, and blockquote-contained lists, plus two inline-`>` negative controls.
+  This repairs the structural coordinate; it adds no prose keyword detector, Markdown
+  runtime dependency, or fallback stack.
+- Red→Green: exact reproductions failed before the fix (`50 / 51` transform tests) and
+  pass after rebuilding (`51 / 51`). The provider/service/L0/route-persistence chain
+  passes `134 / 134`.
+- Gates: API build, root `pnpm check`, Biome (zero errors; two pre-existing complexity
+  warnings), and `git diff --check` pass. Canonical `test:public` passes 19,411 tests:
+  19,378 pass, 0 fail, 0 cancelled, 33 skipped. `check-fallback-layers` still reports
+  the historical whole-PR `+9` count in the transform file; Round 5 adds one structural
+  context branch and no layered fallback.
+
 ## Review Sandbox
 
 - Path: `/tmp/cat-cafe-review/fix-1272-codex-signature-finalization/codex`


### PR DESCRIPTION
## Summary

- strip only the current cat's decorative terminal paw signature from each complete Codex `agent_message` turn
- append one runtime-derived canonical signature when Codex reports `turn.completed`
- preserve signature-like Markdown content in quotes, fenced/indented code, bare list structures, and list-contained blockquotes
- add provider, service, and route/persistence regressions covering a 16-turn reply and content-integrity boundaries

This is the Codex signature-finalization half of #1272. The Claude partial-text lifecycle half is delivered separately in #1276, so this PR uses `Refs #1272` and does not close the umbrella issue by itself.

## Root cause

Codex emits each complete assistant turn as an `item.completed/agent_message`. The server retained every turn verbatim, including a provider-authored paw signature on each progress turn, then persisted the concatenated result as one assistant message. Prompt wording alone could not enforce a single signature across the provider's multi-turn stream.

The finalizer now treats each own terminal signature as transport decoration while retaining the turn body. At `turn.completed`, it emits one canonical signature derived from the active cat identity and effective model. Signature-like samples that are Markdown content are left untouched.

## Five-axis risk assessment

- **Behavior:** medium-high. This changes Codex provider finalization and user-visible message assembly. The focused transform/service/L0/route regressions and full public suite cover both duplicate-signature removal and content-preservation boundaries.
- **Data:** medium. The affected output is persisted assistant-message content, so content loss or accidental deduplication would be user-visible. There is no schema change, migration, production-data access, or destructive data operation.
- **Security:** low. No authentication, authorization, secret handling, network boundary, or executable-command surface changes.
- **Contract:** high. The change consumes the external Codex event lifecycle and preserves the internal route/persistence contract. This is why the merge gate used the full latest-main `pnpm gate`, not only targeted tests.
- **Irreversibility:** low for the code delta: no migration or one-way side effect, and the squash commit is revertable. The actual upstream merge remains separately guarded by direct CVO authorization.

Selected independent source: stateful maintainer review, because it exercised the accepted #1272 content contract and reproduced the Markdown edge cases. No additional cloud source was selected; it would duplicate the same contract surface without a distinct risk axis.

## Review and continuity

Maintainer review APPROVED exact reviewed HEAD `9601b9cfa537c5cabb1b6a26762a02e08523740f` with P1=0 and P2=0 after Round 5.

The latest-main gate linearized the two historical merge commits into current PR HEAD `ce6a7fcebf3b445c33bd24e9ac234a353b7bf3c0` without changing authored content:

- old base = new base = `f30e20c28e5bb83b1b6dba192111dba9a85c8a18`
- all six authored commits are `=` in `git range-diff`
- whole authored diff has the same stable patch-id: `a03237c260daef6635228a40836f8324467f2bf0`
- post-review authored delta paths: none
- continuity decision: `skip=rebase-rereview`

## Validation

Current rebased HEAD `ce6a7fcebf3b445c33bd24e9ac234a353b7bf3c0`:

- full latest-main `pnpm gate`: PASS
- gate phases: install, build, TypeScript, full tests, lint, and check all PASS
- gate public tests ran with process-local Git author identity because the isolated test HOME intentionally cannot see repository-local identity
- focused dossier regression confirming that environment diagnosis: 9/9 PASS
- `git diff --check`: PASS
- root artifact guard: PASS

GitHub required checks for the current rebased HEAD must complete before merge.

The disclosed non-blocking P3 remains unchanged: a CLI run which never reaches `turn.completed` does not receive a canonical signature. This PR intentionally does not redefine timeout/error/cancel finalization semantics.

Refs #1272

[宪宪/gpt-5.6-sol🐾]
