### PR TITLE
fix(#770): mark dead configs deprecated + restore owner trust-anchor to curated System view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,13 +136,9 @@ EMBED_MODE=off
 # TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 
 # ── Optional: GitHub PR Review Notifications（可选）─────────
-# Polls IMAP for GitHub review emails and routes to chat.
-# 轮询 IMAP 邮箱获取 GitHub review 邮件通知。
+# Tracked PRs are polled via the GitHub API (register_pr_tracking); no mailbox needed.
+# 已注册跟踪的 PR 通过 GitHub API 轮询获取 review，无需配置邮箱。
 
-# GITHUB_REVIEW_IMAP_USER=xxx@qq.com
-# GITHUB_REVIEW_IMAP_PASS=<auth-code>
-# GITHUB_REVIEW_IMAP_HOST=imap.qq.com
-# GITHUB_REVIEW_IMAP_PORT=993
 # Legacy-named token used only by background GitHub API review fetches.
 # Repository operations use the authenticated gh CLI; GitHub MCP is retired.
 # GITHUB_MCP_PAT=ghp_...

--- a/SETUP.md
+++ b/SETUP.md
@@ -381,34 +381,16 @@ TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 
 ### GitHub PR Review Notifications
 
-Get notified when GitHub review emails arrive (polls IMAP). Review comments are automatically routed to the right cat and thread.
+Get notified when GitHub reviews arrive. Tracked PRs are polled via the GitHub API — no mailbox setup required — and review comments are automatically routed to the right cat and thread.
 
 ```bash
-# QQ Mail example
-GITHUB_REVIEW_IMAP_USER=xxx@qq.com
-GITHUB_REVIEW_IMAP_PASS=<auth-code>    # app-specific password, not login
-GITHUB_REVIEW_IMAP_HOST=imap.qq.com
-GITHUB_REVIEW_IMAP_PORT=993
-
-# Gmail example (requires 2FA + App Password)
-# GITHUB_REVIEW_IMAP_USER=xxx@gmail.com
-# GITHUB_REVIEW_IMAP_PASS=<app-password>    # Google Account → Security → App Passwords
-# GITHUB_REVIEW_IMAP_HOST=imap.gmail.com
-# GITHUB_REVIEW_IMAP_PORT=993
-
-# Outlook / Hotmail example
-# GITHUB_REVIEW_IMAP_USER=xxx@outlook.com
-# GITHUB_REVIEW_IMAP_PASS=<app-password>    # Microsoft Account → Security → App Passwords
-# GITHUB_REVIEW_IMAP_HOST=outlook.office365.com
-# GITHUB_REVIEW_IMAP_PORT=993
-
 # Optional background GitHub API token for review-content fetching.
 # Repository operations use authenticated gh CLI; GitHub MCP is retired.
 GITHUB_MCP_PAT=ghp_...
 ```
 
 **How routing works (3-tier):**
-1. **PR Registration** (primary): Cats register PRs via `register_pr_tracking` MCP tool when they open a PR. When a review email arrives, it routes directly to that cat's thread.
+1. **PR Registration** (primary): Cats register PRs via `register_pr_tracking` MCP tool when they open a PR. When a review arrives, it routes directly to that cat's thread.
 2. **Title Tag** (fallback): If no registration found, the system looks for a cat name tag in the PR title (e.g., `[宪宪🐾]`) and routes to that cat's Review Inbox.
 3. **Triage** (last resort): If no cat can be identified, the review goes to a Triage thread for manual assignment.
 

--- a/SETUP.zh-CN.md
+++ b/SETUP.zh-CN.md
@@ -381,34 +381,16 @@ TELEGRAM_BOT_TOKEN=123456:ABC-DEF...
 
 ### GitHub PR Review 通知
 
-当 GitHub review 邮件到达时自动通知（轮询 IMAP）。Review 评论自动路由到对应的猫和线程。
+当 GitHub review 到达时自动通知。已注册跟踪的 PR 通过 GitHub API 轮询——无需配置邮箱——review 评论自动路由到对应的猫和线程。
 
 ```bash
-# QQ 邮箱示例
-GITHUB_REVIEW_IMAP_USER=xxx@qq.com
-GITHUB_REVIEW_IMAP_PASS=<授权码>    # 应用专用密码，不是登录密码
-GITHUB_REVIEW_IMAP_HOST=imap.qq.com
-GITHUB_REVIEW_IMAP_PORT=993
-
-# Gmail 示例（需要开启两步验证 + 生成应用专用密码）
-# GITHUB_REVIEW_IMAP_USER=xxx@gmail.com
-# GITHUB_REVIEW_IMAP_PASS=<应用专用密码>    # Google 账号 → 安全性 → 应用专用密码
-# GITHUB_REVIEW_IMAP_HOST=imap.gmail.com
-# GITHUB_REVIEW_IMAP_PORT=993
-
-# Outlook / Hotmail 示例
-# GITHUB_REVIEW_IMAP_USER=xxx@outlook.com
-# GITHUB_REVIEW_IMAP_PASS=<应用专用密码>    # Microsoft 账号 → 安全 → 应用密码
-# GITHUB_REVIEW_IMAP_HOST=outlook.office365.com
-# GITHUB_REVIEW_IMAP_PORT=993
-
 # 可选的后台 GitHub API token，仅用于获取 review 内容。
 # 仓库操作统一使用已认证的 gh CLI；GitHub MCP 已退休。
 GITHUB_MCP_PAT=ghp_...
 ```
 
 **路由机制（三层）：**
-1. **PR 注册**（首选）：猫猫在开 PR 时通过 `register_pr_tracking` MCP 工具注册。收到 review 邮件后，直接路由到该猫的线程。
+1. **PR 注册**（首选）：猫猫在开 PR 时通过 `register_pr_tracking` MCP 工具注册。收到 review 后，直接路由到该猫的线程。
 2. **标题标签**（备选）：如果没有注册记录，系统从 PR 标题中查找猫名标签（如 `[宪宪🐾]`），路由到该猫的 Review 收件箱。
 3. **分诊**（兜底）：如果无法识别猫，review 进入分诊线程等待手动分配。
 

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -78,6 +78,15 @@ export interface EnvDefinition {
   runtimeEditable?: boolean;
   /** If true, this var should appear in .env.example (enforced by check:env-example) */
   exampleRecommended?: boolean;
+  /**
+   * Dead-config marker (#770): set to a human-readable reason when the var has
+   * zero live consumers in this repo. The entry STAYS in the registry (registry
+   * is the canonical inventory — entries are never deleted); the frontend renders
+   * an "已废弃" badge from this field. Physical removal is a maintainer decision.
+   * Invariants (enforced by env-registry tests): deprecated vars are never
+   * runtimeEditable and never part of the SYSTEM_VARS curated projection.
+   */
+  deprecated?: string;
   /** Explicit allowed values for cycle-style toggles (e.g. ['off','shadow','on']) */
   allowedValues?: string[];
   /** Human-friendly label for System Settings page (#770) */
@@ -261,11 +270,16 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'DEFAULT_OWNER_USER_ID',
-    defaultValue: '(未设置)',
-    description: '默认所有者用户 ID（信任锚点，不可从 Hub 修改）',
+    defaultValue: '(未设置 = 单用户本地模式)',
+    description:
+      '所有者信任锚点：未设置时为单用户本地模式（依赖 loopback 保护）；设置后特权操作按此 ID 做 owner 校验。' +
+      '仅可通过编辑 .env 并重启修改——Hub 内可写会造成权限自举（会话可将自己设为 owner），故永久只读',
     category: 'server',
     sensitive: false,
     runtimeEditable: false,
+    label: '所有者用户 ID',
+    settingsGroup: 'security',
+    restartRequired: true,
   },
   {
     name: 'CAT_CAFE_USER_ID',
@@ -905,6 +919,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '模式切换需要确认',
     category: 'cli',
     sensitive: false,
+    deprecated: '仓库内无任何消费者（TD117 #832 backfill 遗留），去留待 maintainer 决定',
   },
   {
     name: 'CAT_CAFE_TMUX_AGENT',
@@ -1518,6 +1533,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'QQ 邮箱地址 (xxx@qq.com)',
     category: 'github_review',
     sensitive: false,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_PASS',
@@ -1525,6 +1541,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'QQ 邮箱授权码 (非登录密码)',
     category: 'github_review',
     sensitive: true,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_HOST',
@@ -1532,6 +1549,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 服务器地址',
     category: 'github_review',
     sensitive: false,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_PORT',
@@ -1539,6 +1557,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 端口 (SSL)',
     category: 'github_review',
     sensitive: false,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
   {
     name: 'GITHUB_REVIEW_POLL_INTERVAL_MS',
@@ -1546,6 +1565,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '邮件轮询间隔 (毫秒)',
     category: 'github_review',
     sensitive: false,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
   {
     name: 'GITHUB_MCP_PAT',
@@ -1561,6 +1581,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 连接代理地址（如 socks5://127.0.0.1:1080）',
     category: 'github_review',
     sensitive: false,
+    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
   },
 
   // --- evidence (F102 记忆系统) ---
@@ -2048,6 +2069,7 @@ export const SYSTEM_VARS: ReadonlySet<string> = new Set([
   'CAT_CAFE_DATA_DIR',
   'CLI_TIMEOUT_MS',
   'CORS_ALLOW_PRIVATE_NETWORK',
+  'DEFAULT_OWNER_USER_ID',
   'DRAFT_TTL_SECONDS',
   'FRONTEND_PORT',
   'FRONTEND_URL',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -919,7 +919,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '模式切换需要确认',
     category: 'cli',
     sensitive: false,
-    deprecated: '仓库内无任何消费者（TD117 #832 backfill 遗留），去留待 maintainer 决定',
+    deprecated:
+      '模式系统消费者已在 F101 Mode v2 重构（2dfece987）中移除，早于 TD117 registry backfill（b58106d0d）；当前无活消费者，去留待 maintainer 决定',
   },
   {
     name: 'CAT_CAFE_TMUX_AGENT',

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -1533,7 +1533,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'QQ 邮箱地址 (xxx@qq.com)',
     category: 'github_review',
     sensitive: false,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_PASS',
@@ -1541,7 +1542,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'QQ 邮箱授权码 (非登录密码)',
     category: 'github_review',
     sensitive: true,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_HOST',
@@ -1549,7 +1551,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 服务器地址',
     category: 'github_review',
     sensitive: false,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
   {
     name: 'GITHUB_REVIEW_IMAP_PORT',
@@ -1557,7 +1560,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 端口 (SSL)',
     category: 'github_review',
     sensitive: false,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
   {
     name: 'GITHUB_REVIEW_POLL_INTERVAL_MS',
@@ -1565,7 +1569,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '邮件轮询间隔 (毫秒)',
     category: 'github_review',
     sensitive: false,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
   {
     name: 'GITHUB_MCP_PAT',
@@ -1581,7 +1586,8 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'IMAP 连接代理地址（如 socks5://127.0.0.1:1080）',
     category: 'github_review',
     sensitive: false,
-    deprecated: 'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除，由 GITHUB_WEBHOOK_SECRET webhook 路径取代',
+    deprecated:
+      'IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取',
   },
 
   // --- evidence (F102 记忆系统) ---

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -939,9 +939,11 @@ describe('#770: SYSTEM_VARS and buildSystemEnvSummary', () => {
 });
 
 describe('#770: deprecated metadata (dead-config marking)', () => {
-  // Vars whose runtime consumers were removed (or never existed) — verified by
-  // repo-wide reference scan including shell scripts and skills:
-  //   - MODE_SWITCH_REQUIRES_APPROVAL: registered in TD117 backfill (#832), no consumer ever existed here
+  // Vars whose runtime consumers were removed — verified by repo-wide reference
+  // scan including shell scripts and skills:
+  //   - MODE_SWITCH_REQUIRES_APPROVAL: Mode-system consumer (ModeOrchestrator) was
+  //     removed in the F101 Mode v2 rework (2dfece987), before the TD117 registry
+  //     backfill (b58106d0d) re-registered the then-already-dead var
   //   - GITHUB_REVIEW_IMAP_* + POLL_INTERVAL: IMAP mail-poll channel removed in v0.9.0 sync (#596);
   //     PR review feedback now flows through register_pr_tracking-driven GitHub API polling
   //     (GITHUB_WEBHOOK_SECRET belongs to the separate Repo Inbox webhook, not this channel)

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -942,8 +942,9 @@ describe('#770: deprecated metadata (dead-config marking)', () => {
   // Vars whose runtime consumers were removed (or never existed) — verified by
   // repo-wide reference scan including shell scripts and skills:
   //   - MODE_SWITCH_REQUIRES_APPROVAL: registered in TD117 backfill (#832), no consumer ever existed here
-  //   - GITHUB_REVIEW_IMAP_* + POLL_INTERVAL: IMAP mail-poll channel removed in v0.9.0 sync (#596),
-  //     replaced by the GITHUB_WEBHOOK_SECRET webhook path
+  //   - GITHUB_REVIEW_IMAP_* + POLL_INTERVAL: IMAP mail-poll channel removed in v0.9.0 sync (#596);
+  //     PR review feedback now flows through register_pr_tracking-driven GitHub API polling
+  //     (GITHUB_WEBHOOK_SECRET belongs to the separate Repo Inbox webhook, not this channel)
   const DEAD_VARS = [
     'MODE_SWITCH_REQUIRES_APPROVAL',
     'GITHUB_REVIEW_IMAP_USER',

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -871,8 +871,8 @@ describe('#770: isEditableEnvVar fail-closed default', () => {
 describe('#770: SYSTEM_VARS and buildSystemEnvSummary', () => {
   afterEach(() => restoreEnv());
 
-  it('SYSTEM_VARS contains exactly 24 curated variables', () => {
-    assert.equal(SYSTEM_VARS.size, 24);
+  it('SYSTEM_VARS contains exactly 25 curated variables', () => {
+    assert.equal(SYSTEM_VARS.size, 25);
   });
 
   it('every SYSTEM_VAR exists in the registry', () => {
@@ -908,7 +908,12 @@ describe('#770: SYSTEM_VARS and buildSystemEnvSummary', () => {
   });
 
   it('security SYSTEM_VARS are explicitly runtimeEditable: false', () => {
-    for (const name of ['PROJECT_ALLOWED_ROOTS', 'PROJECT_ALLOWED_ROOTS_APPEND', 'PROJECT_DENIED_ROOTS']) {
+    for (const name of [
+      'PROJECT_ALLOWED_ROOTS',
+      'PROJECT_ALLOWED_ROOTS_APPEND',
+      'PROJECT_DENIED_ROOTS',
+      'DEFAULT_OWNER_USER_ID',
+    ]) {
       const def = ENV_VARS.find((v) => v.name === name);
       assert.ok(def, `${name} should be in registry`);
       assert.equal(def.runtimeEditable, false, `${name} must not be editable`);
@@ -930,6 +935,92 @@ describe('#770: SYSTEM_VARS and buildSystemEnvSummary', () => {
       assert.ok(entry.label, `${entry.name} should have label`);
       assert.ok(entry.settingsGroup, `${entry.name} should have settingsGroup`);
     }
+  });
+});
+
+describe('#770: deprecated metadata (dead-config marking)', () => {
+  // Vars whose runtime consumers were removed (or never existed) — verified by
+  // repo-wide reference scan including shell scripts and skills:
+  //   - MODE_SWITCH_REQUIRES_APPROVAL: registered in TD117 backfill (#832), no consumer ever existed here
+  //   - GITHUB_REVIEW_IMAP_* + POLL_INTERVAL: IMAP mail-poll channel removed in v0.9.0 sync (#596),
+  //     replaced by the GITHUB_WEBHOOK_SECRET webhook path
+  const DEAD_VARS = [
+    'MODE_SWITCH_REQUIRES_APPROVAL',
+    'GITHUB_REVIEW_IMAP_USER',
+    'GITHUB_REVIEW_IMAP_PASS',
+    'GITHUB_REVIEW_IMAP_HOST',
+    'GITHUB_REVIEW_IMAP_PORT',
+    'GITHUB_REVIEW_POLL_INTERVAL_MS',
+    'GITHUB_REVIEW_IMAP_PROXY',
+  ];
+
+  it('every known dead-config var stays in the registry (canonical truth — no deletion)', () => {
+    const registryNames = new Set(ENV_VARS.map((v) => v.name));
+    for (const name of DEAD_VARS) {
+      assert.ok(registryNames.has(name), `${name} must remain registered (registry entries are never deleted)`);
+    }
+  });
+
+  it('every known dead-config var carries a non-empty deprecated reason', () => {
+    for (const name of DEAD_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be in registry`);
+      assert.equal(typeof def.deprecated, 'string', `${name} must have a deprecated reason string`);
+      assert.ok(def.deprecated.length > 0, `${name} deprecated reason must be non-empty`);
+    }
+  });
+
+  it('deprecated vars are never runtimeEditable', () => {
+    for (const def of ENV_VARS) {
+      if (def.deprecated) {
+        assert.notEqual(def.runtimeEditable, true, `${def.name} is deprecated and must not be editable`);
+      }
+    }
+  });
+
+  it('deprecated vars never appear in the SYSTEM_VARS curated projection', () => {
+    for (const def of ENV_VARS) {
+      if (def.deprecated) {
+        assert.ok(!SYSTEM_VARS.has(def.name), `${def.name} is deprecated and must not be a curated System var`);
+      }
+    }
+  });
+
+  it('buildEnvSummary carries deprecated through to the API payload', () => {
+    const summary = buildEnvSummary();
+    for (const name of DEAD_VARS) {
+      const entry = summary.find((v) => v.name === name);
+      if (!entry) continue; // hubVisible:false vars are excluded from the summary by design
+      assert.equal(typeof entry.deprecated, 'string', `${name} summary entry must expose deprecated`);
+    }
+    // At least one deprecated var must actually reach the payload, otherwise the
+    // frontend "已废弃" badge (EnvSubComponents) has nothing to render.
+    assert.ok(
+      summary.some((v) => typeof v.deprecated === 'string' && v.deprecated.length > 0),
+      'at least one deprecated var must be visible in the env summary',
+    );
+  });
+});
+
+describe('#770: DEFAULT_OWNER_USER_ID trust-anchor projection', () => {
+  it('DEFAULT_OWNER_USER_ID is a curated System var (issue #770 allowlist)', () => {
+    assert.ok(SYSTEM_VARS.has('DEFAULT_OWNER_USER_ID'));
+  });
+
+  it('DEFAULT_OWNER_USER_ID projection is read-only with restart-required semantics', () => {
+    const def = ENV_VARS.find((v) => v.name === 'DEFAULT_OWNER_USER_ID');
+    assert.ok(def, 'DEFAULT_OWNER_USER_ID should be in registry');
+    // Trust anchor: the owner gate derives ALL identity checks from this value.
+    // Allowing runtime edits would let a session grant itself ownership
+    // (privilege bootstrap paradox) — must stay editable only via .env + restart.
+    assert.equal(def.runtimeEditable, false);
+    assert.equal(def.restartRequired, true);
+    assert.equal(def.settingsGroup, 'security');
+    assert.ok(def.label, 'needs a human-friendly label for the System page');
+    assert.ok(
+      def.description.includes('单用户'),
+      'description must explain the unset ⇒ single-user-mode semantics so the read-only value is interpretable',
+    );
   });
 });
 


### PR DESCRIPTION
Part of #770 (items E "dead-config marking" and F "DEFAULT_OWNER_USER_ID remediation" from the staged cleanup).

## What

**Item E — dead-config marking (registry entries retained):**
- New `EnvDefinition.deprecated?: string` field — mirrors the field the frontend `EnvVar` type already declares; the "已废弃" badge in `EnvSubComponents` was wired but had no API data source until now. Registry entries are **not** deleted (registry stays the canonical inventory; physical removal remains a maintainer decision).
- 7 vars marked with evidence-backed reasons:
  - `MODE_SWITCH_REQUIRES_APPROVAL` — Mode-system consumer (ModeOrchestrator) was removed in the F101 Mode v2 rework (`2dfece987`), before the TD117 registry backfill (`b58106d0d`) re-registered the then-already-dead var; no live consumer in the current tree.
  - `GITHUB_REVIEW_IMAP_USER/PASS/HOST/PORT`, `GITHUB_REVIEW_POLL_INTERVAL_MS`, `GITHUB_REVIEW_IMAP_PROXY` — the IMAP mail-poll channel was removed in the v0.9.0 sync (#596); PR review feedback now flows through `register_pr_tracking`-driven GitHub API polling (`ReviewFeedbackTaskSpec`). Note: `GITHUB_WEBHOOK_SECRET` belongs to the separate Repo Inbox webhook and is not this channel's successor.
- Audit method: literal scan across all file types (incl. shell/skills), dynamic-concatenation heuristics, and git history tracing. This caught one false positive from a TS-only scan: `HYPERFOCUS_THRESHOLD_MS` is consumed by `cat-cafe-skills/hyperfocus-brake/hook.sh` and stays unmarked.
- User-facing entry points closed in the same PR: `SETUP.md`, `SETUP.zh-CN.md`, `.env.example` no longer instruct configuring the removed IMAP watcher; the PR-review-notification sections now describe the actual GitHub API polling path.

**Item F — DEFAULT_OWNER_USER_ID trust-anchor projection (presentation-only):**
- Added to `SYSTEM_VARS` (security group, read-only, `restartRequired: true`) — the issue's proposed System allowlist explicitly lists it ("owner/trust-anchor values that explain write/auth behavior") but the #1280 curated projection missed it.
- Description/defaultValue now explain the unset ⇒ single-user-local-mode semantics so the read-only display is interpretable.
- `runtimeEditable` stays `false`, now pinned by a test invariant: every env-write endpoint derives its guard from this var, so runtime editing would enable privilege bootstrap (a session granting itself ownership). Full security analysis (13 consumer files, 6 behavioral endpoint classes) posted as an issue comment on #770.

## Test invariants added (12 assertions)

- deprecated vars are never `runtimeEditable`, never in `SYSTEM_VARS`, always keep their registry entry, always carry a non-empty reason
- `buildEnvSummary` carries `deprecated` through to the API payload (badge data source)
- `DEFAULT_OWNER_USER_ID`: read-only + security group + restart-required + explains single-user semantics

## Verification

- `pnpm check` (incl. feature-truth gate) ✅ · api build ✅ · env-registry tests 70/70 ✅ · web system-settings wiring 5/5 ✅
- Controlled A/B on the full api suite (same worktree, only this diff toggled): failure sets identical in both directions — zero regressions introduced.
- Local cross-review: 2 rounds (sol), findings resolved — incl. correcting the deprecated reasons' replacement-path attribution and closing the user-facing doc entry points.

## Follow-up

A second PR (section projection + control metadata for module settings, already reviewed locally) will be submitted after this one merges — kept separate so each PR stays on one capability boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
