### PR TITLE
fix(web): open Windows markdown links in workspace

### DIFF
--- a/packages/web/src/components/MarkdownContent.tsx
+++ b/packages/web/src/components/MarkdownContent.tsx
@@ -8,7 +8,12 @@ import { UNKNOWN_CAT_COLOR } from '@/lib/color-defaults';
 import { getMentionColor, getMentionRe, getMentionToCat } from '@/lib/mention-highlight';
 import { useChatStore } from '@/stores/chatStore';
 import { MermaidDiagram } from './MermaidDiagram';
-import { createWorkspaceImageComponent, createWorkspaceLinkComponent } from './workspace-md-components';
+import {
+  createChatLinkComponent,
+  createWorkspaceImageComponent,
+  createWorkspaceLinkComponent,
+  workspaceMarkdownUrlTransform,
+} from './workspace-md-components';
 
 /* ── @mention highlighting ─────────────────────────────────── */
 
@@ -283,16 +288,7 @@ function buildMdComponents(tp?: (children: ReactNode) => ReactNode): Components 
     blockquote: ({ children }) => (
       <blockquote className="border-l-[3px] border-cafe pl-3 my-2 italic opacity-80">{children}</blockquote>
     ),
-    a: ({ href, children }) => (
-      <a
-        href={href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-conn-blue-text hover:underline break-all"
-      >
-        {m(children)}
-      </a>
-    ),
+    a: createChatLinkComponent(m),
     hr: () => <hr className="my-3 border-cafe" />,
 
     /* Code blocks with copy button — textProcessor intentionally excluded */
@@ -383,7 +379,11 @@ export function MarkdownContent({
   return (
     <div className={`markdown-content text-sm break-words ${className ?? ''}`}>
       {cmdMatch && <span className="font-semibold text-[var(--semantic-info)]">{cmdMatch[1]}</span>}
-      <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, remarkBreaks]}
+        components={components}
+        urlTransform={workspaceMarkdownUrlTransform}
+      >
         {md}
       </ReactMarkdown>
     </div>

--- a/packages/web/src/components/__tests__/markdown-content-workspace-links.test.ts
+++ b/packages/web/src/components/__tests__/markdown-content-workspace-links.test.ts
@@ -1,9 +1,19 @@
-import React from 'react';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { isRelativeMdLink, MarkdownContent, resolveRelativePath } from '@/components/MarkdownContent';
+import { parseWindowsAbsoluteFileHref, resolveWindowsFileTarget } from '@/components/workspace-md-components';
+import { useChatStore } from '@/stores/chatStore';
+import { apiFetch } from '@/utils/api-client';
 
 Object.assign(globalThis as Record<string, unknown>, { React });
+
+vi.mock('@/utils/api-client', () => ({
+  apiFetch: vi.fn(),
+}));
+
+const apiFetchMock = vi.mocked(apiFetch);
 
 /* ── isRelativeMdLink ────────────────────────────────── */
 describe('isRelativeMdLink', () => {
@@ -71,6 +81,30 @@ describe('resolveRelativePath', () => {
 
 /* ── MarkdownContent with basePath ──────────────────── */
 describe('MarkdownContent workspace link rendering', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    useChatStore.setState({
+      currentProjectPath: 'G:/AIwork/clowder-ai/clowder-ai-main',
+      workspaceMode: 'approval',
+      rightPanelMode: 'status',
+      workspaceWorktreeId: 'clowder-ai-main',
+      workspaceOpenTabs: [],
+      workspaceOpenFilePath: null,
+      workspaceOpenFileLine: null,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    apiFetchMock.mockReset();
+  });
+
   function render(content: string, basePath?: string): string {
     return renderToStaticMarkup(
       React.createElement(MarkdownContent, { content, disableCommandPrefix: true, basePath }),
@@ -96,4 +130,187 @@ describe('MarkdownContent workspace link rendering', () => {
     expect(html).toContain('target="_blank"');
     expect(html).not.toContain('在工作区中打开');
   });
+
+  it('renders a Windows absolute markdown link as workspace-navigable in chat', () => {
+    const html = render(
+      '[综合报告](G:/AIwork/clowder-ai/worktrees/research-harness/project-research/harness/synthesis.md)',
+    );
+
+    expect(html).toContain('在工作区中打开');
+    expect(html).not.toContain('target="_blank"');
+  });
+
+  it('preserves backslash Windows links and blocks unsafe protocols', () => {
+    const fileHtml = render(String.raw`[报告](G:\AIwork\clowder-ai\worktrees\research-harness\synthesis.md:42)`);
+    const unsafeHtml = render('[危险链接](javascript:alert(1))');
+
+    expect(fileHtml).toContain('在工作区中打开');
+    expect(fileHtml).toContain('synthesis.md:42');
+    expect(unsafeHtml).not.toContain('javascript:');
+  });
+
+  it('parses browser-normalized Windows paths and line numbers', () => {
+    expect(parseWindowsAbsoluteFileHref('/G:/AIwork/clowder-ai/docs/report.md:42')).toEqual({
+      path: 'G:/AIwork/clowder-ai/docs/report.md',
+      line: 42,
+    });
+  });
+
+  it('uses the longest worktree root without matching a sibling prefix', () => {
+    const target = parseWindowsAbsoluteFileHref('G:/repo/worktrees/feature/docs/report.md');
+    if (!target) throw new Error('expected a Windows file target');
+    expect(
+      resolveWindowsFileTarget(target, [
+        { id: 'repo', root: 'G:/repo' },
+        { id: 'feature-old', root: 'G:/repo/worktrees/feature-old' },
+        { id: 'feature', root: 'G:/repo/worktrees/feature' },
+      ]),
+    ).toEqual({ worktreeId: 'feature', path: 'docs/report.md', line: null });
+  });
+
+  it('opens a Windows absolute link in its owning worktree', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        worktrees: [
+          {
+            id: 'clowder-ai-main',
+            root: 'G:/AIwork/clowder-ai/clowder-ai-main',
+            branch: 'main',
+            head: 'abc123',
+          },
+          {
+            id: '25e095_research-harness-landscape-20260801',
+            root: 'G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801',
+            branch: 'research/harness-landscape-20260801',
+            head: 'def456',
+          },
+        ],
+      }),
+    } as Response);
+
+    await act(async () => {
+      root.render(
+        React.createElement(MarkdownContent, {
+          content:
+            '[综合报告](G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801/project-research/2026-08-01-coding-agent-harness-landscape/synthesis.md:42)',
+          disableCommandPrefix: true,
+        }),
+      );
+    });
+
+    await act(async () => {
+      container.querySelector('a')?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/workspace/worktrees?repoRoot=G%3A%2FAIwork%2Fclowder-ai%2Fclowder-ai-main',
+    );
+    expect(useChatStore.getState()).toMatchObject({
+      workspaceMode: 'dev',
+      rightPanelMode: 'workspace',
+      workspaceWorktreeId: '25e095_research-harness-landscape-20260801',
+      workspaceOpenFilePath: 'project-research/2026-08-01-coding-agent-harness-landscape/synthesis.md',
+      workspaceOpenFileLine: 42,
+    });
+  });
+
+  it('falls back to the default worktree list when the thread project path is a workspace container', async () => {
+    useChatStore.setState({ currentProjectPath: 'G:/AIwork/clowder-ai' });
+    apiFetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          worktrees: [{ id: 'api', root: 'G:/AIwork/clowder-ai/clowder-ai-runtime/packages/api' }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          worktrees: [
+            {
+              id: 'research-harness-landscape-20260801',
+              root: 'G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801',
+            },
+          ],
+        }),
+      } as Response);
+
+    await act(async () => {
+      root.render(
+        React.createElement(MarkdownContent, {
+          content:
+            '[综合报告](G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801/project-research/2026-08-01-coding-agent-harness-landscape/synthesis.md)',
+          disableCommandPrefix: true,
+        }),
+      );
+    });
+
+    await act(async () => {
+      container.querySelector('a')?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(apiFetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/workspace/worktrees?repoRoot=G%3A%2FAIwork%2Fclowder-ai',
+      '/api/workspace/worktrees',
+    ]);
+    expect(useChatStore.getState()).toMatchObject({
+      workspaceWorktreeId: 'research-harness-landscape-20260801',
+      workspaceOpenFilePath: 'project-research/2026-08-01-coding-agent-harness-landscape/synthesis.md',
+    });
+  });
+
+  it('does not open a default-list worktree outside the current project', async () => {
+    useChatStore.setState({
+      currentProjectPath: 'G:/other-project',
+      workspaceWorktreeId: 'other-project',
+    });
+    apiFetchMock
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ worktrees: [{ id: 'other-project', root: 'G:/other-project' }] }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          worktrees: [
+            {
+              id: 'research-harness-landscape-20260801',
+              root: 'G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801',
+            },
+          ],
+        }),
+      } as Response);
+
+    await act(async () => {
+      root.render(
+        React.createElement(MarkdownContent, {
+          content:
+            '[综合报告](G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801/project-research/2026-08-01-coding-agent-harness-landscape/synthesis.md)',
+          disableCommandPrefix: true,
+        }),
+      );
+    });
+
+    await act(async () => {
+      container.querySelector('a')?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(apiFetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/workspace/worktrees?repoRoot=G%3A%2Fother-project',
+      '/api/workspace/worktrees',
+    ]);
+    expect(useChatStore.getState()).toMatchObject({
+      workspaceWorktreeId: 'other-project',
+      workspaceOpenFilePath: null,
+      workspaceOpenTabs: [],
+    });
+  });
+});
+beforeAll(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  delete (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT;
 });

--- a/packages/web/src/components/workspace-md-components.tsx
+++ b/packages/web/src/components/workspace-md-components.tsx
@@ -1,12 +1,167 @@
 'use client';
 
-import type { Components } from 'react-markdown';
+import { type ReactNode, useCallback } from 'react';
+import { type Components, defaultUrlTransform } from 'react-markdown';
 import { useChatStore } from '@/stores/chatStore';
+import { useToastStore } from '@/stores/toastStore';
 import { API_URL } from '@/utils/api-client';
+import { fetchWorkspaceWorktrees, isPathWithinProject, workspaceWorktreesUrl } from '@/utils/workspace-worktrees';
 import { isRelativeMdLink, resolveRelativePath } from './MarkdownContent';
 
 /** Highlight @mentions in text children */
-type MentionFn = (children: import('react').ReactNode) => import('react').ReactNode;
+type MentionFn = (children: ReactNode) => ReactNode;
+
+interface WindowsFileTarget {
+  path: string;
+  line: number | null;
+}
+
+interface WorktreeRoot {
+  id: string;
+  root: string;
+}
+
+function decodeHref(href: string): string | null {
+  try {
+    return decodeURIComponent(href);
+  } catch {
+    return null;
+  }
+}
+
+export function parseWindowsAbsoluteFileHref(href: string | undefined): WindowsFileTarget | null {
+  if (!href) return null;
+  const decoded = decodeHref(href);
+  if (!decoded) return null;
+
+  let normalized = decoded.replaceAll('\\', '/');
+  if (/^\/[a-zA-Z]:\//.test(normalized)) normalized = normalized.slice(1);
+  if (!/^[a-zA-Z]:\//.test(normalized)) return null;
+
+  const lineMatch = /:(\d+)$/.exec(normalized);
+  const line = lineMatch ? Number.parseInt(lineMatch[1], 10) : null;
+  const path = lineMatch ? normalized.slice(0, lineMatch.index) : normalized;
+  return path.length > 3 ? { path, line } : null;
+}
+
+export function isWindowsAbsoluteFileHref(href: string | undefined): href is string {
+  return parseWindowsAbsoluteFileHref(href) != null;
+}
+
+export function workspaceMarkdownUrlTransform(url: string, key: string): string {
+  return key === 'href' && isWindowsAbsoluteFileHref(url) ? url : defaultUrlTransform(url);
+}
+
+export function resolveWindowsFileTarget(
+  target: WindowsFileTarget,
+  worktrees: WorktreeRoot[],
+): { worktreeId: string; path: string; line: number | null } | null {
+  const absolutePath = target.path.replaceAll('\\', '/');
+  const comparablePath = absolutePath.toLowerCase();
+  const candidates = worktrees
+    .map((worktree) => ({ ...worktree, normalizedRoot: worktree.root.replaceAll('\\', '/').replace(/\/$/, '') }))
+    .filter(({ normalizedRoot }) => comparablePath.startsWith(`${normalizedRoot.toLowerCase()}/`))
+    .sort((a, b) => b.normalizedRoot.length - a.normalizedRoot.length);
+  const match = candidates[0];
+  if (!match) return null;
+
+  return {
+    worktreeId: match.id,
+    path: absolutePath.slice(match.normalizedRoot.length + 1),
+    line: target.line,
+  };
+}
+
+async function resolveWindowsFileTargetFromWorkspace(
+  target: WindowsFileTarget,
+  projectPath: string,
+): Promise<{ worktreeId: string; path: string; line: number | null } | null> {
+  const { url, isScoped } = workspaceWorktreesUrl(projectPath === 'lobby' ? null : projectPath);
+  const scopedWorktrees = (await fetchWorkspaceWorktrees<WorktreeRoot>(url)) ?? [];
+  const resolved = resolveWindowsFileTarget(target, scopedWorktrees);
+  if (resolved || !isScoped) return resolved;
+
+  const defaultWorktrees = (await fetchWorkspaceWorktrees<WorktreeRoot>('/api/workspace/worktrees')) ?? [];
+  return resolveWindowsFileTarget(
+    target,
+    defaultWorktrees.filter((worktree) => isPathWithinProject(worktree.root, projectPath)),
+  );
+}
+
+export function WindowsAbsoluteWorkspaceLink({
+  href,
+  children,
+  withMentions,
+}: {
+  href: string;
+  children: ReactNode;
+  withMentions: MentionFn;
+}) {
+  const setOpenFile = useChatStore((s) => s.setWorkspaceOpenFile);
+  const setWorkspaceMode = useChatStore((s) => s.setWorkspaceMode);
+  const projectPath = useChatStore((s) => s.currentProjectPath);
+  const addToast = useToastStore((s) => s.addToast);
+  const target = parseWindowsAbsoluteFileHref(href);
+
+  const handleClick = useCallback(
+    async (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      if (!target) return;
+
+      try {
+        const resolved = await resolveWindowsFileTargetFromWorkspace(target, projectPath);
+        if (!resolved) throw new Error('file is outside the available worktrees');
+
+        setWorkspaceMode('dev');
+        setOpenFile(resolved.path, resolved.line, resolved.worktreeId);
+      } catch {
+        addToast({
+          type: 'error',
+          title: '无法打开文件',
+          message: '这个文件不在当前项目可用的工作区中。',
+          duration: 5000,
+        });
+      }
+    },
+    [addToast, projectPath, setOpenFile, setWorkspaceMode, target],
+  );
+
+  if (!target) return null;
+
+  return (
+    <a
+      href={href}
+      onClick={(event) => void handleClick(event)}
+      className="text-conn-blue-text hover:underline break-all cursor-pointer"
+      title={`在工作区中打开 ${target.path}${target.line ? `:${target.line}` : ''}`}
+    >
+      {withMentions(children)}
+    </a>
+  );
+}
+
+export function createChatLinkComponent(withMentions: MentionFn): Components['a'] {
+  return function ChatLink({ href, children }) {
+    if (isWindowsAbsoluteFileHref(href)) {
+      return (
+        <WindowsAbsoluteWorkspaceLink href={href} withMentions={withMentions}>
+          {children}
+        </WindowsAbsoluteWorkspaceLink>
+      );
+    }
+
+    return (
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-conn-blue-text hover:underline break-all"
+      >
+        {withMentions(children)}
+      </a>
+    );
+  };
+}
 
 /** Create an `img` override that resolves workspace-relative image paths */
 export function createWorkspaceImageComponent(basePath: string, worktreeId: string): Components['img'] {
@@ -34,6 +189,14 @@ export function createWorkspaceLinkComponent(
 ): Components['a'] {
   return function WorkspaceLink({ href, children }) {
     const setOpenFile = useChatStore((s) => s.setWorkspaceOpenFile);
+
+    if (href && isWindowsAbsoluteFileHref(href)) {
+      return (
+        <WindowsAbsoluteWorkspaceLink href={href} withMentions={withMentions}>
+          {children}
+        </WindowsAbsoluteWorkspaceLink>
+      );
+    }
 
     if (isRelativeMdLink(href)) {
       const resolved = resolveRelativePath(basePath, href);

--- a/packages/web/src/hooks/__tests__/useWorkspace-worktrees.test.tsx
+++ b/packages/web/src/hooks/__tests__/useWorkspace-worktrees.test.tsx
@@ -127,4 +127,114 @@ describe('useWorkspace worktree refresh', () => {
       .filter((url) => url.startsWith('/api/workspace/tree') || url.startsWith('/api/workspace/file'));
     expect(treeAndFileCalls.some((url) => url.includes('worktreeId=230809_cat-cafe'))).toBe(true);
   });
+
+  it('keeps an open default-repo worktree when the thread-scoped list does not contain it', async () => {
+    useChatStore.setState({
+      currentProjectPath: 'G:/AIwork/clowder-ai',
+      workspaceWorktreeId: 'research-harness-landscape-20260801',
+      workspaceOpenFilePath: 'project-research/harness/synthesis.md',
+      workspaceOpenTabs: ['project-research/harness/synthesis.md'],
+    });
+    apiFetchMock.mockImplementation(async (url) => {
+      const path = String(url);
+      if (path.includes('repoRoot=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            worktrees: [{ id: 'api', root: 'G:/AIwork/clowder-ai/clowder-ai-runtime/packages/api' }],
+          }),
+        } as Response;
+      }
+      if (path === '/api/workspace/worktrees') {
+        return {
+          ok: true,
+          json: async () => ({
+            worktrees: [
+              {
+                id: 'research-harness-landscape-20260801',
+                root: 'G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801',
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (path.startsWith('/api/workspace/tree')) {
+        return { ok: true, json: async () => ({ tree: [] }) } as Response;
+      }
+      if (path.startsWith('/api/workspace/file')) {
+        return {
+          ok: true,
+          json: async () => ({
+            path: 'project-research/harness/synthesis.md',
+            content: 'report',
+            sha256: 'sha',
+            size: 6,
+            mime: 'text/markdown',
+            truncated: false,
+          }),
+        } as Response;
+      }
+      return { ok: false, json: async () => ({ error: 'unexpected url' }) } as Response;
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HookHost));
+    });
+    await flushEffects();
+
+    expect(apiFetchMock.mock.calls.map(([url]) => url)).toContain('/api/workspace/worktrees');
+    expect(useChatStore.getState()).toMatchObject({
+      workspaceWorktreeId: 'research-harness-landscape-20260801',
+      workspaceOpenFilePath: 'project-research/harness/synthesis.md',
+      workspaceOpenTabs: ['project-research/harness/synthesis.md'],
+    });
+  });
+
+  it('does not keep a default-repo worktree outside the current project path', async () => {
+    useChatStore.setState({
+      currentProjectPath: 'G:/other-project',
+      workspaceWorktreeId: 'research-harness-landscape-20260801',
+      workspaceOpenFilePath: 'project-research/harness/synthesis.md',
+      workspaceOpenTabs: ['project-research/harness/synthesis.md'],
+    });
+    apiFetchMock.mockImplementation(async (url) => {
+      const path = String(url);
+      if (path.includes('repoRoot=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            worktrees: [{ id: 'other-project', root: 'G:/other-project' }],
+          }),
+        } as Response;
+      }
+      if (path === '/api/workspace/worktrees') {
+        return {
+          ok: true,
+          json: async () => ({
+            worktrees: [
+              {
+                id: 'research-harness-landscape-20260801',
+                root: 'G:/AIwork/clowder-ai/worktrees/research-harness-landscape-20260801',
+              },
+            ],
+          }),
+        } as Response;
+      }
+      if (path.startsWith('/api/workspace/tree')) {
+        return { ok: true, json: async () => ({ tree: [] }) } as Response;
+      }
+      return { ok: false, json: async () => ({ error: 'unexpected url' }) } as Response;
+    });
+
+    await act(async () => {
+      root.render(React.createElement(HookHost));
+    });
+    await flushEffects();
+
+    expect(useChatStore.getState()).toMatchObject({
+      workspaceWorktreeId: 'other-project',
+      workspaceOpenFilePath: null,
+      workspaceOpenTabs: [],
+    });
+  });
 });

--- a/packages/web/src/hooks/useWorkspace.ts
+++ b/packages/web/src/hooks/useWorkspace.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useChatStore } from '@/stores/chatStore';
 import { API_URL, apiFetch } from '@/utils/api-client';
+import { fetchWorktreesPreservingSelection, workspaceWorktreesUrl } from '@/utils/workspace-worktrees';
 import { buildWorktreeAliasMap, resolveListedWorktreeId } from '@/utils/worktree-id-alias';
 
 export interface WorktreeEntry {
@@ -71,29 +72,23 @@ export function useWorkspace() {
 
   // Fetch worktrees — re-fetches when project changes
   const fetchWorktrees = useCallback(async () => {
-    try {
-      const params = new URLSearchParams();
-      if (projectPath && projectPath !== 'default') {
-        params.set('repoRoot', projectPath);
+    const { url, isScoped } = workspaceWorktreesUrl(projectPath);
+    const newList = await fetchWorktreesPreservingSelection<WorktreeEntry>(
+      url,
+      isScoped ? worktreeId : null,
+      projectPath,
+    );
+    if (newList) {
+      setWorktrees(newList);
+      const worktreeAliases = buildWorktreeAliasMap(newList);
+      setWorktreeAliases(worktreeAliases, projectPath);
+      // Auto-select first worktree if none selected or current was removed
+      const listedWorktreeId = resolveListedWorktreeId(newList, worktreeId, worktreeAliases);
+      if (listedWorktreeId && listedWorktreeId !== worktreeId) {
+        normalizeWorktreeId(listedWorktreeId);
+      } else if (!listedWorktreeId && newList.length > 0) {
+        setWorktreeId(newList[0].id);
       }
-      const qs = params.toString();
-      const res = await apiFetch(`/api/workspace/worktrees${qs ? `?${qs}` : ''}`);
-      if (res.ok) {
-        const data = await res.json();
-        const newList: typeof worktrees = data.worktrees ?? [];
-        setWorktrees(newList);
-        const worktreeAliases = buildWorktreeAliasMap(newList);
-        setWorktreeAliases(worktreeAliases, projectPath);
-        // Auto-select first worktree if none selected or current was removed
-        const listedWorktreeId = resolveListedWorktreeId(newList, worktreeId, worktreeAliases);
-        if (listedWorktreeId && listedWorktreeId !== worktreeId) {
-          normalizeWorktreeId(listedWorktreeId);
-        } else if (!listedWorktreeId && newList.length > 0) {
-          setWorktreeId(newList[0].id);
-        }
-      }
-    } catch {
-      /* ignore */
     }
   }, [worktreeId, setWorktreeId, normalizeWorktreeId, setWorktreeAliases, projectPath]);
 

--- a/packages/web/src/utils/workspace-worktrees.ts
+++ b/packages/web/src/utils/workspace-worktrees.ts
@@ -1,0 +1,58 @@
+import { apiFetch } from '@/utils/api-client';
+import { buildWorktreeAliasMap, resolveListedWorktreeId } from '@/utils/worktree-id-alias';
+
+interface WorkspaceWorktree {
+  id: string;
+  canonicalId?: string | null;
+  root: string;
+}
+
+export function workspaceWorktreesUrl(projectPath: string | null | undefined): {
+  url: string;
+  isScoped: boolean;
+} {
+  if (!projectPath || projectPath === 'default') {
+    return { url: '/api/workspace/worktrees', isScoped: false };
+  }
+  const params = new URLSearchParams({ repoRoot: projectPath });
+  return { url: `/api/workspace/worktrees?${params}`, isScoped: true };
+}
+
+export async function fetchWorkspaceWorktrees<T extends WorkspaceWorktree>(url: string): Promise<T[] | null> {
+  try {
+    const response = await apiFetch(url);
+    if (!response.ok) return null;
+    const data = (await response.json()) as { worktrees?: T[] };
+    return data.worktrees ?? [];
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchWorktreesPreservingSelection<T extends WorkspaceWorktree>(
+  scopedUrl: string,
+  currentWorktreeId: string | null,
+  projectPath: string,
+): Promise<T[] | null> {
+  const scopedList = await fetchWorkspaceWorktrees<T>(scopedUrl);
+  if (!scopedList || !currentWorktreeId) return scopedList;
+
+  const scopedAliases = buildWorktreeAliasMap(scopedList);
+  if (resolveListedWorktreeId(scopedList, currentWorktreeId, scopedAliases)) return scopedList;
+
+  const defaultList = await fetchWorkspaceWorktrees<T>('/api/workspace/worktrees');
+  if (!defaultList) return scopedList;
+  const defaultAliases = buildWorktreeAliasMap(defaultList);
+  const listedId = resolveListedWorktreeId(defaultList, currentWorktreeId, defaultAliases);
+  const selected = defaultList.find((worktree) => worktree.id === listedId);
+  return selected && isPathWithinProject(selected.root, projectPath) ? defaultList : scopedList;
+}
+
+export function isPathWithinProject(path: string, projectPath: string): boolean {
+  const normalizedPath = path.replaceAll('\\', '/').replace(/\/$/, '');
+  const normalizedProject = projectPath.replaceAll('\\', '/').replace(/\/$/, '');
+  const windowsPath = /^[a-zA-Z]:\//.test(normalizedPath) && /^[a-zA-Z]:\//.test(normalizedProject);
+  const candidate = windowsPath ? normalizedPath.toLowerCase() : normalizedPath;
+  const root = windowsPath ? normalizedProject.toLowerCase() : normalizedProject;
+  return candidate === root || candidate.startsWith(`${root}/`);
+}

--- a/review-notes/2026-08-03-windows-workspace-links-review-request.md
+++ b/review-notes/2026-08-03-windows-workspace-links-review-request.md
@@ -1,0 +1,125 @@
+# Review Request: Windows Markdown 链接打开右侧 Workspace 文件
+
+Review-Target-ID: fix-523-windows-workspace-links
+Branch: fix/523-windows-workspace-links
+PR: https://github.com/zts212653/clowder-ai/pull/1281
+Implementation commit: 8cb009b3f6b7210e59a5f73ab8af7b8acf9374ce
+
+## What
+
+- 让 `react-markdown` 保留 `G:/...`、`G:\\...`、`/G:/...` 形式的 Windows 绝对文件路径，同时继续过滤危险协议。
+- 点击消息中的蓝色文件链接时拦截浏览器导航，解析可选 `:line`，在右侧 Workspace 中切换到所属 worktree 并打开文件。
+- 以大小写不敏感的最长根路径匹配归属 worktree；thread-scoped 列表找不到时，仅在当前项目边界内回退默认 worktree 列表。
+- 刷新 scoped worktree 时保留已选中的目标 worktree，避免文件刚打开又被错误 worktree 覆盖。
+- 新增组件与 hook 回归测试，覆盖路径解析、URL 安全、最长根匹配、fallback 边界和 refresh 稳定性。
+
+## Why
+
+Windows 路径先被 Markdown URL transform 清空或当作普通浏览器链接；即使成功切换到目标 worktree，后续 scoped refresh 还可能把选择重置并清空文件。结果是蓝色链接看似可点，右侧 Workspace 却没有打开对应报告。
+
+## Original Requirements（必填）
+
+> “没有打开，我要求的是，当我点击你蓝色的链接的时候，可以从右侧的workspace看到对应的文件被选中或者被直接打开。但是实际上效果并不符合预期。”
+>
+> F063 R13：“你们发的文本里的那些地址我点击 右边这里能打开吗？”
+
+- 来源：当前 thread `thread_ms9yrbfwz4db9nde`
+- Feature 真相源：`docs/features/F063-hub-workspace-explorer.md` AC-13 / R13
+- **请对照上面的摘录判断交付物是否解决了 operator 的问题。**
+
+## Tradeoff
+
+- 没有把所有未知 scheme 放行，只在 custom URL transform 中识别 Windows 绝对路径，其余仍交给 `defaultUrlTransform`，保留协议安全边界。
+- 没有依赖当前 thread 的单一 worktree 列表，因为报告位于另一个 worktree；改为 scoped miss 后查询默认列表，但使用 `currentProjectPath` 限制回退，避免跨项目闪跳。
+- 没有重写 Workspace 导航/store 架构；改动限定在 Markdown 链接适配、worktree 归属解析和既有 hook 的 refresh 稳定性。
+
+## Architecture Ownership（必填）
+
+Architecture cell: `hub-action-surface`
+Map delta: none
+Why: 修复现有 Markdown → Workspace 导航链路，不改变 owner、boundary、extension point 或 canonical anchor，也未新建 Store / Queue / Router / Adapter / Dispatcher / Binding。
+
+请 reviewer 检查：
+
+- diff 是否与 `Map delta: none` 一致；
+- `workspace-md-components.tsx` 的 URL transform 是否只额外保留 Windows 绝对路径；
+- 默认 worktree fallback 是否严格受当前项目路径约束；
+- hook refresh 是否能保留目标 worktree 且不污染其他 thread 的状态。
+
+## Open Questions
+
+### 技术 OQ（给 reviewer）
+
+1. `:line` 解析与 Windows drive colon 是否在所有支持形式下无歧义？
+2. 大小写不敏感的最长 root 匹配是否覆盖嵌套 worktree，且不会越过目录边界？
+3. scoped → default fallback 与 refresh preservation 是否存在竞态或 stale-state 风险？
+
+### 价值 OQ（给 operator）
+
+无。
+
+## Next Action
+
+请 `@opus` 对 review 发起消息中所附的 exact PR HEAD：
+
+1. 按 hotfix 规则执行跨个体 quality-gate；
+2. 独立复核 diff、回归测试和真实浏览器路径；
+3. 将 `APPROVE` 或 `REQUEST-CHANGES` verdict 及覆盖 SHA 作为 PR comment 落到 PR #1281。
+
+重点关注 URL 安全、项目边界、worktree refresh 稳定性，以及是否真正满足 F063 AC-13/R13。
+
+## Review Sandbox（必填）
+
+- Path: `/tmp/cat-cafe-review/fix-523-windows-workspace-links/opus`
+- Start Command: `pnpm review:start`
+- Ports: `web=3201`, `api=3202`（禁止 3003/3004/3011/3012/4111）
+
+### 沙盒 Bootstrap
+
+PowerShell 下先清理继承环境并安装依赖：
+
+```powershell
+Remove-Item Env:NODE_ENV -ErrorAction SilentlyContinue
+pnpm install --frozen-lockfile
+pnpm --filter @cat-cafe/shared build
+```
+
+## 自检证据
+
+### Spec 合规
+
+- F063 AC-13：点击猫猫消息中的文件路径，自动切换 Workspace 并打开文件。
+- R13：点击文本地址后，右侧 Workspace 能打开对应文件。
+- Dogfood：在 `http://localhost:3013/thread/thread_ms9yrbfwz4db9nde` 点击 `综合报告` 后 URL 不变；右侧选择 `research-harness-landscape-20260801`，显示 `synthesis.md` 和标题 `Coding Agent Harness`。
+- 截图：`C:\Users\Administrator\AppData\Local\Temp\cat-cafe-evidence\fix-523\windows-workspace-link-post-build.png`
+- `.pen` 匹配：无；这是既有交互的 bugfix，无视觉设计改动。
+- Artifact hygiene：工作树与提交差异均无根目录媒体/设计工件。
+- 当前 checkout 中 `check-hotfix-pattern`、`check-fallback-layers`、`check-architecture-ownership` 脚本不存在；hotfix 限制已人工识别并升级为跨个体 gate。
+
+### 测试结果
+
+```text
+相关 Web 回归：4 files，93 tests passed
+Web TypeScript：通过
+6 个改动文件 Biome：0 errors
+pnpm lint：exit 0，仅既有 warnings
+pnpm check:features：通过
+pnpm check:capability-tips：通过
+pnpm check:followup-tails：通过
+production Web build：exit 0，22/22 页面生成成功
+CI Lint / Build / Windows Smoke：通过
+```
+
+已知基线阻断：
+
+- 根 `pnpm check`：Windows checkout 的 4,505 个未修改 CRLF 文件被 Biome 判定需转 LF；本 PR 六个文件单独检查全绿。
+- 根 `pnpm test`：API package 使用 POSIX 内联 env 赋值，PowerShell 在测试启动前报错。
+- Web 全量 Vitest：21 个与 `upstream/main` 一致的既有失败，集中在 Artifacts、Skills、Thread Organizer、Story Player，均不引用本 PR 模块。
+
+## 相关文档
+
+- Feature：`docs/features/F063-hub-workspace-explorer.md`
+- Issue：https://github.com/zts212653/clowder-ai/issues/523
+- PR：https://github.com/zts212653/clowder-ai/pull/1281
+
+[砚砚/GPT-5.6-sol🐾]


### PR DESCRIPTION
## What

- Preserve Windows absolute Markdown links through `react-markdown` sanitization and intercept them as Workspace navigation.
- Resolve the owning worktree by the longest case-insensitive root match, including optional `:line` suffixes.
- Fall back from a thread-scoped worktree list to the default repository list only within the current project boundary.
- Preserve a selected default-repository worktree during `useWorkspace` refreshes to prevent snapback.

## Why

On Windows, a chat link such as `G:/.../synthesis.md` was either stripped by `react-markdown` or treated as a browser link. Even after selecting the correct feature worktree, the scoped Workspace refresh could replace it with an unrelated fallback worktree and clear the opened file.

This restores F063 AC-13/R13: clicking a file address in a cat message opens that file in the right-side Workspace panel.

Fixes #523

## Verification

- `pnpm --filter @cat-cafe/web exec vitest run src/components/__tests__/markdown-content-workspace-links.test.ts src/hooks/__tests__/useWorkspace-worktrees.test.tsx src/components/__tests__/workspace-navigate-store.test.ts src/stores/__tests__/chatStore-workspace-thread.test.ts` -> 93/93 passed
- `pnpm --filter @cat-cafe/web exec tsc --noEmit` -> passed
- Biome on all 6 changed files -> 0 errors
- `pnpm lint` -> exit 0 (existing warnings only)
- `pnpm check:features`, `pnpm check:capability-tips`, `pnpm check:followup-tails` -> passed
- `NODE_ENV=production pnpm --filter @cat-cafe/web build` -> exit 0, 22/22 pages generated
- Real browser click at `http://localhost:3013/thread/thread_ms9yrbfwz4db9nde`:
  - URL unchanged after clicking `综合报告`
  - scoped/default worktree requests returned HTTP 200
  - target file and tree requests returned HTTP 200
  - right Workspace selected `research-harness-landscape-20260801`
  - `synthesis.md` and `Coding Agent Harness` appeared inside the Workspace panel

## Baseline blockers

- Root `pnpm check` is blocked on this Windows checkout because Biome reports CRLF formatting for 4,505 unchanged files, beginning with `biome.json`; all changed files pass Biome independently.
- Root `pnpm test` reaches the API package and then fails before API tests start because its script uses POSIX inline env assignment (`CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT=1`) under PowerShell.
- Direct Web Vitest has 21 unrelated baseline failures in Artifacts, Skills, Thread Organizer, and Story Player tests. Those files are unchanged from `upstream/main` and do not reference this PR's modules.

## Review focus

- URL safety: custom transform must preserve only Windows absolute file hrefs; unsafe protocols remain filtered.
- Project boundary: default-list fallback must not open a worktree outside `currentProjectPath`.
- State stability: alias normalization and worktree refresh must preserve the selected report without snapback.

[砚砚/GPT-5.6-sol🐾]
