### PR TITLE
fix(web): simplify Context Window and Session State settings hierarchy

### DIFF
--- a/packages/api/src/config/context-window-sizes.ts
+++ b/packages/api/src/config/context-window-sizes.ts
@@ -1,73 +1,28 @@
 /**
- * Context Window Size Fallback Table
- * F24: Hardcoded model → context window mapping for cats whose CLI
- * doesn't report window size (Codex exec, Gemini -p).
+ * Context Window Size — Runtime Helpers
  *
- * Claude CLI reports exact values via modelUsage[model].contextWindow,
- * so these entries are fallback only.
- * Update when new models are released or window sizes change.
+ * The static model → context window catalog lives in
+ * `@cat-cafe/shared` (single source of truth for
+ * both API Auto-mode resolution and Web draft compatibility preview).
+ *
+ * This module re-exports the catalog lookup and adds runtime-only
+ * helpers: known-minimum floors (stale-CLI correction) and the
+ * composite `resolveContextWindow` that merges carrier reports with
+ * catalog + floor.
  */
 
-export const CONTEXT_WINDOW_SIZES: Record<string, number> = {
-  // Claude (exact values from CLI, these are fallback)
-  // Issue #1208: Anthropic confirmed Opus 4.6 / Sonnet 4.6 default to 1M
-  // context windows without a beta header. Update stale 200K fallbacks.
-  'claude-opus-4-6': 1_000_000,
-  'claude-sonnet-4-6': 1_000_000,
-  'claude-sonnet-4-5': 200_000,
-  'claude-haiku-4-5': 200_000,
-  // Fable 5: native 1M context — the maximum is also the default (no [1m]
-  // suffix needed). Also listed in KNOWN_MIN_CONTEXT_WINDOWS below because
-  // stale CLIs (≤2.1.177) mis-REPORT it as 200K, which this table alone
-  // cannot fix (CLI report outranks the fallback table).
-  'claude-fable-5': 1_000_000,
-  // Codex/GPT
-  'gpt-5.3': 128_000,
-  'gpt-5.2': 128_000,
-  'gpt-5.1-codex': 400_000,
-  o3: 200_000,
-  'o4-mini': 200_000,
-  // MiniMax
-  'MiniMax-M3': 1_000_000,
-  // Zhipu / BigModel
-  'glm-5.2': 1_000_000,
-  'glm-5.2[1m]': 1_000_000,
-  'minimax-m3': 1_000_000,
-  // Gemini
-  'gemini-2.5-pro': 1_000_000,
-  'gemini-2.5-flash': 1_000_000,
-  'gemini-3-pro': 1_000_000,
-  'gemini-3.1-pro-preview': 1_000_000,
-};
+// Re-export catalog lookup so existing API consumers keep their import path.
+export { CONTEXT_WINDOW_SIZES, getContextWindowFallback } from '@cat-cafe/shared';
 
-// Normalize provider-prefixed model IDs before lookup. The account routing
-// path in invoke-single-cat sets `callbackEnv.CAT_CAFE_ANTHROPIC_MODEL_OVERRIDE`
-// to a `safeProvider/model` form (see L1459 `safeProvider/safeModel`), and
-// OpenCodeAgentService propagates that prefixed string as `metadata.model`.
-// Without normalization, lookups like `anthropic/claude-opus-4-6` or
-// `openai-compat/gpt-5.3` would miss the table entirely → no windowSize →
-// F24 context_health silently skipped → opencode handoff (clowder#915)
-// bypassed in production. (clowder#915 R2 cloud P1)
-//
-// Use lastIndexOf to handle multi-segment prefixes like `openai-compat/x/y`
-// (defensive — current code emits at most one slash, but the cost is the
-// same and we don't want to be the next migration's footgun).
-function stripProviderPrefix(model: string): string {
-  const slashAt = model.lastIndexOf('/');
-  return slashAt >= 0 ? model.slice(slashAt + 1) : model;
-}
+import { getContextWindowFallback, stripProviderPrefix } from '@cat-cafe/shared';
 
+/** Local prefix-match helper for the small runtime-only floor table. */
 function lookupWithPrefixMatch(table: Record<string, number>, bare: string): number | undefined {
-  if (table[bare]) return table[bare];
-  // Prefix match (e.g. 'claude-opus-4-6-20260101' matches 'claude-opus-4-6')
+  if (table[bare] != null) return table[bare];
   for (const [key, value] of Object.entries(table)) {
     if (bare.startsWith(key)) return value;
   }
   return undefined;
-}
-
-export function getContextWindowFallback(model: string): number | undefined {
-  return lookupWithPrefixMatch(CONTEXT_WINDOW_SIZES, stripProviderPrefix(model));
 }
 
 /**

--- a/packages/shared/src/context-window-catalog.ts
+++ b/packages/shared/src/context-window-catalog.ts
@@ -1,0 +1,77 @@
+/**
+ * Context Window Size Catalog
+ *
+ * Static model → context window mapping shared between API and Web.
+ *
+ * API uses this as the last-resort fallback in Auto mode (after carrier
+ * reports). Web uses it to preview draft compatibility: if a model has a
+ * catalog entry, Auto mode WILL resolve — so the "needs Manual" warning
+ * should not fire.
+ *
+ * This module is pure static data with zero runtime dependencies.
+ * Runtime-only helpers (carrier report correction, known-minimum floors)
+ * stay in `packages/api/src/config/context-window-sizes.ts`.
+ */
+
+export const CONTEXT_WINDOW_SIZES: Readonly<Record<string, number>> = {
+  // Claude (exact values from CLI, these are fallback)
+  // Issue #1208: Anthropic confirmed Opus 4.6 / Sonnet 4.6 default to 1M
+  // context windows without a beta header. Update stale 200K fallbacks.
+  'claude-opus-4-6': 1_000_000,
+  'claude-sonnet-4-6': 1_000_000,
+  'claude-sonnet-4-5': 200_000,
+  'claude-haiku-4-5': 200_000,
+  // Fable 5: native 1M context — the maximum is also the default (no [1m]
+  // suffix needed). Also listed in KNOWN_MIN_CONTEXT_WINDOWS (API-only)
+  // because stale CLIs (≤2.1.177) mis-REPORT it as 200K.
+  'claude-fable-5': 1_000_000,
+  // Codex/GPT
+  'gpt-5.3': 128_000,
+  'gpt-5.2': 128_000,
+  'gpt-5.1-codex': 400_000,
+  o3: 200_000,
+  'o4-mini': 200_000,
+  // MiniMax
+  'MiniMax-M3': 1_000_000,
+  // Zhipu / BigModel
+  'glm-5.2': 1_000_000,
+  'glm-5.2[1m]': 1_000_000,
+  'minimax-m3': 1_000_000,
+  // Gemini
+  'gemini-2.5-pro': 1_000_000,
+  'gemini-2.5-flash': 1_000_000,
+  'gemini-3-pro': 1_000_000,
+  'gemini-3.1-pro-preview': 1_000_000,
+};
+
+/**
+ * Normalize provider-prefixed model IDs before lookup.
+ *
+ * The account routing path sets model strings like
+ * `anthropic/claude-opus-4-6` or `openai-compat/gpt-5.3`.
+ * Without normalization, lookups would miss the table entirely.
+ */
+export function stripProviderPrefix(model: string): string {
+  const slashAt = model.lastIndexOf('/');
+  return slashAt >= 0 ? model.slice(slashAt + 1) : model;
+}
+
+function lookupWithPrefixMatch(table: Readonly<Record<string, number>>, bare: string): number | undefined {
+  if (table[bare] != null) return table[bare];
+  // Prefix match (e.g. 'claude-opus-4-6-20260101' matches 'claude-opus-4-6')
+  for (const [key, value] of Object.entries(table)) {
+    if (bare.startsWith(key)) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Look up a model's known context window from the static catalog.
+ *
+ * Returns `undefined` when the model has no catalog entry — meaning
+ * Auto mode cannot resolve from catalog alone and needs either a
+ * carrier report or a Manual override.
+ */
+export function getContextWindowFallback(model: string): number | undefined {
+  return lookupWithPrefixMatch(CONTEXT_WINDOW_SIZES, stripProviderPrefix(model));
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,6 +34,8 @@ export {
   PET_STATE_PROJECTION_V1,
   projectToPetState,
 } from './concierge/pet-skin-projection.js';
+// #1343: Context window catalog (API Auto-mode fallback + Web draft preview)
+export * from './context-window-catalog.js';
 export { CORE_COMMANDS } from './core-commands.js';
 // Export Eval Hub metric reference normalization (F248 B3)
 export * from './eval-metric-ref.js';

--- a/packages/web/src/components/HubSessionStrategyEditor.tsx
+++ b/packages/web/src/components/HubSessionStrategyEditor.tsx
@@ -2,23 +2,6 @@
 
 import { SESSION_STRATEGY_OPTIONS, type StrategyFormState } from './hub-cat-editor.model';
 import { RangeField, SelectField, TextField } from './hub-cat-editor-fields';
-import { SOURCE_LABELS } from './hub-strategy-types';
-
-const REASON_LABELS: Record<string, string> = {
-  managed_invocation_boundary: '需要受管 invocation 边界',
-  effective_input_ceiling: '缺少有效输入上限',
-  carrier_binding: '缺少当前 carrier 绑定',
-  authoritative_usage: '缺少权威 usage',
-  session_rotation: '缺少 Session 轮换能力',
-  continuity_bootstrap: '缺少连续性重建能力',
-  compression_signal: '缺少压缩事件信号',
-};
-
-function statusLabel(status: StrategyFormState['executionStatus']['status']): string {
-  if (status === 'active') return 'Active';
-  if (status === 'degraded') return 'Degraded';
-  return 'Unavailable';
-}
 
 export function HubSessionStrategyEditor({
   strategyForm,
@@ -31,10 +14,9 @@ export function HubSessionStrategyEditor({
   error: string | null;
   onChange: (patch: Partial<StrategyFormState>) => void;
 }) {
-  const statusMatchesDraft = strategyForm?.strategy === strategyForm?.statusStrategy;
-
   return (
-    <div className="space-y-3 rounded-[14px] bg-[var(--console-runtime-group-bg)] p-[14px]">
+    <section className="space-y-3 rounded-[14px] bg-[var(--console-runtime-group-bg)] p-[14px]">
+      <h3 className="text-sm font-semibold text-cafe">Session State / Chain</h3>
       {loading ? <p className="text-sm text-cafe-secondary">Session 策略加载中...</p> : null}
       {error ? (
         <p className="rounded-[20px] border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-sm text-conn-red-text">
@@ -42,74 +24,47 @@ export function HubSessionStrategyEditor({
         </p>
       ) : null}
       {strategyForm ? (
-        <div className="space-y-4">
-          <div className="rounded-[10px] bg-[var(--console-runtime-field-bg)] px-4 py-3 text-xs leading-5 text-[var(--console-runtime-hint)]">
-            <p className="font-semibold text-cafe">Session State / Chain 始终记录并可见。</p>
-            <p>策略只表达你的意图；能力不足会显示执行状态，不会把策略静默改成另一种。</p>
-            <p>保存后的策略从下一次 invocation 起作用于当前 active session；正在运行的 invocation 保持原快照。</p>
-          </div>
-
-          <div className="flex flex-wrap items-center gap-2 text-xs">
-            <span className="rounded-full bg-[var(--console-field-bg)] px-2.5 py-1 font-semibold text-cafe-secondary">
-              {statusMatchesDraft ? '能力预检' : `已保存 ${strategyForm.statusStrategy} 策略的能力预检`}：
-              {statusLabel(strategyForm.executionStatus.status)}
-            </span>
-            <span className="text-cafe-muted">来源：{SOURCE_LABELS[strategyForm.source] ?? strategyForm.source}</span>
-          </div>
-          {!statusMatchesDraft ? (
-            <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">
-              保存后会重新预检 {strategyForm.strategy}；当前状态不会被套用到未保存的策略。
-            </p>
-          ) : strategyForm.executionStatus.missingCapabilities.length > 0 ? (
-            <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">
-              {strategyForm.executionStatus.missingCapabilities
-                .map((reason) => REASON_LABELS[reason] ?? reason)
-                .join('；')}
-            </p>
-          ) : null}
-
-          <div className="space-y-2">
-            <SelectField
-              label="Session Strategy"
-              value={strategyForm.strategy}
-              options={SESSION_STRATEGY_OPTIONS}
-              onChange={(value) => onChange({ strategy: value as StrategyFormState['strategy'] })}
+        <div className="space-y-2">
+          <SelectField
+            label="Session Strategy"
+            value={strategyForm.strategy}
+            options={SESSION_STRATEGY_OPTIONS}
+            onChange={(value) => onChange({ strategy: value as StrategyFormState['strategy'] })}
+            tone="success"
+          />
+          <RangeField
+            label={strategyForm.strategy === 'compress' ? 'Session Observe Threshold' : 'Session Warn Threshold'}
+            value={strategyForm.warnThreshold}
+            onChange={(value) => onChange({ warnThreshold: value })}
+            hint={
+              strategyForm.strategy === 'compress'
+                ? '仅用于观测；compress 不触发 handoff'
+                : 'context 填充到此比例时发出警告'
+            }
+          />
+          <RangeField
+            label={
+              strategyForm.strategy === 'compress' ? 'Session Observe Threshold (upper)' : 'Session Action Threshold'
+            }
+            value={strategyForm.actionThreshold}
+            onChange={(value) => onChange({ actionThreshold: value })}
+            hint={
+              strategyForm.strategy === 'compress'
+                ? '仅用于观测；Session 在 client 压缩后继续存活'
+                : '能力状态为 Active 时，达到此比例才执行当前策略动作'
+            }
+          />
+          {strategyForm.strategy === 'hybrid' ? (
+            <TextField
+              label="Max Compressions"
+              value={strategyForm.maxCompressions}
+              onChange={(value) => onChange({ maxCompressions: value })}
+              inputMode="numeric"
               tone="success"
             />
-            <RangeField
-              label={strategyForm.strategy === 'compress' ? 'Session Observe Threshold' : 'Session Warn Threshold'}
-              value={strategyForm.warnThreshold}
-              onChange={(value) => onChange({ warnThreshold: value })}
-              hint={
-                strategyForm.strategy === 'compress'
-                  ? '仅用于观测；compress 不触发 handoff'
-                  : 'context 填充到此比例时发出警告'
-              }
-            />
-            <RangeField
-              label={
-                strategyForm.strategy === 'compress' ? 'Session Observe Threshold (upper)' : 'Session Action Threshold'
-              }
-              value={strategyForm.actionThreshold}
-              onChange={(value) => onChange({ actionThreshold: value })}
-              hint={
-                strategyForm.strategy === 'compress'
-                  ? '仅用于观测；Session 在 client 压缩后继续存活'
-                  : '能力状态为 Active 时，达到此比例才执行当前策略动作'
-              }
-            />
-            {strategyForm.strategy === 'hybrid' ? (
-              <TextField
-                label="Max Compressions"
-                value={strategyForm.maxCompressions}
-                onChange={(value) => onChange({ maxCompressions: value })}
-                inputMode="numeric"
-                tone="success"
-              />
-            ) : null}
-          </div>
+          ) : null}
         </div>
       ) : null}
-    </div>
+    </section>
   );
 }

--- a/packages/web/src/components/HubSessionStrategyEditor.tsx
+++ b/packages/web/src/components/HubSessionStrategyEditor.tsx
@@ -16,7 +16,7 @@ export function HubSessionStrategyEditor({
 }) {
   return (
     <section className="space-y-3 rounded-[14px] bg-[var(--console-runtime-group-bg)] p-[14px]">
-      <h3 className="text-sm font-semibold text-cafe">Session State / Chain</h3>
+      <h5 className="text-sm font-semibold text-cafe">Session State / Chain</h5>
       {loading ? <p className="text-sm text-cafe-secondary">Session 策略加载中...</p> : null}
       {error ? (
         <p className="rounded-[20px] border border-conn-red-ring bg-conn-red-bg px-3 py-2 text-sm text-conn-red-text">

--- a/packages/web/src/components/SessionChainPanel.tsx
+++ b/packages/web/src/components/SessionChainPanel.tsx
@@ -35,15 +35,6 @@ interface SessionSummary {
     cacheReadTokens?: number;
     costUsd?: number;
   };
-  appliedPolicy?: {
-    config: { strategy: 'handoff' | 'compress' | 'hybrid' };
-    source: string;
-    revision: string;
-    execution: {
-      status: 'active' | 'degraded' | 'unavailable';
-      missingCapabilities: string[];
-    };
-  };
   runtimeSession?: RuntimeSessionSummary;
 }
 
@@ -144,9 +135,6 @@ function sealedSessionDetails(session: SessionSummary): string | undefined {
         ? `${session.compressionCount} compress`
         : '0 compress observed',
     session.sealReason ? sealReasonLabel(session.sealReason) : null,
-    session.appliedPolicy
-      ? `${session.appliedPolicy.config.strategy} · ${session.appliedPolicy.execution.status}`
-      : null,
   ].filter(Boolean);
   return details.length > 0 ? details.join(' · ') : undefined;
 }
@@ -487,18 +475,6 @@ export function SessionChainPanel({
                   )}
                   {session.compressionCount === 0 && <span className="text-cafe-muted"> · 0 compress observed</span>}
                 </div>
-                {session.appliedPolicy && (
-                  <div
-                    data-testid="session-policy-state"
-                    className="mb-1.5 rounded bg-[var(--console-runtime-field-bg)] px-2 py-1 text-micro text-cafe-secondary"
-                  >
-                    <span className="font-semibold">policy {session.appliedPolicy.config.strategy}</span>
-                    <span> · {session.appliedPolicy.execution.status}</span>
-                    {session.appliedPolicy.execution.missingCapabilities.length > 0 && (
-                      <span> · missing {session.appliedPolicy.execution.missingCapabilities.join(', ')}</span>
-                    )}
-                  </div>
-                )}
                 {session.runtimeSession && (
                   <div
                     data-testid="runtime-session-summary"

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -367,6 +367,94 @@ describe('HubCatEditor', () => {
     expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
   });
 
+  it('derives Context Window compatibility from the edited client instead of the saved member', async () => {
+    const savedAntigravity = {
+      id: 'runtime-antigravity',
+      displayName: 'Runtime antigravity',
+      clientId: 'antigravity',
+      defaultModel: 'test-model',
+      color: { primary: '#16a34a', secondary: '#bbf7d0' },
+      mentionPatterns: ['@runtime-antigravity'],
+      avatar: '/avatars/default.png',
+      roleDescription: 'runtime config',
+      personality: 'test',
+      resolvedContext: {
+        reportsRuntimeWindow: false,
+        nativeWindowControl: false,
+        authoritativeUsage: false,
+        usageTelemetry: 'unavailable' as const,
+        nativeCompressionControl: false,
+        observesCompression: false,
+      },
+    } satisfies CatData;
+
+    await renderAdvancedRuntimeSection('antigravity');
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口');
+
+    await renderAdvancedRuntimeSection('openai', 'gpt-5.6-sol', {}, {}, { cat: savedAntigravity });
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
+      {},
+      {},
+      {
+        cat: {
+          ...savedAntigravity,
+          clientId: 'openai',
+          resolvedContext: {
+            ...actionableContextProjection,
+            reportsRuntimeWindow: true,
+            nativeWindowControl: true,
+          },
+        },
+      },
+    );
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口');
+
+    await renderAdvancedRuntimeSection('openai', 'gpt-5.6-sol', { codexCarrier: 'app_server' });
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口');
+
+    await renderAdvancedRuntimeSection('openai', 'gpt-5.6-sol', { codexCarrier: 'exec_json' });
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+  });
+
+  it('does not reuse a saved Manual source after the editor switches Context Window to Auto', async () => {
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
+      {},
+      {},
+      {
+        cat: {
+          id: 'runtime-antigravity',
+          displayName: 'Runtime antigravity',
+          clientId: 'antigravity',
+          defaultModel: 'test-model',
+          contextWindow: 128_000,
+          color: { primary: '#16a34a', secondary: '#bbf7d0' },
+          mentionPatterns: ['@runtime-antigravity'],
+          avatar: '/avatars/default.png',
+          roleDescription: 'runtime config',
+          personality: 'test',
+          resolvedContext: {
+            source: 'manual',
+            windowTokens: 128_000,
+            reportsRuntimeWindow: false,
+            nativeWindowControl: false,
+            authoritativeUsage: false,
+            usageTelemetry: 'unavailable',
+            nativeCompressionControl: false,
+            observesCompression: false,
+          },
+        },
+      },
+    );
+
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
+  });
+
   it.each([
     'handoff',
     'compress',

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -420,6 +420,15 @@ describe('HubCatEditor', () => {
     expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
   });
 
+  it('warns that the default Google CLI carrier cannot resolve an Auto Context Window', async () => {
+    await renderAdvancedRuntimeSection('google', 'gemini-2.5-pro');
+
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
+
+    await renderAdvancedRuntimeSection('google', 'gemini-2.5-pro', { acpEnabled: true });
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+  });
+
   it('does not reuse a saved Manual source after the editor switches Context Window to Auto', async () => {
     await renderAdvancedRuntimeSection(
       'antigravity',

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -297,6 +297,31 @@ describe('HubCatEditor', () => {
     await renderAdvancedRuntimeSection(
       'antigravity',
       'test-model',
+      { contextWindow: '128000' },
+      {},
+      {
+        cat: {
+          ...baseCat,
+          resolvedContext: {
+            reportsRuntimeWindow: false,
+            nativeWindowControl: false,
+            authoritativeUsage: false,
+            usageTelemetry: 'unavailable',
+            nativeCompressionControl: false,
+            observesCompression: false,
+          },
+        },
+      },
+    );
+
+    expect(document.body.textContent).toContain(
+      '当前 Client 无法校验或调整自身的上下文窗口；请确认 Manual 值不高于 Client 的实际上限。',
+    );
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
       {},
       {},
       {

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -159,6 +159,10 @@ describe('HubCatEditor', () => {
     defaultModel = 'test-model',
     patch: Partial<HubCatEditorFormState> = {},
     speed: { visible?: boolean; fastSupported?: boolean } = {},
+    runtime: {
+      cat?: CatData | null;
+      strategyForm?: Parameters<typeof AdvancedRuntimeSection>[0]['strategyForm'];
+    } = {},
   ) {
     const form: HubCatEditorFormState = {
       catId: `runtime-${clientId}`,
@@ -195,9 +199,9 @@ describe('HubCatEditor', () => {
     await act(async () => {
       root.render(
         React.createElement(AdvancedRuntimeSection, {
-          cat: null,
+          cat: runtime.cat ?? null,
           form,
-          strategyForm: null,
+          strategyForm: runtime.strategyForm ?? null,
           loadingStrategy: false,
           strategyError: null,
           codexSettings: null,
@@ -215,6 +219,176 @@ describe('HubCatEditor', () => {
     });
     return onChange;
   }
+
+  it('keeps Context Window focused on the Auto or Manual choice', async () => {
+    await renderAdvancedRuntimeSection(
+      'openai',
+      'gpt-5.6-sol',
+      {},
+      {},
+      {
+        cat: {
+          id: 'runtime-openai',
+          displayName: 'Runtime openai',
+          clientId: 'openai',
+          defaultModel: 'gpt-5.6-sol',
+          color: { primary: '#16a34a', secondary: '#bbf7d0' },
+          mentionPatterns: ['@runtime-openai'],
+          avatar: '/avatars/default.png',
+          roleDescription: 'runtime config',
+          personality: 'test',
+          resolvedContext: {
+            ...actionableContextProjection,
+            source: 'reported',
+            provenance: 'internal carrier provenance',
+          },
+        },
+      },
+    );
+
+    const input = queryField<HTMLInputElement>(container, 'input[aria-label="Context Window"]');
+    expect(input.placeholder).toBe('留空或 0 = Auto；正整数 = Manual');
+    expect(document.body.textContent).toContain(
+      '填写正整数 = Manual 模式，作为该成员的上下文窗口大小。留空或填 0 = Auto，由运行时自动探测。',
+    );
+    expect(document.body.textContent).not.toContain('解析值');
+    expect(document.body.textContent).not.toContain('模型目录');
+    expect(document.body.textContent).not.toContain('internal carrier provenance');
+  });
+
+  it('shows a concise action only when the selected client cannot resolve or apply Context Window', async () => {
+    const baseCat: CatData = {
+      id: 'runtime-antigravity',
+      displayName: 'Runtime antigravity',
+      clientId: 'antigravity',
+      defaultModel: 'test-model',
+      color: { primary: '#16a34a', secondary: '#bbf7d0' },
+      mentionPatterns: ['@runtime-antigravity'],
+      avatar: '/avatars/default.png',
+      roleDescription: 'runtime config',
+      personality: 'test',
+    };
+
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
+      {},
+      {},
+      {
+        cat: {
+          ...baseCat,
+          resolvedContext: {
+            reportsRuntimeWindow: false,
+            nativeWindowControl: false,
+            authoritativeUsage: false,
+            usageTelemetry: 'unavailable',
+            nativeCompressionControl: false,
+            observesCompression: false,
+            capabilityReason: 'Concrete carrier capability unavailable',
+          },
+        },
+      },
+    );
+
+    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
+    expect(document.body.textContent).not.toContain('Concrete carrier capability unavailable');
+    expect(document.body.textContent).not.toContain('未能解析 Context Window');
+
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
+      {},
+      {},
+      {
+        cat: {
+          ...baseCat,
+          resolvedContext: {
+            reportsRuntimeWindow: true,
+            nativeWindowControl: false,
+            authoritativeUsage: false,
+            usageTelemetry: 'conditional',
+            nativeCompressionControl: false,
+            observesCompression: false,
+          },
+        },
+      },
+    );
+
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+    expect(document.body.textContent).not.toContain('未能解析 Context Window');
+
+    await renderAdvancedRuntimeSection(
+      'antigravity',
+      'test-model',
+      {},
+      {},
+      {
+        cat: {
+          ...baseCat,
+          resolvedContext: {
+            source: 'catalog',
+            windowTokens: 128_000,
+            reportsRuntimeWindow: false,
+            nativeWindowControl: false,
+            authoritativeUsage: false,
+            usageTelemetry: 'unavailable',
+            nativeCompressionControl: false,
+            observesCompression: false,
+          },
+        },
+      },
+    );
+
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
+  });
+
+  it.each([
+    'handoff',
+    'compress',
+    'hybrid',
+  ] as const)('renders Session State / Chain as a heading directly above the %s strategy controls', async (strategy) => {
+    await renderAdvancedRuntimeSection(
+      'openai',
+      'gpt-5.6-sol',
+      {},
+      {},
+      {
+        cat: {
+          id: 'runtime-openai',
+          displayName: 'Runtime openai',
+          clientId: 'openai',
+          defaultModel: 'gpt-5.6-sol',
+          color: { primary: '#16a34a', secondary: '#bbf7d0' },
+          mentionPatterns: ['@runtime-openai'],
+          avatar: '/avatars/default.png',
+          roleDescription: 'runtime config',
+          personality: 'test',
+          resolvedContext: actionableContextProjection,
+        },
+        strategyForm: {
+          strategy,
+          statusStrategy: strategy,
+          warnThreshold: '0.75',
+          actionThreshold: '0.85',
+          maxCompressions: '2',
+          source: 'runtime_override',
+          revision: 'test',
+          changedAt: 0,
+          executionStatus: { status: 'unavailable', missingCapabilities: ['authoritative_usage'] },
+        },
+      },
+    );
+
+    const heading = document.body.querySelector('h3');
+    const strategySelect = queryField<HTMLSelectElement>(container, 'select[aria-label="Session Strategy"]');
+    expect(heading?.textContent).toBe('Session State / Chain');
+    expect(heading?.nextElementSibling?.contains(strategySelect)).toBe(true);
+    expect(strategySelect.value).toBe(strategy);
+    expect(Array.from(strategySelect.options, (option) => option.value)).toEqual(['handoff', 'compress', 'hybrid']);
+    expect(document.body.textContent).not.toContain('能力预检');
+    expect(document.body.textContent).not.toContain('来源：');
+    expect(document.body.textContent).not.toContain('缺少权威 usage');
+  });
 
   it('shows extra CLI args editor for CLI clients and hides it for API-only clients', async () => {
     for (const clientId of ['anthropic', 'openai', 'google', 'kimi', 'opencode'] as const) {
@@ -3481,7 +3655,11 @@ describe('HubCatEditor', () => {
     expect(document.body.textContent).toContain('展开后可配置 TTS clone 参考音频和文本。');
     expect(document.body.textContent).toContain('别名与 @ 路由');
     expect(document.body.textContent).toContain('认证与模型');
-    expect(document.body.textContent).toContain('Session State / Chain 始终记录并可见');
+    expect(
+      Array.from(document.body.querySelectorAll('h3')).some(
+        (heading) => heading.textContent === 'Session State / Chain',
+      ),
+    ).toBe(true);
     expect(document.body.textContent).toContain('── Codex 专属 (仅 Client=Codex 时显示) ──');
     expect(document.body.textContent).toContain('Codex Sandbox (Codex)');
     expect(document.body.textContent).toContain('Codex Approval (Codex)');
@@ -3504,8 +3682,8 @@ describe('HubCatEditor', () => {
     await changeField(queryField(container, 'input[aria-label="Team Strengths"]'), '代码审查、找 bug、深度思考');
     await changeField(queryField(container, 'input[aria-label="Strengths"]'), 'security, testing, debugging');
     await changeField(queryField(container, 'select[aria-label="Session Strategy"]'), 'handoff', 'change');
-    expect(document.body.textContent).toContain('已保存 compress 策略的能力预检');
-    expect(document.body.textContent).toContain('保存后会重新预检 handoff');
+    expect(document.body.textContent).not.toContain('能力预检');
+    expect(document.body.textContent).not.toContain('保存后会重新预检 handoff');
     await changeField(queryField(container, 'input[aria-label="Session Warn Threshold"]'), '0.55', 'change');
     await changeField(queryField(container, 'select[aria-label^="Codex Sandbox"]'), 'danger-full-access', 'change');
     await changeField(queryField(container, 'select[aria-label^="Codex Approval"]'), 'never', 'change');
@@ -3731,7 +3909,11 @@ describe('HubCatEditor', () => {
     });
     await flushEffects();
 
-    expect(document.body.textContent).toContain('Session State / Chain 始终记录并可见');
+    expect(
+      Array.from(document.body.querySelectorAll('h3')).some(
+        (heading) => heading.textContent === 'Session State / Chain',
+      ),
+    ).toBe(true);
     expect(document.body.textContent).not.toContain('Session Chain 未开启');
     expect(queryField<HTMLSelectElement>(container, 'select[aria-label="Session Strategy"]').value).toBe('compress');
     expect(document.body.querySelector('input[aria-label="Session Observe Threshold"]')).toBeTruthy();

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -420,12 +420,23 @@ describe('HubCatEditor', () => {
     expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
   });
 
-  it('warns that the default Google CLI carrier cannot resolve an Auto Context Window', async () => {
+  it('suppresses the Context Window warning for Google drafts when the model has a catalog entry', async () => {
+    // gemini-2.5-pro is in the shared catalog → Auto mode resolves via catalog
     await renderAdvancedRuntimeSection('google', 'gemini-2.5-pro');
+    expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
 
+    // Catalog resolution is Auto-only; Manual still needs the carrier warning.
+    await renderAdvancedRuntimeSection('google', 'gemini-2.5-pro', { contextWindow: '128000' });
+    expect(document.body.textContent).toContain(
+      '当前 Client 无法校验或调整自身的上下文窗口；请确认 Manual 值不高于 Client 的实际上限。',
+    );
+
+    // Unknown model with no catalog entry → warning fires
+    await renderAdvancedRuntimeSection('google', 'gemini-unknown-custom');
     expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
 
-    await renderAdvancedRuntimeSection('google', 'gemini-2.5-pro', { acpEnabled: true });
+    // ACP bypasses the carrier entirely — no warning regardless of model
+    await renderAdvancedRuntimeSection('google', 'gemini-unknown-custom', { acpEnabled: true });
     expect(document.body.textContent).not.toContain('当前 Client 无法自动探测上下文窗口');
   });
 

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -290,7 +290,13 @@ describe('HubCatEditor', () => {
       },
     );
 
-    expect(document.body.textContent).toContain('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
+    const contextWindowInput = queryField<HTMLInputElement>(container, 'input[aria-label="Context Window"]');
+    const compatibilityNotice = document.body.querySelector<HTMLOutputElement>('output#context-window-compat-notice');
+    expect(compatibilityNotice?.textContent).toBe('当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。');
+    expect(contextWindowInput.getAttribute('aria-describedby')).toBe(compatibilityNotice?.id);
+    expect(compatibilityNotice?.className).toContain('border-conn-amber-ring');
+    expect(compatibilityNotice?.className).toContain('bg-conn-amber-bg');
+    expect(compatibilityNotice?.className).toContain('text-conn-amber-text');
     expect(document.body.textContent).not.toContain('Concrete carrier capability unavailable');
     expect(document.body.textContent).not.toContain('未能解析 Context Window');
 

--- a/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
+++ b/packages/web/src/components/__tests__/hub-cat-editor.test.tsx
@@ -512,7 +512,7 @@ describe('HubCatEditor', () => {
       },
     );
 
-    const heading = document.body.querySelector('h3');
+    const heading = document.body.querySelector('h5');
     const strategySelect = queryField<HTMLSelectElement>(container, 'select[aria-label="Session Strategy"]');
     expect(heading?.textContent).toBe('Session State / Chain');
     expect(heading?.nextElementSibling?.contains(strategySelect)).toBe(true);
@@ -3789,7 +3789,7 @@ describe('HubCatEditor', () => {
     expect(document.body.textContent).toContain('别名与 @ 路由');
     expect(document.body.textContent).toContain('认证与模型');
     expect(
-      Array.from(document.body.querySelectorAll('h3')).some(
+      Array.from(document.body.querySelectorAll('h5')).some(
         (heading) => heading.textContent === 'Session State / Chain',
       ),
     ).toBe(true);
@@ -4043,7 +4043,7 @@ describe('HubCatEditor', () => {
     await flushEffects();
 
     expect(
-      Array.from(document.body.querySelectorAll('h3')).some(
+      Array.from(document.body.querySelectorAll('h5')).some(
         (heading) => heading.textContent === 'Session State / Chain',
       ),
     ).toBe(true);

--- a/packages/web/src/components/__tests__/session-chain-panel.test.ts
+++ b/packages/web/src/components/__tests__/session-chain-panel.test.ts
@@ -327,10 +327,10 @@ describe('F24: SessionChainPanel', () => {
     expect(container.textContent).toContain('0 compress observed');
   });
 
-  it('shows the applied policy and exact execution status on the active session node', async () => {
+  it('keeps applied policy details out of active cards and sealed summaries', async () => {
     mockSessionsResponse([
       {
-        id: 'policy-node',
+        id: 'active-policy-node',
         catId: 'opus',
         seq: 0,
         status: 'active',
@@ -348,16 +348,51 @@ describe('F24: SessionChainPanel', () => {
           },
         },
       },
+      {
+        id: 'sealed-policy-node',
+        catId: 'codex',
+        seq: 1,
+        status: 'sealed',
+        messageCount: 12,
+        compressionCount: 2,
+        contextHealth: {
+          usedTokens: 94_720,
+          windowTokens: 128_000,
+          fillRatio: 0.74,
+          source: 'exact',
+        },
+        sealReason: 'threshold',
+        createdAt: Date.now() - 60_000,
+        sealedAt: Date.now() - 30_000,
+        appliedPolicy: {
+          config: { strategy: 'handoff', thresholds: { warn: 0.8, action: 0.9 } },
+          source: 'runtime_override',
+          revision: 'runtime:handoff:1',
+          changedAt: 1,
+          execution: {
+            status: 'unavailable',
+            missingCapabilities: ['authoritative_usage'],
+          },
+        },
+      },
     ]);
 
     renderPanel('thread-policy-state');
     await flushFetch();
 
-    const policyState = container.querySelector('[data-testid="session-policy-state"]');
-    expect(policyState?.textContent).toContain('hybrid');
-    expect(policyState?.textContent).toContain('degraded');
-    expect(policyState?.textContent).toContain('compression_signal');
-    expect(policyState?.textContent).toContain('session_rotation');
+    expect(container.querySelector('[data-testid="session-policy-state"]')).toBeNull();
+    expect(container.textContent).not.toContain('compression_signal');
+    expect(container.textContent).not.toContain('session_rotation');
+
+    expandSealed();
+    const sealedSummary = container.querySelector<HTMLElement>('[data-testid="sealed-session-summary"]');
+    await act(async () => sealedSummary?.querySelector<HTMLButtonElement>('button[aria-expanded="false"]')?.click());
+    expect(sealedSummary?.textContent).toContain('74%');
+    expect(sealedSummary?.textContent).toContain('2 compress');
+    expect(sealedSummary?.textContent).toContain('threshold');
+    expect(sealedSummary?.textContent).not.toContain('handoff');
+    expect(sealedSummary?.textContent).not.toContain('unavailable');
+    expect(sealedSummary?.textContent).not.toContain('authoritative_usage');
   });
 
   it('collapses repeated 0-msg tool_conflict retry corpses into one summary (F201-churn)', async () => {

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { CatData } from '@/hooks/useCatData';
-import { TriangleAlertIcon } from './HubConfigIcons';
 import { HubSessionStrategyEditor } from './HubSessionStrategyEditor';
 import {
   CODEX_APPROVAL_OPTIONS,
@@ -72,12 +71,12 @@ export function AdvancedRuntimeSection({
           onChange={(value) => onChange({ contextWindow: value })}
           inputMode="numeric"
           tone="success"
-          placeholder="留空或 0 = Auto（由 CLI / 模型目录自动探测）"
+          placeholder="留空或 0 = Auto；正整数 = Manual"
         />
         <p className="text-xs leading-5 text-[var(--console-runtime-hint)]">
           填写正整数 = Manual 模式，作为该成员的上下文窗口大小。留空或填 0 = Auto，由运行时自动探测。
         </p>
-        <ResolvedContextInfo cat={cat} />
+        <ContextWindowCompatibilityNotice cat={cat} contextWindow={form.contextWindow} />
         {cliExtensionsAvailable && cliEffortOptions ? (
           <>
             <TextField
@@ -196,52 +195,19 @@ export function AdvancedRuntimeSection({
   );
 }
 
-// ─── #1208 Item 4: Resolved Context Info ─────────────────────────────
+function ContextWindowCompatibilityNotice({ cat, contextWindow }: { cat?: CatData | null; contextWindow: string }) {
+  const capability = cat?.resolvedContext;
+  if (capability?.reportsRuntimeWindow !== false || capability.nativeWindowControl !== false) return null;
 
-const SOURCE_LABELS: Record<string, string> = {
-  reported: 'CLI 实时上报',
-  manual: '手动设置',
-  catalog: '模型目录',
-};
-
-const SOURCE_BADGES: Record<string, string> = {
-  reported: '✓ 运行时',
-  manual: '✓ 手动',
-  catalog: '≈ 目录',
-};
-
-/** Show resolved context window info below the Context Window field. */
-function ResolvedContextInfo({ cat }: { cat?: CatData | null }) {
-  if (!cat) return null;
-
-  const rc = cat.resolvedContext;
-  if (!rc || !rc.source) {
-    return (
-      <div className="text-xs leading-5 text-cafe-muted">
-        <p className="flex items-start gap-1">
-          <TriangleAlertIcon />
-          <span>未能解析 Context Window — 无已知的模型目录条目或 CLI 上报值。</span>
-        </p>
-        {rc?.capabilityReason ? <p className="mt-0.5">原因: {rc.capabilityReason}</p> : null}
-      </div>
-    );
-  }
-
-  const badge = SOURCE_BADGES[rc.source] ?? rc.source;
-  const sourceLabel = SOURCE_LABELS[rc.source] ?? rc.source;
-  const windowK = rc.windowTokens ? Math.round(rc.windowTokens / 1000) : 0;
+  const manualWindow = Number(contextWindow.trim());
+  const isManual = Number.isInteger(manualWindow) && manualWindow > 0;
+  if (!isManual && capability.source) return null;
 
   return (
-    <div className="rounded-[8px] border border-[var(--console-runtime-group-bg)] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-cafe-secondary">
-      <p>
-        <span className="font-semibold">{badge}</span>
-        {' · '}
-        解析值: {windowK}K tokens
-        {' · '}
-        来源: {sourceLabel}
-        {rc.actionable ? '' : '（仅供参考，不触发自动 Session 操作）'}
-      </p>
-      <p className="mt-0.5 text-cafe-muted">{rc.provenance}</p>
-    </div>
+    <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">
+      {isManual
+        ? '当前 Client 无法校验或调整自身的上下文窗口；请确认 Manual 值不高于 Client 的实际上限。'
+        : '当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。'}
+    </p>
   );
 }

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -76,7 +76,7 @@ export function AdvancedRuntimeSection({
         <p className="text-xs leading-5 text-[var(--console-runtime-hint)]">
           填写正整数 = Manual 模式，作为该成员的上下文窗口大小。留空或填 0 = Auto，由运行时自动探测。
         </p>
-        <ContextWindowCompatibilityNotice cat={cat} contextWindow={form.contextWindow} />
+        <ContextWindowCompatibilityNotice cat={cat} form={form} />
         {cliExtensionsAvailable && cliEffortOptions ? (
           <>
             <TextField
@@ -195,13 +195,42 @@ export function AdvancedRuntimeSection({
   );
 }
 
-function ContextWindowCompatibilityNotice({ cat, contextWindow }: { cat?: CatData | null; contextWindow: string }) {
-  const capability = cat?.resolvedContext;
-  if (capability?.reportsRuntimeWindow !== false || capability.nativeWindowControl !== false) return null;
+function selectionMatchesSavedContext(cat: CatData | null | undefined, form: HubCatEditorFormState): boolean {
+  if (!cat || cat.clientId !== form.clientId || Boolean(cat.acp) !== form.acpEnabled) return false;
+  if (form.clientId !== 'openai') return true;
+  return (cat.cli?.carrier ?? '') === form.codexCarrier;
+}
 
-  const manualWindow = Number(contextWindow.trim());
+function draftCannotResolveOrApplyContextWindow(form: HubCatEditorFormState): boolean | null {
+  if (form.acpEnabled) return false;
+  if (form.clientId === 'antigravity' || form.clientId === 'catagent') return true;
+  if (form.clientId !== 'openai') return false;
+  if (form.codexCarrier === 'app_server') return true;
+  if (form.codexCarrier === 'exec_json') return false;
+  return null;
+}
+
+function ContextWindowCompatibilityNotice({ cat, form }: { cat?: CatData | null; form: HubCatEditorFormState }) {
+  const usesSavedContext = selectionMatchesSavedContext(cat, form);
+  const capability = usesSavedContext ? cat?.resolvedContext : null;
+  const projectedIncompatibility =
+    capability?.reportsRuntimeWindow === false && capability.nativeWindowControl === false
+      ? true
+      : capability?.reportsRuntimeWindow === true || capability?.nativeWindowControl === true
+        ? false
+        : null;
+  const cannotResolveOrApply = projectedIncompatibility ?? draftCannotResolveOrApplyContextWindow(form);
+  if (cannotResolveOrApply !== true) return null;
+
+  const manualWindow = Number(form.contextWindow.trim());
   const isManual = Number.isInteger(manualWindow) && manualWindow > 0;
-  if (!isManual && capability.source) return null;
+  const hasCurrentAutoResolution =
+    !isManual &&
+    usesSavedContext &&
+    cat?.contextWindow == null &&
+    cat?.defaultModel === form.defaultModel &&
+    (capability?.source === 'reported' || capability?.source === 'catalog');
+  if (hasCurrentAutoResolution) return null;
 
   return (
     <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -203,7 +203,7 @@ function selectionMatchesSavedContext(cat: CatData | null | undefined, form: Hub
 
 function draftCannotResolveOrApplyContextWindow(form: HubCatEditorFormState): boolean | null {
   if (form.acpEnabled) return false;
-  if (form.clientId === 'antigravity' || form.clientId === 'catagent') return true;
+  if (form.clientId === 'antigravity' || form.clientId === 'catagent' || form.clientId === 'google') return true;
   if (form.clientId !== 'openai') return false;
   if (form.codexCarrier === 'app_server') return true;
   if (form.codexCarrier === 'exec_json') return false;

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getContextWindowFallback } from '@cat-cafe/shared';
 import type { CatData } from '@/hooks/useCatData';
 import { HubSessionStrategyEditor } from './HubSessionStrategyEditor';
 import {
@@ -230,7 +231,8 @@ function ContextWindowCompatibilityNotice({ cat, form }: { cat?: CatData | null;
     cat?.contextWindow == null &&
     cat?.defaultModel === form.defaultModel &&
     (capability?.source === 'reported' || capability?.source === 'catalog');
-  if (hasCurrentAutoResolution) return null;
+  const hasCatalogAutoResolution = !isManual && getContextWindowFallback(form.defaultModel) != null;
+  if (hasCurrentAutoResolution || hasCatalogAutoResolution) return null;
 
   return (
     <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">

--- a/packages/web/src/components/hub-cat-editor-advanced.tsx
+++ b/packages/web/src/components/hub-cat-editor-advanced.tsx
@@ -73,6 +73,7 @@ export function AdvancedRuntimeSection({
           inputMode="numeric"
           tone="success"
           placeholder="留空或 0 = Auto；正整数 = Manual"
+          ariaDescribedBy="context-window-compat-notice"
         />
         <p className="text-xs leading-5 text-[var(--console-runtime-hint)]">
           填写正整数 = Manual 模式，作为该成员的上下文窗口大小。留空或填 0 = Auto，由运行时自动探测。
@@ -235,10 +236,13 @@ function ContextWindowCompatibilityNotice({ cat, form }: { cat?: CatData | null;
   if (hasCurrentAutoResolution || hasCatalogAutoResolution) return null;
 
   return (
-    <p className="rounded-[10px] bg-[var(--console-field-bg)] px-3 py-2 text-xs leading-5 text-[var(--cafe-accent)]">
+    <output
+      id="context-window-compat-notice"
+      className="block rounded-[10px] border border-conn-amber-ring bg-conn-amber-bg px-3 py-2 text-xs leading-5 text-conn-amber-text"
+    >
       {isManual
         ? '当前 Client 无法校验或调整自身的上下文窗口；请确认 Manual 值不高于 Client 的实际上限。'
         : '当前 Client 无法自动探测上下文窗口；请填写正整数使用 Manual 模式。'}
-    </p>
+    </output>
   );
 }

--- a/packages/web/src/components/hub-cat-editor-fields.tsx
+++ b/packages/web/src/components/hub-cat-editor-fields.tsx
@@ -74,6 +74,7 @@ export function TextField({
   suggestions,
   required = false,
   tone = 'neutral',
+  ariaDescribedBy,
 }: {
   label: string;
   ariaLabel?: string;
@@ -84,6 +85,7 @@ export function TextField({
   suggestions?: readonly string[];
   required?: boolean;
   tone?: 'neutral' | 'success';
+  ariaDescribedBy?: string;
 }) {
   const listId = suggestions?.length
     ? `input-suggestions-${(ariaLabel ?? label).replace(/\s+/g, '-').toLowerCase()}`
@@ -96,6 +98,7 @@ export function TextField({
     <FieldShell label={label} required={required} tone={tone}>
       <input
         aria-label={ariaLabel ?? label}
+        aria-describedby={ariaDescribedBy}
         value={value}
         onChange={(event) => onChange(event.target.value)}
         className={`w-full rounded-[10px] border px-3 py-1.5 text-compact leading-5 text-cafe-black placeholder:text-cafe-muted outline-none transition focus:ring-1 ${inputColors}`}


### PR DESCRIPTION
## PR Type

- [x] 🐛 **Patch** — Bug fix, test gap, and bounded static-catalog extraction (no Feature Doc needed)
- [ ] ✨ **Feature** — New capability or behavior change (requires Feature Doc)
- [ ] 📋 **Protocol** — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #1343

## What

- Keep the normal member editor's Context Window surface to the Auto/Manual input and one concise explanation.
- Hide resolved catalog/provenance/carrier diagnostics; show only an actionable client/window incompatibility warning when it affects the choice.
- Render `Session State / Chain` as a subordinate section heading with the existing Session Strategy fields directly underneath.
- Remove applied-policy strategy/execution projections from active Runtime Session Chain cards and sealed-session summaries while retaining meaningful session facts.
- Move the unchanged static context-window catalog into `shared package`; Web draft guidance and API resolution now consume one truth source while the existing API import path remains a compatibility facade.
- Add regression coverage for the compact hierarchy, Auto and Manual warning branches, warning accessibility, strategy field ordering, and both runtime-panel projections.

## Why

The settings page and Runtime Session Chain exposed internal policy diagnostics as if they were normal operator choices. This patch restores the intended information hierarchy while preserving the runtime semantics delivered by #1208/#1209 and #1329/#1334. The catalog extraction prevents Web guidance and API resolution from drifting without creating a second config path.

## Tradeoff

Runtime-derived context values, capability provenance, and applied-policy strategy/execution are no longer projected in normal settings/session cards. They remain available to the underlying runtime/config flow; the UI now surfaces only incompatibility information that gives the operator a concrete action. The shared package gains one static catalog module, but there is no schema, persistence, lifecycle, or runtime resolution-priority change.

## Maintainer Ownership Gate

- Q1 PASS — aligns with the accepted issue and makes member configuration clearer without changing Clowder AI's collaboration direction.
- Q2 PASS — bounded Web hierarchy correction plus a static catalog extraction into `shared package`; the API keeps its existing import path and runtime resolution behavior.
- Q3 PASS — issue #1343 is triaged and accepted by the maintainer.
- Q4 PASS — React/UI, shared static data, API compatibility import, and tests only; no dependency, language, persistence, schema, auth, or external contract addition.
- Q5 PASS — owned debt in nine existing/new source-test files, regression coverage included, commit-level rollback available, and no release/security/production-data/support-matrix expansion.

## Risk Routing

- Behavior: medium — visible settings hierarchy and warning semantics change; covered by targeted UI tests, browser acceptance, and full gate.
- Data: none — no persistence or migration delta.
- Security: none — no auth, secret, permission, or network-boundary delta.
- Contract: low — the shared catalog becomes the source of truth while the API compatibility import path remains stable.
- Irreversible: none — branch commits are revertible; no production state changed.

## Test Evidence

```text
Original RED: targeted hub-cat-editor suite — 78 tests, 73 passed / 5 expected hierarchy failures
Original GREEN: targeted hub-cat-editor suite — 78 passed
Original RED: targeted SessionChainPanel suite — 57 tests, 56 passed / 1 expected policy-row failure
Original GREEN: targeted SessionChainPanel suite — 57 passed

Maintainer P1/P2 RED: exact HEAD 04f5e6b960 exposed h3 under parent h4 and a neutral, unassociated warning.
Maintainer P1/P2 GREEN:
- packages/web targeted Vitest: src/components/__tests__/hub-cat-editor.test.tsx — 81/81 passed
- packages/shared build — passed
- pnpm --filter packages/web exec tsc --noEmit — passed
- biome changed-file check + git diff --check — passed
- env -u NODE_ENV pnpm gate @ 76a926faac4b06723641ce930e7400ae8ef0a190 — GATE PASSED
  (latest-main rebase, build, TypeScript, all tests, lint, and check)
```

Browser acceptance used an isolated checkout and data store at `http://localhost:5182` (API 3182, Redis 6318):

- Settings → Members → `codex-sol`: exact Auto/Manual placeholder and helper copy; internal resolved/provenance details absent.
- Entering `128000` exercised Manual, clearing it restored Auto.
- `Session State / Chain` was followed directly by Session Strategy.
- Handoff, compress, and hybrid each exposed the expected existing strategy fields.
- DOM acceptance: `hiddenInternalDetails=true`, `strategyImmediatelyBelow=true`, options `handoff/compress/hybrid`; 0 browser errors.
- Runtime-panel preview used an API-backed chain with a policy-bearing active card and a policy-bearing sealed card; the source response retained both snapshots while the UI regression verifies neither projection renders and the sealed summary keeps 74% context, 2 compressions, and threshold reason.

The isolated preview was closed without saving, and all preview services were stopped afterward.

## Architecture Ownership

- Architecture cells: existing Web settings/member editor, Runtime Session Chain presentation, shared static context-window catalog, and API compatibility facade
- Map delta: none
- Why: no Store, Queue, Router, Adapter, Dispatcher, Binding, persisted configuration, or runtime resolution boundary changed.


