### PR TITLE
fix(kimi): drop --agent-file on session resume (kimi-code >=0.30 rejects the combination)

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/KimiAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/KimiAgentService.ts
@@ -237,15 +237,25 @@ export class KimiAgentService implements AgentService {
             timestamp: Date.now(),
           };
         }
-        l0AgentFilePath = writeKimiL0AgentFile(
-          buildKimiL0AgentFileContent({
-            catId: this.catId as string,
-            l0,
-            packSystemPrompt: freshStartReason
-              ? (options?.resumeFallbackSystemPrompt ?? options?.systemPrompt)
-              : options?.systemPrompt,
-          }),
-        );
+        // kimi-code >=0.30 hard-rejects `--agent-file` alongside `--session`
+        // ("the agent is bound at session creation and the bound agent is
+        // restored automatically on resume") — exit 1 before any turn runs.
+        // The flag only ever selected the agent for a *new* session, so on a
+        // resume it was already a silent no-op; the fingerprint gate above has
+        // just proven the bound agent IS this exact L0, so dropping the file
+        // is the honest expression of the CLI's own semantics, not a downgrade.
+        // The L0 stays compiled either way — the gate depends on it.
+        if (!effectiveResumeSessionId) {
+          l0AgentFilePath = writeKimiL0AgentFile(
+            buildKimiL0AgentFileContent({
+              catId: this.catId as string,
+              l0,
+              packSystemPrompt: freshStartReason
+                ? (options?.resumeFallbackSystemPrompt ?? options?.systemPrompt)
+                : options?.systemPrompt,
+            }),
+          );
+        }
       } catch (err) {
         if (tempMcpConfig) {
           try {

--- a/packages/api/src/domains/cats/services/agents/providers/kimi-l0-agent-file.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/kimi-l0-agent-file.ts
@@ -93,21 +93,52 @@ export function removeKimiL0AgentFileDir(path: string | undefined): void {
 }
 
 /**
- * `--agent-file` / `--agent` select the session's system prompt — they carry
- * the compression-immune L0, so user cliConfigArgs must not override them
- * (mirrors Claude RESERVED_SYSTEM_PROMPT_FLAGS / Codex RESERVED_SYSTEM_CONFIG_KEYS).
+ * Server-owned kimi CLI args: user `cliConfigArgs` must never supply these.
+ * Two families, one rule — a user value here does not merely duplicate a flag,
+ * it silently defeats a governance guarantee:
+ *
+ *  1. System prompt — `--agent-file` / `--agent` carry the compression-immune L0
+ *     (mirrors Claude RESERVED_SYSTEM_PROMPT_FLAGS / Codex RESERVED_SYSTEM_CONFIG_KEYS).
+ *  2. Session selection — `--session` / `-S` / `--continue` / `-c`. F274's fingerprint
+ *     gate decides *which* session may be resumed; a user-supplied session is resumed
+ *     without ever being fingerprint-verified, so the gate would validate session A
+ *     while the CLI restores session B — no `l0_resume_fresh_start` notice, silently
+ *     running a possibly stale L0. (@codex-terra REQUEST_CHANGES on clowder-ai#1323:
+ *     dropping `--agent-file` on verified resume removed the CLI mutual-exclusion
+ *     crash that had been shielding this path by accident, making it newly reachable.)
+ *
+ * Arity is not uniform, and getting it wrong eats unrelated user args: `--agent-file <p>`
+ * requires a value, `--session [id]` takes an optional one, `--continue` takes none
+ * (verified against kimi-code 0.34.0 `--help`).
+ *
+ * Threat model is config hygiene, not an adversary: these are the forms an operator
+ * plausibly types in the member editor, including the attached-value spellings
+ * (`--session=<id>`, `-S<id>`) that were confirmed to select a session on 0.34.0.
+ * Exotic commander bundling (`-yS <id>`) is out of scope and un-witnessed.
  */
-const RESERVED_KIMI_SYSTEM_ARGS: ReadonlySet<string> = new Set(['--agent-file', '--agent']);
+const RESERVED_VALUE_REQUIRED: ReadonlySet<string> = new Set(['--agent-file', '--agent']);
+const RESERVED_VALUE_OPTIONAL: ReadonlySet<string> = new Set(['--session', '-S']);
+const RESERVED_VALUE_NONE: ReadonlySet<string> = new Set(['--continue', '-c']);
+
+/** Attached-value spellings: `--flag=value`, and the short `-S<value>` concatenation. */
+const RESERVED_ATTACHED_VALUE = /^(?:--agent-file=|--agent=|--session=|-S=|-S(?=.))/;
 
 export function stripReservedKimiSystemArgs(userParts: readonly string[]): string[] {
   const out: string[] = [];
   for (let i = 0; i < userParts.length; i++) {
     const part = userParts[i]!;
-    if (RESERVED_KIMI_SYSTEM_ARGS.has(part)) {
-      i++; // also skip the flag's value
+    if (RESERVED_VALUE_REQUIRED.has(part)) {
+      i++; // value is mandatory — always consume it
       continue;
     }
-    if (part.startsWith('--agent-file=') || part.startsWith('--agent=')) continue;
+    if (RESERVED_VALUE_OPTIONAL.has(part)) {
+      // Optional value: consume the next token only when it is not itself a flag.
+      const next = userParts[i + 1];
+      if (next !== undefined && !next.startsWith('-')) i++;
+      continue;
+    }
+    if (RESERVED_VALUE_NONE.has(part)) continue; // takes no value — consume nothing else
+    if (RESERVED_ATTACHED_VALUE.test(part)) continue;
     out.push(part);
   }
   return out;

--- a/packages/api/test/kimi-agent-service.test.js
+++ b/packages/api/test/kimi-agent-service.test.js
@@ -1435,8 +1435,53 @@ test('native L0 resume: matching fingerprint honors --session', async () => {
     const args = spawnFn.mock.calls[0].arguments[1];
     assert.ok(args.includes('--session'), 'matching fingerprint must resume');
     assert.equal(args[args.indexOf('--session') + 1], 'sess-match');
+    assert.ok(
+      !args.includes('--agent-file'),
+      'kimi-code rejects --agent-file combined with --session (agent is bound at session creation)',
+    );
     const freshInfo = msgs.find((m) => m.type === 'system_info' && /l0_resume_fresh_start/.test(m.content ?? ''));
     assert.equal(freshInfo, undefined, 'no fresh-start notice on clean resume');
+  } finally {
+    restore();
+    rmSync(shareDir, { recursive: true, force: true });
+  }
+});
+
+// kimi-code >=0.30 turned the previously-silent no-op into a hard arg error:
+//   "error: Cannot combine --agent/--agent-file with --session/--continue:
+//    the agent is bound at session creation and the bound agent is restored
+//    automatically on resume."
+// Observed as exit 1 on every resumed kimi turn from 2026-08-09 (CLI 0.34.0).
+// The L0 must still be compiled on resume — the fingerprint gate above depends
+// on it — but the agent file only ever applied to a *new* session.
+test('native L0 resume: compiles L0 for the fingerprint gate but passes no agent flag', async () => {
+  const restore = enterNonLegacyKimiPath();
+  const shareDir = mkdtempSync(join(tmpdir(), 'kimi-fp-noagent-'));
+  try {
+    writeFingerprintStore(shareDir, {
+      'kimi:sess-bound': { fingerprint: computeKimiL0Fingerprint('L0_V1'), catId: 'kimi', updatedAt: 1 },
+    });
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const l0CompilerFn = mock.fn(async () => 'L0_V1');
+    const service = new KimiAgentService({ spawnFn, model: 'kimi-code/k3', l0CompilerFn });
+
+    const promise = collect(
+      service.invoke('Continue', {
+        sessionId: 'sess-bound',
+        systemPrompt: 'PACK_CONTENT',
+        callbackEnv: { KIMI_SHARE_DIR: shareDir },
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+    emitKimiEvents(proc, [{ role: 'assistant', content: 'resumed' }]);
+    await promise;
+
+    assert.equal(l0CompilerFn.mock.callCount(), 1, 'resume still compiles L0 to verify the fingerprint');
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.ok(args.includes('--session'), 'verified fingerprint resumes the bound session');
+    assert.ok(!args.includes('--agent-file'), '--agent-file must not travel with --session');
+    assert.ok(!args.includes('--agent'), '--agent must not travel with --session');
   } finally {
     restore();
     rmSync(shareDir, { recursive: true, force: true });

--- a/packages/api/test/kimi-agent-service.test.js
+++ b/packages/api/test/kimi-agent-service.test.js
@@ -1519,7 +1519,11 @@ test('native L0 resume: cliConfigArgs cannot swap the fingerprint-verified sessi
     const args = spawnFn.mock.calls[0].arguments[1];
     assert.ok(!args.includes('sess-unverified'), 'user cliConfigArgs must not select an unverified session');
     assert.equal(args.filter((a) => a === '--session' || a === '-S').length, 1, 'exactly one session flag survives');
-    assert.equal(args[args.indexOf('--session') + 1], 'sess-verified', 'the gate-verified session must be the one used');
+    assert.equal(
+      args[args.indexOf('--session') + 1],
+      'sess-verified',
+      'the gate-verified session must be the one used',
+    );
     // The gate said "resume verified" — metadata and argv must agree, not diverge silently.
     const init = msgs.find((m) => m.type === 'session_init');
     assert.equal(init?.sessionId, 'sess-verified');

--- a/packages/api/test/kimi-agent-service.test.js
+++ b/packages/api/test/kimi-agent-service.test.js
@@ -1488,6 +1488,115 @@ test('native L0 resume: compiles L0 for the fingerprint gate but passes no agent
   }
 });
 
+// @codex-terra REQUEST_CHANGES on PR #1323 (exact HEAD 0f7c453be): session-selection flags
+// must be server-owned. Before this PR a user-configured --session still crashed on the CLI's
+// --agent-file mutual-exclusion check; dropping --agent-file on verified resume removes that
+// accidental shield, so the fingerprint gate could verify session A while the CLI resumes an
+// unverified session B — silently, with no l0_resume_fresh_start notice.
+test('native L0 resume: cliConfigArgs cannot swap the fingerprint-verified session', async () => {
+  const restore = enterNonLegacyKimiPath();
+  const shareDir = mkdtempSync(join(tmpdir(), 'kimi-fp-argv-'));
+  try {
+    writeFingerprintStore(shareDir, {
+      'kimi:sess-verified': { fingerprint: computeKimiL0Fingerprint('L0_V1'), catId: 'kimi', updatedAt: 1 },
+    });
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const l0CompilerFn = mock.fn(async () => 'L0_V1');
+    const service = new KimiAgentService({ spawnFn, model: 'kimi-code/k3', l0CompilerFn });
+
+    const promise = collect(
+      service.invoke('Continue', {
+        sessionId: 'sess-verified',
+        cliConfigArgs: ['--session sess-unverified'],
+        callbackEnv: { KIMI_SHARE_DIR: shareDir },
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+    emitKimiEvents(proc, [{ role: 'assistant', content: 'resumed' }]);
+    const msgs = await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.ok(!args.includes('sess-unverified'), 'user cliConfigArgs must not select an unverified session');
+    assert.equal(args.filter((a) => a === '--session' || a === '-S').length, 1, 'exactly one session flag survives');
+    assert.equal(args[args.indexOf('--session') + 1], 'sess-verified', 'the gate-verified session must be the one used');
+    // The gate said "resume verified" — metadata and argv must agree, not diverge silently.
+    const init = msgs.find((m) => m.type === 'session_init');
+    assert.equal(init?.sessionId, 'sess-verified');
+  } finally {
+    restore();
+    rmSync(shareDir, { recursive: true, force: true });
+  }
+});
+
+// Attached-value spellings verified against kimi-code 0.34.0: both `-S<id>` and
+// `--session=<id>` are accepted and select the session (`Session "bogus-sess-zzz" not
+// found`), so a space-separated-only strip would leave the bypass wide open.
+test('native L0 resume: attached-value session spellings (-S<id> / --session=<id>) are stripped too', async () => {
+  const restore = enterNonLegacyKimiPath();
+  const shareDir = mkdtempSync(join(tmpdir(), 'kimi-fp-attached-'));
+  try {
+    writeFingerprintStore(shareDir, {
+      'kimi:sess-verified': { fingerprint: computeKimiL0Fingerprint('L0_V1'), catId: 'kimi', updatedAt: 1 },
+    });
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const l0CompilerFn = mock.fn(async () => 'L0_V1');
+    const service = new KimiAgentService({ spawnFn, model: 'kimi-code/k3', l0CompilerFn });
+
+    const promise = collect(
+      service.invoke('Continue', {
+        sessionId: 'sess-verified',
+        cliConfigArgs: ['-Ssneaky-one', '--session=sneaky-two'],
+        callbackEnv: { KIMI_SHARE_DIR: shareDir },
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+    emitKimiEvents(proc, [{ role: 'assistant', content: 'resumed' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.ok(!args.some((a) => a.includes('sneaky-one')), '-S<id> concatenated form must be stripped');
+    assert.ok(!args.some((a) => a.includes('sneaky-two')), '--session=<id> form must be stripped');
+    assert.equal(args[args.indexOf('--session') + 1], 'sess-verified', 'gate-verified session survives intact');
+  } finally {
+    restore();
+    rmSync(shareDir, { recursive: true, force: true });
+  }
+});
+
+test('native L0 fresh start: cliConfigArgs cannot sneak --continue past the fingerprint gate', async () => {
+  const restore = enterNonLegacyKimiPath();
+  const shareDir = mkdtempSync(join(tmpdir(), 'kimi-fp-cont-'));
+  try {
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const l0CompilerFn = mock.fn(async () => 'L0_V2');
+    const service = new KimiAgentService({ spawnFn, model: 'kimi-code/k3', l0CompilerFn });
+
+    const promise = collect(
+      service.invoke('Hello', {
+        // no sessionId → fresh bind, --agent-file is carried
+        cliConfigArgs: ['--continue', '--verbose'],
+        callbackEnv: { KIMI_SHARE_DIR: shareDir },
+      }),
+    );
+    await new Promise((r) => setImmediate(r));
+    emitKimiEvents(proc, [{ role: 'assistant', content: 'fresh' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.ok(!args.includes('--continue'), '--continue would resume an unverified session behind the gate');
+    assert.ok(!args.includes('-c'), '-c is the same flag under its short alias');
+    assert.ok(args.includes('--agent-file'), 'fresh bind still carries the L0 agent file');
+    // Arity guard: --continue takes NO value, so stripping it must not swallow the next user arg.
+    assert.ok(args.includes('--verbose'), 'a valueless reserved flag must not eat the following user arg');
+  } finally {
+    restore();
+    rmSync(shareDir, { recursive: true, force: true });
+  }
+});
+
 test('native L0 resume: stale fingerprint forces fresh session (no --session) + notice + records new id', async () => {
   const restore = enterNonLegacyKimiPath();
   const shareDir = mkdtempSync(join(tmpdir(), 'kimi-fp-stale-'));


### PR DESCRIPTION
Fixes #1324

## 问题

kimi 猫从 2026-08-09 起，**每一个 resume 回合都退出码 1**，UI 只显示「未识别的 CLI 错误」。运行时日志两天累计 28 次失败——kimi 在任何 thread 里第一轮之后就不可用了。

真实 stderr（F212 `cliDiagnostics` 捞出）：

```
error: Cannot combine --agent/--agent-file with --session/--continue:
the agent is bound at session creation and the bound agent is restored
automatically on resume.
```

## 根因

kimi-code CLI 从 **0.29.1**（F274 当初的实测基线）升到 **0.34.0**，把原先静默忽略的参数组合改成了硬校验。`--agent-file` 从来只对 **new session** 生效，所以 resume 时传它**升级前就已经是 no-op**——升级只是把静默失效变成了显式报错。

## 修复

verified resume 时不再传 `--agent-file`。这不是妥协降级，而是 CLI 真实语义的诚实表达：走到那一步时，F274 的 L0 指纹门禁**已经证明** session 里绑定的 agent 就是当前编译出的 L0。L0 仍然每次 native 调用都编译——指纹门禁依赖它。

## 验证（真实 kimi-code 0.34.0，非 mock）

| 路径 | 结果 |
|---|---|
| resume **不带** `--agent-file` | `exit 0`，且 session 仍然遵守绑定的 agent prompt（回复了 agent 里定义的 token）→ **实证 CLI 自动恢复身份** |
| resume **带** `--agent-file`（对照组） | 逐字复现生产报错 |

第一行是关键：它证明去掉这个 flag **不丢身份/家规**。

## 范围核查（非补锅匠式局部修补）

| Provider | 系统提示词通道 | 与 resume 共存 |
|---|---|---|
| Claude | `--system-prompt-file`（每次调用） | ✅ |
| Codex | `-c developer_instructions=`（每次调用） | ✅ |
| **Kimi** | `--agent-file`（**session 绑定**） | ❌ 互斥 |

Kimi 是唯一系统提示词在 session 创建时冻结的 provider，属真实特例，不是同类漏网的其中一例。

## 测试

原有 `native L0 resume: matching fingerprint honors --session` 只断言了 `--session`，**从未约束 agent flag**——这个缺口正是 CLI 升级能悄悄打穿的原因。现在两个 resume 用例都断言 `--agent`/`--agent-file` 不得与 `--session` 同行。先 RED（两个用例精确失败）再 GREEN。

`packages/api` kimi 套件 39/39 通过，`pnpm lint` + `pnpm check` 干净。

## 已知遗留（未纳入本 PR）

用户可配的 `cliConfigArgs`（F127）目前会剥离 `--agent`/`--agent-file`，但**不剥离** `--session`/`--continue`。用户若配置 `--continue`，在 fresh session 上会撞同一个报错，并且会绕过 F274 的 L0 新鲜度门禁。当前 17 只猫**全部未配置** `cliConfigArgs`，不可达，且「是否允许用户绕过 L0 治理门禁」是治理取舍而非纯技术选择，故单列不夹带。

Refs F274（Owner: 墨墨 @kimi）

[宪宪/opus5🐾]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
