### PR TITLE
verdict(eval:friction): 2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/attribution.json
@@ -1,0 +1,36 @@
+{
+  "verdictId": "2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-08-12",
+  "generatedAt": "2026-08-12T03:05:48.059Z",
+  "findings": [
+    {
+      "id": "FR-2026-08-12-cd494b7db6bf",
+      "relatedFeature": "F245",
+      "frictionSignal": {
+        "type": "friction.cluster_cd494b7db6bf",
+        "severity": "medium",
+        "confidence": 0.7,
+        "detectedAt": "2026-08-12T03:05:48.059Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "friction-rollup/cluster_cd494b7db6bf",
+            "excerpt": "cluster 'text_frustration: 还是不行' count=1 severity=medium sensorForms=[reason]"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "triage-top-friction-cluster",
+          "target": "F245/friction-rollup",
+          "rationale": "Highest-ranked friction cluster in the window — eval cat assigns the 7-class root cause in the verdict before handoff."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/lifecycle-root.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/lifecycle-root.json
@@ -1,0 +1,21 @@
+{
+  "verdictId": "2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression",
+  "domainId": "eval:friction",
+  "createdAt": "2026-08-12T03:01:25.648Z",
+  "verdict": "fix",
+  "harnessUnderEval": {
+    "featureId": "F245",
+    "componentId": "friction-rollup",
+    "name": "friction rollup (Top-N + sensorForm)"
+  },
+  "ownerAsk": {
+    "targetFeatureId": "F156",
+    "targetOwnerCatId": "opus-47",
+    "requestedAction": "Treat the Aug 9 to Aug 12 user-feedback singleton as a real F156 fallout regression; complete the in-flight repair for direct Tailscale/IP session recovery so cleared or invalid `cat_cafe_session` state no longer drops phone/tablet browsers into unpaired-user or empty-cat-cafe behavior."
+  },
+  "acceptanceReevalPlan": {
+    "nextEvalAt": "2026-08-15T03:00:00.000Z",
+    "closureCondition": "A subsequent every-3d window shows no recurrence of direct-IP/mobile session-loss friction, and the active F156 repair has landed with verified recovery for phone/tablet Tailscale access."
+  },
+  "schemaVersion": 1
+}

--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/provenance.json
@@ -1,0 +1,27 @@
+{
+  "verdictId": "2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/rollup-report.json",
+      "sha256": "c392a64d872bb100e45891aab3ac4e597b71ddb35f0af2dd14af366fd5871cb9"
+    },
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/measurement-validity.json",
+      "sha256": "158e4c1dc97450123e6f1ad78fdc21b9ff0bb82fcb0b5f6c57b6620cd8d78de1"
+    }
+  ],
+  "generatedAt": "2026-08-12T03:05:48.059Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "2"
+  },
+  "sanitizeRulesVersion": "f267-friction-measurement-v1",
+  "sourceThreadId": "thread_eval_friction",
+  "sourceRefs": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1786244400000,
+    "windowEndMs": 1786503600000,
+    "topN": 10,
+    "tokenCap": 4000
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/measurement-validity.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/measurement-validity.json
@@ -1,0 +1,175 @@
+{
+  "schemaVersion": 1,
+  "measurementTarget": "friction_opportunity_to_action",
+  "window": {
+    "sinceMs": 1786244400000,
+    "untilMs": 1786503600000
+  },
+  "capturedAt": "2026-08-12T03:05:48.059Z",
+  "baselineKind": "prospective_paired_capture",
+  "historicalBaseline": {
+    "classification": "symptom_cohort",
+    "rollupCount": 11,
+    "limitation": "historical_rollups_lack_frozen_canonical_row_ids"
+  },
+  "cancelJoin": {
+    "status": "no_opportunity",
+    "expectedIds": [],
+    "actualIds": [],
+    "intersectionIds": [],
+    "missingIds": [],
+    "extraIds": [],
+    "recall": null
+  },
+  "channels": {
+    "paw-feel": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "cancel": {
+      "opportunity": {
+        "status": "measured",
+        "ids": [],
+        "provenance": "frozen_task_outcome_rows"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "user-feedback": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [
+          "user-feedback:fi_msoh4u90frs9ruzk"
+        ],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [
+          "user-feedback:fi_msoh4u90frs9ruzk"
+        ],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [
+          "user-feedback:fi_msoh4u90frs9ruzk"
+        ],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [
+          "user-feedback:fi_msoh4u90frs9ruzk"
+        ],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [
+          "user-feedback:fi_msoh4u90frs9ruzk"
+        ],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "eval-domain": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    }
+  },
+  "decision": {
+    "status": "insufficient",
+    "reasons": [
+      "cancel_join:no_opportunity",
+      "downstream_degraded"
+    ],
+    "withdrawalConditions": [
+      "rerun_after_closed_window_with_cancel_opportunity",
+      "rerun_after_downstream_dependencies_recover"
+    ]
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/raw/rollup-report.json
@@ -1,0 +1,92 @@
+{
+  "verdictId": "2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1786244400000,
+    "windowEndMs": 1786503600000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1786244400000,
+    "untilMs": 1786503600000
+  },
+  "signalCount": 1,
+  "clusterCount": 1,
+  "degraded": true,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1786244400000,
+      "untilMs": 1786503600000
+    },
+    "generatedAt": "2026-08-12T03:05:48.059Z",
+    "topClusters": [
+      {
+        "clusterId": "cd494b7db6bf",
+        "representative": "text_frustration: 还是不行",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msoh4u90frs9ruzk",
+            "rawRef": "fi_msoh4u90frs9ruzk",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "medium"
+      }
+    ],
+    "actionableCandidates": [
+      {
+        "clusterId": "cd494b7db6bf",
+        "representative": "text_frustration: 还是不行",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msoh4u90frs9ruzk",
+            "rawRef": "fi_msoh4u90frs9ruzk",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "medium",
+        "actionability": "actionable_candidate",
+        "followupDraft": {
+          "clusterId": "cd494b7db6bf",
+          "title": "Investigate friction cluster: text_frustration: 还是不行",
+          "summary": "text_frustration: 还是不行",
+          "evidenceRefs": [
+            "fi_msoh4u90frs9ruzk"
+          ],
+          "reportingMode": "final-only"
+        },
+        "referenceOnlyEvidenceRefs": []
+      }
+    ],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": true,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 292
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/snapshot.json
@@ -1,0 +1,26 @@
+{
+  "verdictId": "2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression",
+  "evalSnapshotId": "eval-F245-2026-08-12",
+  "featureId": "F245",
+  "generatedAt": "2026-08-12T03:05:48.059Z",
+  "window": {
+    "startMs": 1786244400000,
+    "endMs": 1786503600000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 1,
+        "top_cluster_count": 1,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0,
+        "cluster_cd494b7db6bf": 1
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression.md
+++ b/docs/harness-feedback/verdicts/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression.md
@@ -1,0 +1,35 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression
+source_snapshot: "snapshot:bundle/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/snapshot"
+---
+
+# Live Verdict — 2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression
+
+- Verdict: `fix`
+- Phenomenon: The 72h friction window from 2026-08-09 03:00 UTC to 2026-08-12 03:00 UTC surfaced one medium-severity actionable singleton, `text_frustration: 还是不行`, from confirmed user feedback on phone and tablet access. Thread context ties it to direct Tailscale/IP Cat Cafe access falling back into empty or broken session state after client-side session loss, so this is a concrete browser access regression rather than background noise.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: Most likely `execution_gap`: the F156 session/bootstrap recovery path for direct Tailscale/IP browser access still has a regression where cleared or invalid `cat_cafe_session` state can strand mobile browsers in `unpaired-user` or empty-workspace flow instead of recovering the prior Cat Cafe session. (confidence medium)
+- Owner ask: Treat the Aug 9 to Aug 12 user-feedback singleton as a real F156 fallout regression; complete the in-flight repair for direct Tailscale/IP session recovery so cleared or invalid `cat_cafe_session` state no longer drops phone/tablet browsers into unpaired-user or empty-cat-cafe behavior.
+- Re-eval: next eval at 2026-08-15T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/snapshot
+- attribution:bundle/2026-08-12-eval-friction-c9-direct-ip-session-recovery-regression/FR-2026-08-12-cd494b7db6bf
+- metric:official.rollup_signal_count
+- metric:official.rollup_cluster_count
+- metric:official.actionable_candidates
+- metric:official.reference_only_clusters
+- metric:baseline.official.rollup_signal_count
+- metric:baseline.official.rollup_cluster_count
+- metric:baseline.official.actionable_candidates
+- metric:baseline.official.reference_only_clusters
+
+Counterarguments:
+- A single medium-severity user-feedback signal could still be a device-specific stale-session incident rather than a broadly recurring F156 regression.
+- Because the cluster is single-channel and count=1, this verdict may be promoting an already in-flight incident rather than discovering a new repair obligation.
+- The active repair thread may resolve the issue without further F245 escalation, so a keep_observe verdict would also have been defensible if the root-cause thread context were ignored.


### PR DESCRIPTION
Verdict published via manual fallback after `cat_cafe_publish_verdict` failed with `generator_failed` (`docs/harness-feedback/registry/measurement-bundles.yaml` missing in the isolated worktree).

Verdict: fix
Domain: eval:friction
Phenomenon: The 72h friction window from 2026-08-09 03:00 UTC to 2026-08-12 03:00 UTC surfaced one medium-severity actionable singleton, `text_frustration: 还是不行`, from confirmed user feedback on phone and tablet access. Thread context ties it to direct Tailscale/IP Cat Cafe access falling back into empty or broken session state after client-side session loss, so this is a concrete browser access regression rather than background noise.

Reviewed by: opus-47
Action: Treat the Aug 9 to Aug 12 user-feedback singleton as a real F156 fallout regression; complete the in-flight repair for direct Tailscale/IP session recovery so cleared or invalid `cat_cafe_session` state no longer drops phone/tablet browsers into unpaired-user or empty-cat-cafe behavior.
Source thread: thread_eval_friction

This PR contains only verdict/bundle evidence artifacts; code follow-up belongs in the owning F156 repair thread.