### PR TITLE
feat(config): #770 env section/filter/write-policy infrastructure (PR-A, zero projections)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,6 @@ LLM_POSTPROCESS_ENABLED=0
 # WHISPER_URL=http://localhost:9876
 # NEXT_PUBLIC_WHISPER_URL=http://localhost:9876
 # TTS_URL=http://localhost:9879
-# TTS_CACHE_DIR=./data/tts-cache
 # NEXT_PUBLIC_LLM_POSTPROCESS_URL=http://localhost:9878
 
 # ── Optional: Semantic Retrieval 语义检索（可选）──────────────

--- a/docs/architecture/data-dirs.md
+++ b/docs/architecture/data-dirs.md
@@ -1,0 +1,121 @@
+---
+topics: [data-dirs, runtime, deployment]
+doc_kind: operations
+created: 2026-05-21
+issue: 671
+---
+
+# 数据目录三根模型 — DATA_DIR / CACHE_DIR / LOG_DIR
+
+> Issue: [#671 — 统一运行时数据路径](https://github.com/zts212653/clowder-ai/issues/671)
+
+## 设计
+
+运行时有 12 条数据路径，按生命周期划成三组，由三个环境变量统一控制：
+
+| 根 | 含义 | 子路径 | 内容 | 不能丢吗？ |
+|----|------|--------|------|------------|
+| `DATA_DIR` | 持久数据 | `evidence.sqlite` | F102 记忆 SQLite | ✅ |
+| | | `world.sqlite` | F093 World Engine SQLite | ✅ |
+| | | `transcripts/` | F24 session transcript | ✅ |
+| | | `audit-logs/` | append-only 审计日志 | ✅ |
+| | | `cli-raw-archive/` | CLI 原始流量归档 | ✅ |
+| | | `uploads/` | 用户上传文件（头像、附件、参考音频） | ✅ |
+| | | `redis/` | Redis 持久化数据（dump.rdb + AOF） | ✅ |
+| | | `redis-backups/` | Redis 定时备份快照 | ✅ |
+| | | `cat-cafe/` | .cat-cafe 运行时可写状态（账户、凭证、catalog、治理…） | ✅ |
+| `CACHE_DIR` | 可重建缓存 | `tts/` | TTS 音频缓存 | ❌ |
+| | | `connector-media/` | 微信/飞书等下载的临时媒体 | ❌ |
+| `LOG_DIR` | 日志 | — | Pino 滚动日志（直接使用 LOG_DIR，无子目录） | ❌ |
+
+每个根的语义清晰：备份只需要照顾 `DATA_DIR`；磁盘紧张时可以放心清 `CACHE_DIR`；日志按 `LOG_DIR` 接独立磁盘/集中化平台。
+
+## 行为
+
+### 未设置根
+
+各路径沿用 legacy 默认（保持向后兼容）：
+
+- `evidence.sqlite` / `world.sqlite` → `{repoRoot}/`
+- `transcripts/` → `{monorepoRoot}/data/transcripts`
+- `audit-logs/` / `cli-raw-archive/` / `tts/` / `connector-media/` → `{cwd}/data/{name}`
+- `uploads/` → `packages/api/uploads/`（模块相对，保证 connector outbound delivery 看到同一份）
+- `redis/` → `~/.cat-cafe/redis-{profile}/`（由 `start-dev.sh` 基于 REDIS_PROFILE/PORT 动态推导）
+- `redis-backups/` → `~/.cat-cafe/redis-backups/{profile}/`（同上）
+- `cat-cafe/` → `{projectRoot}/.cat-cafe/`（50+ 消费方通过此路径读写账户、凭证、catalog 等运行时状态）
+- `LOG_DIR` → `{cwd}/data/logs/api`
+
+### 设置根
+
+```bash
+DATA_DIR=/srv/clowder/data
+CACHE_DIR=/srv/clowder/cache
+LOG_DIR=/var/log/clowder
+```
+
+各路径变为 `{root}/{子路径}`（LOG_DIR 直接使用，不加子目录）。三个根独立，可以只设其中一个。
+
+## 启动期自动迁移
+
+服务启动时（Fastify 初始化后、SQLite/TranscriptWriter 等消费方初始化前）会：
+
+1. **侦测**：legacy 路径有数据 + 新根下对应位置为空 → 列为待迁移
+2. **空间预检**：在目标卷上调用 `statfs`，要求可用空间 ≥ 待迁移总量 × 1.5
+3. **迁移**：
+   - 同盘：`fs.rename`（原子）
+   - 跨盘：`fs.copyFile` → `sha256` 校验 → 删除源
+   - SQLite 主文件迁移时一并搬运 `-wal` / `-shm` / `-journal` sidecar
+4. **失败保护**：
+   - 空间不足 → 整体放弃迁移，输出 `abortedReason: insufficient-disk-space: need X bytes at Y, have Z`，所有 legacy 数据保持原位
+   - 单条迁移失败 → 该条 legacy 保持原位、log warning；其他可迁移条目继续
+
+启动迁移成功不需要重启（一切都在消费方初始化之前完成）。
+
+`LOG_DIR` 不参与 API 启动迁移：Pino 在 module load 时就绑定了 LOG_DIR，没有 logger restart 流程做不到安全切换。**设置 LOG_DIR 仅影响后续写入；legacy 日志保留在旧路径，需要时由运维手动搬迁。**
+
+`redis/`、`redis-backups/` 和 `cat-cafe/` 不参与 API 启动迁移（它们由 `start-dev.sh` 在服务启动前于 shell 层迁移）。
+
+- **Redis**：当 `DATA_DIR` 已设且 legacy Redis 目录存在于旧路径时，shell 脚本在启动 `redis-server` 之前将整个目录 `mv` 到 `${DATA_DIR}/redis`。跨设备 fallback 使用 `cp -a` + `rm -rf`。
+- **`.cat-cafe/` 状态**：当 `DATA_DIR` 已设时，shell 脚本将 `{projectRoot}/.cat-cafe/` 移动到 `${DATA_DIR}/cat-cafe/`，然后在原位创建指向新路径的 symlink（`ln -sfn`）。这样 50+ 消费方继续用 `resolve(projectRoot, '.cat-cafe', file)` 就透明地读写到新路径。跨设备同样 fallback 到 `cp -a` + `rm -rf`。
+
+## 运行时迁移
+
+如果首次启动迁移因磁盘紧张失败，腾出空间后可以不重启就重试：
+
+```bash
+# 只读：看当前布局和待迁移工作
+curl -H "X-Cat-Cafe-User: $OWNER_ID" \
+  http://localhost:3004/api/config/data-dirs
+
+# 写：触发迁移（owner-only）
+curl -XPOST -H "X-Cat-Cafe-User: $OWNER_ID" \
+  http://localhost:3004/api/config/data-dirs/migrate
+```
+
+响应包含 `restartRecommended: true` 时务必重启服务 —— SQLite 等消费方在内存里持有的句柄仍然指向 legacy inode，需要重启才会重新打开到新路径。
+
+## 部署 checklist
+
+1. 确认目标卷有足够空间（建议 ≥ 当前 legacy 数据总量 × 2）
+2. `.env` 加 `DATA_DIR` / `CACHE_DIR` / `LOG_DIR`（按需选择，可只设其中一个）
+3. 重启服务 → 启动日志会输出 `[#671] Data-dirs migration completed`
+4. 日志的 `movedCount` / `skippedCount` / `failedCount` 是迁移结果摘要；`abortedReason` 出现说明空间检查没过
+5. 验证：`GET /api/config/data-dirs` 应该看到 `pendingMigration.hasWork: false`
+
+## 注意
+
+- **uploads 归 DATA_DIR**：虽然名义上像"缓存"，但里面是用户上传的真实文件，丢了就没了。issue 原稿曾把它放在 CACHE_DIR 下，最终决定归 DATA_DIR。
+- **目标已有数据**：如果新根下对应位置已经有非空数据（例如部分迁移过 / 手动复制过），该条会被 `skipReason: target-not-empty` 跳过，避免覆盖。需要重新迁移就先手动清空目标。
+- **环境变量优先级**：相对路径会用 `path.resolve()` 解析（相对 cwd），空字符串/纯空白视为未设置。
+- **测试隔离**：测试代码原本通过 `process.env.AUDIT_LOG_DIR=tempDir` 等 legacy var 隔离写入。Phase 2 后改为 `process.env.DATA_DIR=tempDir`，audit/upload/transcripts 自动落到 `tempDir/{audit-logs,uploads,transcripts}`。读取时拼上子路径。
+
+## 相关代码
+
+- `packages/api/src/config/data-dirs.ts` — resolver + introspection
+- `packages/api/src/config/data-dirs-migration.ts` — migration engine（排除 logs/redis/catCafeState — 它们由 shell 层迁移）
+- `packages/api/src/index.ts` — 启动期接入
+- `packages/api/src/routes/config.ts` — GET / POST 端点
+- `scripts/start-dev.sh` — Redis DATA_DIR 集成 + shell 层迁移
+- `scripts/user-redis.sh` — 个人 Redis DATA_DIR 集成
+- `packages/api/test/data-dirs.test.js` — resolver 单测（34）
+- `packages/api/test/data-dirs-migration.test.js` — migration 单测（19）

--- a/docs/plans/770-env-config-inventory.md
+++ b/docs/plans/770-env-config-inventory.md
@@ -30,14 +30,12 @@ created: 2026-08-12
 - **现有 UI 覆盖**: component path if an existing module UI already covers this domain
 - **disposition**: `保留 System` / `清出 System` / `投影到模块` / `不进 UI` / `组件补齐` / `产品待决策`
 
-## 服务器 (64)
+## 服务器 (59)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | server | API_SERVER_PORT | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | PREVIEW_GATEWAY_PORT | system | yes | yes | editable | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
-| server | REDIS_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Redis 端口由部署/脚本管理 |
-| server | REDIS_DEV_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Redis 端口由部署/脚本管理 |
 | server | API_SERVER_HOST | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | CORS_ALLOW_PRIVATE_NETWORK | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | UPLOAD_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
@@ -52,7 +50,6 @@ created: 2026-08-12
 | server | CAT_CAFE_HOME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | CAT_CAFE_INVOCATION_REGISTRY | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
 | server | F233_BALL_CUSTODY_PROBE_INTERVAL_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
-| server | CAT_CAFE_REPO_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | CAT_CAFE_REPO_FULL_NAME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | CAT_CAFE_AGENT_KEY_SECRET | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | CAT_CAFE_AGENT_KEY_FILE | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
@@ -72,12 +69,10 @@ created: 2026-08-12
 | server | CAT_CAFE_SERVICES_CONFIG | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | RUNTIME_REPO_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | WORKSPACE_LINKED_ROOTS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
-| server | HYPERFOCUS_THRESHOLD_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | ANTHROPIC_API_KEY | accounts | no | no | module-managed | text | no | equivalent | HubAccountsTab.tsx → `/api/accounts` → accounts/credentials store → account resolver/resolveEnvMap → provider env injection | 清出 System | 由统一账户/凭证系统管理；env 仅作 bootstrap/fallback |
 | server | LOG_LEVEL | system | yes | no | read-only | dropdown | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | LOG_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 日志目录；不进通用 projection |
 | server | DEBUG | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
-| server | MCP_SERVER_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | PREVIEW_GATEWAY_ENABLED | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | CHROME_EXECUTABLE_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
 | server | GAME_NARRATOR_ENABLED | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
@@ -167,13 +162,12 @@ created: 2026-08-12
 | cli | CAT_CAFE_PROCESS_EXECUTION_OWNER | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（execution owner） |
 | cli | CAT_CAFE_EXECUTION_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（execution id） |
 
-## Anthropic 代理网关 (7)
+## Anthropic 代理网关 (6)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | proxy | ANTHROPIC_PROXY_ENABLED | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级网络拓扑选择，与其余 proxy vars 一致，issue #770 allowlist 未列 |
 | proxy | ANTHROPIC_PROXY_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级网络拓扑选择，与其余 proxy vars 一致 |
-| proxy | ANTHROPIC_PROXY_DEBUG | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
 | proxy | ANTHROPIC_PROXY_UPSTREAMS_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
 | proxy | HTTPS_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
 | proxy | HTTP_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
@@ -360,13 +354,13 @@ created: 2026-08-12
 
 ## Summary
 
-- **Total env vars inventoried**: 228
+- **Total env vars inventoried**: 222
 - **保留 System** (真正 system-level 配置，保留在 System view): 28
 - **清出 System** (已有模块 UI 覆盖，从 System view 移除): 34
 - **投影到模块** (无 UI 覆盖且用户确需配置): **0**（PR-A 清空，等 PR-C 按模块 owner 确认后重新添加）
 - **组件补齐** (需专用组件/连接器扩展，不进通用 env 卡): 4
 - **产品待决策** (是否继续支持远程/自托管 sidecar，待产品决策): 4
-- **不进 UI** (部署级 / 内部 / 测试 / deprecated / 无当前 UI 路径): 158
+- **不进 UI** (部署级 / 内部 / 测试 / deprecated / 无当前 UI 路径): 152
 - **未分类 items**: 0（sol 在 HEAD `f790c4ed2` 完成源码审计，结论：之前的 42 项 generic projection 不成立）
 
 > **PR-A 关键修正**：原 42 项“投影到模块”结论已被撤销。

--- a/docs/plans/770-env-config-inventory.md
+++ b/docs/plans/770-env-config-inventory.md
@@ -1,0 +1,440 @@
+---
+topics: [env-registry, system-settings, config-projection, module-sections]
+created: 2026-08-12
+---
+
+# #770 Env Registry Remediation Inventory
+
+> Baseline: `packages/api/src/config/env-registry.ts` @ `00af81c32c9bda328cef8551de5c846a25760550` (main at PR-A branch-off).
+> Overlay A: PR-A `fix/770-section-projection` @ `ff67390aa3c49f6e9514e18050f7dcb7d7f7eaaa` (section projection + control metadata).
+> Overlay B: PR #1340 `fix/770-registry-metadata` @ `f652dd3ba` (deprecated markers + `DEFAULT_OWNER_USER_ID` projection).
+> Classification: 保留 System / 清出 System / 投影到模块 / 不进 UI / 组件补齐 / 产品待决策.
+>
+> **PR-A retraction notice (HEAD `f790c4ed2`)**: the original 42-var “投影到模块”
+> allowlist has been revoked after a source audit. `env-sections.ts` now ships with
+> empty module projections; the section/filter/write-policy infrastructure stays in
+> place. Per-module projected sets will be re-added in PR-C only after each module
+> UI owner confirms a real missing surface. See the Summary and PR-C sections below.
+
+## Legend
+
+- **category**: registry category as defined in `env-registry.ts`
+- **var name**: env var name
+- **section target**: owning module (`system / im / voice / notify / mcp / plugins / ops / accounts / members / rules / concierge / frontend / none`)
+- **registry summary eligible?**: whether the var is eligible for the canonical env summary (`hubVisible !== false`); this is **not** a guarantee that the var is surfaced in a Hub editor today
+- **current editable**: current overlay value (`runtimeEditable === true`)
+- **target write policy**: intended final write semantics (`editable` / `read-only` / `read-only, opt-in editable` / `module-managed` / `no UI write`)
+- **control type**: inferred `text / toggle / dropdown / dirpicker`
+- **dead config?**: `yes` if the description marks it deprecated
+- **覆盖类型**: `exact` (component directly consumes this env var) / `equivalent` (component uses an alternative store such as ConfigStore/themeStore; env is only bootstrap/fallback) / `none` (no UI coverage) / `N/A` (保留 System)
+- **现有 UI 覆盖**: component path if an existing module UI already covers this domain
+- **disposition**: `保留 System` / `清出 System` / `投影到模块` / `不进 UI` / `组件补齐` / `产品待决策`
+
+## 服务器 (64)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| server | API_SERVER_PORT | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | PREVIEW_GATEWAY_PORT | system | yes | yes | editable | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | REDIS_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Redis 端口由部署/脚本管理 |
+| server | REDIS_DEV_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Redis 端口由部署/脚本管理 |
+| server | API_SERVER_HOST | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | CORS_ALLOW_PRIVATE_NETWORK | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | UPLOAD_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | PROJECT_ALLOWED_ROOTS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | PROJECT_ALLOWED_ROOTS_APPEND | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | PROJECT_DENIED_ROOTS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | FRONTEND_URL | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | FRONTEND_PORT | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | DEFAULT_OWNER_USER_ID | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | owner/trust-anchor，security group，只读，restartRequired；未设置 ⇒ 单用户本地模式（#1340 投影结论） |
+| server | CAT_CAFE_USER_ID | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_F255_AWAKENED_LEASE_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_HOME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_INVOCATION_REGISTRY | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| server | F233_BALL_CUSTODY_PROBE_INTERVAL_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_REPO_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_REPO_FULL_NAME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AGENT_KEY_SECRET | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AGENT_KEY_FILE | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AGENT_KEY_FILES | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_REMOTE_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_GPT_PRO_AGENT_KEY_FILE | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_ENABLE_LEGACY_PINCHTAB_BRIDGE | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_REMOTE_TOKEN | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_DESKTOP_MODE | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_PROVISION_GLOBAL_SIDECAR | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AGENT_KEY_ALLOW_MEMORY_SIDECAR | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AGENT_KEY_SIDECAR_DISABLED | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_TEST_SANDBOX | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | CAT_CAFE_TEST_SANDBOX_ALLOW_UNSAFE_ROOT | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | CAT_CAFE_TEST_REAL_HOME | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | CAT_CAFE_REDIS_TEST_ISOLATED | none | no | no | no UI write | dropdown | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | CAT_CAFE_SERVICES_CONFIG | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | RUNTIME_REPO_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | WORKSPACE_LINKED_ROOTS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | HYPERFOCUS_THRESHOLD_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | ANTHROPIC_API_KEY | accounts | no | no | module-managed | text | no | equivalent | HubAccountsTab.tsx → `/api/accounts` → accounts/credentials store → account resolver/resolveEnvMap → provider env injection | 清出 System | 由统一账户/凭证系统管理；env 仅作 bootstrap/fallback |
+| server | LOG_LEVEL | system | yes | no | read-only | dropdown | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | LOG_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 日志目录；不进通用 projection |
+| server | DEBUG | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | MCP_SERVER_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | PREVIEW_GATEWAY_ENABLED | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
+| server | CHROME_EXECUTABLE_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | GAME_NARRATOR_ENABLED | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | COMMUNITY_PUBLISH_DEFAULT_REPO | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | COMMUNITY_PUBLISH_REPO_ALLOWLIST | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | COMMUNITY_NARRATOR_THREAD_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | WEB_PUBLIC_DIR | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_CONFIG_ROOT | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_GLOBAL_CONFIG_ROOT | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_SKIP_HOMEDIR_MIGRATION | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| server | ALLOWED_WORKSPACE_DIRS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_RUNTIME_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_WORKSPACE_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_MCP_CREDS_DIR | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| server | CAT_CAFE_AUTH_TOMBSTONE_GC_TTL_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（auth tombstone GC TTL） |
+| server | CAT_CAFE_VERDICT_REPO_FULL_NAME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（verdict repo 绑定） |
+| server | CAT_CAFE_AGENT_KEY_BOUND_CAT_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（agent-key 绑定身份） |
+| server | CAT_CAFE_PERSONAL_CHROME_SOCKET | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（personal chrome socket） |
+| server | CAT_CAFE_PERSONAL_CHROME_PAIRING_SECRET | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（personal chrome 配对密钥） |
+| server | CAT_CAFE_PERSONAL_CHROME_WEB_STORE_URL | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（personal chrome web store） |
+
+## 存储 (13)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| storage | REDIS_URL | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | REDIS_KEY_PREFIX | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | MEMORY_STORE | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | MESSAGE_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | THREAD_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | TASK_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | SUMMARY_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | BACKLOG_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | DRAFT_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | TRANSCRIPT_DATA_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | ANNOTATION_DATA_DIR | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 系统级存储路径，保留在 System view |
+| storage | DOCS_ROOT | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 系统级文档根目录，保留在 System view |
+| storage | VISIBILITY_CURSOR_V2 | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级 activation gate |
+
+## 猫猫预算 (2)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| budget | MAX_A2A_DEPTH | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | A2A 预算阈值，保留在 System view |
+| budget | WEB_PUSH_TIMEOUT_MS | notify | yes | no | read-only | text | no | none | 无 | 不进 UI | Web Push 超时；不进通用 projection |
+
+## CLI (38)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| cli | CLI_TIMEOUT_MS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| cli | CAT_CAFE_SUPERVISOR_PARENT_PID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_SUPERVISOR_POLL_MS | none | no | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
+| cli | CAT_CAFE_SUPERVISOR_KILL_GRACE_MS | none | no | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
+| cli | CAT_TEMPLATE_PATH | members | yes | no | read-only | text | no | none | 无 | 不进 UI | 成员/模板默认值；不进通用 projection |
+| cli | DEFAULT_CAT_ID | members | yes | no | module-managed | text | no | equivalent | DefaultCatSelector → PUT `/api/config/default-cat` → `persistDefaultCatToEnv` + `setRuntimeDefaultCatId` → `getDefaultCatId` / cat loader → env fallback | 清出 System | 默认猫选择，已有 DefaultCatSelector UI 覆盖；env 仅作 bootstrap/fallback |
+| cli | CAT_CAFE_MCP_SERVER_PATH | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | MCP 路径/凭证目录，内部运行时配置 |
+| cli | AUDIT_LOG_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 审计日志路径；不进通用 projection |
+| cli | CLI_RAW_ARCHIVE_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 原始 CLI 归档路径；不进通用 projection |
+| cli | AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS | ops | yes | no | read-only | text | no | none | 无 | 组件补齐 | 审计日志隐私开关；需专用组件 UI，不进通用 projection |
+| cli | CAT_BRANCH_ROLLBACK_RETRY_DELAYS_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
+| cli | MODE_SWITCH_REQUIRES_APPROVAL | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] Mode consumer 在 registry backfill (b58106d0d4) 之前已由 F101 移除 (2dfece9873)；当前 tree 无 live consumer。registry 条目保留，永不进入 curated projection |
+| cli | CAT_CAFE_TMUX_AGENT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
+| cli | CAT_CAFE_TMUX_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
+| cli | CAT_CAFE_DATA_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| cli | CAT_CAFE_CALLBACK_TOKEN | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 每 invocation 注入的 callback auth secret，内部运行时身份凭证，不进任何 UI |
+| cli | CAT_CAFE_CALLBACK_OUTBOX_ENABLED | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CAT_CAFE_CALLBACK_OUTBOX_DIR | none | yes | no | no UI write | dirpicker | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CAT_CAFE_CALLBACK_OUTBOX_MAX_ATTEMPTS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CAT_CAFE_CALLBACK_OUTBOX_MAX_FLUSH_BATCH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CAT_CAFE_CALLBACK_RETRY_DELAYS_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CAT_CAFE_CALLBACK_FETCH_TIMEOUT_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | callback outbox 内部调优 |
+| cli | CDP_DEBUG | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| cli | CODEX_HOME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI home/brain 目录，内部 |
+| cli | ANTIGRAVITY_BRAIN_HOME | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI home/brain 目录，内部 |
+| cli | CAT_CAFE_API_URL | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_INVOCATION_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_CREDENTIAL_FILE | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_THREAD_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_CAT_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入 |
+| cli | CAT_CAFE_DIAGNOSTICS | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| cli | CAT_CAFE_DISABLE_SHARED_STATE_PREFLIGHT | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| cli | CAT_CAFE_PREFLIGHT_TIMEOUT_MS | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| cli | OPENCODE_DB | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| cli | CAT_CAFE_SUPERVISOR_SOCKET_DIR | none | no | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置（supervisor socket dir） |
+| cli | CAT_CAFE_PROCESS_OWNER_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（process owner） |
+| cli | CAT_CAFE_PROCESS_EXECUTION_OWNER | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（execution owner） |
+| cli | CAT_CAFE_EXECUTION_ID | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 运行时注入（execution id） |
+
+## Anthropic 代理网关 (7)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| proxy | ANTHROPIC_PROXY_ENABLED | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级网络拓扑选择，与其余 proxy vars 一致，issue #770 allowlist 未列 |
+| proxy | ANTHROPIC_PROXY_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级网络拓扑选择，与其余 proxy vars 一致 |
+| proxy | ANTHROPIC_PROXY_DEBUG | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| proxy | ANTHROPIC_PROXY_UPSTREAMS_PATH | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
+| proxy | HTTPS_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
+| proxy | HTTP_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
+| proxy | ALL_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
+
+## 平台接入 (Telegram/飞书) (5)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| connector | CONNECTOR_GATEWAY_AUTOSTART | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | runtime 入口授权开关，不能由用户配置 |
+| connector | WEIXIN_VOICE_ITEM_MODE | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
+| connector | WEIXIN_ENABLE_UNSAFE_VOICE_MODES | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
+| connector | WEIXIN_CAPTURE_INBOUND_VOICE_MEDIA | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
+| connector | CONNECTOR_MEDIA_DIR | im | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | connector 媒体下载目录；不进通用 projection |
+
+## GitHub Review 监控 (14)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| github_review | GITHUB_WEBHOOK_SECRET | plugins | yes | yes | read-only, opt-in editable | text | no | none | 无 | 组件补齐 | GitHub Repo Inbox 配置；需专用组件 UI，不进通用 projection；SECRET 敏感，默认只读，opt-in 可写 |
+| github_review | GITHUB_REPO_ALLOWLIST | plugins | yes | no | read-only | text | no | none | 无 | 组件补齐 | GitHub Repo Inbox 配置；需专用组件 UI，不进通用 projection |
+| github_review | GITHUB_REPO_INBOX_CAT_ID | plugins | yes | no | read-only | text | no | none | 无 | 组件补齐 | GitHub Repo Inbox 配置；需专用组件 UI，不进通用 projection |
+| github_review | GITHUB_AUTHORITATIVE_REVIEW_LOGINS | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] F140 cutover，description 已标废弃；PR-E 只做 deprecated 标记 + 消费者迁移，registry 物理删除归 maintainer |
+| github_review | GITHUB_SETUP_NOISE_BOT_LOGINS | plugins | yes | no | module-managed | text | no | exact | PluginConfigPanel → POST `/api/plugins/github/config` → `.cat-cafe/plugin-config/github.json` → `resolvePluginEnv` → `getGitHubEnvValue` / runtime consumer | 清出 System | 已由 GitHub plugin manifest 覆盖，清出 System 避免双入口 |
+| github_review | GITHUB_SELF_LOGIN | plugins | yes | yes | read-only, opt-in editable | text | no | none | 无 | 不进 UI | GitHub / Repo Inbox 配置；不进通用 projection |
+| github_review | GITHUB_TOKEN | plugins | yes | no | module-managed | text | no | exact | PluginConfigPanel → POST `/api/plugins/github/config` → `.cat-cafe/plugin-config/github.json` → `resolvePluginEnv` → `getGitHubEnvValue` / runtime consumer | 清出 System | 已由 GitHub plugin manifest 覆盖，清出 System 避免双入口 |
+| github_review | GITHUB_REVIEW_IMAP_USER | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+| github_review | GITHUB_REVIEW_IMAP_PASS | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+| github_review | GITHUB_REVIEW_IMAP_HOST | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+| github_review | GITHUB_REVIEW_IMAP_PORT | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+| github_review | GITHUB_REVIEW_POLL_INTERVAL_MS | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+| github_review | GITHUB_MCP_PAT | plugins | yes | yes | module-managed | text | no | exact | PluginConfigPanel → POST `/api/plugins/github/config` → `.cat-cafe/plugin-config/github.json` → `resolvePluginEnv` → `getGitHubEnvValue` / runtime consumer | 清出 System | 已由 GitHub plugin manifest 覆盖，清出 System 避免双入口 |
+| github_review | GITHUB_REVIEW_IMAP_PROXY | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] IMAP 邮件监控通道已在 v0.9.0 (#596) 移除；PR review 反馈现由 register_pr_tracking 驱动的 GitHub API 轮询获取。registry 条目保留，永不进入 curated projection |
+
+## 缅因猫 (Codex) (8)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| codex | CAT_CODEX_SANDBOX_MODE | members | yes | no | module-managed | text | no | equivalent | HubCatEditor.tsx → PATCH `/api/config` → ConfigStore → ConfigRegistry/runtime resolver → `CAT_CODEX_SANDBOX_MODE` env fallback | 清出 System | per-cat/全局 Codex 行为配置，已有 HubCatEditor + ConfigStore 覆盖；env 仅作 bootstrap/fallback |
+| codex | CAT_CODEX_APPROVAL_POLICY | members | yes | no | module-managed | text | no | equivalent | HubCatEditor.tsx → PATCH `/api/config` → ConfigStore → ConfigRegistry/runtime resolver → `CAT_CODEX_APPROVAL_POLICY` env fallback | 清出 System | per-cat/全局 Codex 行为配置，已有 HubCatEditor + ConfigStore 覆盖；env 仅作 bootstrap/fallback |
+| codex | CAT_CAFE_CODEX_CARRIER | members | yes | no | module-managed | dropdown | no | equivalent | HubCatEditor.tsx → PATCH `/api/cats/:id` → cat catalog `cli.carrier` → `resolveCodexCarrier` → `CAT_CAFE_CODEX_CARRIER` env fallback | 清出 System | per-cat carrier 可由 Hub 成员编辑器覆盖；env 仅作 bootstrap/fallback |
+| codex | CAT_CAFE_CODEX_OAUTH_TRANSPORT | members | yes | yes | editable | dropdown | no | none | 无 | 不进 UI | per-cat/全局 Codex 行为配置（OAuth transport）；运行行为类，非账号凭证；不进通用 projection |
+| codex | CAT_CAFE_CODEX_APP_SERVER_IDLE_TTL_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | app-server 内部调优 |
+| codex | CAT_CAFE_CODEX_APP_SERVER_MAX_WARM_HOSTS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | app-server 内部调优 |
+| codex | CODEX_AUTH_MODE | members | yes | no | module-managed | text | no | equivalent | HubCatEditor.tsx → PATCH `/api/config` → ConfigStore → ConfigRegistry/runtime resolver → `CODEX_AUTH_MODE` env fallback | 清出 System | per-cat/全局 Codex 行为配置，已有 HubCatEditor + ConfigStore 覆盖；env 仅作 bootstrap/fallback |
+| codex | OPENAI_API_KEY | accounts | yes | no | module-managed | text | no | equivalent | HubAccountsTab.tsx → `/api/accounts` → accounts/credentials store → account resolver/resolveEnvMap → provider env injection | 清出 System | 由统一账户/凭证系统管理；env 仅作 bootstrap/fallback |
+
+## 暹罗猫 (Gemini) (4)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| gemini | GOOGLE_API_KEY | accounts | no | no | module-managed | text | no | equivalent | HubAccountsTab.tsx → `/api/accounts` → accounts/credentials store → account resolver/resolveEnvMap → provider env injection | 清出 System | 由统一账户/凭证系统管理；env 仅作 bootstrap/fallback |
+| gemini | GEMINI_ADAPTER | members | yes | no | read-only | text | no | none | 无 | 不进 UI | Gemini 适配器选择；不进通用 projection |
+| gemini | CAT_CAFE_AGY_PROFILE_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | AGY profile/cwd 隔离根目录，内部路径 |
+| gemini | CAT_CAFE_AGY_CWD_ROOT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | AGY profile/cwd 隔离根目录，内部路径 |
+
+## Kimi (3)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| kimi | MOONSHOT_API_KEY | accounts | no | no | module-managed | text | no | equivalent | HubAccountsTab.tsx → `/api/accounts` → accounts/credentials store → account resolver/resolveEnvMap → provider env injection | 清出 System | 由统一账户/凭证系统管理；env 仅作 bootstrap/fallback |
+| kimi | KIMI_SHARE_DIR | none | no | no | no UI write | text | no | none | 无 | 不进 UI | kimi-cli 内部路径 |
+| kimi | KIMI_CONFIG_FILE | none | no | no | no UI write | text | no | none | 无 | 不进 UI | kimi-cli 内部路径 |
+
+## 额度监控 (5)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| quota | KIMI_AUTH_TOKEN | ops | no | no | no UI write | text | no | none | 无 | 不进 UI | 额度抓取 token，敏感，建议通过 accounts 注入 |
+| quota | KIMI_QUOTA_API_FALLBACK_ENABLED | ops | no | no | no UI write | text | no | none | 无 | 不进 UI | credentials 文件路径，内部 |
+| quota | QUOTA_OFFICIAL_REFRESH_ENABLED | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 官方额度刷新总开关，运维级 |
+| quota | CLAUDE_CREDENTIALS_PATH | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | credentials 文件路径，内部 |
+| quota | CODEX_CREDENTIALS_PATH | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | credentials 文件路径，内部 |
+
+## 语音合成 (TTS) (5)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| tts | TTS_URL | voice | yes | no | read-only | text | no | none | 无 | 产品待决策 | 远程/自托管 sidecar TTS 端点；是否继续支持待产品决策，当前不进任何 projection |
+| tts | TTS_CACHE_DIR | voice | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 服务端点/缓存目录；不进通用 projection |
+| tts | GENSHIN_VOICE_DIR | voice | yes | no | read-only | dirpicker | no | equivalent | 已有专用模块 UI | 清出 System | 服务端点/缓存目录，服务生命周期 UI 可配置端口/模型，但 URL/dir 级 env 暂无 UI |
+| tts | CHARACTER_VOICE_DIR | voice | yes | no | read-only | dirpicker | no | equivalent | 已有专用模块 UI | 清出 System | 服务端点/缓存目录，服务生命周期 UI 可配置端口/模型，但 URL/dir 级 env 暂无 UI |
+| tts | LISTEN_MODE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 听读模式状态数据库（文件路径，非目录）；不进通用 projection |
+
+## 语音识别 (STT) (1)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| stt | WHISPER_URL | voice | yes | no | read-only | text | no | none | 无 | 产品待决策 | 远程/自托管 sidecar STT 端点；是否继续支持待产品决策，当前不进任何 projection |
+
+## 前端 (6)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| frontend | NEXT_PUBLIC_API_URL | system | yes | no | no UI write | text | no | none | 无 | 不进 UI | 构建时/前端起始地址，部署级 |
+| frontend | NEXT_PUBLIC_WHISPER_URL | voice | yes | no | read-only | text | no | none | 无 | 不进 UI | 服务端点/缓存目录；不进通用 projection |
+| frontend | NEXT_PUBLIC_LLM_POSTPROCESS_URL | voice | yes | no | read-only | text | no | none | 无 | 产品待决策 | 远程/自托管 sidecar LLM 后处理端点；是否继续支持待产品决策，当前不进任何 projection |
+| frontend | NEXT_PUBLIC_PROJECT_ROOT | system | yes | no | no UI write | text | no | none | 无 | 不进 UI | Next.js 构建期或调试开关 |
+| frontend | NEXT_PUBLIC_DEBUG_SKIP_FILE_CHANGE_UI | system | yes | no | no UI write | text | no | none | 无 | 不进 UI | Next.js 构建期或调试开关 |
+| frontend | THEME_CONFIG | frontend | yes | yes | module-managed | text | no | equivalent | F056 Theme Tuner → `themeStore`/localStorage (primary) + PATCH `/api/config/env` (backup) → `restoreFromServer` GET `/api/config/env-summary` → write back to localStorage → `ThemeApplier` reads `themeStore` and `applyThemeCSS` → env fallback | 清出 System | F056 主题系统已有完整 UI 覆盖，当前 runtimeEditable=true，但由模块 UI 管理，清出 System 防双入口 |
+
+## 推送通知 (3)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| push | VAPID_PUBLIC_KEY | notify | yes | no | module-managed | text | no | exact | PushServiceConfig.tsx → POST `/api/config/secrets` → `process.env` / `.env` + `configEventBus` → `configurePushServiceFromEnv` | 清出 System | 已有 PushServiceConfig UI 覆盖 |
+| push | VAPID_PRIVATE_KEY | notify | yes | no | module-managed | text | no | exact | PushServiceConfig.tsx → POST `/api/config/secrets` → `process.env` / `.env` + `configEventBus` → `configurePushServiceFromEnv` | 清出 System | 已有 PushServiceConfig UI 覆盖 |
+| push | VAPID_SUBJECT | notify | yes | no | module-managed | text | no | exact | PushServiceConfig.tsx → POST `/api/config/secrets` → `process.env` / `.env` + `configEventBus` → `configurePushServiceFromEnv` | 清出 System | 已有 PushServiceConfig UI 覆盖 |
+
+## Signal 信号源 (2)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| signal | SIGNALS_ROOT_DIR | plugins | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | Signal 插件/信号源配置，暂无 UI |
+| signal | CAT_CAFE_SIGNAL_USER | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Signal MCP 运行身份绑定，身份锚点类；比照 DEFAULT_OWNER 处理原则，暂不给 UI 编辑面 |
+
+## F102 记忆系统 (21)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| evidence | EMBED_MODE | ops | yes | no | read-only | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F102_ABSTRACTIVE | ops | yes | no | read-only | text | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F102_DURABLE_CANDIDATES | ops | yes | no | read-only | text | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F102_TOPIC_SEGMENTS | ops | yes | no | read-only | text | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F200_CONSUMPTION_RERANK | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_AUTHORITY_BOOST | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_ALWAYS_ON_INJECTION | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_RETRIEVAL_RERANK | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_COMPRESSION | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_PROMOTION_GATE | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_CONTRADICTION_DETECTION | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F163_REVIEW_QUEUE | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | EMBED_URL | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | EVIDENCE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | GLOBAL_KNOWLEDGE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | WORLD_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | TASK_OUTCOME_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | EVENT_MEMORY_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+| evidence | F102_API_BASE | ops | yes | no | read-only | text | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
+| evidence | F102_API_KEY | accounts | yes | yes | read-only, opt-in editable | text | no | equivalent | 已有专用模块 UI | 清出 System | future accounts migration 是目标，但 summarizer 当前仍直接读 process.env；当前 runtimeEditable=true，PR-C 默认只读 + opt-in 可写；consumer cutover 完成前 env fallback 保留 |
+| evidence | EMBED_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
+
+## 可观测性 (OTel) (12)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| telemetry | TELEMETRY_DEBUG | ops | no | no | no UI write | text | no | none | 无 | 不进 UI | 调试遥测，仅限 dev/test |
+| telemetry | TELEMETRY_DEBUG_FORCE | ops | no | no | no UI write | text | no | none | 无 | 不进 UI | 调试遥测，仅限 dev/test |
+| telemetry | TELEMETRY_HMAC_SALT | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | TELEMETRY_EXPORT_RAW_SYSTEM_IDS | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | PROMETHEUS_PORT | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | OTEL_EXPORTER_OTLP_ENDPOINT | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | OTEL_SDK_DISABLED | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | TELEMETRY_ALERT_ERROR_RATE | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | TELEMETRY_ALERT_P95_LATENCY_S | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | TELEMETRY_ALERT_ACTIVE_INVOCATIONS | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级可观测性配置 |
+| telemetry | PROMPT_CAPTURE | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | Prompt X-Ray 开关；已有专用模块 UI，不进通用 projection |
+| telemetry | PROMPT_CAPTURE_CATS | ops | yes | yes | editable | text | no | equivalent | 已有专用模块 UI | 清出 System | Prompt X-Ray 开关；已有专用模块 UI，不进通用 projection |
+
+## 孟加拉猫 (Antigravity) (13)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| antigravity | ANTIGRAVITY_PORT | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | 自动发现，通常无需配置 |
+| antigravity | PINCHTAB_CDP_PORT | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| antigravity | ANTIGRAVITY_CSRF_TOKEN | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| antigravity | ANTIGRAVITY_TLS | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | 自动发现，通常无需配置 |
+| antigravity | ANTIGRAVITY_AUTO_APPROVE | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 执行策略，内部/高级 |
+| antigravity | ANTIGRAVITY_AUTO_RESUME | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 执行策略，内部/高级 |
+| antigravity | ANTIGRAVITY_YOLO_RUN_COMMAND | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 执行策略，内部/高级 |
+| antigravity | ANTIGRAVITY_RUN_COMMAND_TIMEOUT_MS | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 内部路径/端口 |
+| antigravity | ANTIGRAVITY_TRACE_RAW | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 测试/调试专用 |
+| antigravity | ANTIGRAVITY_NATIVE_EXECUTOR | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 执行策略，内部/高级 |
+| antigravity | CAT_CAFE_RIPGREP_PATH | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | Antigravity 内部路径/端口 |
+| antigravity | CAT_CAFE_READONLY | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+| antigravity | CAT_CAFE_RUNTIME_SESSION_SEAL_REAPER_INTERVAL_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用 |
+
+## 会中实时智囊 (F195) (2)
+
+| category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| audio | AUDIO_SERVICE_URL | voice | yes | no | read-only | text | no | none | 无 | 产品待决策 | 远程/自托管 sidecar 音频服务端点；是否继续支持待产品决策，当前不进任何 projection |
+| audio | TRANSCRIPT_DIR | voice | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 服务端点/缓存目录；不进通用 projection |
+
+## Summary
+
+- **Total env vars inventoried**: 228
+- **保留 System** (真正 system-level 配置，保留在 System view): 28
+- **清出 System** (已有模块 UI 覆盖，从 System view 移除): 34
+- **投影到模块** (无 UI 覆盖且用户确需配置): **0**（PR-A 清空，等 PR-C 按模块 owner 确认后重新添加）
+- **组件补齐** (需专用组件/连接器扩展，不进通用 env 卡): 4
+- **产品待决策** (是否继续支持远程/自托管 sidecar，待产品决策): 4
+- **不进 UI** (部署级 / 内部 / 测试 / deprecated / 无当前 UI 路径): 158
+- **未分类 items**: 0（sol 在 HEAD `f790c4ed2` 完成源码审计，结论：之前的 42 项 generic projection 不成立）
+
+> **PR-A 关键修正**：原 42 项“投影到模块”结论已被撤销。
+> 其中 18 项已有专用模块 UI（evidence/F102/F163/F200 实验开关、Prompt X-Ray、语音模型目录），应原地修复专用页面；
+> 24 项为平台管理/内部调优/重复入口/条件性缺口/需组件级扩展，不应直接进入通用 env 卡。
+> `packages/api/src/config/env-sections.ts` 的 `MODULE_SECTION_PROJECTION` 在 PR-A 中全部置空，保留 section/filter/write-policy 基础设施；真正的模块投影将在 PR-C 中随各模块 UI 负责人确认后收敛。
+
+### Invariants
+
+- **保留 System** ⇒ `section target` 必须为 `system`；这些 vars 必须保留在 `SYSTEM_VARS`。
+- **清出 System** ⇒ `覆盖类型` 必须为 `exact` 或 `equivalent`；这些 vars 必须从 `SYSTEM_VARS` 移除且不进任何 module projection。
+- **投影到模块** ⇒ `覆盖类型` 必须为 `none` 且 `section target` 必须是非 `system` 的模块；这些 vars 进入对应 module projection。PR-A 中该集合为空。
+- **不进 UI** ⇒ `覆盖类型` 必须为 `none`（保留 System 除外，记 `N/A`）；这些 vars 不得进入 `SYSTEM_VARS` 或任何 module projection。
+- **组件补齐** ⇒ 需后续专用组件/连接器 UI 承载，不进通用 env 投影；PR-C 前不得进入 `MODULE_SECTION_PROJECTION`。
+- **产品待决策** ⇒ 是否继续支持对应功能待产品决策；决策前不得进入 `MODULE_SECTION_PROJECTION`。
+- Vars with `deprecated: true` metadata ⇒ 永远不得进入 `SYSTEM_VARS` 或任何 module projection（PR-A `filterEnvSummaryForSection` 已 enforce）。Description-only deprecated markers（如 #1340 中的 `GITHUB_AUTHORITATIVE_REVIEW_LOGINS`）不会被 filter 自动拦截，必须从 projection set 显式移除；完整 metadata 标记与消费者迁移归 PR-E。
+
+## PR Split Proposal (after PR-A)
+
+### PR-B: System view cleanup + consolidated retention
+- Scope:
+  - Keep in `SYSTEM_VARS` all vars marked **保留 System** (the 28 true system-level knobs: ports, storage paths, TTL, security boundaries).
+  - Remove from `SYSTEM_VARS` and `SystemSettingsView.tsx` only vars marked **清出 System** (those already covered by module UI).
+  - Move sensitive credentials already covered by accounts/credentials UI (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `MOONSHOT_API_KEY`) to accounts.
+  - Remove credentials already covered by plugin manifests (`GITHUB_TOKEN`, `GITHUB_MCP_PAT`, `GITHUB_SETUP_NOISE_BOT_LOGINS` via `packages/api/src/plugins/github/plugin.yaml`) from the generic System/accounts surface; leave internal-only secrets (`CAT_CAFE_CALLBACK_TOKEN`) hidden, not in accounts.
+- Dependencies: PR-A (unified env renderer foundation) must land first.
+- Verification: `GET /api/config/env-summary?surface=system` returns only true system-level knobs; no duplicated VAPID/connector/plugin fields.
+
+### PR-C: Project env vars to module pages (TBD — 等 UI owner 确认)
+- Scope: for each module, add a "环境变量" subsection using the unified env renderer to surface vars that are **确实没有** dedicated module UI 且 **产品决定** 要暴露的 env vars.
+- Ownership gate: 每个模块在重新向 `MODULE_SECTION_PROJECTION` 添加变量之前，必须确认该变量在现有模块页面中无等价入口，且应由通用 env renderer 而非组件内嵌字段承载。
+- Candidate categories from sol's audit (not yet approved for projection):
+  - **已有专用 UI，应修复原页面**：18 项 evidence/F102/F163/F200 实验开关、`PROMPT_CAPTURE*`、`CHARACTER_VOICE_DIR`、`GENSHIN_VOICE_DIR`。
+  - **组件补齐**（需专用组件/连接器扩展，不进通用 env 卡）：`AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS`；GitHub Repo Inbox 配置（`GITHUB_WEBHOOK_SECRET`、`GITHUB_REPO_ALLOWLIST`、`GITHUB_REPO_INBOX_CAT_ID`），但需先把 connector gateway 从直接读 `process.env` 迁到 plugin config resolver。
+  - **产品待决策**（仅当产品继续支持远程/自托管 sidecar 时，在 `ServiceStatusPanel` 增加“自定义端点”）：`AUDIO_SERVICE_URL`、`TTS_URL`、`WHISPER_URL`、`NEXT_PUBLIC_LLM_POSTPROCESS_URL`。
+- Dependencies: PR-B (so System view no longer duplicates them).
+- Runtime-persistence caveat: Console `PATCH /api/config/env` writes per-user `.env` and mutates the running process, but packaged desktop restart (`ServiceManager._startApi()`) does not reload `.env` (tracked by #1062). PR-C full acceptance for the packaged desktop lane is blocked on #1062; dev-mode acceptance can proceed. `LOG_LEVEL` is the canonical regression sample.
+- Write-policy gate: all projected vars are readable; write is only enabled when the var's **target write policy** is `editable` **and** the runtime persistence contract is satisfied.
+- Verification: each module page can read its projected env vars via the unified renderer; only vars marked `editable` in target write policy are writable; `runtimeEditable=false` / `read-only` / `read-only, opt-in editable` vars render as read-only; build-time vars (`NEXT_PUBLIC_*`) are surfaced read-only with a rebuild-required hint. e2e tests verify no regressions in existing module UIs.
+
+### PR-D: Hide internal/deploy/test vars
+- Scope: ensure all vars marked **不进 UI** have `hubVisible: false` (or are omitted from `buildEnvSummary`) and do not appear in any renderer.
+  - Vars marked **组件补齐** or **产品待决策** are intentionally excluded from this hide rule; they are expected to enter dedicated component UI once their respective owner/scope is resolved.
+- Add lint/rule: new internal-only vars must declare `hubVisible: false` and a justification comment.
+- Dependencies: PR-C (so projection surface is stable before we narrow visibility).
+- Verification: `buildEnvSummary()` no longer returns deploy/internal/test vars; snapshot test updated.
+
+### PR-E: Deprecated cleanup
+- Scope: formally deprecate `GITHUB_AUTHORITATIVE_REVIEW_LOGINS`; migrate any remaining consumers to `GITHUB_SETUP_NOISE_BOT_LOGINS`.
+- Dependencies: PR-D (visibility cleanup first).
+- Verification: no runtime reads of dead config; registry entry retained per maintainer policy—physical removal is maintainer-owned, not done in this PR.
+
+### PR-A sync delta (applied at HEAD `f790c4ed2`)
+
+PR-A previously carried a 42-var module projection. After sol's source audit on HEAD `f790c4ed2` the projection conclusion was retracted:
+
+- **Current projection in PR-A**: 0 vars across the 7 non-system sections (`accounts`, `im`, `members`, `notify`, `ops`, `plugins`, `voice`).
+- **Reason**: the prior 42-var allowlist conflated five distinct categories:
+  1. 18 vars already have dedicated module UI and should be fixed in-place, not duplicated in a generic env card.
+  2. 15 vars are platform-management, internal tuning, or escape-hatch knobs and should not appear in normal user UI.
+  3. 1 var (`NEXT_PUBLIC_WHISPER_URL`) is a duplicate legacy entry.
+  4. 4 vars need component-level extensions rather than generic projection (**组件补齐**).
+  5. 4 vars are conditional gaps that only make sense if the product keeps supporting remote/self-hosted sidecars (**产品待决策**).
+
+**Structural changes to `packages/api/src/config/env-sections.ts`:**
+- Keep `plugins` in `EnvSectionKey`, `ENV_SECTION_KEYS`, and `ENV_SECTION_LABELS`.
+- Remove `mcp` and `concierge`; they had no planned module UI in PR-C.
+- Keep `accounts` in the section type/key/label set for future PR-C use.
+- `MODULE_SECTION_PROJECTION` is intentionally empty in PR-A. It remains the only source of truth for which non-system vars appear in which section; ownership metadata in the registry must **not** be interpreted as an automatic projection.
+
+**Verification:** `MODULE_SECTION_PROJECTION` contains exactly 0 vars in every non-system section; the unit test asserts this. `SYSTEM_VARS` and section keys/labels remain unchanged. Deprecated vars continue to be excluded from all section summaries.

--- a/docs/plans/770-env-config-inventory.md
+++ b/docs/plans/770-env-config-inventory.md
@@ -30,7 +30,7 @@ created: 2026-08-12
 - **现有 UI 覆盖**: component path if an existing module UI already covers this domain
 - **disposition**: `保留 System` / `清出 System` / `投影到模块` / `不进 UI` / `组件补齐` / `产品待决策`
 
-## 服务器 (59)
+## 服务器 (58)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -38,7 +38,6 @@ created: 2026-08-12
 | server | PREVIEW_GATEWAY_PORT | system | yes | yes | editable | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | API_SERVER_HOST | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | CORS_ALLOW_PRIVATE_NETWORK | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
-| server | UPLOAD_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | PROJECT_ALLOWED_ROOTS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | PROJECT_ALLOWED_ROOTS_APPEND | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
 | server | PROJECT_DENIED_ROOTS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS / System Settings 中 |
@@ -94,12 +93,14 @@ created: 2026-08-12
 | server | CAT_CAFE_PERSONAL_CHROME_PAIRING_SECRET | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（personal chrome 配对密钥） |
 | server | CAT_CAFE_PERSONAL_CHROME_WEB_STORE_URL | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 部署/内部专用（personal chrome web store） |
 
-## 存储 (13)
+## 存储 (15)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | storage | REDIS_URL | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
 | storage | REDIS_KEY_PREFIX | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | REDIS_DATA_DIR | none | no | no | no UI write | text | no | none | 无 | 不进 UI | Redis 数据目录，由 shell 启动脚本在 API 前设置；DATA_DIR 设置后覆盖 |
+| storage | REDIS_BACKUP_DIR | none | no | no | no UI write | text | no | none | 无 | 不进 UI | Redis 备份目录，由 shell 启动脚本在 API 前设置；DATA_DIR 设置后覆盖 |
 | storage | MEMORY_STORE | system | yes | no | read-only | toggle | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
 | storage | MESSAGE_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
 | storage | THREAD_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
@@ -107,7 +108,8 @@ created: 2026-08-12
 | storage | SUMMARY_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
 | storage | BACKLOG_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
 | storage | DRAFT_TTL_SECONDS | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
-| storage | TRANSCRIPT_DATA_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 已在 SYSTEM_VARS 中 |
+| storage | DATA_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | issue #671 持久数据根目录 |
+| storage | CACHE_DIR | system | yes | no | read-only | dirpicker | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | issue #671 可重建缓存根目录 |
 | storage | ANNOTATION_DATA_DIR | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 系统级存储路径，保留在 System view |
 | storage | DOCS_ROOT | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | 系统级文档根目录，保留在 System view |
 | storage | VISIBILITY_CURSOR_V2 | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 部署级 activation gate |
@@ -119,7 +121,7 @@ created: 2026-08-12
 | budget | MAX_A2A_DEPTH | system | yes | no | read-only | text | no | N/A | SystemSettingsView.tsx (System Settings page) | 保留 System | A2A 预算阈值，保留在 System view |
 | budget | WEB_PUSH_TIMEOUT_MS | notify | yes | no | read-only | text | no | none | 无 | 不进 UI | Web Push 超时；不进通用 projection |
 
-## CLI (38)
+## CLI (36)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -130,8 +132,6 @@ created: 2026-08-12
 | cli | CAT_TEMPLATE_PATH | members | yes | no | read-only | text | no | none | 无 | 不进 UI | 成员/模板默认值；不进通用 projection |
 | cli | DEFAULT_CAT_ID | members | yes | no | module-managed | text | no | equivalent | DefaultCatSelector → PUT `/api/config/default-cat` → `persistDefaultCatToEnv` + `setRuntimeDefaultCatId` → `getDefaultCatId` / cat loader → env fallback | 清出 System | 默认猫选择，已有 DefaultCatSelector UI 覆盖；env 仅作 bootstrap/fallback |
 | cli | CAT_CAFE_MCP_SERVER_PATH | mcp | yes | no | no UI write | text | no | none | 无 | 不进 UI | MCP 路径/凭证目录，内部运行时配置 |
-| cli | AUDIT_LOG_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 审计日志路径；不进通用 projection |
-| cli | CLI_RAW_ARCHIVE_DIR | ops | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 原始 CLI 归档路径；不进通用 projection |
 | cli | AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS | ops | yes | no | read-only | text | no | none | 无 | 组件补齐 | 审计日志隐私开关；需专用组件 UI，不进通用 projection |
 | cli | CAT_BRANCH_ROLLBACK_RETRY_DELAYS_MS | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | CLI 内部/调试/路径配置 |
 | cli | MODE_SWITCH_REQUIRES_APPROVAL | none | yes | no | no UI write | text | yes | none | 无 | 不进 UI | [DEPRECATED] Mode consumer 在 registry backfill (b58106d0d4) 之前已由 F101 移除 (2dfece9873)；当前 tree 无 live consumer。registry 条目保留，永不进入 curated projection |
@@ -173,7 +173,7 @@ created: 2026-08-12
 | proxy | HTTP_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
 | proxy | ALL_PROXY | none | no | no | no UI write | text | no | none | 无 | 不进 UI | 上游配置/HTTP_PROXY 等部署级 |
 
-## 平台接入 (Telegram/飞书) (5)
+## 平台接入 (Telegram/飞书) (4)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -181,7 +181,6 @@ created: 2026-08-12
 | connector | WEIXIN_VOICE_ITEM_MODE | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
 | connector | WEIXIN_ENABLE_UNSAFE_VOICE_MODES | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
 | connector | WEIXIN_CAPTURE_INBOUND_VOICE_MEDIA | im | yes | yes | read-only, opt-in editable | dropdown | no | none | 无 | 不进 UI | 微信连接器实验开关；不进通用 projection |
-| connector | CONNECTOR_MEDIA_DIR | im | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | connector 媒体下载目录；不进通用 projection |
 
 ## GitHub Review 监控 (14)
 
@@ -242,12 +241,11 @@ created: 2026-08-12
 | quota | CLAUDE_CREDENTIALS_PATH | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | credentials 文件路径，内部 |
 | quota | CODEX_CREDENTIALS_PATH | ops | yes | no | no UI write | text | no | none | 无 | 不进 UI | credentials 文件路径，内部 |
 
-## 语音合成 (TTS) (5)
+## 语音合成 (TTS) (4)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | tts | TTS_URL | voice | yes | no | read-only | text | no | none | 无 | 产品待决策 | 远程/自托管 sidecar TTS 端点；是否继续支持待产品决策，当前不进任何 projection |
-| tts | TTS_CACHE_DIR | voice | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | 服务端点/缓存目录；不进通用 projection |
 | tts | GENSHIN_VOICE_DIR | voice | yes | no | read-only | dirpicker | no | equivalent | 已有专用模块 UI | 清出 System | 服务端点/缓存目录，服务生命周期 UI 可配置端口/模型，但 URL/dir 级 env 暂无 UI |
 | tts | CHARACTER_VOICE_DIR | voice | yes | no | read-only | dirpicker | no | equivalent | 已有专用模块 UI | 清出 System | 服务端点/缓存目录，服务生命周期 UI 可配置端口/模型，但 URL/dir 级 env 暂无 UI |
 | tts | LISTEN_MODE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 听读模式状态数据库（文件路径，非目录）；不进通用 projection |
@@ -284,7 +282,7 @@ created: 2026-08-12
 | signal | SIGNALS_ROOT_DIR | plugins | yes | no | read-only | dirpicker | no | none | 无 | 不进 UI | Signal 插件/信号源配置，暂无 UI |
 | signal | CAT_CAFE_SIGNAL_USER | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | Signal MCP 运行身份绑定，身份锚点类；比照 DEFAULT_OWNER 处理原则，暂不给 UI 编辑面 |
 
-## F102 记忆系统 (21)
+## F102 记忆系统 (19)
 
 | category | var name | section target | registry summary eligible? | current editable | target write policy | control type | dead config? | 覆盖类型 | 现有 UI 覆盖 | disposition | note |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -301,9 +299,7 @@ created: 2026-08-12
 | evidence | F163_CONTRADICTION_DETECTION | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
 | evidence | F163_REVIEW_QUEUE | ops | yes | yes | editable | dropdown | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
 | evidence | EMBED_URL | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
-| evidence | EVIDENCE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
 | evidence | GLOBAL_KNOWLEDGE_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
-| evidence | WORLD_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
 | evidence | TASK_OUTCOME_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
 | evidence | EVENT_MEMORY_DB | none | yes | no | no UI write | text | no | none | 无 | 不进 UI | 服务/数据库路径，内部 |
 | evidence | F102_API_BASE | ops | yes | no | read-only | text | no | equivalent | 已有专用模块 UI | 清出 System | F102/F163/F200 实验开关；已有专用模块 UI，不进通用 projection |
@@ -354,13 +350,13 @@ created: 2026-08-12
 
 ## Summary
 
-- **Total env vars inventoried**: 222
+- **Total env vars inventoried**: 218
 - **保留 System** (真正 system-level 配置，保留在 System view): 28
 - **清出 System** (已有模块 UI 覆盖，从 System view 移除): 34
 - **投影到模块** (无 UI 覆盖且用户确需配置): **0**（PR-A 清空，等 PR-C 按模块 owner 确认后重新添加）
 - **组件补齐** (需专用组件/连接器扩展，不进通用 env 卡): 4
 - **产品待决策** (是否继续支持远程/自托管 sidecar，待产品决策): 4
-- **不进 UI** (部署级 / 内部 / 测试 / deprecated / 无当前 UI 路径): 152
+- **不进 UI** (部署级 / 内部 / 测试 / deprecated / 无当前 UI 路径): 148
 - **未分类 items**: 0（sol 在 HEAD `f790c4ed2` 完成源码审计，结论：之前的 42 项 generic projection 不成立）
 
 > **PR-A 关键修正**：原 42 项“投影到模块”结论已被撤销。

--- a/packages/api/src/config/cat-voices.ts
+++ b/packages/api/src/config/cat-voices.ts
@@ -60,7 +60,7 @@ function hasParentTraversalSegment(value: string): boolean {
 
 export function resolveRefAudioPath(refAudio: string, characterBaseDir: string): string {
   if (refAudio.startsWith('/uploads/')) {
-    const uploadDir = resolve(getDefaultUploadDir(process.env.UPLOAD_DIR));
+    const uploadDir = resolve(getDefaultUploadDir());
     const uploadKey = refAudio.slice('/uploads/'.length);
     if (hasParentTraversalSegment(uploadKey)) return join(uploadDir, 'invalid-ref');
     const resolved = resolve(uploadDir, uploadKey);

--- a/packages/api/src/config/data-dirs-migration.ts
+++ b/packages/api/src/config/data-dirs-migration.ts
@@ -1,0 +1,714 @@
+/**
+ * Data directory migration engine — issue #671.
+ *
+ * When the user sets DATA_DIR / CACHE_DIR / LOG_DIR in their .env and
+ * restarts the service, any existing data at the legacy paths must be
+ * relocated to the new root before any consumer (SQLite, logger, etc.)
+ * opens connections to the new path.
+ *
+ * Protocol (铲屎官 spec):
+ *   1. Probe available space on the target volume
+ *   2. Migrate (rename when on the same filesystem; otherwise copy + verify + delete)
+ *   3. Failure → log a warning, leave the legacy path untouched
+ *   4. Success → cleanup of the legacy file/dir is built into the move
+ *      (rename removes the source; cross-volume copy explicitly deletes
+ *      after verification). The next read/write goes to the new path
+ *      naturally because the resolver only returns the new path when
+ *      the root env var is set.
+ *   5. Restart-required: this engine runs *before* DB connections open,
+ *      so startup migration never needs a restart. Runtime callers can set
+ *      `blockFileMoves` to require a restart before moving file-backed stores;
+ *      when a runtime-safe migration moves data, the result sets
+ *      `restartRecommended`.
+ */
+
+import { createHash } from 'node:crypto';
+import { existsSync, statSync } from 'node:fs';
+import { copyFile, mkdir, readdir, rename, rm, stat, unlink } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { type DataPathKey, type DataPathSpec, describeDataPaths } from './data-dirs.js';
+
+/** SQLite sidecar suffixes that must move alongside the main DB file. */
+const SQLITE_SIDECARS = ['-wal', '-shm', '-journal'];
+
+export interface MigrationPlanItem {
+  readonly spec: DataPathSpec;
+  /** Bytes that need to move (legacy path size, including SQLite sidecars). */
+  readonly sourceBytes: number;
+  /** True if the source path exists and is not a placeholder-only upload dir. */
+  readonly sourceExists: boolean;
+  /** True if the target path is already populated (skip to avoid overwrite). */
+  readonly targetPopulated: boolean;
+  /** True if this item is eligible for migration. */
+  readonly eligible: boolean;
+  /** Reason if not eligible. */
+  readonly skipReason?: string;
+}
+
+export interface MigrationPlan {
+  /** All paths in scope — even the ones we won't move. */
+  readonly items: readonly MigrationPlanItem[];
+  /** Total bytes that will move across all eligible items. */
+  readonly totalBytes: number;
+  /** True if any item is eligible for migration. */
+  readonly hasWork: boolean;
+}
+
+export interface MigrationItemResult {
+  readonly key: DataPathKey;
+  readonly fromPath: string;
+  readonly toPath: string;
+  readonly bytes: number;
+  readonly status: 'moved' | 'skipped' | 'failed';
+  readonly reason?: string;
+  readonly error?: string;
+}
+
+export interface MigrationResult {
+  readonly attempted: boolean;
+  readonly items: readonly MigrationItemResult[];
+  /** True if every eligible item moved successfully. */
+  readonly allSucceeded: boolean;
+  /** True if the caller should surface a restart notice (runtime migration only). */
+  readonly restartRecommended: boolean;
+  /** Top-level abort reason, e.g. insufficient disk space. */
+  readonly abortedReason?: string;
+}
+
+export interface AbortDecision {
+  readonly shouldAbort: boolean;
+  readonly reason?: string;
+  /** Per-path details for the error message (key + which side has data). */
+  readonly leftBehind: readonly { readonly key: DataPathKey; readonly fromPath: string; readonly status: string }[];
+}
+
+/**
+ * Decide whether startup must fail-fast.
+ *
+ * The hazard: when a root env var is set, the resolver returns the new path
+ * unconditionally. If the migration aborted (insufficient space) or any item
+ * failed, the legacy data is still at the old path, but consumers will read
+ * the new (empty) path — that looks like silent data loss.
+ *
+ * Returns `{ shouldAbort: true, reason, leftBehind[] }` when:
+ *   - The migration aborted at the planning stage (e.g. disk space)
+ *   - Any eligible item failed to move
+ *   - A legacy source still exists but its root target is already populated
+ *
+ * Returns `{ shouldAbort: false }` when:
+ *   - No migration was attempted (no root set, or no pending work)
+ *   - All eligible items moved successfully
+ *
+ * Skipped items with no source data do NOT trigger abort. Skipped
+ * target-not-empty items do trigger abort because the resolver now points at
+ * the populated target while legacy data still exists at the old path.
+ */
+export function shouldAbortStartupOnMigration(result: MigrationResult): AbortDecision {
+  if (result.abortedReason) {
+    return {
+      shouldAbort: true,
+      reason: result.abortedReason,
+      leftBehind: result.items
+        .filter((i) => i.status !== 'moved')
+        .map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  const failed = result.items.filter((i) => i.status === 'failed');
+  if (failed.length > 0) {
+    return {
+      shouldAbort: true,
+      reason: `${failed.length} data-dirs path(s) failed to migrate; legacy data still on disk while resolver now points at the new root`,
+      leftBehind: failed.map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  const blocked = result.items.filter((i) => i.status === 'skipped' && i.reason === 'target-not-empty');
+  if (blocked.length > 0) {
+    return {
+      shouldAbort: true,
+      reason: `${blocked.length} data-dirs path(s) blocked by target-not-empty; legacy data still on disk while resolver now points at the new root`,
+      leftBehind: blocked.map((i) => ({ key: i.key, fromPath: i.fromPath, status: i.status })),
+    };
+  }
+  return { shouldAbort: false, leftBehind: [] };
+}
+
+export interface DiskSpaceProbe {
+  readonly availableBytes: number;
+  readonly totalBytes: number;
+}
+
+/** Pluggable I/O hooks for testing without touching real FS. */
+export interface MigrationIO {
+  diskFree(path: string): Promise<DiskSpaceProbe>;
+  logger?: {
+    info: (data: object, msg?: string) => void;
+    warn: (data: object, msg?: string) => void;
+    error: (data: object, msg?: string) => void;
+  };
+}
+
+export interface PlanOptions {
+  readonly repoRoot: string;
+  readonly monorepoRoot: string;
+  /** See DescribeOptions.uploadsLegacyOverride — test-only injection. */
+  readonly uploadsLegacyOverride?: string;
+}
+
+export interface RunOptions extends PlanOptions {
+  /** Trigger context — affects restart recommendation in the result. */
+  readonly trigger: 'startup' | 'runtime';
+  readonly io: MigrationIO;
+  /** Refuse to move SQLite/file-backed stores after startup. */
+  readonly blockFileMoves?: boolean;
+  /** Skip the disk-space pre-flight (useful for tests). */
+  readonly skipSpaceCheck?: boolean;
+  /** Test-only: force the cross-device copy fallback path. */
+  readonly forceCrossDeviceForTesting?: boolean;
+  /** Multiplier applied to required bytes when checking disk free space. */
+  readonly spaceSafetyMultiplier?: number;
+}
+
+const DEFAULT_SAFETY_MULTIPLIER = 1.5;
+const UPLOADS_PLACEHOLDER_FILES = new Set(['.gitkeep']);
+
+/** Recursively measure on-disk size of a file or directory. */
+export async function measurePath(path: string): Promise<number> {
+  if (!existsSync(path)) return 0;
+  const st = await stat(path);
+  if (st.isFile()) {
+    let total = st.size;
+    // Include SQLite sidecars if the main file looks like a DB
+    if (path.endsWith('.sqlite')) {
+      for (const suffix of SQLITE_SIDECARS) {
+        const sidecar = `${path}${suffix}`;
+        if (existsSync(sidecar)) {
+          const ss = await stat(sidecar);
+          total += ss.size;
+        }
+      }
+    }
+    return total;
+  }
+  if (st.isDirectory()) {
+    let total = 0;
+    const entries = await readdir(path, { withFileTypes: true });
+    for (const entry of entries) {
+      total += await measurePath(join(path, entry.name));
+    }
+    return total;
+  }
+  return 0;
+}
+
+/**
+ * Build a migration plan describing what would move and why.
+ * Pure — does not touch the filesystem beyond stat/readdir calls.
+ *
+ * Excluded paths:
+ * - `logs`: Pino captures LOG_DIR at module load; moving logs without a
+ *   logger restart is unsafe. Setting LOG_DIR only redirects future writes.
+ * - `catCafeState`: the `.cat-cafe/` directory contains both writable
+ *   state and bundled tools; the shell startup moves the whole dir to
+ *   `DATA_DIR/cat-cafe/` and plants a symlink at the original path so
+ *   all 50+ in-process consumers remain transparent.
+ * - `redisData` / `redisBackups`: Redis is started by the shell script
+ *   *before* the API server.  The shell layer handles the `--dir` flag
+ *   and pre-start data migration.  Moving Redis data while the server is
+ *   running would corrupt it.
+ */
+export async function buildMigrationPlan(opts: PlanOptions): Promise<MigrationPlan> {
+  const SHELL_MANAGED: ReadonlySet<string> = new Set(['logs', 'catCafeState', 'redisData', 'redisBackups']);
+  const specs = describeDataPaths(opts).filter((s) => !SHELL_MANAGED.has(s.key));
+  const items: MigrationPlanItem[] = [];
+  let totalBytes = 0;
+
+  for (const spec of specs) {
+    // Only consider entries where a root is configured and legacy != root path.
+    if (spec.rootBasedPath === null) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated: false,
+        eligible: false,
+        skipReason: 'root-env-not-set',
+      });
+      continue;
+    }
+
+    if (spec.legacyPath === spec.rootBasedPath) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated: false,
+        eligible: false,
+        skipReason: 'legacy-equals-target',
+      });
+      continue;
+    }
+
+    const sourceExists = await sourceExistsForMigration(spec);
+    const targetPopulated = await isMigrationTargetPopulated(spec);
+
+    if (!sourceExists) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: false,
+        targetPopulated,
+        eligible: false,
+        skipReason: 'no-source-data',
+      });
+      continue;
+    }
+
+    if (targetPopulated) {
+      items.push({
+        spec,
+        sourceBytes: 0,
+        sourceExists: true,
+        targetPopulated: true,
+        eligible: false,
+        skipReason: 'target-not-empty',
+      });
+      continue;
+    }
+
+    const sourceBytes = await measurePath(spec.legacyPath);
+    items.push({
+      spec,
+      sourceBytes,
+      sourceExists: true,
+      targetPopulated: false,
+      eligible: true,
+    });
+    totalBytes += sourceBytes;
+  }
+
+  const hasWork = items.some((i) => i.eligible);
+  return { items, totalBytes, hasWork };
+}
+
+async function sourceExistsForMigration(spec: DataPathSpec): Promise<boolean> {
+  if (!existsSync(spec.legacyPath)) return false;
+  if (spec.key !== 'uploads') return true;
+  return isPopulated(spec.legacyPath, { ignoreUploadsPlaceholder: true });
+}
+
+async function isPopulated(path: string, opts: { readonly ignoreUploadsPlaceholder?: boolean } = {}): Promise<boolean> {
+  try {
+    const st = await stat(path);
+    if (st.isFile()) return st.size > 0;
+    if (st.isDirectory()) {
+      const entries = await readdir(path, { withFileTypes: true });
+      return entries.some((entry) => {
+        if (opts.ignoreUploadsPlaceholder === true && entry.isFile() && UPLOADS_PLACEHOLDER_FILES.has(entry.name)) {
+          return false;
+        }
+        return true;
+      });
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+async function isMigrationTargetPopulated(spec: DataPathSpec): Promise<boolean> {
+  const target = spec.rootBasedPath;
+  if (target === null) return false;
+  if (existsSync(target) && (await isPopulated(target))) return true;
+  if (!spec.isFile || !target.endsWith('.sqlite')) return false;
+
+  for (const suffix of SQLITE_SIDECARS) {
+    const sidecarTarget = `${target}${suffix}`;
+    if (existsSync(sidecarTarget) && (await isPopulated(sidecarTarget))) return true;
+  }
+  return false;
+}
+
+/**
+ * Execute the migration plan with the configured safety guards.
+ * On insufficient disk space, returns `attempted: false` and a reason — no
+ * partial moves happen. On per-item failure, the item is left at the legacy
+ * path and other items continue to migrate independently.
+ */
+export async function runDataDirsMigration(opts: RunOptions): Promise<MigrationResult> {
+  const log = opts.io.logger;
+  const plan = await buildMigrationPlan(opts);
+  const blockedFileMoves = opts.blockFileMoves ? plan.items.filter(isFileStoreMigrationCandidate) : [];
+  if (blockedFileMoves.length > 0) {
+    log?.warn(
+      {
+        trigger: opts.trigger,
+        blocked: blockedFileMoves.map((i) => ({ key: i.spec.key, from: i.spec.legacyPath, to: i.spec.rootBasedPath })),
+      },
+      '[#671] Data-dirs migration blocked until restart because file-backed stores may be open',
+    );
+    return {
+      attempted: false,
+      items: blockedFileMoves.map(planItemToRuntimeFileBlockedResult),
+      allSucceeded: false,
+      restartRecommended: true,
+      abortedReason: 'runtime-file-migration-requires-restart: restart before moving file-backed stores',
+    };
+  }
+
+  if (!plan.hasWork) {
+    const blocked = plan.items.filter((i) => i.skipReason === 'target-not-empty');
+    if (blocked.length > 0) {
+      log?.warn(
+        { trigger: opts.trigger, blocked: blocked.map((i) => ({ key: i.spec.key, from: i.spec.legacyPath })) },
+        '[#671] Data-dirs migration blocked by populated target',
+      );
+      return {
+        attempted: false,
+        items: blocked.map(planItemToSkippedResult),
+        allSucceeded: false,
+        restartRecommended: false,
+      };
+    }
+    log?.info({ trigger: opts.trigger }, '[#671] No data-dirs migration pending');
+    return {
+      attempted: false,
+      items: [],
+      allSucceeded: true,
+      restartRecommended: false,
+    };
+  }
+
+  // Group eligible items by their target root mountpoint for space check.
+  const eligible = plan.items.filter((i) => i.eligible);
+
+  if (!opts.skipSpaceCheck) {
+    const safetyMul = opts.spaceSafetyMultiplier ?? DEFAULT_SAFETY_MULTIPLIER;
+    const byTarget = new Map<string, number>();
+    for (const item of eligible) {
+      const targetRoot = item.spec.rootBasedPath!;
+      const bucket = targetMountKey(targetRoot);
+      byTarget.set(bucket, (byTarget.get(bucket) ?? 0) + item.sourceBytes);
+    }
+
+    for (const [bucketPath, requiredBytes] of byTarget) {
+      const probe = await opts.io.diskFree(bucketPath);
+      const need = Math.ceil(requiredBytes * safetyMul);
+      if (probe.availableBytes < need) {
+        log?.warn(
+          {
+            bucket: bucketPath,
+            requiredBytes: need,
+            availableBytes: probe.availableBytes,
+            trigger: opts.trigger,
+          },
+          '[#671] Insufficient disk space for data-dirs migration — aborting',
+        );
+        return {
+          attempted: false,
+          items: [],
+          allSucceeded: false,
+          restartRecommended: false,
+          abortedReason: `insufficient-disk-space: need ${need} bytes at ${bucketPath}, have ${probe.availableBytes}`,
+        };
+      }
+    }
+  }
+
+  const results: MigrationItemResult[] = [];
+  for (const item of plan.items) {
+    if (!item.eligible) {
+      results.push(planItemToSkippedResult(item));
+      continue;
+    }
+    try {
+      await migrateOne(item.spec, item.spec.isFile, opts.forceCrossDeviceForTesting === true);
+      log?.info(
+        {
+          key: item.spec.key,
+          from: item.spec.legacyPath,
+          to: item.spec.rootBasedPath,
+          bytes: item.sourceBytes,
+        },
+        '[#671] Migrated data-dirs entry',
+      );
+      results.push({
+        key: item.spec.key,
+        fromPath: item.spec.legacyPath,
+        toPath: item.spec.rootBasedPath!,
+        bytes: item.sourceBytes,
+        status: 'moved',
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log?.warn(
+        {
+          key: item.spec.key,
+          from: item.spec.legacyPath,
+          to: item.spec.rootBasedPath,
+          error: message,
+          trigger: opts.trigger,
+        },
+        '[#671] Migration failed for data-dirs entry — legacy path left intact',
+      );
+      results.push({
+        key: item.spec.key,
+        fromPath: item.spec.legacyPath,
+        toPath: item.spec.rootBasedPath!,
+        bytes: item.sourceBytes,
+        status: 'failed',
+        error: message,
+      });
+    }
+  }
+
+  const movedAny = results.some((r) => r.status === 'moved');
+  const blocked = results.some((r) => r.status === 'skipped' && r.reason === 'target-not-empty');
+  const allEligibleSucceeded = eligible.every((item) =>
+    results.find((r) => r.key === item.spec.key && r.status === 'moved'),
+  );
+
+  return {
+    attempted: true,
+    items: results,
+    allSucceeded: allEligibleSucceeded && !blocked,
+    restartRecommended: opts.trigger === 'runtime' && movedAny,
+  };
+}
+
+function planItemToSkippedResult(item: MigrationPlanItem): MigrationItemResult {
+  return {
+    key: item.spec.key,
+    fromPath: item.spec.legacyPath,
+    toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
+    bytes: 0,
+    status: 'skipped',
+    reason: item.skipReason,
+  };
+}
+
+function isFileStoreMigrationCandidate(item: MigrationPlanItem): boolean {
+  return (
+    item.spec.isFile &&
+    item.sourceExists &&
+    item.spec.rootBasedPath !== null &&
+    item.spec.legacyPath !== item.spec.rootBasedPath
+  );
+}
+
+function planItemToRuntimeFileBlockedResult(item: MigrationPlanItem): MigrationItemResult {
+  return {
+    key: item.spec.key,
+    fromPath: item.spec.legacyPath,
+    toPath: item.spec.rootBasedPath ?? item.spec.legacyPath,
+    bytes: 0,
+    status: 'skipped',
+    reason: 'runtime-file-migration-requires-restart',
+  };
+}
+
+/**
+ * Migrate a single path (file or directory) with SQLite sidecar handling.
+ *
+ * SQLite DBs are migrated as an atomic bundle: main file + all sidecars
+ * (-wal, -shm, -journal) move together.  If any sidecar move fails the
+ * main file is rolled back so the legacy DB stays intact (P1 review).
+ */
+async function migrateOne(spec: DataPathSpec, isFile: boolean, forceCrossDevice = false): Promise<void> {
+  const target = spec.rootBasedPath!;
+  await mkdir(dirname(target), { recursive: true });
+
+  if (!isFile) {
+    await moveTree(spec.legacyPath, target, forceCrossDevice);
+    return;
+  }
+
+  // Collect main file + any existing sidecars as one migration bundle.
+  const bundle: Array<{ from: string; to: string }> = [{ from: spec.legacyPath, to: target }];
+  for (const suffix of SQLITE_SIDECARS) {
+    const sidecarSrc = `${spec.legacyPath}${suffix}`;
+    if (existsSync(sidecarSrc)) {
+      bundle.push({ from: sidecarSrc, to: `${target}${suffix}` });
+    }
+  }
+
+  // Try same-device rename for the whole bundle (atomic per-file, fast).
+  const renamed: Array<{ from: string; to: string }> = [];
+  let crossDevice = false;
+  for (const move of bundle) {
+    try {
+      await rename(move.from, move.to);
+      renamed.push(move);
+    } catch (err) {
+      if (isCrossDeviceError(err)) {
+        crossDevice = true;
+        break;
+      }
+      // Non-EXDEV error — roll back already-renamed, then rethrow
+      for (const done of renamed.reverse()) {
+        await rename(done.to, done.from).catch(() => {});
+      }
+      throw err;
+    }
+  }
+  if (!crossDevice) return; // all renamed successfully
+
+  // EXDEV: undo any partial renames, then fall back to staged copy-verify-delete
+  for (const done of renamed.reverse()) {
+    await rename(done.to, done.from).catch(() => {});
+  }
+
+  // Phase 1: copy all files to target (sources untouched)
+  const copied: string[] = [];
+  try {
+    for (const move of bundle) {
+      await copyFile(move.from, move.to);
+      copied.push(move.to);
+    }
+  } catch (err) {
+    // Clean up partial copies — sources stay intact
+    for (const dst of copied) {
+      await unlink(dst).catch(() => {});
+    }
+    throw err;
+  }
+
+  // Phase 2: verify all copies
+  for (const move of bundle) {
+    const srcHash = await hashFile(move.from);
+    const dstHash = await hashFile(move.to);
+    if (srcHash !== dstHash) {
+      // Clean up ALL target copies — sources stay intact
+      for (const m of bundle) {
+        await unlink(m.to).catch(() => {});
+      }
+      throw new Error(`Hash mismatch after copy: ${move.from} → ${move.to}`);
+    }
+  }
+
+  // Phase 3: all verified — delete sources
+  for (const move of bundle) {
+    await unlink(move.from);
+  }
+}
+
+async function moveFile(from: string, to: string): Promise<void> {
+  try {
+    await rename(from, to);
+    return;
+  } catch (err) {
+    if (!isCrossDeviceError(err)) throw err;
+  }
+  // Cross-device fallback: copy → verify hash → delete source
+  await copyFile(from, to);
+  const srcHash = await hashFile(from);
+  const dstHash = await hashFile(to);
+  if (srcHash !== dstHash) {
+    await unlink(to).catch(() => {});
+    throw new Error(`Hash mismatch after copy: ${from} → ${to}`);
+  }
+  await unlink(from);
+}
+
+async function moveTree(from: string, to: string, forceCrossDevice = false): Promise<void> {
+  if (!forceCrossDevice) {
+    try {
+      await rename(from, to);
+      return;
+    } catch (err) {
+      if (!isCrossDeviceError(err)) throw err;
+    }
+  }
+  // Cross-device fallback: recursive copy → spot-check sizes → recursive delete
+  try {
+    await copyTree(from, to);
+    // Best-effort verification: compare total sizes (deep hash would be expensive)
+    const srcSize = await measurePath(from);
+    const dstSize = await measurePath(to);
+    if (srcSize !== dstSize) {
+      throw new Error(`Size mismatch after tree copy: ${from} (${srcSize}) → ${to} (${dstSize})`);
+    }
+  } catch (err) {
+    await rm(to, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+  await rm(from, { recursive: true, force: true });
+}
+
+async function copyTree(from: string, to: string): Promise<void> {
+  await mkdir(to, { recursive: true });
+  const entries = await readdir(from, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = join(from, entry.name);
+    const dst = join(to, entry.name);
+    if (entry.isDirectory()) {
+      await copyTree(src, dst);
+    } else if (entry.isFile()) {
+      await copyFile(src, dst);
+    } else {
+      // Symlinks, sockets, FIFOs, etc. — abort to avoid silent data loss.
+      // Same-device rename handles these transparently; cross-device copy
+      // cannot safely reproduce them, so fail fast with a clear message.
+      const kind = entry.isSymbolicLink() ? 'symlink' : 'special-file';
+      throw new Error(
+        `Cannot migrate non-regular entry: ${src} (${kind}). ` +
+          'Move the directory manually or remove the entry before retrying.',
+      );
+    }
+  }
+}
+
+async function hashFile(path: string): Promise<string> {
+  const { createReadStream } = await import('node:fs');
+  return new Promise((resolveHash, rejectHash) => {
+    const hash = createHash('sha256');
+    const stream = createReadStream(path);
+    stream.on('data', (chunk) => hash.update(chunk));
+    stream.on('end', () => resolveHash(hash.digest('hex')));
+    stream.on('error', rejectHash);
+  });
+}
+
+function isCrossDeviceError(err: unknown): boolean {
+  return typeof err === 'object' && err !== null && (err as { code?: string }).code === 'EXDEV';
+}
+
+/** Choose a stable bucket key for grouping items by target volume. */
+function targetMountKey(targetPath: string): string {
+  // Walk up to find an existing ancestor — that's where free space lives.
+  let cursor = targetPath;
+  while (cursor !== dirname(cursor)) {
+    if (existsSync(cursor)) return cursor;
+    cursor = dirname(cursor);
+  }
+  return cursor;
+}
+
+/** Default disk-free probe using statfs (Node 18.15+). */
+export const defaultDiskSpaceProbe: MigrationIO['diskFree'] = async (path: string) => {
+  // Find a path that exists to call statfs on (statfs fails on missing path)
+  let cursor = path;
+  while (!existsSync(cursor) && cursor !== dirname(cursor)) {
+    cursor = dirname(cursor);
+  }
+  // statfs is available since Node 18.15 — fall back to a generous estimate if missing
+  try {
+    const fsPromises = await import('node:fs/promises');
+    const statfsFn = (
+      fsPromises as unknown as { statfs?: (p: string) => Promise<{ bavail: bigint; blocks: bigint; bsize: number }> }
+    ).statfs;
+    if (typeof statfsFn === 'function') {
+      const result = await statfsFn(cursor);
+      const blockSize = result.bsize;
+      return {
+        availableBytes: Number(result.bavail) * blockSize,
+        totalBytes: Number(result.blocks) * blockSize,
+      };
+    }
+  } catch {
+    /* fall through to synchronous statSync — yields no space info */
+  }
+
+  // Last-ditch fallback: pretend we have plenty of space (don't block migration on probe failure)
+  void statSync(cursor); // throw if the path is invalid
+  return { availableBytes: Number.MAX_SAFE_INTEGER, totalBytes: Number.MAX_SAFE_INTEGER };
+};

--- a/packages/api/src/config/data-dirs.ts
+++ b/packages/api/src/config/data-dirs.ts
@@ -1,0 +1,283 @@
+/**
+ * Unified data directory resolver — issue #671.
+ *
+ * Three root env vars control where runtime data is written:
+ * - DATA_DIR  : persistent data (DBs, transcripts, audit logs, uploads, cli archive)
+ * - CACHE_DIR : rebuildable cache (tts audio, connector media)
+ * - LOG_DIR   : log files (used directly, no subdirectory)
+ *
+ * Behavior: if a root is set, the path is `{root}/{subPath}`; otherwise the
+ * legacy default (preserved for backward compatibility) is used.
+ *
+ * Legacy per-path env vars (EVIDENCE_DB, WORLD_DB, TRANSCRIPT_DATA_DIR,
+ * AUDIT_LOG_DIR, CLI_RAW_ARCHIVE_DIR, UPLOAD_DIR, TTS_CACHE_DIR,
+ * CONNECTOR_MEDIA_DIR) are removed — configure via the three roots instead.
+ */
+
+import { homedir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const THIS_DIR = dirname(fileURLToPath(import.meta.url));
+// packages/api/src/config/ → ../../uploads = packages/api/uploads
+const MODULE_DEFAULT_UPLOAD_DIR = resolve(THIS_DIR, '../../uploads');
+
+export type DataRoot = 'DATA_DIR' | 'CACHE_DIR' | 'LOG_DIR';
+
+function readRoot(name: DataRoot): string | undefined {
+  const raw = process.env[name];
+  return raw && raw.trim() !== '' ? resolve(raw) : undefined;
+}
+
+function joinUnder(root: string, subPath: string): string {
+  return resolve(root, subPath);
+}
+
+// --- DATA_DIR consumers --------------------------------------------------
+
+export function resolveEvidenceDbPath(repoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'evidence.sqlite') : resolve(repoRoot, 'evidence.sqlite');
+}
+
+export function resolveWorldDbPath(repoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'world.sqlite') : resolve(repoRoot, 'world.sqlite');
+}
+
+export function resolveTranscriptsDir(monorepoRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'transcripts') : resolve(monorepoRoot, 'data/transcripts');
+}
+
+export function resolveAuditLogsDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'audit-logs') : resolve(process.cwd(), 'data/audit-logs');
+}
+
+export function resolveCliRawArchiveDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'cli-raw-archive') : resolve(process.cwd(), 'data/cli-raw-archive');
+}
+
+export function resolveUploadsDir(): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'uploads') : MODULE_DEFAULT_UPLOAD_DIR;
+}
+
+// --- .cat-cafe state (writable config/data: accounts, credentials, catalog, governance…)
+// When DATA_DIR is set, the shell startup moves the contents of
+// {projectRoot}/.cat-cafe/ to DATA_DIR/cat-cafe/ and replaces the
+// original with a symlink.  This lets all 50+ consumers keep using
+// `resolve(projectRoot, '.cat-cafe', file)` transparently.
+
+export function resolveCatCafeStateDir(projectRoot: string): string {
+  const root = readRoot('DATA_DIR');
+  return root ? joinUnder(root, 'cat-cafe') : resolve(projectRoot, '.cat-cafe');
+}
+
+// --- Redis data (lifecycle managed by start-dev.sh / user-redis.sh) ------
+// Redis is started by shell scripts *before* the API server, so the shell
+// layer owns the actual `--dir` flag and pre-start migration.  These
+// resolvers exist for introspection (Settings UI / data-dirs endpoint)
+// and for the shell to stay consistent with the TypeScript world.
+
+export function resolveRedisDataDir(): string {
+  const root = readRoot('DATA_DIR');
+  if (root) return joinUnder(root, 'redis');
+  // Legacy: shell script sets REDIS_DATA_DIR based on profile/port before
+  // launching the API.  Fall back to the default dev path if not in env
+  // (e.g. running `node dist/index.js` directly without start-dev.sh).
+  return process.env.REDIS_DATA_DIR || resolve(homedir(), '.cat-cafe/redis-dev');
+}
+
+export function resolveRedisBackupDir(): string {
+  const root = readRoot('DATA_DIR');
+  if (root) return joinUnder(root, 'redis-backups');
+  return process.env.REDIS_BACKUP_DIR || resolve(homedir(), '.cat-cafe/redis-backups/dev');
+}
+
+// --- CACHE_DIR consumers -------------------------------------------------
+
+export function resolveTtsCacheDir(): string {
+  const root = readRoot('CACHE_DIR');
+  return root ? joinUnder(root, 'tts') : resolve(process.cwd(), 'data/tts-cache');
+}
+
+export function resolveConnectorMediaDir(): string {
+  const root = readRoot('CACHE_DIR');
+  return root ? joinUnder(root, 'connector-media') : resolve(process.cwd(), 'data/connector-media');
+}
+
+// --- LOG_DIR (used directly, no subdirectory) ----------------------------
+
+export function resolveLogDir(): string {
+  const root = readRoot('LOG_DIR');
+  return root ?? resolve(process.cwd(), 'data/logs/api');
+}
+
+// --- Introspection (for migration logic + Settings UI) -------------------
+
+export type DataPathKey =
+  | 'evidenceDb'
+  | 'worldDb'
+  | 'transcripts'
+  | 'auditLogs'
+  | 'cliRawArchive'
+  | 'uploads'
+  | 'catCafeState'
+  | 'redisData'
+  | 'redisBackups'
+  | 'ttsCache'
+  | 'connectorMedia'
+  | 'logs';
+
+export interface DataPathSpec {
+  /** Stable identifier */
+  readonly key: DataPathKey;
+  /** Which root env var governs this path */
+  readonly root: DataRoot;
+  /** Sub-path under the root (empty for LOG_DIR which uses the root directly) */
+  readonly subPath: string;
+  /** Path that would be used if the root env var is not set */
+  readonly legacyPath: string;
+  /** Path that would be used if the root env var IS set */
+  readonly rootBasedPath: string | null;
+  /** Currently active path (= rootBasedPath if root is set, else legacyPath) */
+  readonly currentPath: string;
+  /** Is the active path file-shaped (true for SQLite DBs) or directory-shaped */
+  readonly isFile: boolean;
+}
+
+export interface DescribeOptions {
+  readonly repoRoot: string;
+  readonly monorepoRoot: string;
+  /**
+   * Override the uploads legacy path. Production code never needs this — it
+   * exists so unit tests can isolate the migration engine from the real
+   * `packages/api/uploads` directory inside the repo (the module-relative
+   * default resolves to that exact path because the module file lives there).
+   * Pass an absolute path that does NOT shadow real data.
+   */
+  readonly uploadsLegacyOverride?: string;
+}
+
+export function describeDataPaths(opts: DescribeOptions): readonly DataPathSpec[] {
+  const dataRoot = readRoot('DATA_DIR');
+  const cacheRoot = readRoot('CACHE_DIR');
+  const logRoot = readRoot('LOG_DIR');
+  const uploadsLegacy = opts.uploadsLegacyOverride ?? MODULE_DEFAULT_UPLOAD_DIR;
+
+  return [
+    {
+      key: 'evidenceDb',
+      root: 'DATA_DIR',
+      subPath: 'evidence.sqlite',
+      legacyPath: resolve(opts.repoRoot, 'evidence.sqlite'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'evidence.sqlite') : null,
+      currentPath: resolveEvidenceDbPath(opts.repoRoot),
+      isFile: true,
+    },
+    {
+      key: 'worldDb',
+      root: 'DATA_DIR',
+      subPath: 'world.sqlite',
+      legacyPath: resolve(opts.repoRoot, 'world.sqlite'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'world.sqlite') : null,
+      currentPath: resolveWorldDbPath(opts.repoRoot),
+      isFile: true,
+    },
+    {
+      key: 'transcripts',
+      root: 'DATA_DIR',
+      subPath: 'transcripts',
+      legacyPath: resolve(opts.monorepoRoot, 'data/transcripts'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'transcripts') : null,
+      currentPath: resolveTranscriptsDir(opts.monorepoRoot),
+      isFile: false,
+    },
+    {
+      key: 'auditLogs',
+      root: 'DATA_DIR',
+      subPath: 'audit-logs',
+      legacyPath: resolve(process.cwd(), 'data/audit-logs'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'audit-logs') : null,
+      currentPath: resolveAuditLogsDir(),
+      isFile: false,
+    },
+    {
+      key: 'cliRawArchive',
+      root: 'DATA_DIR',
+      subPath: 'cli-raw-archive',
+      legacyPath: resolve(process.cwd(), 'data/cli-raw-archive'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'cli-raw-archive') : null,
+      currentPath: resolveCliRawArchiveDir(),
+      isFile: false,
+    },
+    {
+      key: 'uploads',
+      root: 'DATA_DIR',
+      subPath: 'uploads',
+      legacyPath: uploadsLegacy,
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'uploads') : null,
+      // Note: resolveUploadsDir() always uses MODULE_DEFAULT_UPLOAD_DIR; the
+      // override only affects the legacyPath surfaced for introspection.
+      currentPath: dataRoot ? joinUnder(dataRoot, 'uploads') : uploadsLegacy,
+      isFile: false,
+    },
+    {
+      key: 'catCafeState',
+      root: 'DATA_DIR',
+      subPath: 'cat-cafe',
+      legacyPath: resolve(opts.repoRoot, '.cat-cafe'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'cat-cafe') : null,
+      currentPath: resolveCatCafeStateDir(opts.repoRoot),
+      isFile: false,
+    },
+    {
+      key: 'redisData',
+      root: 'DATA_DIR',
+      subPath: 'redis',
+      legacyPath: process.env.REDIS_DATA_DIR || resolve(homedir(), '.cat-cafe/redis-dev'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'redis') : null,
+      currentPath: resolveRedisDataDir(),
+      isFile: false,
+    },
+    {
+      key: 'redisBackups',
+      root: 'DATA_DIR',
+      subPath: 'redis-backups',
+      legacyPath: process.env.REDIS_BACKUP_DIR || resolve(homedir(), '.cat-cafe/redis-backups/dev'),
+      rootBasedPath: dataRoot ? joinUnder(dataRoot, 'redis-backups') : null,
+      currentPath: resolveRedisBackupDir(),
+      isFile: false,
+    },
+    {
+      key: 'ttsCache',
+      root: 'CACHE_DIR',
+      subPath: 'tts',
+      legacyPath: resolve(process.cwd(), 'data/tts-cache'),
+      rootBasedPath: cacheRoot ? joinUnder(cacheRoot, 'tts') : null,
+      currentPath: resolveTtsCacheDir(),
+      isFile: false,
+    },
+    {
+      key: 'connectorMedia',
+      root: 'CACHE_DIR',
+      subPath: 'connector-media',
+      legacyPath: resolve(process.cwd(), 'data/connector-media'),
+      rootBasedPath: cacheRoot ? joinUnder(cacheRoot, 'connector-media') : null,
+      currentPath: resolveConnectorMediaDir(),
+      isFile: false,
+    },
+    {
+      key: 'logs',
+      root: 'LOG_DIR',
+      subPath: '',
+      legacyPath: resolve(process.cwd(), 'data/logs/api'),
+      rootBasedPath: logRoot ?? null,
+      currentPath: resolveLogDir(),
+      isFile: false,
+    },
+  ];
+}

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -70,6 +70,12 @@ export interface EnvDefinition {
   hubVisible?: boolean;
   /** If false, value is bootstrap-only and cannot be edited at runtime from Hub */
   runtimeEditable?: boolean;
+  /**
+   * Target write policy for the curated env UI (#770). When absent, `runtimeEditable`
+   * remains the source of truth. When present, it overrides `runtimeEditable` for
+   * fail-closed write decisions: only `editable` allows Hub writes.
+   */
+  targetWritePolicy?: 'editable' | 'read-only' | 'read-only-opt-in' | 'module-managed' | 'no-ui-write';
   /** If true, this var should appear in .env.example (enforced by check:env-example) */
   exampleRecommended?: boolean;
   /** Human-readable reason shown by Settings when a retained registry entry has no live consumer. */
@@ -87,6 +93,19 @@ export interface EnvDefinition {
     defaultOn: boolean;
     trueWhen?: 'parseBoolEnv' | 'exactTrue' | 'exactOne' | 'notZero';
   };
+  /**
+   * Explicit UI control type. When omitted, the renderer should infer it via
+   * `inferEnvControl(def)`:
+   * - explicit `control` metadata
+   * - `booleanSemantics` → toggle
+   * - `allowedValues` → dropdown
+   * - everything else → text
+   *
+   * Note: `dirpicker` is NEVER inferred from naming heuristics. A var must be
+   * explicitly marked `control: 'dirpicker'` to avoid misclassifying file
+   * paths such as `CHROME_EXECUTABLE_PATH`.
+   */
+  control?: 'text' | 'toggle' | 'dropdown' | 'dirpicker';
 }
 
 export const ENV_CATEGORIES: Record<EnvCategory, string> = {
@@ -189,6 +208,7 @@ export const ENV_VARS: EnvDefinition[] = [
     label: '上传目录',
     settingsGroup: 'storage',
     restartRequired: true,
+    control: 'dirpicker',
   },
   {
     name: 'PROJECT_ALLOWED_ROOTS',
@@ -200,6 +220,9 @@ export const ENV_VARS: EnvDefinition[] = [
     runtimeEditable: false,
     label: '目录白名单',
     settingsGroup: 'security',
+    // NOT dirpicker: project-path.ts splits this on node:path delimiter into a
+    // multi-root LIST (e.g. /opt/a:/opt/b). A single-directory picker would drop
+    // the list semantics (codex/sol #1344 P2). Renders as multi-path text.
   },
   {
     name: 'PROJECT_ALLOWED_ROOTS_APPEND',
@@ -222,6 +245,9 @@ export const ENV_VARS: EnvDefinition[] = [
     runtimeEditable: false,
     label: '目录黑名单',
     settingsGroup: 'security',
+    // NOT dirpicker: project-path.ts splits this on node:path delimiter into a
+    // multi-root LIST (merged with platform defaults). A single-directory picker
+    // would drop the list semantics (codex/sol #1344 P2). Renders as multi-path text.
   },
   {
     name: 'FRONTEND_URL',
@@ -546,7 +572,7 @@ export const ENV_VARS: EnvDefinition[] = [
   {
     name: 'LOG_LEVEL',
     defaultValue: 'info',
-    description: '日志级别（debug / info / warn / error）',
+    description: '日志级别（Pino 消费：fatal / error / warn / info / debug / trace / silent）',
     category: 'server',
     sensitive: false,
     runtimeEditable: false,
@@ -554,6 +580,7 @@ export const ENV_VARS: EnvDefinition[] = [
     label: '日志级别',
     settingsGroup: 'runtime',
     restartRequired: true,
+    allowedValues: ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
   },
   {
     name: 'LOG_DIR',
@@ -562,6 +589,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'server',
     sensitive: false,
     exampleRecommended: true,
+    control: 'dirpicker',
   },
   {
     name: 'DEBUG',
@@ -675,7 +703,7 @@ export const ENV_VARS: EnvDefinition[] = [
     name: 'CAT_CAFE_RUNTIME_ROOT',
     defaultValue: '(未设置 → process.cwd())',
     description:
-      'F061: Clowder AI runtime 二进制根目录（runtime startup 自动 export 为 $RUNTIME_DIR），优先级高于 capability orchestrator 的 auto-detection，用于 Antigravity MCP config args 路径',
+      'F061: runtime 二进制根目录（runtime startup 自动 export 为 $RUNTIME_DIR），优先级高于 capability orchestrator 的 auto-detection，用于 Antigravity MCP config args 路径',
     category: 'server',
     sensitive: false,
     runtimeEditable: false,
@@ -804,6 +832,7 @@ export const ENV_VARS: EnvDefinition[] = [
     label: '会话记录目录',
     settingsGroup: 'storage',
     restartRequired: true,
+    control: 'dirpicker',
   },
   {
     name: 'ANNOTATION_DATA_DIR',
@@ -949,6 +978,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '审计日志目录',
     category: 'cli',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'CLI_RAW_ARCHIVE_DIR',
@@ -956,6 +986,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'CLI 原始日志归档目录',
     category: 'cli',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS',
@@ -1004,6 +1035,7 @@ export const ENV_VARS: EnvDefinition[] = [
     label: '数据根目录',
     settingsGroup: 'storage',
     restartRequired: true,
+    control: 'dirpicker',
   },
   {
     name: 'CAT_CAFE_CALLBACK_TOKEN',
@@ -1025,6 +1057,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'Callback outbox 目录',
     category: 'cli',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'CAT_CAFE_CALLBACK_OUTBOX_MAX_ATTEMPTS',
@@ -1234,6 +1267,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'connector',
     sensitive: false,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
     allowedValues: ['minimal', 'playtime', 'playtime-sec', 'playtime-encode', 'metadata'],
   },
   {
@@ -1243,6 +1277,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'connector',
     sensitive: false,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
     allowedValues: ['0', '1'],
   },
   {
@@ -1252,6 +1287,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'connector',
     sensitive: false,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
     allowedValues: ['0', '1'],
   },
 
@@ -1263,6 +1299,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'github_review',
     sensitive: true,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
     exampleRecommended: true,
   },
   {
@@ -1304,6 +1341,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'github_review',
     sensitive: false,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
   },
   {
     name: 'GITHUB_TOKEN',
@@ -1470,6 +1508,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'TTS 音频缓存目录；设置后覆盖 CAT_CAFE_DATA_DIR 下的稳定默认位置',
     category: 'tts',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'LISTEN_MODE_DB',
@@ -1477,6 +1516,9 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '听读模式持久状态数据库；设置后覆盖 CAT_CAFE_DATA_DIR 下的默认位置',
     category: 'tts',
     sensitive: false,
+    // NOT dirpicker: resolveDocumentListenStatePath() consumes this as the full
+    // SQLite FILE path (default ends in listen-mode.sqlite). A directory picker
+    // would make listen-mode open a directory as a database (codex #1344 P2).
   },
   {
     name: 'GENSHIN_VOICE_DIR',
@@ -1484,6 +1526,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'GPT-SoVITS 角色模型目录',
     category: 'tts',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'CHARACTER_VOICE_DIR',
@@ -1491,6 +1534,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '角色语音模型根目录（优先级高于 GENSHIN_VOICE_DIR）',
     category: 'tts',
     sensitive: false,
+    control: 'dirpicker',
   },
 
   // --- stt ---
@@ -1509,6 +1553,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: '连接器媒体下载目录',
     category: 'connector',
     sensitive: false,
+    control: 'dirpicker',
   },
 
   // --- frontend ---
@@ -1592,6 +1637,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'Signal 信号源数据目录',
     category: 'signal',
     sensitive: false,
+    control: 'dirpicker',
   },
   {
     name: 'CAT_CAFE_SIGNAL_USER',
@@ -1827,6 +1873,7 @@ export const ENV_VARS: EnvDefinition[] = [
     category: 'evidence',
     sensitive: true,
     runtimeEditable: true,
+    targetWritePolicy: 'read-only-opt-in',
   },
   {
     name: 'EMBED_PORT',
@@ -2071,6 +2118,7 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'F195 Phase D 转写持久化目录（Python 写 MD + meta.json，Node 读 meta 做路径注入）',
     category: 'audio',
     sensitive: false,
+    control: 'dirpicker',
   },
 ];
 
@@ -2111,6 +2159,61 @@ export function buildEnvSummary(): Array<EnvDefinition & { currentValue: string 
   });
 }
 
+export type EnvControlType = 'text' | 'toggle' | 'dropdown' | 'dirpicker';
+
+/**
+ * Infer the best UI control for an env var from its metadata.
+ * Order of precedence:
+ * 1. Explicit `control` metadata if present.
+ * 2. `booleanSemantics` → toggle.
+ * 3. `allowedValues` → dropdown.
+ * 4. Directory-like name heuristic (only for vars explicitly marked with
+ *    `control: 'dirpicker'`; this function does NOT auto-infer dirpicker from
+ *    names to avoid misclassifying file paths such as `CHROME_EXECUTABLE_PATH`).
+ * 5. Default → text.
+ */
+export function inferEnvControl(def: EnvDefinition): EnvControlType {
+  if (def.control) return def.control;
+  if (def.booleanSemantics) return 'toggle';
+  if (def.allowedValues && def.allowedValues.length > 0) return 'dropdown';
+  return 'text';
+}
+
+export function isEditableEnvVar(def: EnvDefinition): boolean {
+  // #770: fail-closed — only explicitly opted-in vars are editable.
+  // Every editable key must declare runtimeEditable: true. The 'read-only'
+  // policy is the only policy that blocks API writes here; 'read-only-opt-in'
+  // means the generic Hub UI hides the editor by default (see
+  // isEditableVariable in EnvSubComponents.tsx) but the variable remains
+  // API-editable so the existing owner/session gate can still authorize
+  // sensitive writes (e.g. F102_API_KEY).
+  if (def.targetWritePolicy === 'read-only') {
+    return false;
+  }
+  return def.runtimeEditable === true;
+}
+
+/** True if this env var is both sensitive AND editable under the current policy. */
+export function isSensitiveEditableEnvVar(def: EnvDefinition): boolean {
+  return def.sensitive && isEditableEnvVar(def);
+}
+
+export function isEditableEnvVarName(name: string): boolean {
+  return ENV_VARS.some((def) => def.name === name && isHubVisibleEnvVar(def) && isEditableEnvVar(def));
+}
+
+/** Check if any of the given env var names are sensitive-editable (requires owner gate). */
+export function hasSensitiveEditableVars(names: Iterable<string>): boolean {
+  const nameSet = new Set(names);
+  return ENV_VARS.some((def) => nameSet.has(def.name) && isSensitiveEditableEnvVar(def));
+}
+
+/** Return only the sensitive-editable keys from the given names (for audit filtering). */
+export function filterSensitiveEditableKeys(names: Iterable<string>): string[] {
+  const nameSet = new Set(names);
+  return ENV_VARS.filter((def) => nameSet.has(def.name) && isSensitiveEditableEnvVar(def)).map((def) => def.name);
+}
+
 /**
  * Curated platform-level settings for the System page. The full registry stays
  * canonical for Environment & Files and module-owned surfaces.
@@ -2143,31 +2246,71 @@ export const SYSTEM_VARS: ReadonlySet<string> = new Set([
   'UPLOAD_DIR',
 ]);
 
+/**
+ * Build a filtered env summary containing only System Settings vars.
+ * Used by GET /api/config/env-summary?surface=system.
+ * Deprecated variables are excluded even if they are in SYSTEM_VARS, as an extra
+ * defense-in-depth layer (the primary invariant is that deprecated vars are
+ * never added to SYSTEM_VARS in the first place).
+ */
 export function buildSystemEnvSummary(): Array<EnvDefinition & { currentValue: string | null }> {
-  return buildEnvSummary().filter((variable) => SYSTEM_VARS.has(variable.name));
+  return buildEnvSummary().filter((v) => SYSTEM_VARS.has(v.name) && !v.deprecated);
 }
 
-export function isEditableEnvVar(def: EnvDefinition): boolean {
-  return def.runtimeEditable === true;
+import {
+  buildModuleSectionEnvSummary,
+  ENV_SECTION_KEYS,
+  ENV_SECTION_LABELS,
+  type EnvSectionKey,
+  MODULE_SECTION_PROJECTION,
+} from './env-sections.js';
+
+export type { EnvSectionKey };
+export { ENV_SECTION_KEYS, ENV_SECTION_LABELS };
+
+/**
+ * #770: full section projection. `system` is exactly `SYSTEM_VARS`; every other
+ * section is defined in `env-sections.ts`. A test enforces that these stay in
+ * sync.
+ */
+export const SECTION_PROJECTION: Readonly<Record<EnvSectionKey, ReadonlySet<string>>> = {
+  system: SYSTEM_VARS,
+  ...MODULE_SECTION_PROJECTION,
+};
+
+/** Return the projection set for a section. Unknown sections return an empty set (fail-closed). */
+export function getSectionProjection(section: string): ReadonlySet<string> {
+  return SECTION_PROJECTION[section as EnvSectionKey] ?? new Set<string>();
 }
 
-/** True if this env var is both sensitive AND explicitly opted into runtime editing. */
-export function isSensitiveEditableEnvVar(def: EnvDefinition): boolean {
-  return def.sensitive && def.runtimeEditable === true;
+/** True if the named env var is part of the given section's projection. */
+export function isEnvVarInSection(name: string, section: EnvSectionKey): boolean {
+  return getSectionProjection(section).has(name);
 }
 
-export function isEditableEnvVarName(name: string): boolean {
-  return ENV_VARS.some((def) => def.name === name && isHubVisibleEnvVar(def) && isEditableEnvVar(def));
+/**
+ * Return all section keys a variable belongs to. Usually a variable is in at
+ * most one curated section (plus `system`), but this helper makes overlaps
+ * explicit and testable.
+ */
+export function getEnvVarSections(name: string): EnvSectionKey[] {
+  return ENV_SECTION_KEYS.filter((section) => getSectionProjection(section).has(name));
 }
 
-/** Check if any of the given env var names are sensitive-editable (requires owner gate). */
-export function hasSensitiveEditableVars(names: Iterable<string>): boolean {
-  const nameSet = new Set(names);
-  return ENV_VARS.some((def) => nameSet.has(def.name) && isSensitiveEditableEnvVar(def));
-}
-
-/** Return only the sensitive-editable keys from the given names (for audit filtering). */
-export function filterSensitiveEditableKeys(names: Iterable<string>): string[] {
-  const nameSet = new Set(names);
-  return ENV_VARS.filter((def) => nameSet.has(def.name) && isSensitiveEditableEnvVar(def)).map((def) => def.name);
+/**
+ * Build a filtered env summary for any section (system or module).
+ * - Deprecated variables are excluded.
+ * - Variables not in the section projection are excluded.
+ * - `hubVisible: false` vars are excluded.
+ * Module summaries are derived from the canonical `buildEnvSummary()` so that
+ * masking and visibility policy stay in one place.
+ */
+export function buildSectionEnvSummary(section: string): Array<EnvDefinition & { currentValue: string | null }> {
+  if (!ENV_SECTION_KEYS.includes(section as EnvSectionKey)) {
+    return [];
+  }
+  if (section === 'system') {
+    return buildSystemEnvSummary();
+  }
+  return buildModuleSectionEnvSummary(section as Exclude<EnvSectionKey, 'system'>, buildEnvSummary());
 }

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -182,18 +182,6 @@ export const ENV_VARS: EnvDefinition[] = [
     booleanSemantics: { defaultOn: false, trueWhen: 'exactTrue' },
   },
   {
-    name: 'UPLOAD_DIR',
-    defaultValue: './uploads',
-    description: '用户上传的文件（图片、附件等）存放位置',
-    category: 'server',
-    sensitive: false,
-    runtimeEditable: false,
-    label: '上传目录',
-    settingsGroup: 'storage',
-    restartRequired: true,
-    control: 'dirpicker',
-  },
-  {
     name: 'PROJECT_ALLOWED_ROOTS',
     defaultValue: '(未设置 — 使用 denylist 模式，仅拦截系统目录)',
     description:
@@ -729,6 +717,24 @@ export const ENV_VARS: EnvDefinition[] = [
     restartRequired: true,
   },
   {
+    name: 'REDIS_DATA_DIR',
+    hubVisible: false,
+    defaultValue: '(未设置 → ~/.cat-cafe/redis-dev)',
+    description: 'Redis 数据目录（shell 层在 API 启动前设置；API 仅作 introspection）。DATA_DIR 设置后会被覆盖。',
+    category: 'storage',
+    sensitive: false,
+    runtimeEditable: false,
+  },
+  {
+    name: 'REDIS_BACKUP_DIR',
+    hubVisible: false,
+    defaultValue: '(未设置 → ~/.cat-cafe/redis-backups/dev)',
+    description: 'Redis 备份目录（shell 层在 API 启动前设置；API 仅作 introspection）。DATA_DIR 设置后会被覆盖。',
+    category: 'storage',
+    sensitive: false,
+    runtimeEditable: false,
+  },
+  {
     name: 'MEMORY_STORE',
     defaultValue: '(未设置)',
     description: '当 Redis 不可用时允许以内存模式启动。已配置 Redis 时此选项不改变存储后端',
@@ -808,13 +814,27 @@ export const ENV_VARS: EnvDefinition[] = [
     restartRequired: true,
   },
   {
-    name: 'TRANSCRIPT_DATA_DIR',
-    defaultValue: '<项目根>/data/transcripts',
-    description: '猫猫的对话录制文件存放位置',
+    name: 'DATA_DIR',
+    defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
+    description:
+      '持久数据根目录（issue #671）：设置后 evidence.sqlite/world.sqlite/transcripts/audit-logs/cli-raw-archive/uploads 全部移到该目录下对应子路径。未设置时各路径沿用旧默认。',
     category: 'storage',
     sensitive: false,
     runtimeEditable: false,
-    label: '会话记录目录',
+    label: '数据根目录',
+    settingsGroup: 'storage',
+    restartRequired: true,
+    control: 'dirpicker',
+  },
+  {
+    name: 'CACHE_DIR',
+    defaultValue: '(未设置 → 各路径沿用 legacy 默认)',
+    description:
+      '可重建缓存根目录（issue #671）：设置后 tts/connector-media 移到该目录下对应子路径。未设置时各路径沿用旧默认。',
+    category: 'storage',
+    sensitive: false,
+    runtimeEditable: false,
+    label: '缓存根目录',
     settingsGroup: 'storage',
     restartRequired: true,
     control: 'dirpicker',
@@ -959,22 +979,6 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'MCP Server 路径',
     category: 'cli',
     sensitive: false,
-  },
-  {
-    name: 'AUDIT_LOG_DIR',
-    defaultValue: './data/audit-logs',
-    description: '审计日志目录',
-    category: 'cli',
-    sensitive: false,
-    control: 'dirpicker',
-  },
-  {
-    name: 'CLI_RAW_ARCHIVE_DIR',
-    defaultValue: './data/cli-raw-archive',
-    description: 'CLI 原始日志归档目录',
-    category: 'cli',
-    sensitive: false,
-    control: 'dirpicker',
   },
   {
     name: 'AUDIT_LOG_INCLUDE_PROMPT_SNIPPETS',
@@ -1507,14 +1511,6 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
-    name: 'TTS_CACHE_DIR',
-    defaultValue: `\${CAT_CAFE_DATA_DIR:-~/.cat-cafe}/assets/tts`,
-    description: 'TTS 音频缓存目录；设置后覆盖 CAT_CAFE_DATA_DIR 下的稳定默认位置',
-    category: 'tts',
-    sensitive: false,
-    control: 'dirpicker',
-  },
-  {
     name: 'LISTEN_MODE_DB',
     defaultValue: `\${CAT_CAFE_DATA_DIR:-~/.cat-cafe}/listen-mode.sqlite`,
     description: '听读模式持久状态数据库；设置后覆盖 CAT_CAFE_DATA_DIR 下的默认位置',
@@ -1548,16 +1544,6 @@ export const ENV_VARS: EnvDefinition[] = [
     description: 'Whisper STT 服务地址（服务端）',
     category: 'stt',
     sensitive: false,
-  },
-
-  // --- connector media ---
-  {
-    name: 'CONNECTOR_MEDIA_DIR',
-    defaultValue: './data/connector-media',
-    description: '连接器媒体下载目录',
-    category: 'connector',
-    sensitive: false,
-    control: 'dirpicker',
   },
 
   // --- frontend ---
@@ -1832,23 +1818,9 @@ export const ENV_VARS: EnvDefinition[] = [
     sensitive: false,
   },
   {
-    name: 'EVIDENCE_DB',
-    defaultValue: '{repoRoot}/evidence.sqlite',
-    description: 'F102 SQLite 数据库路径',
-    category: 'evidence',
-    sensitive: false,
-  },
-  {
     name: 'GLOBAL_KNOWLEDGE_DB',
     defaultValue: '~/.cat-cafe/global_knowledge.sqlite',
     description: 'F-4: 全局知识 SQLite 路径（Skills + MEMORY.md 编译产物）',
-    category: 'evidence',
-    sensitive: false,
-  },
-  {
-    name: 'WORLD_DB',
-    defaultValue: '{repoRoot}/world.sqlite',
-    description: 'F093 World Engine SQLite 数据库路径',
     category: 'evidence',
     sensitive: false,
   },
@@ -2246,9 +2218,11 @@ export const SYSTEM_VARS: ReadonlySet<string> = new Set([
   'API_SERVER_HOST',
   'API_SERVER_PORT',
   'BACKLOG_TTL_SECONDS',
+  'CACHE_DIR',
   'CAT_CAFE_DATA_DIR',
   'CLI_TIMEOUT_MS',
   'CORS_ALLOW_PRIVATE_NETWORK',
+  'DATA_DIR',
   'DEFAULT_OWNER_USER_ID',
   'DRAFT_TTL_SECONDS',
   'FRONTEND_PORT',
@@ -2266,8 +2240,6 @@ export const SYSTEM_VARS: ReadonlySet<string> = new Set([
   'SUMMARY_TTL_SECONDS',
   'TASK_TTL_SECONDS',
   'THREAD_TTL_SECONDS',
-  'TRANSCRIPT_DATA_DIR',
-  'UPLOAD_DIR',
 ]);
 
 /**

--- a/packages/api/src/config/env-registry.ts
+++ b/packages/api/src/config/env-registry.ts
@@ -157,23 +157,6 @@ export const ENV_VARS: EnvDefinition[] = [
     restartRequired: true,
   },
   {
-    name: 'REDIS_PORT',
-    defaultValue: '6399',
-    description: 'Redis 端口（governance pack 用于生成外部项目规则）',
-    category: 'server',
-    sensitive: false,
-    runtimeEditable: false,
-    exampleRecommended: true,
-  },
-  {
-    name: 'REDIS_DEV_PORT',
-    defaultValue: '6398',
-    description: 'Redis 开发/测试端口（governance pack 用于生成外部项目规则）',
-    category: 'server',
-    sensitive: false,
-    runtimeEditable: false,
-  },
-  {
     name: 'API_SERVER_HOST',
     defaultValue: '127.0.0.1',
     description: 'API 监听地址（改为 0.0.0.0 可让手机/平板通过局域网或 Tailscale 访问）',
@@ -287,6 +270,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_USER_ID',
+    hubVisible: false,
     defaultValue: 'default-user',
     description: '当前用户 ID',
     category: 'server',
@@ -294,6 +278,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_F255_AWAKENED_LEASE_MS',
+    hubVisible: false,
     defaultValue: '5400000',
     description: 'F255 Present loop 醒来租约时长（毫秒，默认 90 分钟；启动时读取）',
     category: 'server',
@@ -302,6 +287,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_HOME',
+    hubVisible: false,
     defaultValue: '<repoRoot>/.cat-cafe',
     description:
       'Service install data root (Python interpreter, per-service venvs, Piper voice models, etc.). Honored by scripts/services/* and the venv-probe path in service-registry — override to share install state across users / containers / mounts.',
@@ -311,6 +297,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_INVOCATION_REGISTRY',
+    hubVisible: false,
     defaultValue: 'redis（Redis 不可用时启动失败）',
     description:
       'F298 callback auth 后端：redis 为 durable 默认；memory 仅限显式 degraded 本地/测试模式，并在容量满时拒绝新 admission',
@@ -320,6 +307,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AUTH_TOMBSTONE_GC_TTL_MS',
+    hubVisible: false,
     defaultValue: '2592000000',
     description: 'F298 callback auth 终态 tombstone GC 保留期（毫秒，默认 30 天；active principal 永不使用 TTL）',
     category: 'server',
@@ -328,6 +316,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'F233_BALL_CUSTODY_PROBE_INTERVAL_MS',
+    hubVisible: false,
     defaultValue: '60000',
     description: 'F233 ball-custody ProbeScheduler 轮询间隔（毫秒，启动时读取）',
     category: 'server',
@@ -335,15 +324,8 @@ export const ENV_VARS: EnvDefinition[] = [
     runtimeEditable: false,
   },
   {
-    name: 'CAT_CAFE_REPO_ROOT',
-    defaultValue: '(进程 CWD)',
-    description: 'F233 Phase C feat trajectory collector 所读 cat-cafe 仓根目录（含 .git）。未设置时用 process.cwd()',
-    category: 'server',
-    sensitive: false,
-    runtimeEditable: false,
-  },
-  {
     name: 'CAT_CAFE_REPO_FULL_NAME',
+    hubVisible: false,
     defaultValue: 'zts212653/cat-cafe',
     description: 'F233 Phase C feat trajectory collector 调 gh CLI 用的 owner/repo（GitHub PR 元数据查询）',
     category: 'server',
@@ -352,6 +334,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_VERDICT_REPO_FULL_NAME',
+    hubVisible: false,
     defaultValue: 'CAT_CAFE_REPO_FULL_NAME or zts212653/cat-cafe',
     description:
       'F248 verdict publisher canonical owner/repo; automatic, pre-push, and managed agent-shell publication fail closed on target mismatch',
@@ -361,6 +344,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGENT_KEY_SECRET',
+    hubVisible: false,
     defaultValue: '(空)',
     description: 'F178 Persistent MCP Agent-Key Auth — 共享密钥（直接环境变量提供）',
     category: 'server',
@@ -369,6 +353,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGENT_KEY_FILE',
+    hubVisible: false,
     defaultValue: '(空)',
     description: 'F178 Persistent MCP Agent-Key Auth — 密钥文件路径（CAT_CAFE_AGENT_KEY_SECRET 的备选）',
     category: 'server',
@@ -377,6 +362,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGENT_KEY_FILES',
+    hubVisible: false,
     defaultValue: '(空)',
     description: 'F178 Persistent MCP Agent-Key Auth — catId 到密钥文件路径的 JSON 映射（Antigravity variants）',
     category: 'server',
@@ -395,6 +381,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_REMOTE_PORT',
+    hubVisible: false,
     defaultValue: '3098',
     description:
       'F247 B1a Cloud Cat — remote-spike.ts 监听端口（公网 Remote MCP gateway for cloud cat e.g. ChatGPT Pro 砚砚 Pro）',
@@ -404,6 +391,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_GPT_PRO_AGENT_KEY_FILE',
+    hubVisible: false,
     defaultValue: '$CAT_CAFE_DATA_DIR/agent-keys/gpt-pro.secret',
     description:
       'F247 Cloud Cat — gpt-pro Remote MCP agent-key sidecar override；默认由 runtime owner 自动 provision/renew，无需手工 mint。',
@@ -443,6 +431,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_ENABLE_LEGACY_PINCHTAB_BRIDGE',
+    hubVisible: false,
     defaultValue: '0',
     description:
       'F247 Cloud Cat — 显式启用会控制前台浏览器的 legacy PinchTab bridge；默认 0，Host Adapter 缺失时 fail closed。',
@@ -452,6 +441,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_REMOTE_TOKEN',
+    hubVisible: false,
     defaultValue: '(空)',
     description:
       'F247 B1a Cloud Cat — remote-spike.ts ?token= disposable interim guard（B1a 单防线；B1b 升级 verified CF Access OAuth 替换）',
@@ -461,6 +451,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_DESKTOP_MODE',
+    hubVisible: false,
     defaultValue: 'fable-phase0',
     description:
       'F247 B1a Cloud Cat — remote-spike.ts 工具白名单 mode 选择（fable-phase0 / cloud-pro-phase0；收窄到 10 项 collab+memory 工具）',
@@ -470,6 +461,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_PROVISION_GLOBAL_SIDECAR',
+    hubVisible: false,
     defaultValue: '0',
     description:
       'F178 Persistent MCP Agent-Key Auth — 仅全局 sidecar owner（runtime 主实例）设为 1；alpha/dev 不得设置，避免覆盖 ~/.cat-cafe/agent-keys。',
@@ -479,6 +471,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGENT_KEY_ALLOW_MEMORY_SIDECAR',
+    hubVisible: false,
     defaultValue: '0',
     description:
       'F178 Persistent MCP Agent-Key Auth — 本地降级开发开关；仅在 CAT_CAFE_PROVISION_GLOBAL_SIDECAR=1 且无 Redis 时允许 memory backend 写 sidecar。',
@@ -488,6 +481,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGENT_KEY_SIDECAR_DISABLED',
+    hubVisible: false,
     defaultValue: '0',
     description: 'F178 Persistent MCP Agent-Key Auth — 强制关闭全局 sidecar provisioning，优先级高于 owner 标记。',
     category: 'server',
@@ -542,6 +536,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'RUNTIME_REPO_PATH',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: 'Runtime 仓库路径（自动更新用）',
     category: 'server',
@@ -549,15 +544,9 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'WORKSPACE_LINKED_ROOTS',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: '工作区关联的项目根（冒号分隔）',
-    category: 'server',
-    sensitive: false,
-  },
-  {
-    name: 'HYPERFOCUS_THRESHOLD_MS',
-    defaultValue: '5400000 (90分钟)',
-    description: 'Hyperfocus 健康提醒阈值',
     category: 'server',
     sensitive: false,
   },
@@ -600,15 +589,6 @@ export const ENV_VARS: EnvDefinition[] = [
     hubVisible: false,
   },
   {
-    name: 'MCP_SERVER_PORT',
-    defaultValue: '3011',
-    description: 'MCP Server 监听端口',
-    category: 'server',
-    sensitive: false,
-    runtimeEditable: false,
-    exampleRecommended: true,
-  },
-  {
     name: 'PREVIEW_GATEWAY_ENABLED',
     defaultValue: '1（启用）',
     description: '设为 0 禁用 Preview Gateway（F120）',
@@ -622,6 +602,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CHROME_EXECUTABLE_PATH',
+    hubVisible: false,
     defaultValue: '(未设置 → 自动检测系统 Chrome/Edge/Chromium)',
     description: '对话导出截图使用的 Chromium 系浏览器路径。未设置时按 Chrome > Edge > Chromium 优先级自动检测',
     category: 'server',
@@ -661,6 +642,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'WEB_PUBLIC_DIR',
+    hubVisible: false,
     defaultValue: '../web/public',
     description: 'Web 前端静态文件目录（connector gateway 静态资源服务）',
     category: 'server',
@@ -693,6 +675,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ALLOWED_WORKSPACE_DIRS',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: 'MCP Server 允许访问的工作目录列表（逗号分隔）',
     category: 'server',
@@ -701,6 +684,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_RUNTIME_ROOT',
+    hubVisible: false,
     defaultValue: '(未设置 → process.cwd())',
     description:
       'F061: runtime 二进制根目录（runtime startup 自动 export 为 $RUNTIME_DIR），优先级高于 capability orchestrator 的 auto-detection，用于 Antigravity MCP config args 路径',
@@ -710,6 +694,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_WORKSPACE_ROOT',
+    hubVisible: false,
     defaultValue: '(未设置 → process.cwd())',
     description:
       'F061: Bengal MCP 工具的 workspace 根目录（runtime startup 自动 export 为 $PROJECT_DIR），用于 Antigravity MCP config 的 ALLOWED_WORKSPACE_DIRS env 注入',
@@ -850,6 +835,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'VISIBILITY_CURSOR_V2',
+    hubVisible: false,
     defaultValue: '(未设置 → off)',
     description:
       '#1269: Activation gate for v2 cursor durable-slot initiation. Set to "on" to enable v2 encoding in previously untouched durable slots (delivery/read/seen positions). Canonical comparison always uses v2 regardless of this flag. Deployment-scoped: OFF by default, rollback-safe (existing v2 slots remain advanceable).',
@@ -951,6 +937,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_TEMPLATE_PATH',
+    hubVisible: false,
     defaultValue: '(repo 根 cat-template.json)',
     description: '猫猫模板文件路径',
     category: 'cli',
@@ -967,6 +954,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_MCP_SERVER_PATH',
+    hubVisible: false,
     defaultValue: '(自动检测)',
     description: 'MCP Server 路径',
     category: 'cli',
@@ -997,6 +985,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_BRANCH_ROLLBACK_RETRY_DELAYS_MS',
+    hubVisible: false,
     defaultValue: '1000,2000,4000',
     description: 'Branch 回滚重试间隔',
     category: 'cli',
@@ -1013,6 +1002,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_TMUX_AGENT',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: '设为 1 启用 tmux agent 模式',
     category: 'cli',
@@ -1020,6 +1010,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_TMUX_PATH',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: 'Tmux 可执行文件路径',
     category: 'cli',
@@ -1039,6 +1030,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_TOKEN',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: 'Callback 鉴权 token',
     category: 'cli',
@@ -1046,6 +1038,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_OUTBOX_ENABLED',
+    hubVisible: false,
     defaultValue: 'true',
     description: 'Callback outbox 是否启用',
     category: 'cli',
@@ -1053,6 +1046,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_OUTBOX_DIR',
+    hubVisible: false,
     defaultValue: '(自动)',
     description: 'Callback outbox 目录',
     category: 'cli',
@@ -1061,6 +1055,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_OUTBOX_MAX_ATTEMPTS',
+    hubVisible: false,
     defaultValue: '(默认)',
     description: 'Outbox 最大重试次数',
     category: 'cli',
@@ -1068,6 +1063,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_OUTBOX_MAX_FLUSH_BATCH',
+    hubVisible: false,
     defaultValue: '(默认)',
     description: 'Outbox 单次 flush 批量',
     category: 'cli',
@@ -1075,6 +1071,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_RETRY_DELAYS_MS',
+    hubVisible: false,
     defaultValue: '(默认)',
     description: 'Callback 重试间隔（逗号分隔）',
     category: 'cli',
@@ -1082,6 +1079,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CALLBACK_FETCH_TIMEOUT_MS',
+    hubVisible: false,
     defaultValue: '10000',
     description: 'Callback fetch 每次尝试超时（毫秒，防 hung socket 永久挂起，照 #1368）',
     category: 'cli',
@@ -1089,6 +1087,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CDP_DEBUG',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: 'CDP Bridge 调试模式',
     category: 'cli',
@@ -1096,6 +1095,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CODEX_HOME',
+    hubVisible: false,
     defaultValue: '~/.codex',
     description: 'Codex CLI home 目录',
     category: 'cli',
@@ -1103,6 +1103,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_BRAIN_HOME',
+    hubVisible: false,
     defaultValue: '~/.gemini/antigravity/brain',
     description: 'Antigravity built-in generate_image brain dir (F172 Phase G scanner)',
     category: 'cli',
@@ -1195,6 +1196,7 @@ export const ENV_VARS: EnvDefinition[] = [
   // --- proxy ---
   {
     name: 'ANTHROPIC_PROXY_ENABLED',
+    hubVisible: false,
     defaultValue: '1',
     description: 'Anthropic 代理网关开关（0 关闭）',
     category: 'proxy',
@@ -1202,20 +1204,15 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTHROPIC_PROXY_PORT',
+    hubVisible: false,
     defaultValue: '9877',
     description: '代理网关监听端口',
     category: 'proxy',
     sensitive: false,
   },
   {
-    name: 'ANTHROPIC_PROXY_DEBUG',
-    defaultValue: '(未设置)',
-    description: '设为 1 启用代理调试日志',
-    category: 'proxy',
-    sensitive: false,
-  },
-  {
     name: 'ANTHROPIC_PROXY_UPSTREAMS_PATH',
+    hubVisible: false,
     defaultValue: '.cat-cafe/proxy-upstreams.json',
     description: 'upstream 配置文件路径（解决 runtime 与源码分离问题）',
     category: 'proxy',
@@ -1252,6 +1249,7 @@ export const ENV_VARS: EnvDefinition[] = [
   // Only infrastructure-level and diagnostic vars remain here.
   {
     name: 'CONNECTOR_GATEWAY_AUTOSTART',
+    hubVisible: false,
     defaultValue: 'explicit-runtime-opt-in',
     description:
       '预配置 IM connector 自动接入开关：仅显式 true 启用。官方 runtime 入口默认注入 1；start:direct/alpha/dev/review 与绕过入口的 API 命令默认禁用。授权只能由官方 wrapper 或启动进程环境显式注入；项目 dotenv 配置不会授予该能力',
@@ -1378,6 +1376,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CODEX_OAUTH_TRANSPORT',
+    hubVisible: false,
     defaultValue: 'builtin',
     description: 'Codex OAuth provider 传输策略（builtin 默认；HTTPS-only 故障回滚用 https）',
     category: 'codex',
@@ -1387,6 +1386,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CODEX_APP_SERVER_IDLE_TTL_MS',
+    hubVisible: false,
     defaultValue: '300000',
     description: 'Codex app-server 空闲 host 保温时长（毫秒；0 表示每轮结束立即回收）',
     category: 'codex',
@@ -1395,6 +1395,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_CODEX_APP_SERVER_MAX_WARM_HOSTS',
+    hubVisible: false,
     defaultValue: '16',
     description: '每个 Codex profile 最多保留的空闲 app-server host 数；不限制正在执行的并发 host',
     category: 'codex',
@@ -1427,6 +1428,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'GEMINI_ADAPTER',
+    hubVisible: false,
     defaultValue: 'antigravity-cli',
     description: '暹罗猫适配器 (antigravity-cli/gemini-cli/antigravity)',
     category: 'gemini',
@@ -1434,6 +1436,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGY_PROFILE_ROOT',
+    hubVisible: false,
     defaultValue: '~/.cat-cafe/agy-profiles',
     description: 'F210 Phase G：隔离 AGY profile HOME 根目录；每只 AGY profile 猫会在此目录下创建独立 HOME。',
     category: 'gemini',
@@ -1442,6 +1445,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_AGY_CWD_ROOT',
+    hubVisible: false,
     defaultValue: '~/.cat-cafe/agy-cwd',
     description:
       'F210 cache-leak fix：无 agyProfile 时 AGY spawn cwd sandbox 根目录（每只 AGY 猫在此创建 <catId> 子目录），让 agy cwd-relative cache（cache/projects.json）落 sandbox 而非 repo root。',
@@ -1559,6 +1563,7 @@ export const ENV_VARS: EnvDefinition[] = [
   // --- frontend ---
   {
     name: 'NEXT_PUBLIC_API_URL',
+    hubVisible: false,
     defaultValue: 'http://localhost:3004',
     description: '前端连接的 API 地址',
     category: 'frontend',
@@ -1583,6 +1588,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'NEXT_PUBLIC_PROJECT_ROOT',
+    hubVisible: false,
     defaultValue: '(空)',
     description: '前端项目根路径',
     category: 'frontend',
@@ -1591,6 +1597,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'NEXT_PUBLIC_DEBUG_SKIP_FILE_CHANGE_UI',
+    hubVisible: false,
     defaultValue: '(未设置)',
     description: '设为 1 跳过文件变更 UI',
     category: 'frontend',
@@ -1930,6 +1937,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'TELEMETRY_HMAC_SALT',
+    hubVisible: false,
     defaultValue: '(dev/test 自动 fallback)',
     description: 'HMAC salt — 遥测系统 ID 伪名化用。生产环境必设，缺失则禁用 OTel',
     category: 'telemetry',
@@ -1938,6 +1946,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'TELEMETRY_EXPORT_RAW_SYSTEM_IDS',
+    hubVisible: false,
     defaultValue: '(未设置 → HMAC 伪名化)',
     description: '设为 1 跳过 HMAC，导出原始系统 ID（仅限自托管受控环境）',
     category: 'telemetry',
@@ -1954,6 +1963,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'OTEL_EXPORTER_OTLP_ENDPOINT',
+    hubVisible: false,
     defaultValue: '(未设置 → 仅 Prometheus)',
     description: 'OTLP 导出端点（设置后同时推送 traces/metrics/logs 到该端点）',
     category: 'telemetry',
@@ -1962,6 +1972,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'OTEL_SDK_DISABLED',
+    hubVisible: false,
     defaultValue: '(未设置 → 启用)',
     description: '设为 true 完全禁用 OTel SDK',
     category: 'telemetry',
@@ -1970,6 +1981,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'TELEMETRY_ALERT_ERROR_RATE',
+    hubVisible: false,
     defaultValue: '0.3',
     description: 'Burn-rate 告警：错误率阈值（0-1）',
     category: 'telemetry',
@@ -1978,6 +1990,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'TELEMETRY_ALERT_P95_LATENCY_S',
+    hubVisible: false,
     defaultValue: '120',
     description: 'Burn-rate 告警：P95 延迟阈值（秒）',
     category: 'telemetry',
@@ -1986,6 +1999,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'TELEMETRY_ALERT_ACTIVE_INVOCATIONS',
+    hubVisible: false,
     defaultValue: '50',
     description: 'Burn-rate 告警：活跃 invocation 数阈值',
     category: 'telemetry',
@@ -2012,6 +2026,7 @@ export const ENV_VARS: EnvDefinition[] = [
   // --- antigravity (F061 Bridge) ---
   {
     name: 'ANTIGRAVITY_PORT',
+    hubVisible: false,
     defaultValue: '(未设置 → 自动发现)',
     description: 'Antigravity Language Server ConnectRPC 端口（覆盖自动发现）',
     category: 'antigravity',
@@ -2019,6 +2034,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'PINCHTAB_CDP_PORT',
+    hubVisible: false,
     defaultValue: '9870',
     description: 'PinchTab Chrome CDP 调试端口（覆盖默认 remote-debugging-port）',
     category: 'antigravity',
@@ -2026,6 +2042,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_CSRF_TOKEN',
+    hubVisible: false,
     defaultValue: '(未设置 → 自动发现)',
     description: 'Antigravity Language Server CSRF Token（覆盖自动发现）',
     category: 'antigravity',
@@ -2033,6 +2050,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_TLS',
+    hubVisible: false,
     defaultValue: 'true',
     description: 'Antigravity ConnectRPC 是否使用 TLS（默认 true）',
     category: 'antigravity',
@@ -2062,6 +2080,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_RUN_COMMAND_TIMEOUT_MS',
+    hubVisible: false,
     defaultValue: '600000',
     description: '受控 YOLO run_command 单次原生命令执行超时（毫秒，1..3600000）；无效值回退默认值',
     category: 'antigravity',
@@ -2069,6 +2088,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_TRACE_RAW',
+    hubVisible: false,
     defaultValue: '(未设置 → 关闭)',
     description: '设为 1 启用 Antigravity 原始轨迹 dump（rpc raw response + step shape snapshot）',
     category: 'antigravity',
@@ -2076,6 +2096,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'ANTIGRAVITY_NATIVE_EXECUTOR',
+    hubVisible: false,
     defaultValue: '(未设置 → 开启)',
     description: '设为 0 关闭 Antigravity 原生 executeAndPush（回落到通用 submit 路径）',
     category: 'antigravity',
@@ -2083,6 +2104,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_RIPGREP_PATH',
+    hubVisible: false,
     defaultValue: '(未设置 → 使用内置 @vscode/ripgrep，失败时回落 PATH rg)',
     description: 'Antigravity grep_search native executor 的 ripgrep 二进制路径覆盖（异常部署/调试用）',
     category: 'antigravity',
@@ -2091,6 +2113,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_READONLY',
+    hubVisible: false,
     defaultValue: '(未设置 → 全量注册)',
     description: 'MCP Server 只读模式：跳过 post_message 等写操作工具注册（Antigravity 持久 MCP 用）',
     category: 'antigravity',
@@ -2098,6 +2121,7 @@ export const ENV_VARS: EnvDefinition[] = [
   },
   {
     name: 'CAT_CAFE_RUNTIME_SESSION_SEAL_REAPER_INTERVAL_MS',
+    hubVisible: false,
     defaultValue: '30000',
     description: 'F211 runtime session pending seal reaper 轮询间隔（毫秒，启动时读取）',
     category: 'antigravity',

--- a/packages/api/src/config/env-sections.ts
+++ b/packages/api/src/config/env-sections.ts
@@ -1,0 +1,113 @@
+/**
+ * #770: canonical section projection for module-level env configuration.
+ *
+ * The env registry (`env-registry.ts`) is the single canonical truth source for
+ * *definitions*. This file is the single canonical truth source for *which
+ * non-system variables appear in which module section* of the Hub UI.
+ *
+ * The `system` projection lives in `env-registry.ts` as `SYSTEM_VARS` and is
+ * merged there into the final `SECTION_PROJECTION` export. This avoids a
+ * circular import: `env-sections.ts` must not import `SYSTEM_VARS`.
+ *
+ * Design principles:
+ * - Fail-closed: a variable that is not in `system` and not in any module
+ *   section projection is hidden from the curated UI by default.
+ * - Deprecated variables are excluded from every section summary.
+ * - Module sections contain only non-system vars; system vars are not repeated.
+ * - Masking and visibility policy live in the canonical `buildEnvSummary()` in
+ *   `env-registry.ts`; this file only applies the section filter.
+ */
+
+import type { EnvDefinition } from './env-registry.js';
+
+/** Hub UI sections that can host env configuration cards. */
+export type EnvSectionKey = 'system' | 'im' | 'voice' | 'notify' | 'ops' | 'accounts' | 'members' | 'plugins';
+
+/**
+ * Module-level projection: for each section, the set of env var names that
+ * should be surfaced in that section's settings UI.
+ *
+ * Notes on scope boundaries:
+ * - `system` is intentionally omitted here; it is merged in `env-registry.ts`.
+ * - PR-A intentionally leaves all module projections empty. A source audit
+ *   (sol, HEAD f790c4ed2) showed the previously proposed 42-var projection
+ *   mixed vars that already have dedicated module UI, internal/deploy-only
+ *   knobs, and entries that need component-level extensions rather than a
+ *   generic env card. The section/filter/write-policy infrastructure lands in
+ *   PR-A; the actual per-module projected sets will be re-added in PR-C after
+ *   each UI owner confirms a real dedicated surface is missing.
+ * - Ownership metadata in the registry does **not** imply projection; only the
+ *   sets below determine which non-system vars appear in the curated UI.
+ */
+export const MODULE_SECTION_PROJECTION: Readonly<Record<Exclude<EnvSectionKey, 'system'>, ReadonlySet<string>>> = {
+  im: new Set(),
+  voice: new Set(),
+  notify: new Set(),
+  ops: new Set(),
+  accounts: new Set(),
+  members: new Set(),
+  plugins: new Set(),
+};
+
+/** All section keys, in a stable order suitable for UI navigation. */
+export const ENV_SECTION_KEYS: readonly EnvSectionKey[] = [
+  'system',
+  'im',
+  'voice',
+  'notify',
+  'ops',
+  'accounts',
+  'members',
+  'plugins',
+];
+
+/** Human-readable labels for each section. */
+export const ENV_SECTION_LABELS: Readonly<Record<EnvSectionKey, string>> = {
+  system: '系统',
+  im: '即时通讯',
+  voice: '语音',
+  notify: '通知',
+  ops: '运维',
+  accounts: '账户',
+  members: '成员',
+  plugins: '插件',
+};
+
+/** Return the module projection set for a section. */
+export function getModuleSectionProjection(section: Exclude<EnvSectionKey, 'system'>): ReadonlySet<string> {
+  return MODULE_SECTION_PROJECTION[section];
+}
+
+/**
+ * Filter a canonical env summary down to the vars allowed in a section.
+ * - Variables not in `allowed` are excluded.
+ * - Deprecated variables are excluded.
+ * - `hubVisible: false` vars are excluded (defensive: canonical summary should
+ *   already have removed them, but the guard keeps the contract explicit).
+ *
+ * `canonicalSummary` must come from `buildEnvSummary()` in `env-registry.ts`
+ * so that sensitive values are already masked and URL credentials are already
+ * stripped.
+ */
+export function filterEnvSummaryForSection(
+  allowed: ReadonlySet<string>,
+  canonicalSummary: readonly (EnvDefinition & { currentValue: string | null })[],
+): Array<EnvDefinition & { currentValue: string | null }> {
+  return canonicalSummary.filter((def) => allowed.has(def.name) && !def.deprecated && def.hubVisible !== false);
+}
+
+/**
+ * Build a filtered env summary for a module section.
+ * - Variables not in the section projection are excluded.
+ * - Deprecated variables are excluded.
+ * - `hubVisible: false` vars are excluded.
+ *
+ * The second argument must be the canonical masked summary from
+ * `buildEnvSummary()`; masking policy is intentionally not duplicated here.
+ */
+export function buildModuleSectionEnvSummary(
+  section: Exclude<EnvSectionKey, 'system'>,
+  canonicalSummary: readonly (EnvDefinition & { currentValue: string | null })[],
+): Array<EnvDefinition & { currentValue: string | null }> {
+  return filterEnvSummaryForSection(MODULE_SECTION_PROJECTION[section], canonicalSummary);
+}

--- a/packages/api/src/domains/cats/services/agents/providers/generated-image-publication.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/generated-image-publication.ts
@@ -42,7 +42,7 @@ export interface PublishedGeneratedImage extends SavedImageAsset {
 }
 
 export async function publishGeneratedImage(input: GeneratedImagePublicationInput): Promise<PublishedGeneratedImage> {
-  const resolvedUploadDir = getDefaultUploadDir(input.uploadDir ?? process.env.UPLOAD_DIR);
+  const resolvedUploadDir = getDefaultUploadDir(input.uploadDir);
   const publicationStem = buildPublicationStem(input.publicationKey);
 
   const expectedFilename = `${sanitizeFilenameStem(publicationStem)}${mimeToImageExt(input.mimeType)}`;

--- a/packages/api/src/domains/cats/services/agents/providers/image-paths.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/image-paths.ts
@@ -10,13 +10,13 @@ import { getDefaultUploadDir, resolveInternalRouteUrl } from '../../../../../uti
 /**
  * Extract absolute image file paths from contentBlocks.
  * Converts relative URL paths (/uploads/foo.png) to absolute filesystem paths.
- * @param uploadDir Override for the upload directory (defaults to UPLOAD_DIR env or './uploads')
+ * @param uploadDir Override for the upload directory (defaults to DATA_DIR/uploads or packages/api/uploads)
  */
 export function extractImagePaths(contentBlocks: readonly MessageContent[] | undefined, uploadDir?: string): string[] {
   if (!contentBlocks) return [];
 
   const paths: string[] = [];
-  const resolvedUploadDir = getDefaultUploadDir(uploadDir ?? process.env.UPLOAD_DIR);
+  const resolvedUploadDir = getDefaultUploadDir(uploadDir);
   for (const block of contentBlocks) {
     if (block.type !== 'image') continue;
     const url = block.url;

--- a/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
+++ b/packages/api/src/domains/cats/services/orchestration/EventAuditLog.ts
@@ -19,6 +19,7 @@ import { randomUUID } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import { appendFile, mkdir, readdir, readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
+import { resolveAuditLogsDir } from '../../../../config/data-dirs.js';
 import { createModuleLogger } from '../../../../infrastructure/logger.js';
 
 const log = createModuleLogger('audit');
@@ -35,15 +36,12 @@ export interface AuditEvent {
 
 export type AuditEventInput = Omit<AuditEvent, 'id' | 'timestamp'>;
 
-/** Default audit log directory */
-const DEFAULT_AUDIT_DIR = './data/audit-logs';
-
 export class EventAuditLog {
   private readonly auditDir: string;
   private initialized = false;
 
   constructor(options?: { auditDir?: string }) {
-    this.auditDir = options?.auditDir ?? process.env.AUDIT_LOG_DIR ?? DEFAULT_AUDIT_DIR;
+    this.auditDir = options?.auditDir ?? resolveAuditLogsDir();
   }
 
   /**

--- a/packages/api/src/domains/cats/services/session/CliRawArchive.ts
+++ b/packages/api/src/domains/cats/services/session/CliRawArchive.ts
@@ -1,7 +1,7 @@
 import { appendFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { resolveCliRawArchiveDir } from '../../../../config/data-dirs.js';
 
-const DEFAULT_CLI_RAW_ARCHIVE_DIR = './data/cli-raw-archive';
 const INVOCATION_ID_PATTERN = /^[\w-]+$/;
 
 export interface RawArchiveEntry {
@@ -15,7 +15,7 @@ export class CliRawArchive {
   private readonly initInFlight = new Map<string, Promise<void>>();
 
   constructor(options?: { archiveDir?: string }) {
-    this.archiveDir = options?.archiveDir ?? process.env.CLI_RAW_ARCHIVE_DIR ?? DEFAULT_CLI_RAW_ARCHIVE_DIR;
+    this.archiveDir = options?.archiveDir ?? resolveCliRawArchiveDir();
   }
 
   /** F118: Get the archive file path for a given invocationId (today's date) */

--- a/packages/api/src/domains/cats/services/tts/document-listen-paths.ts
+++ b/packages/api/src/domains/cats/services/tts/document-listen-paths.ts
@@ -19,7 +19,8 @@ function resolveDataRoot(env: NodeJS.ProcessEnv, homeDir: string): string {
 /**
  * F279 owns its durable state path. This deliberately depends only on the
  * current-main data-root environment contract, not F289's paused migration
- * catalog. Generated WAV files remain governed separately by TTS_CACHE_DIR.
+ * catalog. Generated WAV files are governed by DATA_DIR/CACHE_DIR via
+ * `resolveTtsCacheDir()` in `config/data-dirs.js`.
  */
 export function resolveDocumentListenStatePath(
   env: NodeJS.ProcessEnv = process.env,
@@ -29,16 +30,4 @@ export function resolveDocumentListenStatePath(
   if (explicitPath) return expandHomePath(explicitPath, homeDir);
 
   return join(resolveDataRoot(env, homeDir), 'listen-mode.sqlite');
-}
-
-/**
- * Resolve the reusable TTS asset cache independently from the runtime
- * checkout. An explicit override keeps compatibility with existing installs;
- * otherwise audio lives below the stable user data root.
- */
-export function resolveTtsCacheDir(env: NodeJS.ProcessEnv = process.env, homeDir: string = homedir()): string {
-  const explicitPath = nonEmpty(env.TTS_CACHE_DIR);
-  if (explicitPath) return expandHomePath(explicitPath, homeDir);
-
-  return join(resolveDataRoot(env, homeDir), 'assets', 'tts');
 }

--- a/packages/api/src/domains/preview/port-validator.ts
+++ b/packages/api/src/domains/preview/port-validator.ts
@@ -26,9 +26,7 @@ export function collectRuntimePorts(): number[] {
   const envKeys = [
     'API_SERVER_PORT',
     'FRONTEND_PORT',
-    'MCP_SERVER_PORT',
     'PREVIEW_GATEWAY_PORT',
-    'REDIS_PORT',
     'VITE_PORT',
     'ANTHROPIC_PROXY_PORT', // P1 fix (砚砚 review): proxy port must be excluded
     'EMBED_PORT', // P1 fix: custom embed port

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,8 +5,9 @@
 
 // 必须最先 import：Node 24.16 undici setTypeOfService EINVAL 崩溃防护（见文件头注释）
 import './settos-guard.js';
+import { existsSync as fsExistsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve as pathResolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
   type CatConfig,
@@ -37,6 +38,18 @@ import {
 import { getCatModel } from './config/cat-models.js';
 import { resolveCodexCarrierTruth } from './config/codex-cli.js';
 import { configEventBus } from './config/config-event-bus.js';
+import {
+  resolveConnectorMediaDir,
+  resolveEvidenceDbPath,
+  resolveTranscriptsDir,
+  resolveTtsCacheDir,
+  resolveWorldDbPath,
+} from './config/data-dirs.js';
+import {
+  defaultDiskSpaceProbe,
+  runDataDirsMigration,
+  shouldAbortStartupOnMigration,
+} from './config/data-dirs-migration.js';
 import { resolveFrontendBaseUrl, resolveFrontendCorsOrigins } from './config/frontend-origin.js';
 import { resolveRuntimeDeploymentRevision } from './config/runtime-deployment-revision.js';
 import { initRuntimeOverrides } from './config/session-strategy-overrides.js';
@@ -184,10 +197,7 @@ import { RedisInvocationRecordStore } from './domains/cats/services/stores/redis
 import { RedisMessageStore } from './domains/cats/services/stores/redis/RedisMessageStore.js';
 import { RedisPresentationLedgerStore } from './domains/cats/services/stores/redis/RedisPresentationLedgerStore.js';
 import { DocumentListenRepository } from './domains/cats/services/tts/DocumentListenRepository.js';
-import {
-  resolveDocumentListenStatePath,
-  resolveTtsCacheDir,
-} from './domains/cats/services/tts/document-listen-paths.js';
+import { resolveDocumentListenStatePath } from './domains/cats/services/tts/document-listen-paths.js';
 import { MlxAudioTtsProvider } from './domains/cats/services/tts/MlxAudioTtsProvider.js';
 import { initStreamingTtsRegistry } from './domains/cats/services/tts/StreamingTtsChunker.js';
 import { TtsRegistry } from './domains/cats/services/tts/TtsRegistry.js';
@@ -461,6 +471,53 @@ async function main(): Promise<void> {
 
   if (isDebugMode) {
     app.log.info({ logDir: LOG_DIR_PATH }, '[api] Debug mode enabled (--debug flag)');
+  }
+
+  // #671: Migrate legacy data paths to DATA_DIR/CACHE_DIR before any consumer
+  // opens connections (SQLite, transcript writer, etc.). Logs are excluded.
+  {
+    const cwd = process.cwd();
+    const probeRepoRoot = fsExistsSync(pathResolve(cwd, 'docs', 'features'))
+      ? cwd
+      : fsExistsSync(pathResolve(cwd, '..', '..', 'docs', 'features'))
+        ? pathResolve(cwd, '..', '..')
+        : cwd;
+    const migrationResult = await runDataDirsMigration({
+      repoRoot: probeRepoRoot,
+      monorepoRoot: findMonorepoRoot(cwd),
+      trigger: 'startup',
+      io: { diskFree: defaultDiskSpaceProbe, logger: app.log },
+    });
+    if (migrationResult.attempted) {
+      app.log.info(
+        {
+          movedCount: migrationResult.items.filter((i) => i.status === 'moved').length,
+          skippedCount: migrationResult.items.filter((i) => i.status === 'skipped').length,
+          failedCount: migrationResult.items.filter((i) => i.status === 'failed').length,
+          allSucceeded: migrationResult.allSucceeded,
+          abortedReason: migrationResult.abortedReason,
+        },
+        '[#671] Data-dirs migration completed',
+      );
+    }
+
+    // Fail-fast: if the migration aborted or any item failed, the resolver
+    // now points at the new root but the legacy data is still on disk.
+    // Continuing would let SQLite/transcript/audit-log consumers open empty
+    // files at the new path — silent data loss from the operator's POV.
+    const abort = shouldAbortStartupOnMigration(migrationResult);
+    if (abort.shouldAbort) {
+      app.log.fatal(
+        {
+          reason: abort.reason,
+          leftBehind: abort.leftBehind,
+          DATA_DIR: process.env.DATA_DIR ?? null,
+          CACHE_DIR: process.env.CACHE_DIR ?? null,
+        },
+        '[#671] Data-dirs migration did not complete cleanly — refusing to start to avoid silent data loss. Free space (or restore the legacy paths) and retry, or unset the root env vars to fall back to legacy locations.',
+      );
+      process.exit(1);
+    }
   }
 
   // CORS for frontend
@@ -1042,7 +1099,8 @@ async function main(): Promise<void> {
   const runtimeSessionStore = createRuntimeSessionStore(redis);
   // F24: Transcript Writer/Reader for session chain
   // E7 fix: resolve relative to monorepo root, not CWD (same fix as docsRoot in PR #524)
-  const transcriptDataDir = process.env.TRANSCRIPT_DATA_DIR ?? `${findMonorepoRoot(process.cwd())}/data/transcripts`;
+  // #671: DATA_DIR/transcripts when set; otherwise monorepo-relative legacy default.
+  const transcriptDataDir = resolveTranscriptsDir(findMonorepoRoot(process.cwd()));
   const transcriptWriter = new TranscriptWriter({ dataDir: transcriptDataDir });
   const transcriptReader = new TranscriptReader({ dataDir: transcriptDataDir });
   // F065 Phase C: HandoffConfig for LLM-generated digest on seal
@@ -1124,7 +1182,7 @@ async function main(): Promise<void> {
   );
   const memoryServices = await createMemoryServices({
     type: 'sqlite',
-    sqlitePath: process.env.EVIDENCE_DB ?? resolve(repoRoot, 'evidence.sqlite'),
+    sqlitePath: resolveEvidenceDbPath(repoRoot),
     docsRoot,
     markersDir,
     dataDir: process.env.CAT_CAFE_DATA_DIR,
@@ -2099,7 +2157,7 @@ async function main(): Promise<void> {
   const { WorldRuntimeCoordinator } = await import('./domains/world/WorldRuntimeCoordinator.js');
   const { WorldContextProvider } = await import('./domains/world/WorldContextProvider.js');
   const { WorldKnowledgeAdapter } = await import('./domains/world/WorldKnowledgeAdapter.js');
-  const worldDbPath = process.env.WORLD_DB ?? resolve(repoRoot, 'world.sqlite');
+  const worldDbPath = resolveWorldDbPath(repoRoot);
   const worldStore = new SqliteWorldStore(worldDbPath);
   await worldStore.initialize();
   const worldCoordinator = new WorldRuntimeCoordinator(worldStore);
@@ -5285,12 +5343,12 @@ async function main(): Promise<void> {
   });
 
   // Serve uploaded files (images)
-  const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir();
   await app.register(uploadsRoutes, { uploadDir });
   await app.register(refAudioUploadRoutes);
 
   // F088: Serve downloaded connector media files
-  const connectorMediaDir = process.env.CONNECTOR_MEDIA_DIR ?? './data/connector-media';
+  const connectorMediaDir = resolveConnectorMediaDir();
   await app.register(connectorMediaRoutes, { mediaDir: connectorMediaDir });
 
   // F34: TTS Provider (mlx-audio → Python TTS server)

--- a/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
+++ b/packages/api/src/infrastructure/connectors/connector-gateway-bootstrap.ts
@@ -27,7 +27,7 @@ import {
 import type { RedisClient } from '@cat-cafe/shared/utils';
 import type { FastifyBaseLogger } from 'fastify';
 import { isCatAvailable } from '../../config/cat-config-loader.js';
-import { resolveTtsCacheDir } from '../../domains/cats/services/tts/document-listen-paths.js';
+import { resolveConnectorMediaDir, resolveTtsCacheDir } from '../../config/data-dirs.js';
 import type { IssueCommentClassification } from '../../domains/community/issue-analysis/issue-comment-classifier.js';
 import type { ConnectorWebhookHandler } from '../../routes/connector-webhooks.js';
 import { resolveActiveProjectRoot } from '../../utils/active-project-root.js';
@@ -103,7 +103,7 @@ export interface ConnectorGatewayConfig {
   /** Override co-creator userId for connector threads. Read from DEFAULT_OWNER_USER_ID env. */
   coCreatorUserId?: string | undefined;
   whisperUrl?: string | undefined;
-  connectorMediaDir?: string | undefined;
+  connectorMediaDir: string;
   /** F151: XiaoYi OpenClaw 模式 */
   xiaoyiAk?: string | undefined;
   xiaoyiSk?: string | undefined;
@@ -269,7 +269,7 @@ export function loadConnectorGatewayConfig(): ConnectorGatewayConfig {
     wecomEncodingAesKey: process.env.WECOM_ENCODING_AES_KEY,
     coCreatorUserId: process.env.DEFAULT_OWNER_USER_ID,
     whisperUrl: process.env.WHISPER_URL,
-    connectorMediaDir: process.env.CONNECTOR_MEDIA_DIR,
+    connectorMediaDir: resolveConnectorMediaDir(),
     xiaoyiAk: process.env.XIAOYI_AK,
     xiaoyiSk: process.env.XIAOYI_SK,
     xiaoyiAgentId: process.env.XIAOYI_AGENT_ID,
@@ -520,7 +520,7 @@ export async function startConnectorGateway(
   });
 
   // Phase 5+6: Media service + STT provider (optional)
-  const mediaDir = config.connectorMediaDir ?? './data/connector-media';
+  const mediaDir = config.connectorMediaDir;
   const mediaService = new ConnectorMediaService({
     mediaDir,
   });
@@ -967,7 +967,7 @@ export async function startConnectorGateway(
   }
 
   // R3-P1: Resolve route URLs to local file paths for real media delivery
-  const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir();
   const ttsCacheDir = resolve(resolveTtsCacheDir());
   const resolvedMediaDir = resolve(mediaDir);
   const webPublicDir = resolve(process.env.WEB_PUBLIC_DIR ?? '../web/public');

--- a/packages/api/src/infrastructure/logger.ts
+++ b/packages/api/src/infrastructure/logger.ts
@@ -13,6 +13,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { format as utilFormat } from 'node:util';
 import pino from 'pino';
+import { resolveLogDir } from '../config/data-dirs.js';
 
 /**
  * --debug CLI flag: `node dist/index.js --debug` sets log level to 'debug'.
@@ -20,7 +21,7 @@ import pino from 'pino';
  */
 export const isDebugMode = process.argv.includes('--debug');
 const LOG_LEVEL = (isDebugMode ? 'debug' : (process.env.LOG_LEVEL ?? 'info')) as pino.Level;
-const LOG_DIR = process.env.LOG_DIR ? resolve(process.env.LOG_DIR) : resolve(process.cwd(), 'data', 'logs', 'api');
+const LOG_DIR = resolveLogDir();
 const RETENTION_FILES = 14;
 
 /**

--- a/packages/api/src/routes/avatars.ts
+++ b/packages/api/src/routes/avatars.ts
@@ -129,7 +129,7 @@ export const avatarsRoutes: FastifyPluginAsync = async (app) => {
     }
 
     const ext = extForMime(file.mimetype);
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `avatar-${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`;
     await writeFile(join(uploadDir, filename), buffer);

--- a/packages/api/src/routes/callback-document-routes.ts
+++ b/packages/api/src/routes/callback-document-routes.ts
@@ -71,7 +71,7 @@ export function registerCallbackDocumentRoutes(
     }
 
     // Copy generated file to uploads directory (P1-1: ensure dir exists)
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const uniqueName = `doc-${randomBytes(6).toString('hex')}-${result.fileName}`;
     const destPath = resolve(uploadDir, uniqueName);

--- a/packages/api/src/routes/callbacks.ts
+++ b/packages/api/src/routes/callbacks.ts
@@ -4066,7 +4066,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
 
     // F211 BUG1 fix: resolve /uploads/ relative image URLs to absolute paths
     // so external runtimes (Antigravity/Bengal) can access image files.
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
 
     // F236 Track-1: cat-controlled response mode. anchor (default) = token-lean previews + drillDown;
     // full = complete bodies per ordinary item inside a bounded, cursor-continuable aggregate page.
@@ -4617,7 +4617,7 @@ export const callbacksRoutes: FastifyPluginAsync<CallbackRoutesOptions> = async 
       reply.status(404);
       return { error: 'Message not found' };
     }
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     // F236 AC-B1: bounded drill terminal. Default preview truncates content (keeps the `content`
     // field name for consumer continuity + adds contentLength/truncated); mode=full returns the
     // complete content + contentBlocks. Image hints stay in both modes.

--- a/packages/api/src/routes/config.ts
+++ b/packages/api/src/routes/config.ts
@@ -22,6 +22,7 @@ import {
 } from '../config/cat-config-loader.js';
 import { configEventBus, createChangeSetId } from '../config/config-event-bus.js';
 import type { ConfigSnapshot } from '../config/config-snapshot.js';
+import { resolveAuditLogsDir, resolveCliRawArchiveDir } from '../config/data-dirs.js';
 import {
   buildEnvSummary,
   buildSystemEnvSummary,
@@ -284,7 +285,7 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
         projectRoot,
         homeDir: home,
         dataDirs: {
-          auditLogs: resolve(apiCwd, process.env.AUDIT_LOG_DIR ?? './data/audit-logs'),
+          auditLogs: resolveAuditLogsDir(),
           // F212 Phase F (cloud codex R3 P2 on 3083d7c5f + R4 P2-#2 on fc69597675): use
           // the path the pino destination CAPTURED at logger import. Reading process.env.
           // LOG_DIR directly would let runtime `PATCH /api/config/env` edits change what
@@ -292,10 +293,13 @@ export async function configRoutes(app: FastifyInstance, opts: ConfigRoutesOptio
           // AC-F5 hint would then point users to a directory that has no current logs.
           // Single source of truth = LOG_DIR_PATH.
           runtimeLogs: LOG_DIR_PATH,
-          cliArchive: resolve(apiCwd, process.env.CLI_RAW_ARCHIVE_DIR ?? './data/cli-raw-archive'),
+          cliArchive: resolveCliRawArchiveDir(),
           redisDevSandbox: resolve(home, '.cat-cafe/redis-dev-sandbox'),
-          uploads: getDefaultUploadDir(process.env.UPLOAD_DIR),
+          uploads: getDefaultUploadDir(),
         },
+        DATA_DIR: process.env.DATA_DIR ?? null,
+        CACHE_DIR: process.env.CACHE_DIR ?? null,
+        LOG_DIR: process.env.LOG_DIR ?? null,
       },
     };
   });

--- a/packages/api/src/routes/invocations.ts
+++ b/packages/api/src/routes/invocations.ts
@@ -48,7 +48,7 @@ export interface InvocationsRoutesOptions {
 }
 
 export const invocationsRoutes: FastifyPluginAsync<InvocationsRoutesOptions> = async (app, opts) => {
-  const uploadDir = getDefaultUploadDir(opts.uploadDir ?? process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir(opts.uploadDir);
 
   // GET /api/invocations/:id — query InvocationRecord state
   app.get<{ Params: { id: string } }>('/api/invocations/:id', async (request, reply) => {

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -450,7 +450,7 @@ export function shouldMarkDecisionNotification(content: string): boolean {
 }
 
 export const messagesRoutes: FastifyPluginAsync<MessagesRoutesOptions> = async (app, opts) => {
-  const uploadDir = getDefaultUploadDir(opts.uploadDir ?? process.env.UPLOAD_DIR);
+  const uploadDir = getDefaultUploadDir(opts.uploadDir);
   const turnExecutionStore = opts.turnExecutionStore;
 
   // Register multipart parser for image uploads

--- a/packages/api/src/routes/preview.ts
+++ b/packages/api/src/routes/preview.ts
@@ -247,7 +247,7 @@ export const previewRoutes: FastifyPluginAsync<PreviewRouteOpts> = async (app, o
     }
     const ext = match[1] === 'jpeg' ? 'jpg' : match[1]!;
     const buffer = Buffer.from(match[2]!, 'base64');
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `screenshot-${Date.now()}-${randomUUID().slice(0, 8)}.${ext}`;
     await writeFile(join(uploadDir, filename), buffer);

--- a/packages/api/src/routes/ref-audio-upload.ts
+++ b/packages/api/src/routes/ref-audio-upload.ts
@@ -86,7 +86,7 @@ export const refAudioUploadRoutes: FastifyPluginAsync = async (app) => {
       });
     }
 
-    const uploadDir = getDefaultUploadDir(process.env.UPLOAD_DIR);
+    const uploadDir = getDefaultUploadDir();
     await mkdir(uploadDir, { recursive: true });
     const filename = `ref-audio-${Date.now()}-${randomUUID().slice(0, 8)}.${detected}`;
     await writeFile(join(uploadDir, filename), buffer, { flag: 'wx' });

--- a/packages/api/src/utils/upload-paths.ts
+++ b/packages/api/src/utils/upload-paths.ts
@@ -1,17 +1,14 @@
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const THIS_DIR = dirname(fileURLToPath(import.meta.url));
-const MODULE_DEFAULT_UPLOAD_DIR = resolve(THIS_DIR, '../../uploads');
+import { resolve } from 'node:path';
+import { resolveUploadsDir } from '../config/data-dirs.js';
 
 /**
  * Resolve the upload directory.
- * Explicit UPLOAD_DIR keeps the historical cwd-based behavior.
- * Without configuration, default to packages/api/uploads so API routes and
- * connector outbound delivery share the same on-disk truth source.
+ * Explicit override keeps the historical cwd-based behavior.
+ * Without configuration, use the data-dir resolver (DATA_DIR/uploads or the
+ * module-relative packages/api/uploads fallback).
  */
 export function getDefaultUploadDir(configuredUploadDir?: string): string {
-  return configuredUploadDir ? resolve(configuredUploadDir) : MODULE_DEFAULT_UPLOAD_DIR;
+  return configuredUploadDir ? resolve(configuredUploadDir) : resolveUploadsDir();
 }
 
 const INTERNAL_ROUTE_PREFIXES = ['/uploads/', '/api/connector-media/', '/api/tts/audio/'];

--- a/packages/api/test/data-dirs-migration.test.js
+++ b/packages/api/test/data-dirs-migration.test.js
@@ -1,0 +1,603 @@
+import assert from 'node:assert/strict';
+import { existsSync, symlinkSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+const { buildMigrationPlan, measurePath, runDataDirsMigration, shouldAbortStartupOnMigration } = await import(
+  '../dist/config/data-dirs-migration.js'
+);
+
+function snapshotEnv() {
+  return {
+    DATA_DIR: process.env.DATA_DIR,
+    CACHE_DIR: process.env.CACHE_DIR,
+    LOG_DIR: process.env.LOG_DIR,
+  };
+}
+
+function restoreEnv(snap) {
+  for (const key of Object.keys(snap)) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
+
+function clearRoots() {
+  delete process.env.DATA_DIR;
+  delete process.env.CACHE_DIR;
+  delete process.env.LOG_DIR;
+}
+
+function plentyOfSpaceIO() {
+  return {
+    diskFree: async () => ({ availableBytes: 1_000_000_000_000, totalBytes: 2_000_000_000_000 }),
+  };
+}
+
+function squeezedSpaceIO(availableBytes) {
+  return {
+    diskFree: async () => ({ availableBytes, totalBytes: availableBytes * 2 }),
+  };
+}
+
+describe('data-dirs-migration', () => {
+  let savedEnv;
+  let workRoot;
+
+  beforeEach(async () => {
+    savedEnv = snapshotEnv();
+    clearRoots();
+    workRoot = await mkdtemp(join(tmpdir(), 'cat-cafe-671-mig-'));
+  });
+
+  afterEach(async () => {
+    restoreEnv(savedEnv);
+    if (workRoot) await rm(workRoot, { recursive: true, force: true });
+  });
+
+  describe('buildMigrationPlan', () => {
+    test('reports no work when no root env var is set', async () => {
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
+      assert.equal(plan.hasWork, false);
+      assert.equal(plan.totalBytes, 0);
+      const reasons = new Set(plan.items.map((i) => i.skipReason));
+      assert.ok(reasons.has('root-env-not-set'));
+    });
+
+    test('skips items with no source data', async () => {
+      // chdir to a clean dir so cwd-relative legacy paths (audit-logs, cli-raw-archive)
+      // don't see leftover data from prior test runs in the project root.
+      const cleanCwd = await mkdtemp(join(tmpdir(), 'cat-cafe-671-cwd-'));
+      const originalCwd = process.cwd();
+      process.chdir(cleanCwd);
+      try {
+        process.env.DATA_DIR = join(workRoot, 'data');
+        const plan = await buildMigrationPlan({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        });
+        assert.equal(plan.hasWork, false);
+        for (const item of plan.items) {
+          if (item.spec.root === 'DATA_DIR') {
+            assert.ok(['no-source-data', 'legacy-equals-target'].includes(item.skipReason));
+          }
+        }
+      } finally {
+        process.chdir(originalCwd);
+        await rm(cleanCwd, { recursive: true, force: true });
+      }
+    });
+
+    test('detects eligible items with source data + empty target', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'fake sqlite content', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'data');
+
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
+      assert.equal(plan.hasWork, true);
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.ok(evidence);
+      assert.equal(evidence.eligible, true);
+      assert.ok(evidence.sourceBytes > 0);
+    });
+
+    test('skips items where target is already populated', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'fake', 'utf-8');
+      const targetDb = join(workRoot, 'data', 'evidence.sqlite');
+      await mkdir(join(workRoot, 'data'), { recursive: true });
+      await writeFile(targetDb, 'existing target content', 'utf-8');
+
+      process.env.DATA_DIR = join(workRoot, 'data');
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.equal(evidence.eligible, false);
+      assert.equal(evidence.skipReason, 'target-not-empty');
+    });
+
+    test('treats populated SQLite target sidecars as target-not-empty', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy main', 'utf-8');
+      const dataRoot = join(workRoot, 'data');
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite-wal'), 'target wal', 'utf-8');
+
+      process.env.DATA_DIR = dataRoot;
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+      });
+      const evidence = plan.items.find((i) => i.spec.key === 'evidenceDb');
+      assert.equal(evidence.eligible, false);
+      assert.equal(evidence.targetPopulated, true);
+      assert.equal(evidence.skipReason, 'target-not-empty');
+    });
+
+    test('treats uploads legacy .gitkeep placeholder as no source data', async () => {
+      const legacyUploads = join(workRoot, 'packages', 'api', 'uploads');
+      const dataRoot = join(workRoot, 'data');
+      await mkdir(legacyUploads, { recursive: true });
+      await mkdir(join(dataRoot, 'uploads'), { recursive: true });
+      await writeFile(join(legacyUploads, '.gitkeep'), '', 'utf-8');
+      await writeFile(join(dataRoot, 'uploads', 'real-upload.png'), 'target upload', 'utf-8');
+
+      process.env.DATA_DIR = dataRoot;
+      const plan = await buildMigrationPlan({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: legacyUploads,
+      });
+
+      const uploads = plan.items.find((i) => i.spec.key === 'uploads');
+      assert.equal(uploads.eligible, false);
+      assert.equal(uploads.sourceExists, false);
+      assert.equal(uploads.skipReason, 'no-source-data');
+    });
+  });
+
+  describe('measurePath', () => {
+    test('returns 0 for missing paths', async () => {
+      assert.equal(await measurePath('/tmp/this-does-not-exist-671'), 0);
+    });
+
+    test('returns file size for plain files', async () => {
+      const file = join(workRoot, 'sample.txt');
+      await writeFile(file, 'abcdef', 'utf-8');
+      assert.equal(await measurePath(file), 6);
+    });
+
+    test('includes SQLite sidecars (-wal, -shm) for *.sqlite files', async () => {
+      const db = join(workRoot, 'evidence.sqlite');
+      await writeFile(db, '1234567890', 'utf-8'); // 10 bytes
+      await writeFile(`${db}-wal`, '12345', 'utf-8'); // 5 bytes
+      await writeFile(`${db}-shm`, 'XX', 'utf-8'); // 2 bytes
+      assert.equal(await measurePath(db), 17);
+    });
+
+    test('recursively sums directory contents', async () => {
+      const dir = join(workRoot, 'tree');
+      await mkdir(join(dir, 'sub'), { recursive: true });
+      await writeFile(join(dir, 'a.txt'), 'hello', 'utf-8'); // 5
+      await writeFile(join(dir, 'sub', 'b.txt'), 'world!', 'utf-8'); // 6
+      assert.equal(await measurePath(dir), 11);
+    });
+  });
+
+  describe('runDataDirsMigration', () => {
+    test('returns attempted=false when no work pending', async () => {
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, true);
+      assert.equal(result.restartRecommended, false);
+    });
+
+    test('migrates eligible file paths and SQLite sidecars', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'evidence-data', 'utf-8');
+      await writeFile(`${legacyDb}-wal`, 'wal-data', 'utf-8');
+      await writeFile(`${legacyDb}-shm`, 'shm-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, true);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.ok(evidence);
+      assert.equal(evidence.status, 'moved');
+
+      // New paths exist with content
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), true);
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite-wal')), true);
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite-shm')), true);
+      assert.equal(await readFile(join(dataRoot, 'evidence.sqlite'), 'utf-8'), 'evidence-data');
+
+      // Legacy paths cleaned up
+      assert.equal(existsSync(legacyDb), false);
+      assert.equal(existsSync(`${legacyDb}-wal`), false);
+      assert.equal(existsSync(`${legacyDb}-shm`), false);
+    });
+
+    test('rolls back main SQLite file when sidecar migration fails', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      const legacyWal = `${legacyDb}-wal`;
+      await writeFile(legacyDb, 'main-db-data', 'utf-8');
+      await writeFile(legacyWal, 'wal-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      await mkdir(dataRoot, { recursive: true });
+      // Plant a directory at the WAL target path — rename(file, dir) fails
+      // with EISDIR, triggering the rollback logic in migrateOne.
+      await mkdir(join(dataRoot, 'evidence.sqlite-wal'), { recursive: true });
+
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'failed', 'migration must fail when sidecar target is blocked');
+      // Legacy data must be fully intact (rollback succeeded)
+      assert.equal(existsSync(legacyDb), true, 'legacy main DB must survive rollback');
+      assert.equal(existsSync(legacyWal), true, 'legacy WAL must survive rollback');
+      assert.equal(await readFile(legacyDb, 'utf-8'), 'main-db-data');
+      assert.equal(await readFile(legacyWal, 'utf-8'), 'wal-data');
+      // Target main file must NOT remain (rolled back)
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), false, 'target main DB must be rolled back');
+    });
+
+    test('migrates eligible directory paths recursively', async () => {
+      // Set up legacy audit-logs dir relative to workRoot (acts as cwd surrogate)
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'audit-2026-01-01.ndjson'), '{"a":1}\n', 'utf-8');
+      await writeFile(join(legacyAudit, 'audit-2026-01-02.ndjson'), '{"b":2}\n', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      // Temporarily run from workRoot so cwd-relative legacy resolves correctly
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+        });
+        assert.equal(result.attempted, true);
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        assert.equal(audit.status, 'moved');
+        assert.equal(existsSync(join(dataRoot, 'audit-logs', 'audit-2026-01-01.ndjson')), true);
+        assert.equal(existsSync(join(dataRoot, 'audit-logs', 'audit-2026-01-02.ndjson')), true);
+        assert.equal(existsSync(legacyAudit), false);
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    test('aborts when disk space is insufficient — no partial moves', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'x'.repeat(1000), 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: squeezedSpaceIO(500), // need ~1500, only have 500
+      });
+
+      assert.equal(result.attempted, false);
+      assert.ok(result.abortedReason?.includes('insufficient-disk-space'));
+      assert.equal(existsSync(legacyDb), true, 'legacy file must remain untouched on abort');
+      assert.equal(existsSync(join(dataRoot, 'evidence.sqlite')), false);
+    });
+
+    test('recommends restart only for runtime trigger', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'data', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'newdata');
+
+      const startup = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(startup.restartRecommended, false);
+
+      // Reset by moving file back
+      await writeFile(legacyDb, 'data', 'utf-8');
+      await rm(join(workRoot, 'newdata'), { recursive: true, force: true });
+
+      const runtime = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'runtime',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(runtime.restartRecommended, true);
+    });
+
+    test('blockFileMoves refuses runtime SQLite moves without touching legacy data', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy evidence', 'utf-8');
+      process.env.DATA_DIR = join(workRoot, 'newdata');
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'runtime',
+        blockFileMoves: true,
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, false);
+      assert.equal(result.restartRecommended, true);
+      assert.match(result.abortedReason, /restart/i);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'runtime-file-migration-requires-restart');
+      assert.equal(existsSync(legacyDb), true);
+      assert.equal(existsSync(join(workRoot, 'newdata', 'evidence.sqlite')), false);
+    });
+
+    test('shouldAbortStartupOnMigration: no work → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: false,
+        items: [],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
+    });
+
+    test('shouldAbortStartupOnMigration: all moved → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/new/e', bytes: 10, status: 'moved' },
+          { key: 'worldDb', fromPath: '/old/w', toPath: '/new/w', bytes: 10, status: 'moved' },
+        ],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
+    });
+
+    test('shouldAbortStartupOnMigration: aborted at planning stage → abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: false,
+        items: [],
+        allSucceeded: false,
+        restartRecommended: false,
+        abortedReason: 'insufficient-disk-space: need 1000, have 500',
+      });
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('insufficient-disk-space'));
+    });
+
+    test('shouldAbortStartupOnMigration: per-item failure → abort with leftBehind list', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          { key: 'evidenceDb', fromPath: '/old/e', toPath: '/new/e', bytes: 10, status: 'moved' },
+          { key: 'worldDb', fromPath: '/old/w', toPath: '/new/w', bytes: 10, status: 'failed', error: 'EACCES' },
+          {
+            key: 'auditLogs',
+            fromPath: '/old/a',
+            toPath: '/new/a',
+            bytes: 0,
+            status: 'skipped',
+            reason: 'no-source-data',
+          },
+        ],
+        allSucceeded: false,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('1 data-dirs path(s) failed'));
+      assert.equal(decision.leftBehind.length, 1);
+      assert.equal(decision.leftBehind[0].key, 'worldDb');
+      assert.equal(decision.leftBehind[0].status, 'failed');
+    });
+
+    test('shouldAbortStartupOnMigration: only skipped items → no abort', () => {
+      const decision = shouldAbortStartupOnMigration({
+        attempted: true,
+        items: [
+          {
+            key: 'evidenceDb',
+            fromPath: '/old/e',
+            toPath: '/old/e',
+            bytes: 0,
+            status: 'skipped',
+            reason: 'no-source-data',
+          },
+        ],
+        allSucceeded: true,
+        restartRecommended: false,
+      });
+      assert.equal(decision.shouldAbort, false);
+    });
+
+    test('startup surfaces target-not-empty blocked migrations when no item is eligible', async () => {
+      const legacyDb = join(workRoot, 'evidence.sqlite');
+      await writeFile(legacyDb, 'legacy evidence', 'utf-8');
+      const dataRoot = join(workRoot, 'newdata');
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite'), 'existing target', 'utf-8');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+
+      assert.equal(result.attempted, false);
+      assert.equal(result.allSucceeded, false);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'target-not-empty');
+
+      const decision = shouldAbortStartupOnMigration(result);
+      assert.equal(decision.shouldAbort, true);
+      assert.ok(decision.reason.includes('target-not-empty'));
+      assert.equal(decision.leftBehind.length, 1);
+      assert.equal(decision.leftBehind[0].key, 'evidenceDb');
+      assert.equal(decision.leftBehind[0].status, 'skipped');
+    });
+
+    test('cross-device dir migration fails on symlinks instead of silently dropping them', async () => {
+      // Create a data directory containing a symlink
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'real.ndjson'), '{"a":1}\n', 'utf-8');
+      // Create a relative symlink inside the directory (relative so it
+      // survives same-device rename to a different parent directory)
+      await symlink('real.ndjson', join(legacyAudit, 'link.ndjson'));
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+        });
+        // On same device, rename handles symlinks transparently → moved.
+        // The test checks that the migration either succeeds (same device)
+        // or fails with a clear error (cross device), never silently drops.
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        if (audit.status === 'moved') {
+          // Same-device rename succeeded — symlink preserved
+          assert.equal(existsSync(join(dataRoot, 'audit-logs', 'link.ndjson')), true);
+        } else {
+          // Cross-device path hit the symlink guard → failed with message
+          assert.equal(audit.status, 'failed');
+          assert.ok(audit.error.includes('non-regular entry'));
+          // Legacy data stays intact
+          assert.equal(existsSync(join(legacyAudit, 'real.ndjson')), true);
+          assert.equal(existsSync(join(legacyAudit, 'link.ndjson')), true);
+        }
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    test('cross-device dir migration removes partial target when copy fails', async () => {
+      const legacyAudit = join(workRoot, 'data', 'audit-logs');
+      await mkdir(legacyAudit, { recursive: true });
+      await writeFile(join(legacyAudit, 'first.ndjson'), '{"first":true}\n', 'utf-8');
+      await symlink('first.ndjson', join(legacyAudit, 'link.ndjson'));
+
+      const dataRoot = join(workRoot, 'newdata');
+      process.env.DATA_DIR = dataRoot;
+
+      const originalCwd = process.cwd();
+      process.chdir(workRoot);
+      try {
+        const result = await runDataDirsMigration({
+          repoRoot: workRoot,
+          monorepoRoot: workRoot,
+          uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+          trigger: 'startup',
+          io: plentyOfSpaceIO(),
+          forceCrossDeviceForTesting: true,
+        });
+        const audit = result.items.find((i) => i.key === 'auditLogs');
+        assert.equal(audit.status, 'failed');
+        assert.ok(audit.error.includes('non-regular entry'));
+        assert.equal(existsSync(join(legacyAudit, 'first.ndjson')), true, 'legacy file must remain');
+        assert.equal(existsSync(join(legacyAudit, 'link.ndjson')), true, 'legacy symlink must remain');
+        assert.equal(existsSync(join(dataRoot, 'audit-logs')), false, 'partial target must be removed');
+      } finally {
+        process.chdir(originalCwd);
+      }
+    });
+
+    test('continues other items when one fails (per-item isolation)', async () => {
+      const legacyA = join(workRoot, 'evidence.sqlite');
+      const legacyB = join(workRoot, 'world.sqlite');
+      await writeFile(legacyA, 'a-data', 'utf-8');
+      await writeFile(legacyB, 'b-data', 'utf-8');
+
+      const dataRoot = join(workRoot, 'newdata');
+      // Pre-create the evidence target as a populated file → forces target-not-empty
+      // for evidence, world should still migrate.
+      await mkdir(dataRoot, { recursive: true });
+      await writeFile(join(dataRoot, 'evidence.sqlite'), 'existing', 'utf-8');
+      process.env.DATA_DIR = dataRoot;
+
+      const result = await runDataDirsMigration({
+        repoRoot: workRoot,
+        monorepoRoot: workRoot,
+        uploadsLegacyOverride: join(workRoot, 'mock-uploads-legacy'),
+        trigger: 'startup',
+        io: plentyOfSpaceIO(),
+      });
+      assert.equal(result.attempted, true);
+      const evidence = result.items.find((i) => i.key === 'evidenceDb');
+      const world = result.items.find((i) => i.key === 'worldDb');
+      assert.equal(evidence.status, 'skipped');
+      assert.equal(evidence.reason, 'target-not-empty');
+      assert.equal(world.status, 'moved');
+      assert.equal(existsSync(join(dataRoot, 'world.sqlite')), true);
+      assert.equal(existsSync(legacyB), false);
+      // The pre-existing target evidence stays intact
+      assert.equal(await readFile(join(dataRoot, 'evidence.sqlite'), 'utf-8'), 'existing');
+    });
+  });
+});

--- a/packages/api/test/data-dirs.test.js
+++ b/packages/api/test/data-dirs.test.js
@@ -1,0 +1,290 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+
+const {
+  resolveEvidenceDbPath,
+  resolveWorldDbPath,
+  resolveTranscriptsDir,
+  resolveAuditLogsDir,
+  resolveCliRawArchiveDir,
+  resolveUploadsDir,
+  resolveCatCafeStateDir,
+  resolveRedisDataDir,
+  resolveRedisBackupDir,
+  resolveTtsCacheDir,
+  resolveConnectorMediaDir,
+  resolveLogDir,
+  describeDataPaths,
+} = await import('../dist/config/data-dirs.js');
+
+import { homedir } from 'node:os';
+
+const REPO_ROOT = '/tmp/issue-671-repo';
+const MONOREPO_ROOT = '/tmp/issue-671-monorepo';
+
+const REDIS_ENV_KEYS = ['REDIS_DATA_DIR', 'REDIS_BACKUP_DIR'];
+
+function snapshotEnv() {
+  const snap = {
+    DATA_DIR: process.env.DATA_DIR,
+    CACHE_DIR: process.env.CACHE_DIR,
+    LOG_DIR: process.env.LOG_DIR,
+  };
+  for (const k of REDIS_ENV_KEYS) snap[k] = process.env[k];
+  return snap;
+}
+
+function restoreEnv(snap) {
+  for (const key of Object.keys(snap)) {
+    if (snap[key] === undefined) delete process.env[key];
+    else process.env[key] = snap[key];
+  }
+}
+
+function clearRoots() {
+  delete process.env.DATA_DIR;
+  delete process.env.CACHE_DIR;
+  delete process.env.LOG_DIR;
+  for (const k of REDIS_ENV_KEYS) delete process.env[k];
+}
+
+describe('data-dirs resolver (issue #671)', () => {
+  let savedEnv;
+
+  beforeEach(() => {
+    savedEnv = snapshotEnv();
+    clearRoots();
+  });
+
+  afterEach(() => {
+    restoreEnv(savedEnv);
+  });
+
+  describe('legacy defaults (no root configured)', () => {
+    test('evidence.sqlite falls back to repoRoot', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('world.sqlite falls back to repoRoot', () => {
+      assert.equal(resolveWorldDbPath(REPO_ROOT), resolve(REPO_ROOT, 'world.sqlite'));
+    });
+
+    test('transcripts falls back to monorepoRoot/data/transcripts', () => {
+      assert.equal(resolveTranscriptsDir(MONOREPO_ROOT), resolve(MONOREPO_ROOT, 'data/transcripts'));
+    });
+
+    test('audit-logs falls back to cwd/data/audit-logs', () => {
+      assert.equal(resolveAuditLogsDir(), resolve(process.cwd(), 'data/audit-logs'));
+    });
+
+    test('cli-raw-archive falls back to cwd/data/cli-raw-archive', () => {
+      assert.equal(resolveCliRawArchiveDir(), resolve(process.cwd(), 'data/cli-raw-archive'));
+    });
+
+    test('uploads falls back to module-relative packages/api/uploads', () => {
+      const dir = resolveUploadsDir();
+      // Module default resolves to <pkg>/uploads at runtime (under dist/, two levels up = packages/api)
+      assert.ok(dir.endsWith('/uploads'), `expected to end with /uploads, got ${dir}`);
+      assert.ok(dir.includes('packages/api'), `expected to include packages/api, got ${dir}`);
+    });
+
+    test('tts-cache falls back to cwd/data/tts-cache', () => {
+      assert.equal(resolveTtsCacheDir(), resolve(process.cwd(), 'data/tts-cache'));
+    });
+
+    test('connector-media falls back to cwd/data/connector-media', () => {
+      assert.equal(resolveConnectorMediaDir(), resolve(process.cwd(), 'data/connector-media'));
+    });
+
+    test('logs falls back to cwd/data/logs/api', () => {
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+
+    test('.cat-cafe state falls back to projectRoot/.cat-cafe', () => {
+      assert.equal(resolveCatCafeStateDir(REPO_ROOT), resolve(REPO_ROOT, '.cat-cafe'));
+    });
+
+    test('redis data falls back to REDIS_DATA_DIR env or home default', () => {
+      // No REDIS_DATA_DIR in env → homedir-based default
+      const dir = resolveRedisDataDir();
+      assert.equal(dir, resolve(homedir(), '.cat-cafe/redis-dev'));
+    });
+
+    test('redis data respects REDIS_DATA_DIR env when set', () => {
+      process.env.REDIS_DATA_DIR = '/tmp/custom-redis';
+      assert.equal(resolveRedisDataDir(), '/tmp/custom-redis');
+      delete process.env.REDIS_DATA_DIR;
+    });
+
+    test('redis backups falls back to REDIS_BACKUP_DIR env or home default', () => {
+      const dir = resolveRedisBackupDir();
+      assert.equal(dir, resolve(homedir(), '.cat-cafe/redis-backups/dev'));
+    });
+
+    test('redis backups respects REDIS_BACKUP_DIR env when set', () => {
+      process.env.REDIS_BACKUP_DIR = '/tmp/custom-redis-backups';
+      assert.equal(resolveRedisBackupDir(), '/tmp/custom-redis-backups');
+      delete process.env.REDIS_BACKUP_DIR;
+    });
+  });
+
+  describe('DATA_DIR root configured', () => {
+    beforeEach(() => {
+      process.env.DATA_DIR = '/tmp/issue-671-data';
+    });
+
+    test('evidence.sqlite goes under DATA_DIR', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), '/tmp/issue-671-data/evidence.sqlite');
+    });
+
+    test('world.sqlite goes under DATA_DIR', () => {
+      assert.equal(resolveWorldDbPath(REPO_ROOT), '/tmp/issue-671-data/world.sqlite');
+    });
+
+    test('transcripts goes under DATA_DIR (overrides monorepoRoot)', () => {
+      assert.equal(resolveTranscriptsDir(MONOREPO_ROOT), '/tmp/issue-671-data/transcripts');
+    });
+
+    test('audit-logs goes under DATA_DIR', () => {
+      assert.equal(resolveAuditLogsDir(), '/tmp/issue-671-data/audit-logs');
+    });
+
+    test('cli-raw-archive goes under DATA_DIR', () => {
+      assert.equal(resolveCliRawArchiveDir(), '/tmp/issue-671-data/cli-raw-archive');
+    });
+
+    test('uploads goes under DATA_DIR (overrides module default)', () => {
+      assert.equal(resolveUploadsDir(), '/tmp/issue-671-data/uploads');
+    });
+
+    test('.cat-cafe state goes under DATA_DIR', () => {
+      assert.equal(resolveCatCafeStateDir(REPO_ROOT), '/tmp/issue-671-data/cat-cafe');
+    });
+
+    test('redis data goes under DATA_DIR', () => {
+      assert.equal(resolveRedisDataDir(), '/tmp/issue-671-data/redis');
+    });
+
+    test('redis backups goes under DATA_DIR', () => {
+      assert.equal(resolveRedisBackupDir(), '/tmp/issue-671-data/redis-backups');
+    });
+
+    test('DATA_DIR overrides REDIS_DATA_DIR env', () => {
+      process.env.REDIS_DATA_DIR = '/should/be/ignored';
+      assert.equal(resolveRedisDataDir(), '/tmp/issue-671-data/redis');
+      delete process.env.REDIS_DATA_DIR;
+    });
+
+    test('DATA_DIR does not affect cache or log paths', () => {
+      assert.equal(resolveTtsCacheDir(), resolve(process.cwd(), 'data/tts-cache'));
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('CACHE_DIR root configured', () => {
+    beforeEach(() => {
+      process.env.CACHE_DIR = '/tmp/issue-671-cache';
+    });
+
+    test('tts-cache goes under CACHE_DIR', () => {
+      assert.equal(resolveTtsCacheDir(), '/tmp/issue-671-cache/tts');
+    });
+
+    test('connector-media goes under CACHE_DIR', () => {
+      assert.equal(resolveConnectorMediaDir(), '/tmp/issue-671-cache/connector-media');
+    });
+
+    test('CACHE_DIR does not affect data or log paths', () => {
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('LOG_DIR root configured', () => {
+    test('LOG_DIR is used directly without subdirectory', () => {
+      process.env.LOG_DIR = '/tmp/issue-671-logs';
+      assert.equal(resolveLogDir(), '/tmp/issue-671-logs');
+    });
+  });
+
+  describe('empty/whitespace root values are treated as unset', () => {
+    test('DATA_DIR="" falls back to legacy', () => {
+      process.env.DATA_DIR = '';
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('DATA_DIR="   " (whitespace) falls back to legacy', () => {
+      process.env.DATA_DIR = '   ';
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), resolve(REPO_ROOT, 'evidence.sqlite'));
+    });
+
+    test('LOG_DIR="" falls back to default', () => {
+      process.env.LOG_DIR = '';
+      assert.equal(resolveLogDir(), resolve(process.cwd(), 'data/logs/api'));
+    });
+  });
+
+  describe('relative root paths are resolved against cwd', () => {
+    test('DATA_DIR=./mydata becomes absolute', () => {
+      process.env.DATA_DIR = './mydata';
+      const expected = resolve(process.cwd(), 'mydata/evidence.sqlite');
+      assert.equal(resolveEvidenceDbPath(REPO_ROOT), expected);
+    });
+  });
+
+  describe('describeDataPaths introspection', () => {
+    test('returns 12 specs with correct keys when no root set', () => {
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      assert.equal(specs.length, 12);
+      const keys = specs.map((s) => s.key).sort();
+      assert.deepEqual(keys, [
+        'auditLogs',
+        'catCafeState',
+        'cliRawArchive',
+        'connectorMedia',
+        'evidenceDb',
+        'logs',
+        'redisBackups',
+        'redisData',
+        'transcripts',
+        'ttsCache',
+        'uploads',
+        'worldDb',
+      ]);
+      // No root → rootBasedPath is null for all
+      for (const s of specs) {
+        assert.equal(s.rootBasedPath, null, `expected rootBasedPath=null for ${s.key}`);
+        assert.equal(s.currentPath, s.legacyPath, `expected currentPath=legacyPath for ${s.key}`);
+      }
+    });
+
+    test('isFile flag is true only for SQLite DBs', () => {
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      const fileKeys = specs
+        .filter((s) => s.isFile)
+        .map((s) => s.key)
+        .sort();
+      assert.deepEqual(fileKeys, ['evidenceDb', 'worldDb']);
+    });
+
+    test('with all roots set, rootBasedPath equals currentPath', () => {
+      process.env.DATA_DIR = '/tmp/d';
+      process.env.CACHE_DIR = '/tmp/c';
+      process.env.LOG_DIR = '/tmp/l';
+      const specs = describeDataPaths({ repoRoot: REPO_ROOT, monorepoRoot: MONOREPO_ROOT });
+      for (const s of specs) {
+        assert.notEqual(s.rootBasedPath, null, `expected rootBasedPath set for ${s.key}`);
+        assert.equal(s.currentPath, s.rootBasedPath, `mismatch for ${s.key}`);
+      }
+      // Spot check sub-paths
+      const evidence = specs.find((s) => s.key === 'evidenceDb');
+      assert.equal(evidence.currentPath, '/tmp/d/evidence.sqlite');
+      const tts = specs.find((s) => s.key === 'ttsCache');
+      assert.equal(tts.currentPath, '/tmp/c/tts');
+      const logs = specs.find((s) => s.key === 'logs');
+      assert.equal(logs.currentPath, '/tmp/l');
+      assert.equal(logs.subPath, '', 'logs subPath should be empty');
+    });
+  });
+});

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -214,7 +214,7 @@ describe('env-registry', () => {
   it('hasSensitiveEditableVars detects whitelisted sensitive vars', () => {
     assert.ok(hasSensitiveEditableVars(['GITHUB_MCP_PAT']));
     assert.ok(hasSensitiveEditableVars(['GITHUB_MCP_PAT', 'FRONTEND_URL']));
-    assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'AUDIT_LOG_DIR']));
+    assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'CAT_CAFE_CALLBACK_OUTBOX_DIR']));
     assert.ok(hasSensitiveEditableVars(['F102_API_KEY']), 'F102_API_KEY is API-editable behind owner gate');
     assert.ok(!hasSensitiveEditableVars(['OPENAI_API_KEY']), 'OPENAI_API_KEY is no longer editable (#340 P6)');
   });
@@ -1397,7 +1397,7 @@ describe('#770 PR-A: section projection + control metadata', () => {
     // PR-A: module projections are empty, so non-system vars have no curated
     // section until PR-C re-adds them with UI-owner sign-off.
     assert.deepEqual(getEnvVarSections('TTS_URL'), []);
-    assert.deepEqual(getEnvVarSections('CONNECTOR_MEDIA_DIR'), []);
+    assert.deepEqual(getEnvVarSections('CAT_CAFE_USER_ID'), []);
     assert.deepEqual(getEnvVarSections('API_SERVER_PORT'), ['system']);
   });
 
@@ -1418,8 +1418,8 @@ describe('#770 PR-A: section projection + control metadata', () => {
   });
 
   it('inferEnvControl respects explicit control metadata', () => {
-    const upload = ENV_VARS.find((v) => v.name === 'UPLOAD_DIR');
-    assert.equal(inferEnvControl(upload), 'dirpicker');
+    const dataDir = ENV_VARS.find((v) => v.name === 'DATA_DIR');
+    assert.equal(inferEnvControl(dataDir), 'dirpicker');
   });
 
   it('inferEnvControl defaults plain text vars to text', () => {
@@ -1429,17 +1429,13 @@ describe('#770 PR-A: section projection + control metadata', () => {
 
   it('marks directory-type vars with control: dirpicker', () => {
     const DIR_VARS = [
-      'UPLOAD_DIR',
-      'TRANSCRIPT_DATA_DIR',
+      'DATA_DIR',
+      'CACHE_DIR',
       'CAT_CAFE_DATA_DIR',
       'LOG_DIR',
-      'TTS_CACHE_DIR',
       'GENSHIN_VOICE_DIR',
       'CHARACTER_VOICE_DIR',
-      'CONNECTOR_MEDIA_DIR',
       'TRANSCRIPT_DIR',
-      'AUDIT_LOG_DIR',
-      'CLI_RAW_ARCHIVE_DIR',
       'SIGNALS_ROOT_DIR',
       'CAT_CAFE_CALLBACK_OUTBOX_DIR',
     ];

--- a/packages/api/test/env-registry.test.js
+++ b/packages/api/test/env-registry.test.js
@@ -8,20 +8,32 @@ import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'no
 import { tmpdir } from 'node:os';
 import { resolve } from 'node:path';
 import { afterEach, describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
 import Fastify from 'fastify';
 import {
   buildEnvSummary,
+  buildSectionEnvSummary,
   buildSystemEnvSummary,
   ENV_CATEGORIES,
+  ENV_SECTION_KEYS,
   ENV_VARS,
+  getEnvVarSections,
   hasSensitiveEditableVars,
+  inferEnvControl,
   isEditableEnvVar,
+  isEditableEnvVarName,
   isSensitiveEditableEnvVar,
   maskUrlCredentials,
   parseBoolEnv,
+  SECTION_PROJECTION,
   SETTINGS_GROUPS,
   SYSTEM_VARS,
 } from '../dist/config/env-registry.js';
+import {
+  ENV_SECTION_LABELS,
+  filterEnvSummaryForSection,
+  MODULE_SECTION_PROJECTION,
+} from '../dist/config/env-sections.js';
 
 // Save and restore env vars around tests
 const savedEnv = {};
@@ -175,14 +187,23 @@ describe('env-registry', () => {
     assert.equal(hindsightVars.length, 0, 'All HINDSIGHT_* vars should be removed');
   });
 
-  it('marks GITHUB_MCP_PAT, F102_API_KEY as sensitive + runtimeEditable (#340 P6: OPENAI_API_KEY removed)', () => {
-    for (const name of ['GITHUB_MCP_PAT', 'F102_API_KEY']) {
-      const def = ENV_VARS.find((v) => v.name === name);
-      assert.ok(def, `${name} should be in registry`);
-      assert.equal(def.sensitive, true, `${name} should be sensitive`);
-      assert.equal(def.runtimeEditable, true, `${name} should be runtimeEditable`);
-      assert.ok(isSensitiveEditableEnvVar(def), `${name} should pass isSensitiveEditableEnvVar`);
-    }
+  it('marks GITHUB_MCP_PAT as sensitive + editable; F102_API_KEY stays sensitive but UI-read-only-opt-in (#770)', () => {
+    const githubMcpPat = ENV_VARS.find((v) => v.name === 'GITHUB_MCP_PAT');
+    assert.ok(githubMcpPat, 'GITHUB_MCP_PAT should be in registry');
+    assert.equal(githubMcpPat.sensitive, true);
+    assert.equal(githubMcpPat.runtimeEditable, true);
+    assert.ok(isSensitiveEditableEnvVar(githubMcpPat));
+
+    const f102 = ENV_VARS.find((v) => v.name === 'F102_API_KEY');
+    assert.ok(f102, 'F102_API_KEY should be in registry');
+    assert.equal(f102.sensitive, true);
+    assert.equal(f102.runtimeEditable, true);
+    assert.equal(f102.targetWritePolicy, 'read-only-opt-in');
+    // API editability stays true so the existing owner/session gate remains
+    // the single authority for sensitive writes (see sensitive-env-write.test.js).
+    assert.ok(isEditableEnvVar(f102), 'F102_API_KEY stays API-editable behind owner gate');
+    assert.ok(isSensitiveEditableEnvVar(f102), 'F102_API_KEY is still sensitive-editable for owner gate');
+
     // #340 P6: OPENAI_API_KEY is no longer runtimeEditable (managed by accounts system)
     const openai = ENV_VARS.find((v) => v.name === 'OPENAI_API_KEY');
     assert.ok(openai, 'OPENAI_API_KEY should still be in registry');
@@ -192,8 +213,9 @@ describe('env-registry', () => {
 
   it('hasSensitiveEditableVars detects whitelisted sensitive vars', () => {
     assert.ok(hasSensitiveEditableVars(['GITHUB_MCP_PAT']));
-    assert.ok(hasSensitiveEditableVars(['FRONTEND_URL', 'F102_API_KEY']));
+    assert.ok(hasSensitiveEditableVars(['GITHUB_MCP_PAT', 'FRONTEND_URL']));
     assert.ok(!hasSensitiveEditableVars(['FRONTEND_URL', 'AUDIT_LOG_DIR']));
+    assert.ok(hasSensitiveEditableVars(['F102_API_KEY']), 'F102_API_KEY is API-editable behind owner gate');
     assert.ok(!hasSensitiveEditableVars(['OPENAI_API_KEY']), 'OPENAI_API_KEY is no longer editable (#340 P6)');
   });
 
@@ -987,5 +1009,572 @@ describe('PATCH /api/config/env (route)', () => {
       await app.close();
       rmSync(tempRoot, { recursive: true, force: true });
     }
+  });
+
+  it('#770: read-only-opt-in sensitive vars still require owner/session gate', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const tempRoot = mkdtempSync(resolve(tmpdir(), 'cat-cafe-env-'));
+    const envFilePath = resolve(tempRoot, '.env');
+    writeFileSync(envFilePath, ['GITHUB_WEBHOOK_SECRET=whsec_old', 'F102_API_KEY=old-key'].join('\n') + '\n', 'utf8');
+
+    function addSessionHook(app) {
+      app.addHook('preHandler', async (request) => {
+        const sessionUser = request.headers['x-test-session-user'];
+        if (typeof sessionUser === 'string' && sessionUser.trim()) {
+          request.sessionUserId = sessionUser.trim();
+        }
+      });
+    }
+
+    const app = Fastify({ logger: false });
+    addSessionHook(app);
+    try {
+      await configRoutes(app, {
+        projectRoot: tempRoot,
+        envFilePath,
+        auditLog: { append: async () => {} },
+      });
+      await app.ready();
+
+      const beforeRaw = readFileSync(envFilePath, 'utf8');
+      // Only the sensitive read-only-opt-in vars are gated by the existing
+      // owner/session check; non-sensitive ones are freely runtime-editable.
+      for (const name of ['GITHUB_WEBHOOK_SECRET', 'F102_API_KEY']) {
+        const res = await app.inject({
+          method: 'PATCH',
+          url: '/api/config/env',
+          headers: { 'x-cat-cafe-user': 'codex' },
+          payload: { updates: [{ name, value: `${name}-changed` }] },
+        });
+        assert.equal(res.statusCode, 401, `${name} should require session auth`);
+        assert.match(JSON.parse(res.payload).error, /session authentication/);
+        assert.equal(readFileSync(envFilePath, 'utf8'), beforeRaw, `${name} must not mutate .env`);
+      }
+    } finally {
+      await app.close();
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────
+// #770 System Settings tests
+// ────────────────────────────────────────────────────
+
+describe('#770: isEditableEnvVar fail-closed default', () => {
+  it('vars without runtimeEditable declaration are not editable', () => {
+    // Find vars that have no runtimeEditable field at all
+    const undeclared = ENV_VARS.filter((v) => v.runtimeEditable === undefined);
+    assert.ok(undeclared.length > 0, 'should have vars without runtimeEditable');
+    for (const def of undeclared) {
+      assert.equal(isEditableEnvVar(def), false, `${def.name} has no runtimeEditable — fail-closed should reject`);
+    }
+  });
+
+  it('only explicit runtimeEditable: true passes', () => {
+    const editable = ENV_VARS.filter((v) => isEditableEnvVar(v));
+    for (const def of editable) {
+      assert.equal(
+        def.runtimeEditable,
+        true,
+        `${def.name} passes isEditableEnvVar but runtimeEditable is ${def.runtimeEditable}`,
+      );
+    }
+  });
+});
+
+describe('#770: SYSTEM_VARS and buildSystemEnvSummary', () => {
+  afterEach(() => restoreEnv());
+
+  it('SYSTEM_VARS contains exactly 25 curated variables', () => {
+    assert.equal(SYSTEM_VARS.size, 25);
+  });
+
+  it('every SYSTEM_VAR exists in the registry', () => {
+    const registryNames = new Set(ENV_VARS.map((v) => v.name));
+    for (const name of SYSTEM_VARS) {
+      assert.ok(registryNames.has(name), `${name} is in SYSTEM_VARS but not in ENV_VARS`);
+    }
+  });
+
+  it('every SYSTEM_VAR has a settingsGroup', () => {
+    for (const name of SYSTEM_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def.settingsGroup, `${name} should have a settingsGroup`);
+    }
+  });
+
+  it('every SYSTEM_VAR has explicit runtimeEditable (boolean, not undefined)', () => {
+    for (const name of SYSTEM_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.equal(
+        typeof def.runtimeEditable,
+        'boolean',
+        `${name} must have explicit runtimeEditable (got ${def.runtimeEditable})`,
+      );
+    }
+  });
+
+  it('every SYSTEM_VAR has a label', () => {
+    for (const name of SYSTEM_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def.label, `${name} should have a label`);
+    }
+  });
+
+  it('security SYSTEM_VARS are explicitly runtimeEditable: false', () => {
+    for (const name of [
+      'PROJECT_ALLOWED_ROOTS',
+      'PROJECT_ALLOWED_ROOTS_APPEND',
+      'PROJECT_DENIED_ROOTS',
+      'DEFAULT_OWNER_USER_ID',
+    ]) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be in registry`);
+      assert.equal(def.runtimeEditable, false, `${name} must not be editable`);
+      assert.equal(def.settingsGroup, 'security');
+    }
+  });
+
+  it('buildSystemEnvSummary returns only SYSTEM_VARS entries', () => {
+    const summary = buildSystemEnvSummary();
+    assert.equal(summary.length, SYSTEM_VARS.size);
+    for (const entry of summary) {
+      assert.ok(SYSTEM_VARS.has(entry.name), `${entry.name} should be in SYSTEM_VARS`);
+    }
+  });
+
+  it('buildSystemEnvSummary includes metadata fields', () => {
+    const summary = buildSystemEnvSummary();
+    for (const entry of summary) {
+      assert.ok(entry.label, `${entry.name} should have label`);
+      assert.ok(entry.settingsGroup, `${entry.name} should have settingsGroup`);
+    }
+  });
+
+  it('buildSystemEnvSummary excludes deprecated vars (system-path defense)', () => {
+    // Temporarily mark a real SYSTEM_VAR deprecated to exercise the filter branch.
+    const def = ENV_VARS.find((v) => v.name === 'PREVIEW_GATEWAY_PORT');
+    assert.ok(def, 'PREVIEW_GATEWAY_PORT exists in registry');
+    const originalDeprecated = def.deprecated;
+    def.deprecated = 'synthetic test marker';
+    try {
+      const summary = buildSystemEnvSummary();
+      const names = summary.map((e) => e.name);
+      assert.ok(!names.includes('PREVIEW_GATEWAY_PORT'), 'deprecated SYSTEM_VAR must be excluded from system summary');
+      for (const entry of summary) {
+        assert.ok(!entry.deprecated, `${entry.name} is deprecated and must not appear in System summary`);
+      }
+    } finally {
+      if (originalDeprecated === undefined) {
+        delete def.deprecated;
+      } else {
+        def.deprecated = originalDeprecated;
+      }
+    }
+  });
+});
+
+describe('#770: deprecated metadata (dead-config marking)', () => {
+  // Vars whose runtime consumers were removed — verified by repo-wide reference
+  // scan including shell scripts and skills:
+  //   - MODE_SWITCH_REQUIRES_APPROVAL: Mode-system consumer (ModeOrchestrator) was
+  //     removed in the F101 Mode v2 rework (2dfece987), before the TD117 registry
+  //     backfill (b58106d0d) re-registered the then-already-dead var
+  //   - GITHUB_REVIEW_IMAP_* + POLL_INTERVAL: IMAP mail-poll channel removed in v0.9.0 sync (#596);
+  //     PR review feedback now flows through register_pr_tracking-driven GitHub API polling
+  //     (GITHUB_WEBHOOK_SECRET belongs to the separate Repo Inbox webhook, not this channel)
+  const DEAD_VARS = [
+    'MODE_SWITCH_REQUIRES_APPROVAL',
+    'GITHUB_REVIEW_IMAP_USER',
+    'GITHUB_REVIEW_IMAP_PASS',
+    'GITHUB_REVIEW_IMAP_HOST',
+    'GITHUB_REVIEW_IMAP_PORT',
+    'GITHUB_REVIEW_POLL_INTERVAL_MS',
+    'GITHUB_REVIEW_IMAP_PROXY',
+  ];
+
+  it('every known dead-config var stays in the registry (canonical truth — no deletion)', () => {
+    const registryNames = new Set(ENV_VARS.map((v) => v.name));
+    for (const name of DEAD_VARS) {
+      assert.ok(registryNames.has(name), `${name} must remain registered (registry entries are never deleted)`);
+    }
+  });
+
+  it('every known dead-config var carries a non-empty deprecated reason', () => {
+    for (const name of DEAD_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be in registry`);
+      assert.equal(typeof def.deprecated, 'string', `${name} must have a deprecated reason string`);
+      assert.ok(def.deprecated.length > 0, `${name} deprecated reason must be non-empty`);
+    }
+  });
+
+  it('deprecated vars are never runtimeEditable', () => {
+    for (const def of ENV_VARS) {
+      if (def.deprecated) {
+        assert.notEqual(def.runtimeEditable, true, `${def.name} is deprecated and must not be editable`);
+      }
+    }
+  });
+
+  it('deprecated vars never appear in the SYSTEM_VARS curated projection', () => {
+    for (const def of ENV_VARS) {
+      if (def.deprecated) {
+        assert.ok(!SYSTEM_VARS.has(def.name), `${def.name} is deprecated and must not be a curated System var`);
+      }
+    }
+  });
+
+  it('buildEnvSummary carries deprecated through to the API payload', () => {
+    const summary = buildEnvSummary();
+    for (const name of DEAD_VARS) {
+      const entry = summary.find((v) => v.name === name);
+      if (!entry) continue; // hubVisible:false vars are excluded from the summary by design
+      assert.equal(typeof entry.deprecated, 'string', `${name} summary entry must expose deprecated`);
+    }
+    // At least one deprecated var must actually reach the payload, otherwise the
+    // frontend "已废弃" badge (EnvSubComponents) has nothing to render.
+    assert.ok(
+      summary.some((v) => typeof v.deprecated === 'string' && v.deprecated.length > 0),
+      'at least one deprecated var must be visible in the env summary',
+    );
+  });
+});
+
+describe('#770: DEFAULT_OWNER_USER_ID trust-anchor projection', () => {
+  it('DEFAULT_OWNER_USER_ID is a curated System var (issue #770 allowlist)', () => {
+    assert.ok(SYSTEM_VARS.has('DEFAULT_OWNER_USER_ID'));
+  });
+
+  it('DEFAULT_OWNER_USER_ID projection is read-only with restart-required semantics', () => {
+    const def = ENV_VARS.find((v) => v.name === 'DEFAULT_OWNER_USER_ID');
+    assert.ok(def, 'DEFAULT_OWNER_USER_ID should be in registry');
+    // Trust anchor: the owner gate derives ALL identity checks from this value.
+    // Allowing runtime edits would let a session grant itself ownership
+    // (privilege bootstrap paradox) — must stay editable only via .env + restart.
+    assert.equal(def.runtimeEditable, false);
+    assert.equal(def.restartRequired, true);
+    assert.equal(def.settingsGroup, 'security');
+    assert.ok(def.label, 'needs a human-friendly label for the System page');
+    assert.ok(
+      def.description.includes('单用户'),
+      'description must explain the unset ⇒ single-user-mode semantics so the read-only value is interpretable',
+    );
+  });
+});
+
+describe('#770: SETTINGS_GROUPS', () => {
+  it('has exactly 5 groups', () => {
+    const keys = Object.keys(SETTINGS_GROUPS);
+    assert.equal(keys.length, 5);
+  });
+
+  it('contains network, storage, lifecycle, runtime, security', () => {
+    for (const key of ['network', 'storage', 'lifecycle', 'runtime', 'security']) {
+      assert.ok(key in SETTINGS_GROUPS, `SETTINGS_GROUPS should have ${key}`);
+      assert.ok(typeof SETTINGS_GROUPS[key] === 'string', `SETTINGS_GROUPS.${key} should be a string label`);
+    }
+  });
+});
+
+describe('#770: parseBoolEnv', () => {
+  it('parses "1" as true', () => {
+    assert.equal(parseBoolEnv('1'), true);
+  });
+  it('parses "true" as true (case-insensitive)', () => {
+    assert.equal(parseBoolEnv('true'), true);
+    assert.equal(parseBoolEnv('TRUE'), true);
+    assert.equal(parseBoolEnv('True'), true);
+  });
+  it('parses "0" as false', () => {
+    assert.equal(parseBoolEnv('0'), false);
+  });
+  it('parses undefined with default', () => {
+    assert.equal(parseBoolEnv(undefined), false);
+    assert.equal(parseBoolEnv(undefined, true), true);
+  });
+  it('parses other strings as false', () => {
+    assert.equal(parseBoolEnv('false'), false);
+    assert.equal(parseBoolEnv('no'), false);
+    assert.equal(parseBoolEnv(''), false);
+  });
+});
+
+describe('#770: GET /api/config/env-summary?surface=system', () => {
+  afterEach(() => restoreEnv());
+
+  it('returns only SYSTEM_VARS with groups when surface=system', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/config/env-summary?surface=system',
+      });
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+
+      assert.ok(body.groups, 'response should have groups');
+      assert.ok(body.variables, 'response should have variables');
+      assert.equal(body.variables.length, SYSTEM_VARS.size);
+
+      // Every variable should be a known SYSTEM_VAR
+      for (const v of body.variables) {
+        assert.ok(SYSTEM_VARS.has(v.name), `${v.name} should be in SYSTEM_VARS`);
+      }
+
+      // Should NOT have paths/categories (those are full-summary only)
+      assert.equal(body.paths, undefined, 'system surface should not include paths');
+      assert.equal(body.categories, undefined, 'system surface should not include categories');
+    } finally {
+      await app.close();
+    }
+  });
+
+  it('full summary (no surface param) still works unchanged', async () => {
+    const { configRoutes } = await import('../dist/routes/config.js');
+    const app = Fastify({ logger: false });
+    try {
+      await configRoutes(app);
+      await app.ready();
+
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/config/env-summary',
+      });
+      assert.equal(res.statusCode, 200);
+      const body = JSON.parse(res.payload);
+      assert.ok(body.categories, 'full summary should have categories');
+      assert.ok(body.paths, 'full summary should have paths');
+      assert.ok(body.variables.length > SYSTEM_VARS.size, 'full summary should have more vars');
+    } finally {
+      await app.close();
+    }
+  });
+});
+
+describe('#770 PR-A: section projection + control metadata', () => {
+  it('SECTION_PROJECTION.system is exactly SYSTEM_VARS', () => {
+    assert.deepEqual(
+      new Set(SECTION_PROJECTION.system),
+      SYSTEM_VARS,
+      'system projection must stay identical to SYSTEM_VARS',
+    );
+  });
+
+  it('exposes all known section keys with labels', () => {
+    assert.ok(ENV_SECTION_KEYS.length >= 8, 'should have system + 7 module sections');
+    for (const key of ENV_SECTION_KEYS) {
+      assert.ok(SECTION_PROJECTION[key], `SECTION_PROJECTION.${key} should exist`);
+    }
+  });
+
+  it('fail-closed: unknown section returns empty summary', () => {
+    const summary = buildSectionEnvSummary('nonexistent');
+    assert.deepEqual(summary, []);
+  });
+
+  it('buildSectionEnvSummary returns only projected vars for a module section', () => {
+    // PR-A intentionally ships with empty module projections while the
+    // per-module UI ownership is re-audited; infrastructure stays, content is
+    // added back in PR-C.
+    const voice = buildSectionEnvSummary('voice');
+    assert.equal(voice.length, 0, 'voice section projection is empty in PR-A');
+    assert.ok(!voice.some((v) => v.name === 'API_SERVER_PORT'), 'voice section should not include system vars');
+  });
+
+  it('hubVisible:false vars are excluded from section summaries', () => {
+    const members = buildSectionEnvSummary('members');
+    const names = new Set(members.map((v) => v.name));
+    assert.ok(!names.has('GOOGLE_API_KEY'), 'GOOGLE_API_KEY is hubVisible:false and should be hidden');
+  });
+
+  it('getEnvVarSections reports section membership', () => {
+    // PR-A: module projections are empty, so non-system vars have no curated
+    // section until PR-C re-adds them with UI-owner sign-off.
+    assert.deepEqual(getEnvVarSections('TTS_URL'), []);
+    assert.deepEqual(getEnvVarSections('CONNECTOR_MEDIA_DIR'), []);
+    assert.deepEqual(getEnvVarSections('API_SERVER_PORT'), ['system']);
+  });
+
+  it('LOG_LEVEL allowedValues match Pino LevelWithSilent', () => {
+    const def = ENV_VARS.find((v) => v.name === 'LOG_LEVEL');
+    assert.ok(def, 'LOG_LEVEL should be registered');
+    assert.deepEqual(
+      def.allowedValues,
+      ['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent'],
+      'must align with pino.LevelWithSilent consumed by infrastructure/logger.ts',
+    );
+    assert.equal(inferEnvControl(def), 'dropdown');
+  });
+
+  it('inferEnvControl maps booleanSemantics to toggle', () => {
+    const cors = ENV_VARS.find((v) => v.name === 'CORS_ALLOW_PRIVATE_NETWORK');
+    assert.equal(inferEnvControl(cors), 'toggle');
+  });
+
+  it('inferEnvControl respects explicit control metadata', () => {
+    const upload = ENV_VARS.find((v) => v.name === 'UPLOAD_DIR');
+    assert.equal(inferEnvControl(upload), 'dirpicker');
+  });
+
+  it('inferEnvControl defaults plain text vars to text', () => {
+    const apiPort = ENV_VARS.find((v) => v.name === 'API_SERVER_PORT');
+    assert.equal(inferEnvControl(apiPort), 'text');
+  });
+
+  it('marks directory-type vars with control: dirpicker', () => {
+    const DIR_VARS = [
+      'UPLOAD_DIR',
+      'TRANSCRIPT_DATA_DIR',
+      'CAT_CAFE_DATA_DIR',
+      'LOG_DIR',
+      'TTS_CACHE_DIR',
+      'GENSHIN_VOICE_DIR',
+      'CHARACTER_VOICE_DIR',
+      'CONNECTOR_MEDIA_DIR',
+      'TRANSCRIPT_DIR',
+      'AUDIT_LOG_DIR',
+      'CLI_RAW_ARCHIVE_DIR',
+      'SIGNALS_ROOT_DIR',
+      'CAT_CAFE_CALLBACK_OUTBOX_DIR',
+    ];
+    for (const name of DIR_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be registered`);
+      assert.equal(def.control, 'dirpicker', `${name} should be marked as dirpicker`);
+    }
+  });
+
+  it('does not mark file paths as dirpicker', () => {
+    const FILE_VARS = ['CHROME_EXECUTABLE_PATH', 'KIMI_CONFIG_FILE', 'CAT_TEMPLATE_PATH', 'LISTEN_MODE_DB'];
+    for (const name of FILE_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be registered`);
+      assert.notEqual(def.control, 'dirpicker', `${name} is a file path, not a directory`);
+    }
+  });
+
+  it('does not mark multi-path list vars as dirpicker', () => {
+    // PROJECT_ALLOWED_ROOTS / PROJECT_DENIED_ROOTS are split by project-path.ts
+    // on node:path delimiter into a LIST of roots (e.g. /opt/a:/opt/b). A single
+    // -directory picker would silently drop the list semantics (codex/sol #1344
+    // P2). They render as multi-path text; a real multi-dir control is out of
+    // scope for PR-A (do not extend the control protocol here).
+    const MULTI_PATH_VARS = ['PROJECT_ALLOWED_ROOTS', 'PROJECT_DENIED_ROOTS'];
+    for (const name of MULTI_PATH_VARS) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be registered`);
+      assert.notEqual(def.control, 'dirpicker', `${name} is a multi-path list, not a single directory`);
+      assert.equal(inferEnvControl(def), 'text', `${name} must render as multi-path text`);
+    }
+  });
+
+  it('inventory doc stays in sync with the live registry (set + control types)', () => {
+    // #770 PR-A: docs/plans/770-env-config-inventory.md is the audit baseline for
+    // the follow-up B/C/D/E slices, so it must not drift from the registry after a
+    // rebase. Parse the inventory tables and enforce two invariants:
+    //   1. the documented var set is exactly ENV_VARS (no missing / no stale);
+    //   2. each row's "control type" column equals inferEnvControl(def).
+    const inventoryPath = fileURLToPath(new URL('../../../docs/plans/770-env-config-inventory.md', import.meta.url));
+    const rows = [];
+    for (const line of readFileSync(inventoryPath, 'utf8').split('\n')) {
+      if (!line.startsWith('|')) continue;
+      const cols = line.split('|').map((c) => c.trim());
+      const name = cols[2];
+      if (!name || name === 'var name' || name.startsWith('---')) continue;
+      rows.push({ name, control: cols[7] });
+    }
+    const registryNames = new Set(ENV_VARS.map((v) => v.name));
+    const docNames = new Set(rows.map((r) => r.name));
+    const missing = [...registryNames].filter((n) => !docNames.has(n)).sort();
+    const stale = [...docNames].filter((n) => !registryNames.has(n)).sort();
+    assert.deepEqual(missing, [], `inventory is missing registry vars: ${missing.join(', ')}`);
+    assert.deepEqual(stale, [], `inventory lists vars no longer in registry: ${stale.join(', ')}`);
+    assert.equal(rows.length, ENV_VARS.length, 'inventory must have exactly one row per registry var');
+    const byName = new Map(ENV_VARS.map((v) => [v.name, v]));
+    const controlDrift = rows
+      .filter((r) => byName.has(r.name) && r.control !== inferEnvControl(byName.get(r.name)))
+      .map((r) => `${r.name}: doc=${r.control} vs registry=${inferEnvControl(byName.get(r.name))}`);
+    assert.deepEqual(controlDrift, [], `inventory control-type drift:\n${controlDrift.join('\n')}`);
+  });
+
+  it('every module projection target exists in ENV_VARS', () => {
+    const registryNames = new Set(ENV_VARS.map((v) => v.name));
+    for (const section of Object.keys(MODULE_SECTION_PROJECTION)) {
+      for (const name of MODULE_SECTION_PROJECTION[section]) {
+        assert.ok(registryNames.has(name), `${name} in section ${section} must be registered`);
+      }
+    }
+  });
+
+  it('module sections never repeat system vars', () => {
+    for (const section of Object.keys(MODULE_SECTION_PROJECTION)) {
+      for (const name of MODULE_SECTION_PROJECTION[section]) {
+        assert.ok(!SYSTEM_VARS.has(name), `${name} must not appear in both system and section ${section}`);
+      }
+    }
+  });
+
+  it('every section key has a label', () => {
+    for (const key of ENV_SECTION_KEYS) {
+      assert.ok(ENV_SECTION_LABELS[key], `section ${key} must have a label`);
+    }
+  });
+
+  it('deprecated vars are excluded from section summaries', () => {
+    const fakeSummary = [
+      { name: 'TTS_URL', currentValue: 'http://tts', deprecated: 'removed', hubVisible: true },
+      { name: 'WHISPER_URL', currentValue: 'http://whisper', deprecated: undefined, hubVisible: true },
+    ];
+    const allowed = new Set(['TTS_URL', 'WHISPER_URL']);
+    const voice = filterEnvSummaryForSection(allowed, fakeSummary);
+    const names = voice.map((v) => v.name);
+    assert.ok(!names.includes('TTS_URL'), 'deprecated var should be filtered out');
+    assert.ok(names.includes('WHISPER_URL'), 'non-deprecated var should remain');
+  });
+
+  it('targetWritePolicy read-only-opt-in vars stay API-editable but UI-hidden by default', () => {
+    const OPT_IN_READONLY = [
+      'WEIXIN_VOICE_ITEM_MODE',
+      'WEIXIN_ENABLE_UNSAFE_VOICE_MODES',
+      'WEIXIN_CAPTURE_INBOUND_VOICE_MEDIA',
+      'GITHUB_WEBHOOK_SECRET',
+      'GITHUB_SELF_LOGIN',
+      'F102_API_KEY',
+    ];
+    for (const name of OPT_IN_READONLY) {
+      const def = ENV_VARS.find((v) => v.name === name);
+      assert.ok(def, `${name} should be in registry`);
+      assert.equal(def.targetWritePolicy, 'read-only-opt-in');
+      assert.equal(def.runtimeEditable, true, `${name} runtimeEditable stays true for backward compat`);
+      // API layer stays editable so the owner/session gate (not the registry)
+      // remains the authority for sensitive writes. The generic Hub UI hides
+      // these editors via isEditableVariable in EnvSubComponents.tsx.
+      assert.equal(isEditableEnvVar(def), true, `${name} must remain API-editable`);
+      assert.equal(isEditableEnvVarName(name), true, `${name} must remain editable by name`);
+    }
+  });
+
+  it('MODULE_SECTION_PROJECTION is intentionally empty in PR-A', () => {
+    // PR-A lands the section/filter/write-policy infrastructure without a
+    // module projection allowlist. The previous 42-var projection was retracted
+    // after an ownership audit showed most entries already have dedicated UI
+    // coverage, are internal/deploy-only, or need component-level extensions
+    // rather than a generic env card. PR-C will re-add sets per module owner.
+    for (const section of Object.keys(MODULE_SECTION_PROJECTION)) {
+      assert.equal(MODULE_SECTION_PROJECTION[section].size, 0, `${section} projection must be empty until PR-C`);
+    }
+  });
+
+  it('ENV_SECTION_KEYS is the exact locked set of sections', () => {
+    assert.deepEqual(
+      new Set(ENV_SECTION_KEYS),
+      new Set(['system', 'im', 'voice', 'notify', 'ops', 'accounts', 'members', 'plugins']),
+    );
   });
 });

--- a/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
+++ b/packages/web/src/components/__tests__/hub-env-files-tab.test.tsx
@@ -12,7 +12,7 @@ import { HubEnvFilesTab } from '@/components/HubEnvFilesTab';
 const mockApiFetch = vi.mocked(apiFetch);
 
 const MOCK_ENV_SUMMARY = {
-  categories: { server: '服务器', storage: '存储' },
+  categories: { server: '服务器', storage: '存储', evidence: '证据' },
   variables: [
     {
       name: 'API_SERVER_PORT',
@@ -57,6 +57,16 @@ const MOCK_ENV_SUMMARY = {
       description: 'OpenAI API Key',
       category: 'server',
       sensitive: true,
+      currentValue: '***',
+    },
+    {
+      name: 'F102_API_KEY',
+      defaultValue: '(未设置)',
+      description: 'F102 summarizer API key',
+      category: 'evidence',
+      sensitive: true,
+      runtimeEditable: true,
+      targetWritePolicy: 'read-only-opt-in',
       currentValue: '***',
     },
   ],
@@ -252,6 +262,35 @@ describe('HubEnvFilesTab', () => {
     await flushEffects();
 
     expect(container.textContent).toContain('保存失败（测试）');
+  });
+
+  it('does not render editor or save payload for read-only-opt-in vars', async () => {
+    await act(async () => {
+      root.render(React.createElement(HubEnvFilesTab));
+    });
+    await flushEffects();
+
+    // runtimeEditable=true but targetWritePolicy=read-only-opt-in → no input
+    expect(container.querySelector('input[aria-label="F102_API_KEY"]')).toBeNull();
+    expect(container.textContent).toContain('F102_API_KEY');
+
+    const frontendUrlInput = container.querySelector('input[aria-label="FRONTEND_URL"]') as HTMLInputElement;
+    await changeField(frontendUrlInput, 'http://localhost:3200');
+
+    const saveButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === '保存到 .env',
+    );
+    await act(async () => {
+      saveButton?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flushEffects();
+
+    const patchCall = mockApiFetch.mock.calls.find(
+      ([path, init]) => path === '/api/config/env' && init?.method === 'PATCH',
+    );
+    expect(patchCall).toBeTruthy();
+    expect(String(patchCall?.[1]?.body)).not.toContain('F102_API_KEY');
+    expect(String(patchCall?.[1]?.body)).toContain('FRONTEND_URL');
   });
 
   it('serializes save requests when 保存到 .env is double-clicked', async () => {

--- a/packages/web/src/components/settings/EnvSubComponents.tsx
+++ b/packages/web/src/components/settings/EnvSubComponents.tsx
@@ -26,6 +26,8 @@ export interface EnvVar {
   sensitive: boolean;
   maskMode?: 'url';
   runtimeEditable?: boolean;
+  /** #770: target write policy from env registry; overrides runtimeEditable for UI editability. */
+  targetWritePolicy?: 'editable' | 'read-only' | 'read-only-opt-in' | 'module-managed' | 'no-ui-write';
   deprecated?: string;
   allowedValues?: string[];
   currentValue: string | null;
@@ -99,12 +101,18 @@ function needsRestart(variable: EnvVar): boolean {
   return variable.runtimeEditable === false || RESTART_REQUIRED_ENV_VARS.has(variable.name);
 }
 
+/** #770: fail-closed — only vars with explicit runtimeEditable: true are editable.
+ * When the registry supplies a targetWritePolicy, it overrides runtimeEditable.
+ */
 export function isEditableVariable(variable: EnvVar): boolean {
+  if (variable.targetWritePolicy && variable.targetWritePolicy !== 'editable') {
+    return false;
+  }
   return variable.runtimeEditable === true;
 }
 
 export function isSensitiveEditable(variable: EnvVar): boolean {
-  return variable.sensitive && variable.runtimeEditable === true;
+  return variable.sensitive && isEditableVariable(variable);
 }
 
 export function isMaskedUrlVariable(variable: EnvVar): boolean {

--- a/scripts/check-env-example.test.mjs
+++ b/scripts/check-env-example.test.mjs
@@ -46,6 +46,8 @@ const EXAMPLE_ALLOWLIST = new Map([
   ['WECOM_AGENT_SECRET', 'F240 connector manifest/preconfigured gateway env, not global env registry'],
   ['WECOM_TOKEN', 'F240 connector manifest/preconfigured gateway env, not global env registry'],
   ['WECOM_ENCODING_AES_KEY', 'F240 connector manifest/preconfigured gateway env, not global env registry'],
+  ['REDIS_PORT', 'Redis server port, consumed by shell start scripts before API boot'],
+  ['MCP_SERVER_PORT', 'MCP server port placeholder in .env.example, not currently consumed by TypeScript API'],
 ]);
 
 // ── Parse .env.example keys ──

--- a/scripts/check-env-port-drift.test.mjs
+++ b/scripts/check-env-port-drift.test.mjs
@@ -502,12 +502,9 @@ describe(`Code-side port defaults are internally consistent (${repoLabel}: API=$
     );
   });
 
-  it('setup.sh leaves TTS_CACHE_DIR unset so the API uses the stable user-data default', () => {
+  it('setup.sh leaves CACHE_DIR unset so the API uses the stable user-data default', () => {
     const content = readFileSync(resolve(ROOT, 'scripts/setup.sh'), 'utf-8');
-    assert.ok(
-      !/^TTS_CACHE_DIR=/m.test(content),
-      'setup.sh must not pin the TTS cache to a checkout-relative directory',
-    );
+    assert.ok(!/^CACHE_DIR=/m.test(content), 'setup.sh must not pin the cache root to a checkout-relative directory');
   });
 
   it(`runtime-worktree.sh API port fallback is ${expectedApiPort}`, () => {


### PR DESCRIPTION
## Summary

Implements the **contract-only** slice of clowder-ai#770: the canonical env section, filter, and write-policy infrastructure for curated System / module settings.

- Rebased onto post-#1340 main.
- Adds the section/filter/write-policy scaffolding (`EnvSectionKey`, `ENV_SECTION_KEYS`, `ENV_SECTION_LABELS`, `isEditableEnvVar`, `filterEnvSummaryForSection`) with **empty** `MODULE_SECTION_PROJECTION`.
- Adds fail-closed control metadata for vars that are currently editable but should be read-only / opt-in editable in the curated UI.
- Syncs `ENV_SECTION_KEYS` / `ENV_SECTION_LABELS` and updates env-registry tests.
- Adds the reviewable inventory/rationale as `docs/plans/770-env-config-inventory.md` so the 218-variable classification (28 system / 34 moved-out / 0 projection / 4 component-gap / 4 product-pending / 148 no-UI / 0 unclassified) can be independently checked.

## Scope boundary

This PR is intentionally **infrastructure-only**:

- It defines the section taxonomy, filtering rules, and write-policy metadata that future renderers will consume.
- It does **not** project any non-system env vars into module sections (`MODULE_SECTION_PROJECTION` is empty).
- It does **not** wire new API surface parameters beyond `surface=system`, nor does it implement module UI cards/settings sections.

API/query consumers, module UI wiring, and per-module projection allowlists are planned as follow-up slices under #770 and will reference this inventory as the source of truth.

## Follow-up tracking

- #770 remains the umbrella issue.
- PR-B: System view cleanup + consolidated retention.
- PR-C: Project env vars to module pages (only after module UI owners confirm each var needs a generic env renderer surface).
- PR-D: Hide internal/deploy/test vars.
- PR-E: Deprecated cleanup.

## Verification

- `pnpm --filter @cat-cafe/api build` ✅
- `pnpm --filter @cat-cafe/api lint` ✅
- env-registry.test.js: 91/91 pass ✅
- `pnpm check` ✅

Does **not** close #770.
