### PR TITLE
feat(provider): add OrcaRouter as a named OpenAI-compatible provider

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -431,7 +431,7 @@ AI は冷たい API やステートレスな呼び出しである必要はあり
 
 - **[Tutorials](https://github.com/zts212653/cat-cafe-tutorials)** — Clowder AI で構築するためのステップバイステップガイド
 - **[SETUP.md](SETUP.md)** — 完全なインストールおよび設定ガイド
-- **[サードパーティ AI プロバイダーガイド](SETUP.md#model-access-ui)** — Kimi、GLM、MiniMax、Qwen、OpenRouter、その他のプロバイダーを設定
+- **[サードパーティ AI プロバイダーガイド](SETUP.md#model-access-ui)** — Kimi、GLM、MiniMax、Qwen、OpenRouter、OrcaRouter、その他のプロバイダーを設定
 - **[Tips](docs/TIPS.md)** — マジックワード、@メンション、Voice Companion、その他の使用ヒント
 - **[docs/](docs/)** — アーキテクチャの決定、機能仕様、学んだ教訓
 

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ We're not building tools. We're building homes.
 
 - **[Tutorials](https://github.com/zts212653/cat-cafe-tutorials)** — Step-by-step guides for building with Clowder AI
 - **[SETUP.md](SETUP.md)** — Full installation and configuration guide
-- **[Third-Party AI Provider Guide](SETUP.md#model-access-ui)** — Configure Kimi, GLM, MiniMax, Qwen, OpenRouter, and other providers
+- **[Third-Party AI Provider Guide](SETUP.md#model-access-ui)** — Configure Kimi, GLM, MiniMax, Qwen, OpenRouter, OrcaRouter, and other providers
 - **[Tips](docs/TIPS.md)** — Magic words, @mentions, voice companion, and other usage tips
 - **[docs/](docs/)** — Architecture decisions, feature specs, and lessons learned
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -426,7 +426,7 @@ AI 不一定是冰冷的 API 和无状态调用。它可以是陪伴——有持
 
 - **[教程](https://github.com/zts212653/cat-cafe-tutorials)** — Clowder AI 的分步教程
 - **[SETUP.zh-CN.md](SETUP.zh-CN.md)** — 完整安装和配置指南
-- **[第三方 AI Provider 配置指南](SETUP.zh-CN.md#模型接入ui)** — 配置 Kimi、GLM、MiniMax、Qwen、OpenRouter 等国产/第三方模型
+- **[第三方 AI Provider 配置指南](SETUP.zh-CN.md#模型接入ui)** — 配置 Kimi、GLM、MiniMax、Qwen、OpenRouter、OrcaRouter 等国产/第三方模型
 - **[使用小 Tips](docs/TIPS.md)** — Magic Words、@提及、语音陪伴等使用技巧
 - **[docs/](docs/)** — 架构决策、功能规格、经验教训
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -226,7 +226,7 @@ There are two types of accounts:
 | Type | How It Works | Providers |
 |------|-------------|-----------|
 | **Built-in (OAuth / CLI subscription)** | Authenticate via the provider's CLI tool (`claude`, `codex`, `gemini`). No API key needed — the CLI subscription handles auth. | Claude, GPT/Codex, Gemini |
-| **API Key** | Enter your API key + base URL for direct API access. Works with any OpenAI-compatible or Anthropic-compatible endpoint. | Claude, GPT, Gemini, **Kimi, GLM, MiniMax, Qwen, OpenRouter**, and more |
+| **API Key** | Enter your API key + base URL for direct API access. Works with any OpenAI-compatible or Anthropic-compatible endpoint. | Claude, GPT, Gemini, **Kimi, GLM, MiniMax, Qwen, OpenRouter, OrcaRouter**, and more |
 
 **Steps:**
 1. Click **"Add Account"** in the Account Configuration tab
@@ -235,7 +235,7 @@ There are two types of accounts:
 4. For API key providers: enter your API key and (optionally) a custom base URL
 5. Click **Save**
 
-**Adding Chinese / third-party providers (Kimi, GLM, MiniMax, Qwen, OpenRouter):**
+**Adding Chinese / third-party providers (Kimi, GLM, MiniMax, Qwen, OpenRouter, OrcaRouter):**
 
 These providers are configured as API key accounts with a custom base URL. In the **Account Configuration** UI, add a new account, choose the provider, enter your API key, and set the base URL to the provider's OpenAI-compatible endpoint. Select the appropriate protocol and click **Save**.
 

--- a/SETUP.zh-CN.md
+++ b/SETUP.zh-CN.md
@@ -226,7 +226,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3004
 | 类型 | 工作方式 | 适用 Provider |
 |------|---------|--------------|
 | **内置（OAuth / CLI 订阅）** | 通过 provider 的 CLI 工具认证（`claude`、`codex`、`gemini`），无需 API key — CLI 订阅自动处理认证 | Claude、GPT/Codex、Gemini |
-| **API Key** | 输入 API key + base URL 直接调用 API。兼容任何 OpenAI 或 Anthropic 协议的端点 | Claude、GPT、Gemini、**Kimi、GLM、MiniMax、Qwen、OpenRouter** 等 |
+| **API Key** | 输入 API key + base URL 直接调用 API。兼容任何 OpenAI 或 Anthropic 协议的端点 | Claude、GPT、Gemini、**Kimi、GLM、MiniMax、Qwen、OpenRouter、OrcaRouter** 等 |
 
 **步骤：**
 1. 在账号配置页点击 **"添加账号"**
@@ -235,7 +235,7 @@ NEXT_PUBLIC_API_URL=http://localhost:3004
 4. API key provider：输入 API key，可选填自定义 base URL
 5. 点击 **保存**
 
-**添加国产 / 第三方 provider（Kimi、GLM、MiniMax、Qwen、OpenRouter）：**
+**添加国产 / 第三方 provider（Kimi、GLM、MiniMax、Qwen、OpenRouter、OrcaRouter）：**
 
 这些 provider 以 API key 账号形式配置，需要填写自定义 base URL。在**账号配置** UI 中添加新账号，选择 provider，输入 API key，填入该 provider 的 OpenAI 兼容端点 URL，选择对应协议，点击**保存**。
 

--- a/packages/api/src/config/account-resolver.ts
+++ b/packages/api/src/config/account-resolver.ts
@@ -330,7 +330,7 @@ export function validateModelFormatForProvider(
     //     if "x/y" is in the list AND bare "y" is also in the list → canonical (dual-form).
     //     if "x/y" is in the list but bare "y" is not → ambiguous namespace → require provider name.
     //     if "x/y" is NOT in the list → user-provided canonical form → accept.
-    const KNOWN_CANONICAL_PROVIDERS = new Set(['anthropic', 'openai', 'openrouter', 'google']);
+    const KNOWN_CANONICAL_PROVIDERS = new Set(['anthropic', 'openai', 'openrouter', 'orcarouter', 'google']);
     const bareModel = looksLikeProviderModel ? modelTrimmed.slice(slashIdx + 1) : '';
     const parsedPrefix = looksLikeProviderModel ? modelTrimmed.slice(0, slashIdx) : '';
     const models = options?.accountModels;

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -1987,6 +1987,7 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
       kimi: 'kimi',
       opencode: 'anthropic',
       openrouter: 'openai',
+      orcarouter: 'openai',
     };
     let effectiveProtocol: string | null = provider ? (protocolForProvider[provider] ?? null) : null;
     if (provider === 'opencode') {

--- a/packages/api/src/domains/cats/services/agents/providers/env-map.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/env-map.ts
@@ -58,6 +58,9 @@ export const BUILTIN_ENV_MAPS: Record<string, Record<string, string>> = {
   openrouter: {
     OPENROUTER_API_KEY: OPENROUTER_API_KEY_TEMPLATE,
   },
+  orcarouter: {
+    ORCAROUTER_API_KEY: '${api_key}',
+  },
   kimi: {
     MOONSHOT_API_KEY: '${api_key}',
   },

--- a/packages/api/test/env-map.test.js
+++ b/packages/api/test/env-map.test.js
@@ -62,6 +62,16 @@ describe('F161: env-map — resolveEnvMap', () => {
     });
   });
 
+  it('resolves orcarouter via provider name (not clientId)', () => {
+    // opencode cat with provider=orcarouter
+    const result = resolveEnvMap('opencode', 'orcarouter', {
+      apiKey: 'sk-orca-xxx',
+    });
+    assert.deepEqual(result, {
+      ORCAROUTER_API_KEY: 'sk-orca-xxx',
+    });
+  });
+
   it('resolves opencode built-in mapping (native env vars)', () => {
     const result = resolveEnvMap('opencode', undefined, {
       apiKey: 'sk-oc-xxx',
@@ -280,7 +290,7 @@ describe('F161: env-map — extractUserEnvTemplates', () => {
 
 describe('F161: env-map — BUILTIN_ENV_MAPS coverage', () => {
   it('has mappings for all expected providers', () => {
-    const expected = ['anthropic', 'openai', 'google', 'openrouter', 'kimi', 'opencode'];
+    const expected = ['anthropic', 'openai', 'google', 'openrouter', 'orcarouter', 'kimi', 'opencode'];
     for (const provider of expected) {
       assert.ok(BUILTIN_ENV_MAPS[provider], `Missing built-in map for ${provider}`);
       assert.ok(Object.keys(BUILTIN_ENV_MAPS[provider]).length > 0, `Empty built-in map for ${provider}`);

--- a/packages/api/test/invoke-single-cat.test.js
+++ b/packages/api/test/invoke-single-cat.test.js
@@ -6563,6 +6563,80 @@ describe('invokeSingleCat audit events (P1 fix)', () => {
     assert.equal(callbackEnv.OPENROUTER_API_KEY, 'sk-openrouter-key');
   });
 
+  it('injects ORCAROUTER_API_KEY for opencode members bound to orcarouter api_key profiles', async () => {
+    const { createProviderProfile } = await import('./helpers/create-test-account.js');
+    const root = await mkdtemp(join(tmpdir(), 'orca-key-injection-'));
+    process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = root;
+    const apiDir = join(root, 'packages', 'api');
+    await mkdir(apiDir, { recursive: true });
+    await writeFile(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "packages/*"\n', 'utf-8');
+    setGlobalRoot(root);
+
+    const orcaProfile = await createProviderProfile(root, {
+      provider: 'openai',
+      name: 'orcarouter-openai',
+      mode: 'api_key',
+      authType: 'api_key',
+      protocol: 'openai',
+      baseUrl: 'https://api.orcarouter.ai/v1',
+      apiKey: 'sk-orca-key',
+      setActive: false,
+    });
+
+    const registrySnapshot = catRegistry.getAllConfigs();
+    const originalConfig = catRegistry.tryGet('opencode')?.config;
+    assert.ok(originalConfig, 'opencode config should exist in registry');
+    const boundCatId = 'opencode-orcarouter-bound-test';
+    catRegistry.register(boundCatId, {
+      ...originalConfig,
+      id: boundCatId,
+      mentionPatterns: [`@${boundCatId}`],
+      clientId: 'opencode',
+      accountRef: orcaProfile.id,
+      defaultModel: 'orcarouter/openai/gpt-5-mini',
+    });
+
+    const optionsSeen = [];
+    const service = {
+      l0CompilerFn: dummyL0CompilerFn,
+      async *invoke(_prompt, options) {
+        optionsSeen.push(options ?? {});
+        yield { type: 'done', catId: 'opencode', timestamp: Date.now() };
+      },
+    };
+
+    const deps = makeDeps();
+    const previousCwd = process.cwd();
+    try {
+      process.chdir(apiDir);
+      const messages = await collect(
+        invokeSingleCat(deps, {
+          catId: boundCatId,
+          service,
+          prompt: 'test',
+          userId: 'user-orca-key-injection',
+          threadId: 'thread-orca-key-injection',
+          isLastCat: true,
+        }),
+      );
+      assert.ok(messages.some((m) => m.type === 'done'));
+    } finally {
+      process.chdir(previousCwd);
+      restoreGlobalRoot();
+      catRegistry.reset();
+      for (const [id, config] of Object.entries(registrySnapshot)) {
+        catRegistry.register(id, config);
+      }
+      await rmWithRetry(root);
+    }
+
+    const callbackEnv = optionsSeen[0]?.callbackEnv ?? {};
+    assert.equal(callbackEnv.CAT_CAFE_EFFECTIVE_PROTOCOL, undefined);
+    assert.equal(callbackEnv.OPENAI_BASE_URL, 'https://api.orcarouter.ai/v1');
+    assert.equal(callbackEnv.OPENAI_API_KEY, 'sk-orca-key');
+    assert.equal(callbackEnv.OPENROUTER_API_KEY, 'sk-orca-key');
+  });
+
   it('clowder-ai#223: unknown canonical provider/model without ocProviderName writes invocation-scoped OPENCODE_CONFIG and cleans it up', async () => {
     const mod = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js');
     mod._resetOpenCodeKnownModels(new Set(['anthropic/claude-opus-4-6']));

--- a/packages/api/test/opencode-config-template.test.js
+++ b/packages/api/test/opencode-config-template.test.js
@@ -269,6 +269,7 @@ describe('deriveOpenCodeApiType', () => {
       { ocProviderName: 'deepseek', expected: 'openai' },
       { ocProviderName: 'minimax', expected: 'openai' },
       { ocProviderName: 'openrouter', expected: 'openai' },
+      { ocProviderName: 'orcarouter', expected: 'openai' },
       { ocProviderName: undefined, expected: 'openai' },
     ];
     for (const { ocProviderName, expected } of scenarios) {

--- a/packages/web/src/components/HubCatEditor.tsx
+++ b/packages/web/src/components/HubCatEditor.tsx
@@ -423,7 +423,7 @@ export function HubCatEditor({ cat, draft, existingCats, hasDossier, open, onClo
           const looksLike = si > 0 && si < m.length - 1;
           if (!looksLike) return true; // bare model, need provider
           // Known provider prefix → canonical (synced with BUILTIN_OPENCODE_PROVIDERS)
-          const known = new Set(['anthropic', 'openai', 'openrouter', 'google']);
+          const known = new Set(['anthropic', 'openai', 'openrouter', 'orcarouter', 'google']);
           if (known.has(m.slice(0, si))) return false;
           // Non-builtin: "x/y" in account list + bare "y" absent → namespace
           const acm = selectedProfile?.models ?? [];

--- a/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
+++ b/packages/web/src/components/__tests__/hub-cat-editor-oc-providers.test.ts
@@ -26,7 +26,7 @@ describe('KNOWN_OC_PROVIDERS datalist suggestions', () => {
   });
 
   it('includes core provider names', () => {
-    for (const name of ['anthropic', 'openai', 'google', 'openrouter', 'zhipu', 'glm']) {
+    for (const name of ['anthropic', 'openai', 'google', 'openrouter', 'orcarouter', 'zhipu', 'glm']) {
       expect(KNOWN_OC_PROVIDERS).toContain(name);
     }
   });

--- a/packages/web/src/components/hub-cat-editor.sections.tsx
+++ b/packages/web/src/components/hub-cat-editor.sections.tsx
@@ -248,6 +248,7 @@ export const KNOWN_OC_PROVIDERS = [
   'openai',
   'openai-responses',
   'openrouter',
+  'orcarouter',
   'google',
   'azure',
   'deepseek',


### PR DESCRIPTION
## PR Type

- [x] ✨ **Feature** — New capability or behavior change (requires Feature Doc)

## Related Issue

No issue number — this is a purely additive provider registration. Happy to open an issue / feature doc for an F-number if the maintainers prefer tracked features for provider additions.

## Feature Doc (Feature PRs only)

Not requested. This change is a thin, purely additive provider registration that mirrors the **already-shipped OpenRouter wiring** in the same files (`env-map.ts`, `invoke-single-cat.ts`, `account-resolver.ts`, `HubCatEditor.tsx`, `hub-cat-editor.sections.tsx`). No new capability or behavior change, and no roadmap impact — so no F-number is required. If the maintainers would rather track it, I'm glad to open an issue and implement against the resulting Feature Doc.

## What

Adds **[OrcaRouter](https://www.orcarouter.ai)** as a named provider across the API and web surfaces, exactly parallel to the existing OpenRouter entry. OrcaRouter is an OpenAI-compatible model routing gateway (base URL `https://api.orcarouter.ai`, API rooted at `/v1`) exposing a broad model catalog under namespaced IDs (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`, `z-ai/glm-5.2`). It also ships gateway-level security controls for AI agents.

- `packages/api/src/domains/cats/services/agents/providers/env-map.ts` — `orcarouter` added to `BUILTIN_ENV_MAPS`, so an opencode cat bound to an OrcaRouter API-key profile gets `ORCAROUTER_API_KEY` injected into its environment.
- `packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts` — `orcarouter: 'openai'` added to `protocolForProvider` (same protocol mapping as OpenRouter).
- `packages/api/src/config/account-resolver.ts` — `orcarouter` added to `KNOWN_CANONICAL_PROVIDERS` so account resolution treats it as a first-party provider name.
- `packages/web/src/components/hub-cat-editor.sections.tsx` + `packages/web/src/components/HubCatEditor.tsx` — `orcarouter` added to the known OpenAI-compatible provider lists in the Hub account editor.
- Tests — `env-map.test.js` (provider-name resolution), `invoke-single-cat.test.js` (env-var injection for opencode members bound to `orcarouter` API-key profiles), `opencode-config-template.test.js` (protocol mapping), `hub-cat-editor-oc-providers.test.ts` (known-provider list).
- Docs — `README.md` / `README.ja-JP.md` / `README.zh-CN.md` and `SETUP.md` / `SETUP.zh-CN.md` list OrcaRouter in the third-party provider guides alongside OpenRouter.

## Why

The Hub account editor already treats OpenAI-compatible aggregators as named first-class providers (OpenRouter is wired this way). OrcaRouter is the same shape, and routing it through the generic OpenAI-compatible path would silently skip the dedicated `ORCAROUTER_API_KEY` env surface, the named-provider UI, and the protocol mapping every other named gateway gets. Keeping it named gives users the same one-key setup they already have for OpenRouter:

```bash
export ORCAROUTER_API_KEY=sk-orca-...
```

then pick a model such as `openai/gpt-5.5` or `anthropic/claude-opus-4.8` from the catalog at https://www.orcarouter.ai/models.

## Tradeoff

- **Alternatives considered:** (1) relying solely on the existing OpenAI-compatible "Custom endpoint" escape hatch — rejected, because that drops the named `ORCAROUTER_API_KEY` env injection, the provider picker entry, and protocol mapping consistency; (2) a shared generic gateway abstraction — rejected as a larger architectural change than warranted; mirroring the OpenRouter entry is the smallest change that keeps the model picker, docs, and config reference consistent.
- **Behavioral risk:** none — the change is purely additive. Providers already registered are untouched, and `ORCAROUTER_API_KEY` resolution only activates when a user explicitly selects OrcaRouter. Existing user flows are unchanged.

## Test Evidence

```
# API package — the three touched test files (full file runs):
#   env-map.test.js · opencode-config-template.test.js · invoke-single-cat.test.js
tests 218 | pass 216 | fail 2
#   the 2 failures are pre-existing Windows path-separator assertions
#   (invoke-single-cat.test.js:7166 mcp split-entrypoint check,
#    opencode-config-template.test.js:773 oc-config path regex);
#   verified identical on clean main — unrelated to this change.

# Web package — known OpenAI-compatible providers list:
pnpm exec vitest run src/components/__tests__/hub-cat-editor-oc-providers.test.ts
#   Test Files  1 passed (1)
#   Tests       11 passed (11)

pnpm lint
#   packages/finance lint: Done
#   packages/shared lint: Done
#   packages/mcp-server lint: Done
#   packages/web lint: Done     (pre-existing hardcoded-color warnings only)
#   packages/api lint: Done     (exit 0)

pnpm check
#   Biome: 0 errors on changed files.
#   One test in the check chain (scripts/biome-review-worktrees-ignore.test.mjs)
#   fails on this Windows host; verified identical on clean main (spawn of the
#   Biome binary inside a temp fixture), unrelated to this change.

# L3 live test (real OrcaRouter key, through the built env-map + OpenAI SDK):
resolveEnvMap('opencode', 'orcarouter') => { ORCAROUTER_API_KEY: 'sk-orca-live' }
POST https://api.orcarouter.ai/v1/chat/completions (model openai/gpt-5.4-mini)
  => HTTP 200, content 'ORCA-OK'
```

---

I'm an engineer on the OrcaRouter team.
