### PR TITLE
feat(F253): add ChatGPT multi-cat review rounds

### DIFF
--- a/cat-cafe-skills/BOOTSTRAP.md
+++ b/cat-cafe-skills/BOOTSTRAP.md
@@ -11,6 +11,9 @@ feat-lifecycle → Design Gate(设计确认) → writing-plans → worktree → 
     → quality-gate → [fresh-context-review] → request-review → receive-review
     → merge-gate → feat-lifecycle(完成)
 
+ChatGPT author → chatgpt-review-rounds（独立检视→交叉检视→指定猫写 Git ledger）
+    → ChatGPT fix → repeat → merge-gate → operator acceptance
+
 co-creation docs → co-creation-docs → direct push | merge-gate(docs PR)
 ```
 
@@ -30,6 +33,7 @@ co-creation docs → co-creation-docs → direct push | merge-gate(docs PR)
 | `quality-gate` | 开发完了自检（愿景+spec+验证） | ② |
 | `fresh-context-review` | *（可选）* Author-triggered pre-review scan（finding generator, not approval） | ②½ |
 | `request-review` | 发 review 请求给 reviewer | ③ |
+| `chatgpt-review-rounds` | ChatGPT 作者代码的多猫独立检视、交叉共识与逐轮 Git ledger | ③ |
 | `receive-review` | 处理 review 反馈（Red→Green） | ③ |
 | `merge-gate` | 门禁→PR→remote review→merge→清理 | ④⑤⑥ |
 | `open-source-teardown` | 热门开源项目/竞品 agent/runtime 的源码拆解、算法剥皮、营销水分和 tradeoff 判断 | — |
@@ -75,6 +79,7 @@ co-creation docs → co-creation-docs → direct push | merge-gate(docs PR)
 | `refs/commit-signatures.md` | 猫猫签名表 + @ 句柄 |
 | `refs/pr-template.md` | PR 模板 + remote review 触发模板 |
 | `refs/review-request-template.md` | Review 请求信模板 |
+| `refs/chatgpt-review-round-template.md` | ChatGPT 多猫 Review round 共识 ledger 模板 |
 | `refs/vision-evidence-workflow.md` | 前端截图/录屏证据流程（B1） |
 | `refs/requirements-checklist-template.md` | 需求点 checklist 模板（B3） |
 | `refs/f190-frontend-lessons.md` | F190 Console intake 的前端案例与红区教训 |

--- a/cat-cafe-skills/chatgpt-review-rounds/SKILL.md
+++ b/cat-cafe-skills/chatgpt-review-rounds/SKILL.md
@@ -119,6 +119,7 @@ review(<change-id>): record ChatGPT round <NN> consensus
 - barrier 前找不到其他 reviewer finding 内容。
 - recorder 之外没有该轮 Git 写入。
 - ledger 的 `reviewedCodeHead`、PR head 和 reviewer 实际读取目标一致。
+- `ledgerOnlyContinuity` 证明 `reviewedCodeHead..ledger commit` 只新增本轮 ledger 文件，没有代码、测试、配置或其他文档变化。
 - `approved_for_merge` 必须机械对应 `openFindings=0`。
 
 ## 下一步

--- a/cat-cafe-skills/chatgpt-review-rounds/SKILL.md
+++ b/cat-cafe-skills/chatgpt-review-rounds/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: chatgpt-review-rounds
+description: >
+  Operator-approved multi-cat review rounds for code authored by ChatGPT desktop Codex.
+  Use when: ChatGPT has pushed a code HEAD and co-creator requires independent cat reviews,
+  cross-review consensus, and a Git ledger written by one designated recorder.
+  Not for: ordinary cat-authored changes, single-source risk-routed review, self-check, or cloud-only review.
+  Output: one immutable consensus ledger commit per round; repeat until approved_for_merge and openFindings=0.
+triggers:
+  - "ChatGPT 提交代码"
+  - "多猫独立检视"
+  - "交叉检视"
+  - "review round"
+  - "共识 ledger"
+---
+
+# ChatGPT Multi-Cat Review Rounds
+
+这条 lane 只服务于 operator 拍板的“ChatGPT 执行、Cat Café 设计与 Review”工作流。它有意使用多只猫，
+是 `request-review` 默认单一风险源规则的窄例外，不能扩张成所有 PR 的固定 Review 税。
+
+## 角色与真相源
+
+- **Author**：ChatGPT 桌面 Codex；只改代码、测试和实现文档，不改已经封存的 round ledger。
+- **Reviewers**：至少两只非作者猫；先独立检视，再交叉检视。
+- **Recorder**：每轮由 co-creator 指定；是该轮唯一 Git writer，只转录共识，不擅自改实现。
+- **Acceptance owner**：co-creator；在 main 合入后亲自验收。
+- **代码真相源**：`reviewedCodeHead` 指向的精确 commit。
+- **Review 真相源**：`review-notes/chatgpt/<change-id>/round-<NN>.md`。
+
+## Round 状态机
+
+```text
+submitted
+  → independent_review
+  → cross_review
+  → consensus_recording
+  → fix_required → ChatGPT push new code HEAD → next round
+  → approved_for_merge → ChatGPT merge main → operator_acceptance
+```
+
+### 1. 固定本轮输入
+
+记录 branch、PR、`reviewedCodeHead`、需求/Feature Doc、ChatGPT 测试证据、reviewer 名单和 operator 指定的
+recorder。代码 HEAD 在该轮内漂移时，本轮作废；先固定新 HEAD，再重新开始独立检视。
+
+### 2. `independent_review`：隔离判断
+
+- 每只猫只读同一个 `reviewedCodeHead`，可以读 diff、源文件和运行验证。
+- 私下保留自己的 findings；在全部 reviewer 完成前不得阅读、索取或预测其他猫的意见。
+- 本阶段是 Git **只读**：禁止编辑共享分支，禁止 `commit`、`push`、`rebase`、`checkout`。
+- 完成时只报告 `independent_review complete @ <reviewedCodeHead>`，不提前公开 findings。
+
+### 3. Barrier 后进入 `cross_review`
+
+只有全部 reviewer 都完成独立检视，才同时公开各自意见并开始交叉核验：
+
+1. 合并重复 findings，但保留各自证据来源。
+2. 对每条 finding 核对文件位置、复现路径、预期行为和严重级别。
+3. 被证据推翻的 finding 标为 `not_a_defect`；不能靠多数票抹掉技术分歧。
+4. 技术分歧继续查证；价值或验收分歧交给 co-creator。
+5. 形成唯一的 consensus finding 集与上一轮 finding 的 closure 状态。
+
+交叉检视仍是 Git 只读；任何 reviewer 都不能抢先落盘。
+
+### 4. `consensus_recording`：单写者封板
+
+co-creator 指定的 recorder 使用
+[`refs/chatgpt-review-round-template.md`](../refs/chatgpt-review-round-template.md) 创建该轮 ledger：
+
+```text
+review-notes/chatgpt/<change-id>/round-<NN>.md
+```
+
+ledger 必须绑定 `reviewedCodeHead`，列出 reviewer/recorder、上一轮 closure、共识 findings、`openFindings`
+和 verdict。只有 recorder 可以提交并推送这个文件；**push 成功才代表本轮检视完毕**。
+
+提交消息：
+
+```text
+review(<change-id>): record ChatGPT round <NN> consensus
+```
+
+### 5. ChatGPT 修复与下一轮
+
+- `openFindings > 0` 时 verdict 必须是 `fix_required`。
+- ChatGPT 只处理 ledger 中的共识 findings，逐条引用 Finding ID，补测试、运行验证并提交新 code HEAD。
+- ChatGPT 不修改历史 ledger；下一轮由 recorder 记录哪些 finding 已 `fixed`、`reopened` 或仍 `open`。
+- 新 code HEAD 必须重新经过完整的独立检视 → 交叉检视，不能只找原 finding 提出者续签。
+
+### 6. 终态与合入
+
+只有最新一轮同时满足下列条件，recorder 才能写 `approved_for_merge`：
+
+- 所有历史共识 findings 已关闭；
+- 本轮没有新 finding；
+- `openFindings=0`；
+- ledger 精确绑定本轮 `reviewedCodeHead`；
+- 风险匹配的测试与 merge gate 全绿。
+
+最终 ledger commit 只允许改该 round 文件。它不改变已审代码语义；merge-gate 用 continuityProof 证明
+`reviewedCodeHead..HEAD` 仅包含 recorder ledger。出现任何代码、测试、配置或其他文档变化，approval 立即 stale，
+必须从新 code HEAD 开下一轮。证据闭合后由 ChatGPT squash merge main，随后等待 co-creator 亲自验收。
+
+## Common Mistakes
+
+| 错误 | 后果 | 修正 |
+|---|---|---|
+| reviewer 边审边互看 | 锚定导致假共识 | 全员完成独立检视后再开 barrier |
+| 独立阶段有人 commit/push | 审查目标漂移、身份混乱 | Review 全阶段只读，recorder 最后单写 |
+| 把每只猫的原始笔记全塞进 Git | 噪音取代结论 | ledger 只保存证据化共识与 closure |
+| ChatGPT 修改历史 ledger | Author 改写 Review 真相 | 历史 round immutable，下一轮记录状态变化 |
+| ledger commit 之后直接宣称 exact-HEAD approval | 元数据 SHA 冒充代码 SHA | 绑定 reviewedCodeHead，并证明 ledger-only continuity |
+| 只清 P1/P2，遗留共识 P3 | 不满足“所有问题关闭” | 接受的任何严重级别 finding 都必须关闭 |
+
+## 验证
+
+- 每轮至少两个不同 reviewer catId，且都不等于 ChatGPT author identity。
+- barrier 前找不到其他 reviewer finding 内容。
+- recorder 之外没有该轮 Git 写入。
+- ledger 的 `reviewedCodeHead`、PR head 和 reviewer 实际读取目标一致。
+- `approved_for_merge` 必须机械对应 `openFindings=0`。
+
+## 下一步
+
+- `fix_required` → ChatGPT 按 ledger 修复并提交新 code HEAD → 开下一轮。
+- `approved_for_merge` → `merge-gate` → ChatGPT 合入 main → `@co-creator` 亲自验收。

--- a/cat-cafe-skills/manifest.yaml
+++ b/cat-cafe-skills/manifest.yaml
@@ -320,7 +320,8 @@ skills:
     description: >
       Route a change to a non-author local peer when local review is the selected independent validation source.
       Use when: risk routing chooses a stateful local reviewer for implementation, governance, or semantic context.
-      Not for: cloud as the selected source, vision-guardian acceptance, self-check, or review feedback handling.
+      Not for: operator-approved ChatGPT multi-cat rounds (use chatgpt-review-rounds), cloud as the selected source,
+      vision-guardian acceptance, self-check, or review feedback handling.
       Output: risk-matched review packet + provenance-matched verdict route; mailbox archive only when the change needs the full packet.
     triggers:
       - "请 review"
@@ -330,9 +331,33 @@ skills:
       - "收到 review"
       - "自检"
     output: "Risk-matched local review packet in thread/PR; optional mailbox archive"
-    next: ["receive-review"]
+    next: ["receive-review", "chatgpt-review-rounds"]
     sop_step: 3
     merged_from: ["cat-cafe-requesting-review"]
+
+  # ── ChatGPT 多猫 Review Round ──
+  chatgpt-review-rounds:
+    category: "开发流程"
+    description: >
+      Operator-approved multi-cat review rounds for code authored by ChatGPT desktop Codex.
+      Use when: ChatGPT has pushed a code HEAD and co-creator requires independent cat reviews,
+      cross-review consensus, and a Git ledger written by one designated recorder.
+      Not for: ordinary cat-authored changes, single-source risk-routed review, self-check, or cloud-only review.
+      Output: one immutable consensus ledger commit per round; repeat until approved_for_merge and openFindings=0.
+    triggers:
+      - "ChatGPT 提交代码"
+      - "多猫独立检视"
+      - "交叉检视"
+      - "review round"
+      - "共识 ledger"
+    not_for:
+      - "普通猫作者的单一 reviewer 流程"
+      - "自检"
+      - "cloud-only review"
+    output: "Operator-designated Git consensus ledger per round; repeat to approved_for_merge"
+    next: ["merge-gate"]
+    sop_step: 3
+    merged_from: null
 
   # ── 接收 Review ──
   receive-review:
@@ -340,7 +365,8 @@ skills:
     description: >
       处理 reviewer 反馈：Red→Green 修复 + 技术论证（禁止表演性同意）。
       Use when: 收到 review 结果、reviewer 提了 P1/P2、需要处理反馈。
-      Not for: 发 review 请求（用 request-review）、自检（用 quality-gate）。
+      Not for: ChatGPT multi-cat round ledger（用 chatgpt-review-rounds）、发 review 请求（用 request-review）、
+      自检（用 quality-gate）。
       Output: 逐项修复确认 + reviewer 放行。
     triggers:
       - "review 结果"

--- a/cat-cafe-skills/merge-gate/SKILL.md
+++ b/cat-cafe-skills/merge-gate/SKILL.md
@@ -47,11 +47,23 @@ triggers:
 
 默认只选一个合适的独立 source：家里语境与治理语义优先 local；context-blind 安全 / 契约代码扫描优先 cloud。**动作类型（“开了 PR”“改了代码”）不是叠加理由。**
 
+**ChatGPT author lane 例外**：co-creator 明确启用 `chatgpt-review-rounds` 时，独立源是“至少两只猫先
+独立检视、再交叉检视”的共识 round，不套用默认单 reviewer。此 lane 的合入证据必须包含最新
+`reviewedCodeHead`、operator 指定 recorder 推送的 round ledger、`verdict=approved_for_merge`、
+`openFindings=0`，以及所有严重级别共识 findings 已关闭的证据。
+
 ### Review Continuity Guard（review 是否真的覆盖当前 HEAD）
 
 `pnpm gate`、rebase、fixup、biome 格式化刷新等都可能让 HEAD 变化。**HEAD 变化只触发 provenance 判定，不自动等于 re-review**：先分清 review 后是否真的改了本 PR 的内容、base 前进是否与本 PR 有逻辑关联；两者都没有，或只有可机械证明的派生物重建 / 规范化，旧 review 用 continuityProof 桥接。只有真实的作者 delta 或相关 base delta 回 active source，而且只看那一小块。
 
 **Report 载体铁则（斩断 SHA 自噬环，operator 2026-07-15 投诉②修复）**：**review verdict 之后、merge 之前，不得再向被审分支 commit 任何 review report / handoff 信 / evidence 说明类文档**——这类内容的合法载体只有 PR comment、thread 消息、tracking 系统。被审分支的 HEAD 只应因代码内容（含 rebase）变化。病灶机制：report 进分支 → SHA 变 → 旧 APPROVE 失效 → re-review → 新 report → SHA 又变（round-10 自噬环）。review **请求**信（mailbox，reviewer 开审前已在 HEAD 内）不受此限。
+
+窄例外：`chatgpt-review-rounds` 中由 co-creator 指定 recorder 写入的 immutable round ledger 是该 lane
+的显式 Git 真相源，不是任意 review report。它只能新增
+`review-notes/chatgpt/<change-id>/round-<NN>.md`，必须绑定 ledger 前的 `reviewedCodeHead`。最终
+`approved_for_merge` ledger 写入后，用 continuityProof 证明 `reviewedCodeHead..currentHead` 只有该
+ledger；一旦混入实现、测试、配置或其他文档变化，approval stale，必须开新 round。其他 lane 仍严格禁止
+review 后向被审分支写 report。
 
 但 continuity 不是一个布尔 `reviewer`。进入 merge-gate 后必须维护 **Review Provenance Matrix**，先判当前 HEAD 变化由谁产生，再决定下一步 gate owner，避免把 cloud / CI / PR check 的外部 gate 投射成本地旧 reviewer。
 
@@ -64,6 +76,9 @@ triggers:
 | `currentHead` | PR 当前 `headRefOid` |
 | `headChangeCause` | `local-gate` / `cloud-finding` / `ci-fix` / `rebase` / `pr-meta` |
 | `nextGateOwner` | `local-peer` / `cloud` / `ci` / `author` / `guardian` |
+
+ChatGPT round 追加记录：`reviewRound`、`reviewedCodeHead`、`roundLedgerPath`、`roundVerdict`、
+`openFindings`、`recorderCatId` 与 `ledgerOnlyContinuity`。缺任一项不得消费 `approved_for_merge`。
 
 **判定规则**：
 - `headChangeCause = cloud-finding`（cloud P1/P2/COMMENTED 修复后 push 新 SHA）→ `nextGateOwner = cloud`：只重新触发 cloud review + 等 PR tracking；**禁止为了 cloud P1/P2 修复 @ 本地旧 reviewer**。

--- a/cat-cafe-skills/receive-review/SKILL.md
+++ b/cat-cafe-skills/receive-review/SKILL.md
@@ -4,7 +4,8 @@ tips_exempt: harness-internal review re-entry convention; no distinct end-user c
 description: >
   处理 reviewer 反馈：Red→Green 修复 + 技术论证（禁止表演性同意）。
   Use when: 收到 review 结果、reviewer 提了 P1/P2、需要处理反馈。
-  Not for: 发 review 请求（用 request-review）、自检（用 quality-gate）。
+  Not for: ChatGPT multi-cat round ledger（用 chatgpt-review-rounds）、发 review 请求（用 request-review）、
+  自检（用 quality-gate）。
   Output: 逐项修复确认 + reviewer 放行。
 triggers:
   - "review 结果"
@@ -20,6 +21,13 @@ triggers:
 # Receive Review
 
 处理 reviewer 反馈的完整流程。核心原则：**技术正确性 > 社交舒适，验证后再实现，禁止表演性同意。**
+
+## ChatGPT multi-cat round 分流
+
+若反馈来自 `review-notes/chatgpt/<change-id>/round-<NN>.md`，不要逐个唤醒原 reviewer，也不要为每条
+finding 再建一套 Cat Café task 真相源。改用 `chatgpt-review-rounds`：ChatGPT 只消费 recorder 已推送的
+共识 ledger，修复并提交新 code HEAD；所有 finding 的关闭与新增问题由下一轮完整的独立检视和交叉检视确认。
+历史 ledger 不得由 ChatGPT 改写。
 
 ## 触发入口
 

--- a/cat-cafe-skills/refs/chatgpt-review-round-template.md
+++ b/cat-cafe-skills/refs/chatgpt-review-round-template.md
@@ -44,4 +44,5 @@ verdict: fix_required | approved_for_merge
 - Independent notes stayed private until every reviewer completed: `yes`
 - Cross-review consensus completed: `yes`
 - Git writer for this round was the operator-designated recorder: `yes`
+- `ledgerOnlyContinuity`: `yes` — `reviewedCodeHead..ledger commit` changes only this round ledger file
 - Recorder signature: `[nickname/model🐾]`

--- a/cat-cafe-skills/refs/chatgpt-review-round-template.md
+++ b/cat-cafe-skills/refs/chatgpt-review-round-template.md
@@ -1,0 +1,47 @@
+# ChatGPT Multi-Cat Review Round
+
+```yaml
+changeId: <PR-number-or-branch-slug>
+round: <NN>
+reviewedCodeHead: <full-commit-sha>
+reviewers:
+  - <catId>
+  - <catId>
+recorder: <co-creator-designated-catId>
+independentReviewCompleted: true
+crossReviewCompleted: true
+openFindings: <integer>
+verdict: fix_required | approved_for_merge
+```
+
+## Input evidence
+
+- Requirements / Feature Doc: `<path-or-anchor>`
+- PR / branch: `<reference>`
+- ChatGPT test evidence: `<commands-and-results>`
+
+## Previous-round closure
+
+| Finding | Status (`fixed` / `reopened` / `not_a_defect`) | Evidence |
+|---|---|---|
+| `<ID>` | `<status>` | `<commit/test/path>` |
+
+## Consensus findings
+
+| ID | Severity | Location / reproduction | Expected vs actual | Required closure |
+|---|---|---|---|---|
+| `R<NN>-P<N>-<N>` | `P1/P2/P3` | `<evidence>` | `<behavior>` | `<test/outcome>` |
+
+## Disposition
+
+- New findings: `<count>`
+- Open historical findings: `<count>`
+- `openFindings`: `<total>`
+- Verdict rationale: `<why fix_required or approved_for_merge>`
+
+## Provenance
+
+- Independent notes stayed private until every reviewer completed: `yes`
+- Cross-review consensus completed: `yes`
+- Git writer for this round was the operator-designated recorder: `yes`
+- Recorder signature: `[nickname/model🐾]`

--- a/cat-cafe-skills/request-review/SKILL.md
+++ b/cat-cafe-skills/request-review/SKILL.md
@@ -4,7 +4,8 @@ tips_exempt: harness-internal review routing convention; no distinct end-user ca
 description: >
   Route a change to a non-author local peer when local review is the selected independent validation source.
   Use when: risk routing chooses a stateful local reviewer for implementation, governance, or semantic context.
-  Not for: cloud as the selected source, vision-guardian acceptance, self-check, or review feedback handling.
+  Not for: operator-approved ChatGPT multi-cat rounds (use chatgpt-review-rounds), cloud as the selected source,
+  vision-guardian acceptance, self-check, or review feedback handling.
   Output: risk-matched review packet in the current thread/PR; mailbox archive only when the change needs the full packet.
 triggers:
   - "请 review"
@@ -17,6 +18,12 @@ triggers:
 # Request Review
 
 把当前 diff、最高风险面和真实验证证据送到一只非作者猫眼前。默认只选一个合适的独立验证源；local peer、cloud、愿景守护各按自己的风险触发，不能因为“进入 review”就自动叠加。
+
+## ChatGPT author 专属分流
+
+当 author 是 ChatGPT 桌面 Codex，且 co-creator 已明确启用“多猫独立检视 → 交叉检视 → 指定猫写 Git
+共识 ledger”的 round 协议时，停止本 skill 的单 reviewer 路径，改用 `chatgpt-review-rounds`。这是一条
+operator 授权的窄例外；普通猫作者和其他 PR 继续使用下方风险择源规则。
 
 ## 先选验证源
 

--- a/docs/SOP.md
+++ b/docs/SOP.md
@@ -3,7 +3,7 @@ feature_ids: [F042]
 topics: [sop]
 doc_kind: note
 created: 2026-02-26
-updated: 2026-07-27
+updated: 2026-08-04
 ---
 
 # Clowder AI 开发 SOP
@@ -114,6 +114,24 @@ Phase N merge → 碰头（不是"要不要继续"，是"方向对不对"）→ 
 - 愿景守护看最终产品结果，只在 feature close 触发。
 
 只有不同风险面确实需要不同视角时才叠加，并分别写明触发理由。P1/P2 修复后只回提出 finding 的 active source 覆盖真实修复 delta；不把另一个旧 reviewer 拉来续签，也不因 SHA-only / 可证明机械变化重开 reviewer。
+
+#### ChatGPT author 多猫 Review round（operator 指定 lane）
+
+当实现作者是 ChatGPT 桌面 Codex，且 co-creator 明确启用本 lane 时，它是上方“默认单一独立源”的窄例外：
+
+1. ChatGPT 提交精确 code HEAD、PR 与测试证据。
+2. 至少两只非作者猫读取同一个 HEAD，各自独立检视并私下保留意见；全部完成前禁止互看。
+3. 独立检视与后续交叉检视期间 Git 只读：reviewer 不改共享分支，不 commit/push/rebase。
+4. 全员通过 barrier 后公开意见，交叉核验证据、合并重复项并形成共识；技术分歧继续查证，价值分歧交给 co-creator。
+5. 每轮只有 co-creator 指定的记录猫可以把共识写入
+   `review-notes/chatgpt/<change-id>/round-<NN>.md` 并推送；push 成功才算本轮结束。
+6. ChatGPT 按 ledger 修复、测试并提交新 code HEAD，再从独立检视开始下一轮；ChatGPT 不得改写历史 ledger。
+7. 最新一轮只有在所有历史共识 findings 已关闭、无新 finding、`openFindings=0` 时才能记录
+   `approved_for_merge`。风险门禁全绿后由 ChatGPT squash merge main，随后等待 co-creator 亲自验收。
+
+最终 recorder ledger commit 只允许新增该 round 文件。它通过 `reviewedCodeHead` 绑定已审代码，并以
+continuityProof 证明 ledger-only HEAD 变化；如果 ledger 后出现代码、测试、配置或其他文档变化，终态立即
+stale，必须用新 code HEAD 开下一轮。执行细节与模板见 `chatgpt-review-rounds` skill。
 
 ### Sol 测试
 

--- a/docs/features/F253-qc-loop.md
+++ b/docs/features/F253-qc-loop.md
@@ -10,7 +10,7 @@ tips_exempt: internal QC tooling — no user-visible capability change
 
 # F253: Clowder AI QC Loop — 自动化质量门禁全链路
 
-> **Status**: done (Phase D governance amendment awaiting peer review) | **Owner**: Ragdoll (Opus-4.6) | **Priority**: P1 | **Phase A-C completed**: 2026-06-28
+> **Status**: done (Phase D governance amendment 2026-08-04) | **Owner**: Ragdoll (Opus-4.6) | **Priority**: P1 | **Phase A-C completed**: 2026-06-28
 
 ## Why
 
@@ -318,12 +318,12 @@ F253 **消费** F167 的 hold_ball / review-feedback / merge-gate 事件，**产
 - [x] AC-C2: CI repair loop 实现 same-class detection + max 2 rounds escalate — `scripts/classify-ci-error.mjs` (`classifyCiError` + `shouldAutoFix`) + merge-gate SKILL.md protocol docs（12 tests）
 - [x] AC-C3: `eval:qc` domain 注册在 F192 eval domain registry — `docs/harness-feedback/eval-domains/eval-qc.yaml` + `qc-metrics-provider.ts` + `qc-generator-adapter.ts` + `eval-cat-invocation.ts` DOMAIN_INSTRUCTIONS + `index.ts` wiring（4 tests → 12 tests after cloud P1+P2 fixes）
 
-### Phase D（ChatGPT author 多猫共识 Review rounds）🚧
+### Phase D（ChatGPT author 多猫共识 Review rounds）✅
 
-- [ ] AC-D1: ChatGPT author lane 有独立 skill + round ledger 模板，并明确至少两只非作者猫、独立阶段禁止互看、review 期间 Git 只读（验证：`pnpm check:skills` + review routing guard）
-- [ ] AC-D2: SOP 人类文本与机器定义都覆盖 independent barrier → cross-review → operator-designated recorder → ChatGPT fix/new HEAD → repeat 状态机（验证：`pnpm check:sop-definitions`）
-- [ ] AC-D3: merge-gate 只接受绑定 reviewed code HEAD 的 `approved_for_merge` / `openFindings: 0` ledger；recorder ledger-only commit 之外的 HEAD 改动使 verdict stale（验证：review routing guard + peer review）
-- [ ] AC-D4: ChatGPT 负责合入 main，合入后状态进入 operator acceptance 而非自动宣告验收完成（验证：skill、SOP 与 merge-gate 文本一致）
+- [x] AC-D1: ChatGPT author lane 有独立 skill + round ledger 模板，并明确至少两只非作者猫、独立阶段禁止互看、review 期间 Git 只读（验证：`pnpm check:skills` + review routing guard）
+- [x] AC-D2: SOP 人类文本与机器定义都覆盖 independent barrier → cross-review → operator-designated recorder → ChatGPT fix/new HEAD → repeat 状态机（验证：`pnpm check:sop-definitions`）
+- [x] AC-D3: merge-gate 只接受绑定 reviewed code HEAD 的 `approved_for_merge` / `openFindings: 0` ledger；recorder ledger-only commit 之外的 HEAD 改动使 verdict stale（验证：review routing guard + peer review）
+- [x] AC-D4: ChatGPT 负责合入 main，合入后状态进入 operator acceptance 而非自动宣告验收完成（验证：skill、SOP 与 merge-gate 文本一致）
 
 ## 需求点 Checklist
 

--- a/docs/features/F253-qc-loop.md
+++ b/docs/features/F253-qc-loop.md
@@ -10,7 +10,7 @@ tips_exempt: internal QC tooling — no user-visible capability change
 
 # F253: Clowder AI QC Loop — 自动化质量门禁全链路
 
-> **Status**: done | **Owner**: Ragdoll (Opus-4.6) | **Priority**: P1 | **Completed**: 2026-06-28
+> **Status**: done (Phase D governance amendment awaiting peer review) | **Owner**: Ragdoll (Opus-4.6) | **Priority**: P1 | **Phase A-C completed**: 2026-06-28
 
 ## Why
 
@@ -139,6 +139,20 @@ qc.idle
 | **Layer 3: Final Approver** | named 猫猫（可 = Layer 2 reviewer） | 确认 final HEAD 覆盖全部 review findings | 在 stale HEAD 上签字 | 金规"merge-gate"行的前提 |
 
 **关键约束**：如果 reviewer 给了 semantic fix 建议（不只是 hygiene），author 改完后 **review provenance 必须重新闭合**（Layer 3 re-confirm on final HEAD）。Layer 3 的 APPROVE 是 merge-gate evidence 的 `reviewer` + `review_head` 来源。
+
+### Phase D: ChatGPT author 多猫共识 Review rounds（2026-08-04 operator directive）
+
+当实现作者是 **ChatGPT 桌面 Codex**，且 operator 明确启用本 lane 时，采用多猫独立判断后再共识收敛的窄例外；普通 Cat Café 代码 review 仍走上方按风险路由的 QC Loop。
+
+1. ChatGPT 提交精确 code HEAD、PR 与测试证据后，至少两只非作者猫读取同一个 HEAD，分别独立检视并把意见保留在自己的本地上下文；独立阶段禁止互看意见。
+2. 独立检视与后续交叉检视期间，所有 reviewer 对 Git 只读：不修改共享分支，不 commit/push/rebase/checkout。
+3. 只有所有 reviewer 都明确完成独立检视后，才开启交叉检视；猫猫相互核验证据、去重 finding，并形成统一共识。
+4. 只有 operator 指定的 recorder 能把共识写入 `review-notes/chatgpt/<change-id>/round-<NN>.md` 并 push。push 成功代表该轮检视完成；历史 ledger 不由 ChatGPT 改写。
+5. ChatGPT 按该轮 ledger 修复、测试、提交新 code HEAD，然后重新从独立检视开始下一轮。所有已接受 finding（含 P3）关闭且没有新 finding 前禁止合入。
+6. 最后一轮 ledger 必须记录 `approved_for_merge`、`openFindings: 0` 并绑定 reviewed code HEAD。recorder 的 ledger-only commit 是唯一允许的 review 期 Git 写入；若 HEAD 还有任何代码、测试、配置或其他文档变化，approval 立即 stale，必须开启新一轮。
+7. 风险门禁全绿后由 ChatGPT squash merge main；merge 后不代表用户验收完成，必须等待 operator 亲自验收。
+
+执行真相源：`chatgpt-review-rounds` skill；每轮结构真相源：`cat-cafe-skills/refs/chatgpt-review-round-template.md`。
 
 ### QC 触发策略
 
@@ -304,6 +318,13 @@ F253 **消费** F167 的 hold_ball / review-feedback / merge-gate 事件，**产
 - [x] AC-C2: CI repair loop 实现 same-class detection + max 2 rounds escalate — `scripts/classify-ci-error.mjs` (`classifyCiError` + `shouldAutoFix`) + merge-gate SKILL.md protocol docs（12 tests）
 - [x] AC-C3: `eval:qc` domain 注册在 F192 eval domain registry — `docs/harness-feedback/eval-domains/eval-qc.yaml` + `qc-metrics-provider.ts` + `qc-generator-adapter.ts` + `eval-cat-invocation.ts` DOMAIN_INSTRUCTIONS + `index.ts` wiring（4 tests → 12 tests after cloud P1+P2 fixes）
 
+### Phase D（ChatGPT author 多猫共识 Review rounds）🚧
+
+- [ ] AC-D1: ChatGPT author lane 有独立 skill + round ledger 模板，并明确至少两只非作者猫、独立阶段禁止互看、review 期间 Git 只读（验证：`pnpm check:skills` + review routing guard）
+- [ ] AC-D2: SOP 人类文本与机器定义都覆盖 independent barrier → cross-review → operator-designated recorder → ChatGPT fix/new HEAD → repeat 状态机（验证：`pnpm check:sop-definitions`）
+- [ ] AC-D3: merge-gate 只接受绑定 reviewed code HEAD 的 `approved_for_merge` / `openFindings: 0` ledger；recorder ledger-only commit 之外的 HEAD 改动使 verdict stale（验证：review routing guard + peer review）
+- [ ] AC-D4: ChatGPT 负责合入 main，合入后状态进入 operator acceptance 而非自动宣告验收完成（验证：skill、SOP 与 merge-gate 文本一致）
+
 ## 需求点 Checklist
 
 | ID | 需求点（operator experience/转述） | AC 编号 | 验证方式 | 状态 |
@@ -311,6 +332,8 @@ F253 **消费** F167 的 hold_ball / review-feedback / merge-gate 事件，**产
 | R1 | "靠 QC 把废品拦住" — 自动化质量门禁 | AC-A1, AC-A2, AC-A4 | `pnpm gate --auto-fix` 运行 + merge-gate evidence 验证 | [ ] |
 | R2 | "偷方法，不偷口号" — 学 no-mistakes 的 pipeline，保 Clowder AI 价值观 | AC-A1~A4, AC-B1 | review spec 确认无匿名化/无授权自动化 | [ ] |
 | R3 | "就算质量好也会有问题" — 需要可度量的质量追踪 | AC-C3 | telemetry 查询 | [ ] |
+| R4 | ChatGPT 提交后，多猫先独立检视、再交叉检视并统一共识 | AC-D1, AC-D2 | skill + SOP + routing guard | [ ] |
+| R5 | 只有 operator 指定猫写入本轮共识；ChatGPT 逐轮修复，清零后合入并等亲自验收 | AC-D3, AC-D4 | ledger template + merge-gate provenance | [ ] |
 
 ### 覆盖检查
 - [x] 每个需求点都能映射到至少一个 AC
@@ -341,6 +364,9 @@ tips_exempt: internal tooling — QC Loop 是开发工具链改进，无用户�
 | **Leader Creep**：一只猫事实上变成 QC 大副 / qc-bot 演化为 verdict signer | 社会学 | Non-Goals #1 #5 硬约束 + 定期审计 qc-bot commit 范围（不得超出 hygiene） |
 | **Alarm Fatigue**：低风险变更也触发完整 QC → 猫麻木 | 社会学 | 触发策略分层（低风险 doc polish 只 Tier 1 或跳过） |
 | **Identity Flattening**：为追求"流程统一"抹掉猫的专长和直觉差异 | 社会学 | reviewer 选择由 author 基于关系画像决定（不 round-robin）+ finding 带 named cat 签名 |
+| 独立检视提前互看造成意见锚定 | 社会学 | 至少两只猫在同一 reviewedCodeHead 上独立完成；全员完成前不开放交叉意见 |
+| 多猫意见散落或多人同时写 Git | 技术/协作 | operator 指定唯一 recorder；以已 push 的 round ledger 为该轮共识真相源 |
+| recorder ledger commit 使 final HEAD 与 review HEAD 不同 | 技术 | merge-gate 只允许 ledger-only continuity proof；其他文件变化一律使 approval stale |
 
 ## Eval / Tracking Contract
 
@@ -366,6 +392,10 @@ tips_exempt: internal tooling — QC Loop 是开发工具链改进，无用户�
 | KD-8 | per-PR pipeline stateless + aggregate telemetry 复用 F192 stateful storage | per-PR evidence = merge-gate 扩展（stateless 重建）；aggregate verdict = F192 eval domain（stateful 累积）。不建 daemon/Redis。 | 2026-06-26 |
 | KD-9 | 扩展 `pnpm gate --auto-fix` 不造 `pnpm qc:hygiene`；evidence manifest 扩展 merge-gate Provenance Matrix 不造 `pnpm qc:evidence` | 已有基础设施足够——`scripts/pre-merge-check.sh` 已有 hygiene 全链路，merge-gate 已有 Review Provenance Matrix 5 字段。造新命令 = 平行轮子。（operator push back + 47 Architecture Inventory） | 2026-06-26 |
 | KD-10 | eval:qc evalCat = opus (4.6) = F253 author 暂时 OK | domain analysis ≠ PR review，author-as-eval-cat 适用于 single-feature 阶段（eval:qc 看的是 aggregate QC metrics，不是 review 个别 PR）。未来 F253 重大改造前应轮换 evalCat 避免 self-eval bias。（愿景守护 47 caveat #2 透明化） | 2026-06-28 |
+| KD-11 | ChatGPT author lane 先多猫独立检视，再开放交叉检视 | 防止 reviewer 被先出现的意见锚定，同时保留多模型盲点正交性 | 2026-08-04（operator directive） |
+| KD-12 | operator 指定唯一 recorder 把共识 ledger 写入 Git；其他 reviewer 全程 Git 只读 | 单一真相源 + 清晰 provenance，避免各猫意见分支互相覆盖 | 2026-08-04（operator directive） |
+| KD-13 | 每次 ChatGPT 修复产生新 code HEAD 后完整开启下一轮；所有 accepted findings 清零才可合入 | review 只对精确 HEAD 有效，不能用上一轮 verdict 覆盖新代码 | 2026-08-04（operator directive） |
+| KD-14 | ChatGPT 合入 main 后仍等待 operator 亲自验收 | 技术门禁通过不等于 operator 的最终体验验收 | 2026-08-04（operator directive） |
 
 ## Future Phase Candidates
 

--- a/packages/shared/src/types/sop-definition.generated.ts
+++ b/packages/shared/src/types/sop-definition.generated.ts
@@ -244,6 +244,71 @@ export const DEVELOPMENT_SOP_DEFINITION = {
             futureCandidate: 'review_packet_schema',
           },
         },
+        {
+          id: 'review-chatgpt-independent-first',
+          kind: 'hard_rule',
+          text: 'ChatGPT 提交代码进入专属多猫 Review round；至少两只非作者猫先独立检视，全部完成前不得互看意见',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'request-review' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'Reviewer-private notes and the independent-review barrier are conversational state until a typed review-round carrier exists.',
+            futureCandidate: 'chatgpt_review_round_barrier',
+          },
+        },
+        {
+          id: 'review-chatgpt-readonly-until-consensus',
+          kind: 'hard_rule',
+          text: 'ChatGPT Review 的独立检视与交叉检视阶段只读；任何猫不得 commit、push、rebase 或修改共享分支',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'request-review' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'Git write ownership is bound to the operator-designated recorder, but review-round identity is not yet emitted as a structured Git policy event.',
+            futureCandidate: 'chatgpt_review_round_git_write_guard',
+          },
+        },
+        {
+          id: 'review-chatgpt-cross-review-after-barrier',
+          kind: 'hard_rule',
+          text: '全部独立检视完成后才进入交叉检视；争议必须基于证据收敛，价值分歧交给co-creator',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'request-review' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'Independent completion, note release, evidence convergence, and value escalation are semantic review-round transitions.',
+            futureCandidate: 'chatgpt_review_round_state',
+          },
+        },
+        {
+          id: 'review-chatgpt-designated-recorder',
+          kind: 'hard_rule',
+          text: '每轮只有co-creator指定的记录猫可以将共识 ledger 提交并推送到 Git；写回成功才算本轮结束',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'request-review' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'The Git ledger is durable truth, but recorder appointment and the successful round-close write are not yet represented by one typed receipt.',
+            futureCandidate: 'chatgpt_review_round_receipt',
+          },
+        },
+        {
+          id: 'review-chatgpt-repeat-until-zero',
+          kind: 'hard_rule',
+          text: 'ChatGPT 按 ledger 修复后提交新 code HEAD 并开始下一轮；最新轮 open findings 非零不得合入',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'request-review' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'Each new code HEAD requires a fresh independent and cross-review round; ledger closure is currently markdown evidence.',
+            futureCandidate: 'chatgpt_review_round_open_findings_gate',
+          },
+        },
       ],
       pitfalls: [
         {
@@ -276,6 +341,19 @@ export const DEVELOPMENT_SOP_DEFINITION = {
             type: 'command_pattern',
             mustMatch: 'gh pr merge .*--squash',
             mustNotMatch: 'git merge --squash|git reset --soft',
+          },
+        },
+        {
+          id: 'merge-chatgpt-review-round-closed',
+          kind: 'hard_rule',
+          text: 'ChatGPT 仅在最新共识 ledger 为 approved_for_merge、openFindings=0 且风险门禁全绿时合入 main；合入后等待co-creator亲自验收',
+          severity: 'blocker',
+          owner: { type: 'stage_suggested_skill', skill: 'merge-gate' },
+          predicate: {
+            type: 'manual_only',
+            reason:
+              'The final ledger, reviewedCodeHead continuity proof, gate evidence, merge receipt, and post-merge operator acceptance are not yet one typed state object.',
+            futureCandidate: 'chatgpt_review_round_merge_gate',
           },
         },
         {

--- a/scripts/check-external-review-closure.mjs
+++ b/scripts/check-external-review-closure.mjs
@@ -4,9 +4,13 @@ import { existsSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { checkReviewEntryMode, evaluateReviewEntryFixtureScenario, reviewModeFor } from './review-entry-mode.mjs';
-import { checkReviewContinuityLanguage, checkReviewRoutingSurfaces } from './review-routing-surface-guard.mjs';
+import {
+  checkChatgptReviewRoundLanguage,
+  checkReviewContinuityLanguage,
+  checkReviewRoutingSurfaces,
+} from './review-routing-surface-guard.mjs';
 
-export { checkReviewContinuityLanguage };
+export { checkChatgptReviewRoundLanguage, checkReviewContinuityLanguage };
 
 const EXTERNAL_REVIEW = /(?:external|外部).{0,20}(?:pull request|pr|review|复审)|github.{0,20}(?:review|复审)/is;
 const VERDICT = /\b(?:approve|approved|block|blocked|changes.requested|p[012])\b|放行|退回|结论/is;
@@ -303,12 +307,14 @@ export function runExternalReviewClosureCheck(root = process.cwd()) {
   const skill = read('cat-cafe-skills/cross-cat-handoff/SKILL.md');
   const requestReviewSkill = read('cat-cafe-skills/request-review/SKILL.md');
   const receiveReviewSkill = read('cat-cafe-skills/receive-review/SKILL.md');
+  const chatgptReviewRoundsSkill = read('cat-cafe-skills/chatgpt-review-rounds/SKILL.md');
   const errors = [
     ...boundary.errors,
     ...checkReviewRoutingSurfaces({
       handoffSkill: skill,
       requestReviewSkill,
       receiveReviewSkill,
+      chatgptReviewRoundsSkill,
       mergeGateSkill: read('cat-cafe-skills/merge-gate/SKILL.md'),
       ironLaw: read('assets/prompt-templates/l4-iron-laws.md'),
       // The inbound maintainer playbook is deliberately home-only. Keep checking

--- a/scripts/check-external-review-closure.test.mjs
+++ b/scripts/check-external-review-closure.test.mjs
@@ -13,6 +13,32 @@ const routingFixture = JSON.parse(
 );
 
 describe('review completion dual-route hard guard', () => {
+  it('locks the operator-approved ChatGPT multi-cat review round contract', () => {
+    assert.equal(typeof reviewGuard.checkChatgptReviewRoundLanguage, 'function');
+    if (typeof reviewGuard.checkChatgptReviewRoundLanguage !== 'function') return;
+
+    const valid = reviewGuard.checkChatgptReviewRoundLanguage(`
+      只服务于 operator 拍板的“ChatGPT 执行、Cat Café 设计与 Review”工作流
+      independent_review: 每只猫只读同一个 \`reviewedCodeHead\`，私下保留自己的 findings，
+      不得阅读、索取或预测其他猫的意见
+      cross_review: begins only after every independent review is complete
+      recorder: co-creator 指定的 recorder，只有 recorder 可以提交并推送
+      ledger: review-notes/chatgpt/<change-id>/round-<NN>.md binds reviewedCodeHead and consensus findings
+      closure: push 成功才代表本轮检视完毕；ChatGPT 不修改历史 ledger
+      lifecycle: ChatGPT fixes accepted findings, then a new round repeats until openFindings=0
+      terminal: approved_for_merge allows ChatGPT to merge main，等待 co-creator 亲自验收
+    `);
+    assert.deepEqual(valid, []);
+
+    const invalid = reviewGuard.checkChatgptReviewRoundLanguage(
+      'Several cats review together and ChatGPT merges when it looks good.',
+    );
+    assert.match(invalid.join('\n'), /independent_review/);
+    assert.match(invalid.join('\n'), /co-creator 指定的 recorder/);
+    assert.match(invalid.join('\n'), /reviewedCodeHead/);
+    assert.match(invalid.join('\n'), /openFindings=0/);
+  });
+
   it('rejects active guidance that turns every SHA change or every diff into mandatory re-review', () => {
     const errors = reviewGuard.checkReviewContinuityLanguage({
       ironLaw: 'Review 必须跨个体：自己的代码由别人 review。',

--- a/scripts/review-routing-surface-guard.mjs
+++ b/scripts/review-routing-surface-guard.mjs
@@ -19,10 +19,31 @@ export function checkReviewContinuityLanguage({ ironLaw, requestReview, mergeGat
   return errors;
 }
 
+export function checkChatgptReviewRoundLanguage(source) {
+  return requireTokens(source, 'chatgpt-review-rounds convention', [
+    '只服务于 operator 拍板的“ChatGPT 执行、Cat Café 设计与 Review”工作流',
+    'independent_review',
+    '只读同一个 `reviewedCodeHead`',
+    '私下保留自己的 findings',
+    '不得阅读、索取或预测其他猫的意见',
+    'cross_review',
+    'co-creator 指定的 recorder',
+    '只有 recorder 可以提交并推送',
+    'review-notes/chatgpt/<change-id>/round-<NN>.md',
+    'reviewedCodeHead',
+    'push 成功才代表本轮检视完毕',
+    'ChatGPT 不修改历史 ledger',
+    'openFindings=0',
+    'approved_for_merge',
+    '等待 co-creator 亲自验收',
+  ]);
+}
+
 export function checkReviewRoutingSurfaces({
   handoffSkill,
   requestReviewSkill,
   receiveReviewSkill,
+  chatgptReviewRoundsSkill,
   mergeGateSkill,
   ironLaw,
   inboundPrReference,
@@ -67,6 +88,7 @@ export function checkReviewRoutingSurfaces({
       'coordination.phase=active',
       'reviewReentry',
     ]),
+    ...checkChatgptReviewRoundLanguage(chatgptReviewRoundsSkill),
     ...requireTokens(mergeGateSkill, 'merge-gate review provenance convention', [
       'reviewReentry',
       'already-consumed exact-HEAD review',

--- a/scripts/sop-definitions.test.mjs
+++ b/scripts/sop-definitions.test.mjs
@@ -30,8 +30,14 @@ const EXPECTED_PORTED_RULE_TEXTS = [
   'Fresh-context 是 finding generator，不是 approval authority——不产出 verdict，不记入 Review Provenance Matrix',
   '同一个体不能 review 自己的代码',
   '涉及用户意图或愿景的 Review 请求必须附原始需求摘录',
+  'ChatGPT 提交代码进入专属多猫 Review round；至少两只非作者猫先独立检视，全部完成前不得互看意见',
+  'ChatGPT Review 的独立检视与交叉检视阶段只读；任何猫不得 commit、push、rebase 或修改共享分支',
+  '全部独立检视完成后才进入交叉检视；争议必须基于证据收敛，价值分歧交给co-creator',
+  '每轮只有co-creator指定的记录猫可以将共识 ledger 提交并推送到 Git；写回成功才算本轮结束',
+  'ChatGPT 按 ledger 修复后提交新 code HEAD 并开始下一轮；最新轮 open findings 非零不得合入',
   'P1/P2 修复后的实质内容未被对应 review source 覆盖；SHA-only / 可证明机械变化用 continuityProof，不重开 reviewer',
   '必须用 gh pr merge --squash（禁止本地 squash）',
+  'ChatGPT 仅在最新共识 ledger 为 approved_for_merge、openFindings=0 且风险门禁全绿时合入 main；合入后等待co-creator亲自验收',
   '云端 review 同一 SHA 不重复触发',
   'merge 前核对 feature doc 是否说真话（Status/AC/Phase vs 代码现实），merge 后记录已合入状态',
   '触及 runtime 加载面的 PR 合入后必须分开声明 main 与 live runtime 状态；未获co-creator授权时记录 live=dormant，不得冒充已生效',
@@ -68,7 +74,7 @@ describe('SOP definition catalog', () => {
     );
   });
 
-  it('ports all 24 development SOP rules into development.yaml with predicates', () => {
+  it('ports all 30 development SOP rules into development.yaml with predicates', () => {
     const { runtimeDefinitions } = loadSopDefinitionCatalog();
     const development = runtimeDefinitions[0];
 
@@ -82,7 +88,7 @@ describe('SOP definition catalog', () => {
     assert.equal(development.stages.find((stage) => stage.id === 'impl')?.suggestedSkill, 'worktree');
 
     const rules = development.stages.flatMap((stage) => [...stage.hardRules, ...stage.pitfalls]);
-    assert.equal(rules.length, 24);
+    assert.equal(rules.length, 30);
     assert.deepEqual(
       rules.map((rule) => rule.text),
       EXPECTED_PORTED_RULE_TEXTS,

--- a/sop-definitions/development.yaml
+++ b/sop-definitions/development.yaml
@@ -154,6 +154,41 @@ stages:
           type: manual_only
           reason: Review packet content is free-form markdown; no structured requirement-excerpt field yet.
           future_candidate: review_packet_schema
+      - id: review-chatgpt-independent-first
+        text: ChatGPT 提交代码进入专属多猫 Review round；至少两只非作者猫先独立检视，全部完成前不得互看意见
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: Reviewer-private notes and the independent-review barrier are conversational state until a typed review-round carrier exists.
+          future_candidate: chatgpt_review_round_barrier
+      - id: review-chatgpt-readonly-until-consensus
+        text: ChatGPT Review 的独立检视与交叉检视阶段只读；任何猫不得 commit、push、rebase 或修改共享分支
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: Git write ownership is bound to the operator-designated recorder, but review-round identity is not yet emitted as a structured Git policy event.
+          future_candidate: chatgpt_review_round_git_write_guard
+      - id: review-chatgpt-cross-review-after-barrier
+        text: 全部独立检视完成后才进入交叉检视；争议必须基于证据收敛，价值分歧交给co-creator
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: Independent completion, note release, evidence convergence, and value escalation are semantic review-round transitions.
+          future_candidate: chatgpt_review_round_state
+      - id: review-chatgpt-designated-recorder
+        text: 每轮只有co-creator指定的记录猫可以将共识 ledger 提交并推送到 Git；写回成功才算本轮结束
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: The Git ledger is durable truth, but recorder appointment and the successful round-close write are not yet represented by one typed receipt.
+          future_candidate: chatgpt_review_round_receipt
+      - id: review-chatgpt-repeat-until-zero
+        text: ChatGPT 按 ledger 修复后提交新 code HEAD 并开始下一轮；最新轮 open findings 非零不得合入
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: Each new code HEAD requires a fresh independent and cross-review round; ledger closure is currently markdown evidence.
+          future_candidate: chatgpt_review_round_open_findings_gate
     pitfalls:
       - id: review-retrigger-after-p1
         text: P1/P2 修复后的实质内容未被对应 review source 覆盖；SHA-only / 可证明机械变化用 continuityProof，不重开 reviewer
@@ -174,6 +209,13 @@ stages:
           type: command_pattern
           must_match: gh pr merge .*--squash
           must_not_match: git merge --squash|git reset --soft
+      - id: merge-chatgpt-review-round-closed
+        text: ChatGPT 仅在最新共识 ledger 为 approved_for_merge、openFindings=0 且风险门禁全绿时合入 main；合入后等待co-creator亲自验收
+        severity: blocker
+        predicate:
+          type: manual_only
+          reason: The final ledger, reviewedCodeHead continuity proof, gate evidence, merge receipt, and post-merge operator acceptance are not yet one typed state object.
+          future_candidate: chatgpt_review_round_merge_gate
       - id: merge-cloud-review-sha-dedup
         text: 云端 review 同一 SHA 不重复触发
         severity: warn


### PR DESCRIPTION
## Why

Implement the operator-directed workflow for ChatGPT desktop Codex changes: cats review the same code HEAD independently, cross-review only after the barrier, and one operator-designated recorder writes the immutable Git consensus ledger.

## What

- add the chatgpt-review-rounds skill and round ledger template
- extend F253, human SOP, machine SOP, request/receive review routing, and merge provenance
- add regression guards for the independent-review, recorder, repeat-until-zero, and operator-acceptance contract

## Risk routing

- Behavior: governance and developer-workflow behavior only; no product runtime path changes
- Data: no storage, migration, production-data, or TTL changes
- Security: no authentication, authorization, secret, network, or production boundary changes
- Contract: changes the internal review/SOP contract and generated SOP projection; medium governance risk covered by stateful non-author local review on the exact final HEAD
- Irreversible: squash merge is revertable; no irreversible user or external-system effect
- cloudReview=not-selected reason=context-heavy Cat Cafe governance semantics are the risk surface; context-blind cloud review adds no distinct safety boundary
- fullGate=not-required reason=no security/data/migration/external-contract/runtime behavior change; repository check, lint, build, and targeted governance gates already passed

## Validation

- pnpm check
- pnpm lint
- pnpm build
- pnpm check:skills
- pnpm check:review-completion-routing
- pnpm check:sop-definitions
- pnpm check:features
- node --test scripts/check-external-review-closure.test.mjs

All listed commands passed. Full pnpm test was also attempted; it remains red only on pre-existing public-worktree/environment fixtures such as missing source-only Claude settings, missing home-only scripts/AGENTS identity text, tmux absence, and long WeChat integration cases. No failures touched this diff.

Independent local review: Kimi APPROVE on final HEAD 3827fbe30075128549fdc5d50b449d33008fc73e; no open P1/P2/P3.

[CodeX/GPT-5🐾]