### PR TITLE
verdict(eval:friction): 2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-08-06",
+  "generatedAt": "2026-08-06T03:06:57.744Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "no friction cluster surfaced in the selected window",
+    "evidence": "friction-rollup/cluster_count"
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/provenance.json
@@ -1,0 +1,19 @@
+{
+  "verdictId": "2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/rollup-report.json",
+      "sha256": "364af460e53945c1c5e9bbad2e932a7766ad284eb6622342574f7edb884fac12"
+    },
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/measurement-validity.json",
+      "sha256": "7eed9b0c5573e882d9c3d73dd51af2e15488828618b6ce3fbeec267508e60c9f"
+    }
+  ],
+  "generatedAt": "2026-08-06T03:06:57.744Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "2"
+  },
+  "sanitizeRulesVersion": "f267-friction-measurement-v1"
+}

--- a/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/measurement-validity.json
+++ b/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/measurement-validity.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 1,
+  "measurementTarget": "friction_opportunity_to_action",
+  "window": {
+    "sinceMs": 1785726000000,
+    "untilMs": 1785985200000
+  },
+  "capturedAt": "2026-08-06T03:06:57.744Z",
+  "baselineKind": "prospective_paired_capture",
+  "historicalBaseline": {
+    "classification": "symptom_cohort",
+    "rollupCount": 11,
+    "limitation": "historical_rollups_lack_frozen_canonical_row_ids"
+  },
+  "cancelJoin": {
+    "status": "no_opportunity",
+    "expectedIds": [],
+    "actualIds": [],
+    "intersectionIds": [],
+    "missingIds": [],
+    "extraIds": [],
+    "recall": null
+  },
+  "channels": {
+    "paw-feel": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "cancel": {
+      "opportunity": {
+        "status": "measured",
+        "ids": [],
+        "provenance": "frozen_task_outcome_rows"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "user-feedback": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "eval-domain": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    }
+  },
+  "decision": {
+    "status": "insufficient",
+    "reasons": [
+      "cancel_join:no_opportunity",
+      "downstream_degraded"
+    ],
+    "withdrawalConditions": [
+      "rerun_after_closed_window_with_cancel_opportunity",
+      "rerun_after_downstream_dependencies_recover"
+    ]
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/raw/rollup-report.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1785726000000,
+    "windowEndMs": 1785985200000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1785726000000,
+    "untilMs": 1785985200000
+  },
+  "signalCount": 0,
+  "clusterCount": 0,
+  "degraded": true,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1785726000000,
+      "untilMs": 1785985200000
+    },
+    "generatedAt": "2026-08-06T03:06:57.744Z",
+    "topClusters": [],
+    "actionableCandidates": [],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": true,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 78
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle",
+  "evalSnapshotId": "eval-F245-2026-08-06",
+  "featureId": "F245",
+  "generatedAt": "2026-08-06T03:06:57.744Z",
+  "window": {
+    "startMs": 1785726000000,
+    "endMs": 1785985200000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 0,
+        "top_cluster_count": 0,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle.md
+++ b/docs/harness-feedback/verdicts/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle.md
@@ -1,0 +1,31 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle
+source_snapshot: "snapshot:bundle/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/snapshot"
+---
+
+# Live Verdict — 2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle
+
+- Verdict: `keep_observe`
+- Phenomenon: The 72h friction window from 2026-08-03 03:00 UTC to 2026-08-06 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This is the seventh consecutive quiet 72h window after the earlier high-severity singleton `cli_error: API 配额超限`, while the rollup remains degraded because embedding-based clustering is still disabled on this runtime.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: No active recurrent root cause is observable in the current window; the only recent friction spike still looks most plausibly like transient environment_drift from API quota exhaustion rather than an ongoing harness defect. (confidence medium)
+- Owner ask: Keep the every-3d friction rollup active; only escalate if `cli_error: API 配额超限` recurs, a new actionableCandidate appears, or a referenceOnly eval-domain cluster starts recurring.
+- Re-eval: next eval at 2026-08-09T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/snapshot
+- attribution:bundle/2026-08-06-eval-friction-c8-empty-window-after-seventh-quiet-cycle/eval-F245-2026-08-06:no-finding
+- metric:official.rollup_signal_count
+- metric:official.rollup_cluster_count
+- metric:official.actionable_candidates
+- metric:official.reference_only_clusters
+
+Counterarguments:
+- Seven consecutive zero-signal windows after one high-severity singleton still do not prove the upstream quota condition is resolved; the next recurrence would reopen this as actionable.
+- Because embedding-based clustering remains disabled, degraded lexical clustering may miss semantically related low-volume friction even when no exact cluster surfaces.
+- The absence of recurrence may reflect traffic shape rather than harness health; if usage on the affected path was low during this window, the quiet cycle can overstate improvement.


### PR DESCRIPTION
Verdict published via manual fallback after `cat_cafe_publish_verdict` failed with `generator_failed` (`docs/harness-feedback/registry/measurement-bundles.yaml` missing in the isolated worktree).

Verdict: keep_observe
Domain: eval:friction
Phenomenon: The 72h friction window from 2026-08-03 03:00 UTC to 2026-08-06 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. This is the seventh consecutive quiet 72h window after the earlier high-severity singleton `cli_error: API 配额超限`, while the rollup remains degraded because embedding-based clustering is still disabled on this runtime.

Reviewed by: opus-47
Action: Keep the every-3d friction rollup active; only escalate if `cli_error: API 配额超限` recurs, a new actionableCandidate appears, or a referenceOnly eval-domain cluster starts recurring.
Source thread: thread_eval_friction

---
**Cat-owned artifact gate — No operator merge needed.**
(Interim: keep_observe + no actionable findings. Rollup mechanism deferred to future Phase. See docs/SOP.md § artifact-only-pr-merge-gate for cat merge contract.)