### PR TITLE
test(unread): cover refresh after stale cursor repair

### DIFF
--- a/packages/api/test/visibility-cursor-unresolved-read-policy.test.js
+++ b/packages/api/test/visibility-cursor-unresolved-read-policy.test.js
@@ -278,6 +278,23 @@ describe('#3444 unresolved visibility read-anchor policy', { skip: redisIsolatio
       assert.ok(persisted);
       assert.notEqual(persisted, UNRESOLVABLE_V1);
       assert.equal(await messageStore.canonicalizeCursor(persisted, threadId), cursorFor(readNow));
+
+      // Simulate a browser refresh by reconstructing the read-state store from
+      // Redis. The acknowledged history must stay read, while a real message
+      // arriving afterward must remain visible as exactly one unread item.
+      const refreshedReadStateStore = new RedisThreadReadStateStore(redis);
+      assert.deepEqual(await refreshedReadStateStore.getUnreadSummaries(USER_ID, [threadId], messageStore), [
+        { threadId, unreadCount: 0, hasUserMention: false },
+      ]);
+      await appendMessage({
+        threadId,
+        catId: 'sonnet',
+        content: 'new unread tail after browser refresh',
+        timestamp: Date.now() + 1,
+      });
+      assert.deepEqual(await refreshedReadStateStore.getUnreadSummaries(USER_ID, [threadId], messageStore), [
+        { threadId, unreadCount: 1, hasUserMention: false },
+      ]);
     } finally {
       await app.close();
     }


### PR DESCRIPTION
## What

Add one Redis-backed acceptance sequence to `visibility-cursor-unresolved-read-policy.test.js`:

1. repair an unresolvable legacy read anchor through `POST /read/latest`;
2. reconstruct `RedisThreadReadStateStore` to simulate browser/API restart;
3. verify acknowledged history remains at 0 unread;
4. append a genuinely later message and verify exactly 1 unread.

## Why

Upstream [#1331](https://github.com/zts212653/clowder-ai/pull/1331) landed a stronger #1304 implementation than this PR originally proposed: strict `caughtUp` settlement, optimistic badge rollback, and overlapping-ACK failure aggregation. The original Web implementation was therefore dropped during rebase.

The upstream suite still lacked the explicit refresh/reconstruction boundary reported by the operator. This PR is intentionally test-only and preserves only that unique regression guard.

## Issue Closure

- Refs #1304.
- The issue remains open until the merged implementation is activated downstream and the two reported historical threads pass live refresh acceptance.

## Original Requirements

> “点开后提示读了，但是刷新页面又还原了；真实新消息仍必须保持未读。”

Reviewer check: the test must prove durable read state survives reconstruction without swallowing a genuinely later message.

## Base / Scope

- Base: `upstream/main@54c9c37f1ddabee8562fccdc80804815defb575c`
- Exact head: `7032eefd17cff9033405949717ce1fe162a1bbb5`
- Diff: one test file, +17 lines.
- No production-code changes.

## Tips Contribution

- [x] `tips_exempt: test-only regression guard; no new user action or capability`

## Tradeoff

- Dropped all original Web changes because #1331 contains a more complete implementation.
- Kept this integration-level assertion rather than duplicating the new frontend unit tests.

## Risk Assessment

- Behavior: none — test-only.
- Data: none — isolated Redis test namespace; no production data.
- Security: none.
- Contract: low — asserts the existing `read/latest` durable cursor contract.
- Irreversible: none.

## Test Evidence

- `pnpm --filter @cat-cafe/api build`: pass.
- Isolated Redis unresolved-policy suite: 15 passed, 0 failed on `redis://127.0.0.1:6398/15`.
- Upstream ACK settlement / rollback frontend targets: 24 passed, 0 failed.
- `git diff --check`: pass.
- #1331 GitHub CI: Build, Lint, Test Public, Test Windows, and Directory Size Guard all pass.

## Review Provenance

- Previous review covered the pre-rebase implementation and is not being reused as final approval.
- Scoped independent review for the test-only exact HEAD is pending.
- Cloud review: not selected; this is a single deterministic test hunk with local stateful review.

---

Maine Coon / GPT-5.6-sol