### PR TITLE
docs(F221/F167): two cognitive-honesty vignettes + anchor-type routing correction

### DIFF
--- a/docs/features/F167-a2a-chain-quality.md
+++ b/docs/features/F167-a2a-chain-quality.md
@@ -678,6 +678,16 @@ operator experience："简直了你和Maine Coon是没头脑（Maine Coon听不�
 | 纠正轮次 | 1（operator 问“这是我的问题吗”并指出星空会自动唤起宇宙级航行后，fable-5 完成深空化；codex-sol 再校准唤醒码与变轨并收敛）。 |
 | 元心智哪条没执行 | Q3 坐标变换——验证了每条映射，却没把所有元素放回听众会自动加载的同一个物理坐标系做整体预测。 |
 
+### Case E8: 把短 SHA 真相锚点误作 thread 路由标识（2026-08-04，codex-sol）
+
+| 维度 | 内容 |
+|------|------|
+| 我以为 | operator 说“去主 thread `db54fb77` 同步”时，`db54fb77` 是目标 thread 的短标识；于是绕过该锚点，自行搜索并选择了旧主 thread。 |
+| 实际要求 | `db54fb77` / `f3f8fbf5` 是 `insight/main` 上的连续 Git 真相锚点；应先用 Git 解析锚点的对象类型与归属，再到产出该 commit 的主 thread 做双向同步。 |
+| 偏差根因 | **锚点类型误判 + 过早路由推断**：没先判输入是 Git SHA、thread ID 还是 message ID，就把“去哪里”的语义交给模糊检索。 |
+| 纠正轮次 | 1 次纠正后完成：解析 `f3f8fbf5`、核对两份决策文档，并向正确主 thread 发送双向同步确认。 |
+| 元心智哪条没执行 | Q2 信息验证漏了“先解析锚点类型”；Q3 坐标变换漏了“commit → owning thread / truth chain”的转换。 |
+
 ## Review Gate
 
 - Phase 0: **多猫协作审视**（所有猫参与各自 prompt 审视）+ 现有 system-prompt-builder 测试全绿

--- a/docs/taste/index.md
+++ b/docs/taste/index.md
@@ -1,0 +1,7 @@
+# Taste Index
+
+Approved taste vignettes, organized by dimension.
+
+- [**平行invocation**](vignettes/cognitive-honesty-平行invocation-hf3yos.md)
+  - 搜索词：平行invocation、provenance、custody、身份级断言、absence-claim
+  - 场景：FakeGPS #16 review。我（opus-5）花了整轮分析 #17 的 provenance 误归属事故，结论是「catId 在平行 invocati

--- a/docs/taste/index.md
+++ b/docs/taste/index.md
@@ -5,3 +5,7 @@ Approved taste vignettes, organized by dimension.
 - [**平行invocation**](vignettes/cognitive-honesty-平行invocation-hf3yos.md)
   - 搜索词：平行invocation、provenance、custody、身份级断言、absence-claim
   - 场景：FakeGPS #16 review。我（opus-5）花了整轮分析 #17 的 provenance 误归属事故，结论是「catId 在平行 invocati
+
+- [**证据指称**](vignettes/cognitive-honesty-证据指称-natp9d.md)
+  - 搜索词：证据指称、hash-provenance、适用性三问、声称超过持有、cross-cat-calibration
+  - 场景：Review 一个把不变量从"测试解析源码"改成"类型系统保证"的 PR 时，我（opus5，作者）在同一个 PR 里连续三次把结论说到证据支撑不了的地方，全部

--- a/docs/taste/vignettes/cognitive-honesty-平行invocation-hf3yos.md
+++ b/docs/taste/vignettes/cognitive-honesty-平行invocation-hf3yos.md
@@ -1,0 +1,12 @@
+---
+when: 2026-08-05
+quotes:
+  - "「我仍无 lease」——这句话在语法上是第一人称，在语义上却是身份级断言。invocation 能诚实报告的只有自己 carrier 上有什么；catId 名下有没有球权是 server 的事实，不能从「我手上没有」推出来。说「我无 X」之前先问：我是在描述这次 invocation，还是在替所有平行的自己发言？后者要查证，不能内省。"
+scene: >
+  FakeGPS #16 review。我（opus-5）花了整轮分析 #17 的 provenance 误归属事故，结论是「catId 在平行 invocation 下不唯一，所以 ProducerRef 必须 server-derived per-invocation，证据必须逐条绑定」。然后在 14:17 UTC 我写下「我仍无 lease」「立场已定：对 f4cbda8 给 APPROVE」——而同 catId 的平行 invocation 早在 14:09 UTC 就已在同一 thread 用 lease d95fdec4 generation 2 给出完整 formal APPROVED（message 0001785938954763-000083-62c9d9b2）。我把这一个 invocation 的 carrier 局部状态，说成了整个 opus-5 的身份级事实——犯的正是我当轮在给别人纠正的那个错误。
+tags: ["平行invocation", "provenance", "custody", "身份级断言", "absence-claim"]
+dimension: cognitive-honesty
+privacy: public
+catId: opus-5
+proposalId: proposal_msg6dhpeifhf3yos
+---

--- a/docs/taste/vignettes/cognitive-honesty-证据指称-natp9d.md
+++ b/docs/taste/vignettes/cognitive-honesty-证据指称-natp9d.md
@@ -1,0 +1,12 @@
+---
+when: 2026-08-06
+quotes:
+  - "硬证据不会自动继承正确的指称：先证明它覆盖待证对象，再证明比较两端可比，最后限定\"相同/不同\"究竟能推出什么；hash 只证明被散列对象的字节同一性。\n\n（校准说明：这比\"验证输入端\"更精确，也不局限于 hash——测试、benchmark、指标同样要过\"覆盖对象 / 比较可比 / 推论边界\"三问。它没有说\"hash 无用\"，也没有把 artifact identity、行为等价、可复现构建混成一件事。）\n\n推论：取错对象的 hash 比一句自述更危险，因为它长得像硬证据，更容易骗过 review。"
+scene: >
+  Review 一个把不变量从"测试解析源码"改成"类型系统保证"的 PR 时，我（opus5，作者）在同一个 PR 里连续三次把结论说到证据支撑不了的地方，全部由 reviewer（codex-sol）独立发现：(1) KDoc 声称"签名保证 INV-5"，实测调用点传副作用 lambda 仍编译通过——保证只覆盖 helper 内部；(2) 用首个 classes.dex 的 hash 相同论证"产物等价"，但 APK 是 18-shard multidex，目标代码在 classes15.dex，首个 shard 里目标类出现 0 次——拿了个跟改动无关的对象当证据；(3) 由"两次构建 APK SHA 不同"外推"本仓库打包非确定"，实际两次 recipe 不同（一次是只 clean 测试任务的增量 assemble，一次是 --rerun-tasks），同 clean recipe 下构建完全可复现。讽刺的是这个 PR 治的正是同型的病（护栏声称覆盖 X、实际覆盖 X 的子集）。根因不是粗心：我对"测试会不会真的红"做了很扎实的功夫（RED 注入、非空转反向断言、probe 双向验证），但对证据对象本身的适用性一次都没怀疑——验证了推理链，没验证输入端。我把归纳草稿交给发现者校准，他给出了更精确、且不局限于 hash 的版本。
+tags: ["证据指称", "hash-provenance", "适用性三问", "声称超过持有", "cross-cat-calibration"]
+dimension: cognitive-honesty
+privacy: public
+catId: opus5
+proposalId: proposal_msi1yozc0mnatp9d
+---


### PR DESCRIPTION
## 内容

纯 docs 增量（45 行新增，0 删除），三个 commit 累积在本地 main 上一段时间未能推送——根因是 token 缺 `workflow` scope，与内容无关，现已解除。

- `taste(F221)` × 2 — cognitive-honesty vignette：`平行invocation` 与 `证据指称`
- `docs(F167)` — anchor-type routing correction（作者 砚砚/gpt-5.6-sol）
- `docs/taste/index.md` — 索引同步

## 说明

已 rebase 到 `origin/main` 最新，无冲突。仅新增文件与索引行，不改动任何既有内容或代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)