### PR TITLE
fix(F167): a scheduler wake row was not a valid approval origin, so timer-woken sessions could never hand off

### DIFF
--- a/packages/api/src/domains/approval-hub/ApprovalIngress.ts
+++ b/packages/api/src/domains/approval-hub/ApprovalIngress.ts
@@ -2,6 +2,7 @@ import type { ApprovalEnvelope, ApprovalOriginRef, ApprovalProducerId, CatId, Ri
 import { approvalProducerMeta, validateApprovalEnvelope, validateApprovalOriginRef } from '@cat-cafe/shared';
 import type { SocketManager } from '../../infrastructure/websocket/index.js';
 import type { IMessageStore, StoredMessage } from '../cats/services/stores/ports/MessageStore.js';
+import { isSystemUserMessage } from '../cats/services/stores/visibility.js';
 import { approvalCardIdempotencyKey, buildApprovalCardBlock } from './buildApprovalCardBlock.js';
 import type { ApprovalPublicationStore } from './ports/ApprovalPublicationStore.js';
 
@@ -218,7 +219,27 @@ export class ApprovalIngress {
     const origin = await this.deps.messageStore.getById(draft.originRef.messageId);
     if (!origin || origin.deletedAt || origin._tombstone) throw new Error('Approval origin message not found');
     if (origin.threadId !== draft.originRef.threadId) throw new Error('Approval origin message thread mismatch');
-    if (origin.userId !== draft.ownerUserId) throw new Error('Approval origin message owner mismatch');
+    // Cross-tenant isolation is the assertion ABOVE: the origin must live in the
+    // caller's own thread. What remains here is a narrower question — who may have
+    // authored a row inside that thread — and a system pseudo-user speaking in your
+    // own thread is not another tenant.
+    //
+    // Without the exemption this rejected precisely the sessions that need it most.
+    // A session-handoff proposal anchors on the message that triggered the
+    // invocation, and for any long-running session that message IS the scheduler's
+    // wake row ("持球唤醒"), persisted as userId='scheduler' / catId=null. So a
+    // timer-woken cat could never hand off, while the same proposal from an
+    // A2A-triggered turn (authored by the real owner) went through — the failure
+    // was invisible except as a 500 with no actionable text.
+    //
+    // isSystemUserMessage is the store layer's existing predicate for exactly this
+    // distinction, and it is deliberately reused rather than re-derived here: it
+    // requires BOTH a system userId AND a system/null catId, so a cat-authored row
+    // wearing a system userId stays rejected. A second, private definition of "is
+    // this the system" is how the two drift apart.
+    if (origin.userId !== draft.ownerUserId && !isSystemUserMessage(origin)) {
+      throw new Error('Approval origin message owner mismatch');
+    }
   }
 
   private async findPersistedCard(

--- a/packages/api/src/domains/approval-hub/ApprovalIngress.ts
+++ b/packages/api/src/domains/approval-hub/ApprovalIngress.ts
@@ -219,16 +219,18 @@ export class ApprovalIngress {
     const origin = await this.deps.messageStore.getById(draft.originRef.messageId);
     if (!origin || origin.deletedAt || origin._tombstone) throw new Error('Approval origin message not found');
     if (origin.threadId !== draft.originRef.threadId) throw new Error('Approval origin message thread mismatch');
-    // Cross-tenant isolation is the assertion ABOVE: the origin must live in the
-    // caller's own thread. What remains here is a narrower question — who may have
-    // authored a row inside that thread — and a system pseudo-user speaking in your
-    // own thread is not another tenant.
+    // Cross-tenant isolation rests on the assertion ABOVE: the origin must live in
+    // the thread the draft names. What remains here is a narrower question — who
+    // may have authored a row inside that thread — and a system pseudo-user
+    // speaking in your own thread is not another tenant.
     //
-    // Read that precisely (@codex-luna's review): the threadId equality is a
-    // CALLER invariant, not an authorization check this class performs on an
-    // arbitrary draft. It holds on the F225 session-handoff path because that
-    // producer builds the draft from an authenticated InvocationRecord — a request
-    // body cannot rewrite threadId, userId or the trigger messageId.
+    // State that precisely (@codex-luna's review): the CALLER invariant is the
+    // AUTHENTICATED ORIGIN BINDING, not the threadId comparison. This class does
+    // perform that comparison; what it cannot verify is whether the originRef it
+    // was handed — threadId, and the ownerUserId compared below — came from an
+    // authenticated record at all. On the F225 session-handoff path they do: that
+    // producer derives them from an authenticated InvocationRecord, and a request
+    // body cannot rewrite them.
     //
     // ApprovalIngress serves several producers, so that is a property of the F225
     // path and NOT of this class. Any producer deriving a draft from untrusted

--- a/packages/api/src/domains/approval-hub/ApprovalIngress.ts
+++ b/packages/api/src/domains/approval-hub/ApprovalIngress.ts
@@ -224,13 +224,17 @@ export class ApprovalIngress {
     // authored a row inside that thread — and a system pseudo-user speaking in your
     // own thread is not another tenant.
     //
-    // Read that precisely (砚砚 review): the threadId equality is a CALLER
-    // invariant, not an authorization check this class performs on an arbitrary
-    // draft. It holds today because the only producer of this draft builds it from
-    // an authenticated InvocationRecord — request bodies cannot rewrite threadId,
-    // userId or the trigger messageId. A future producer that derives a draft from
-    // untrusted input must re-establish that binding itself; the exemption below
-    // assumes it rather than proving it.
+    // Read that precisely (@codex-luna's review): the threadId equality is a
+    // CALLER invariant, not an authorization check this class performs on an
+    // arbitrary draft. It holds on the F225 session-handoff path because that
+    // producer builds the draft from an authenticated InvocationRecord — a request
+    // body cannot rewrite threadId, userId or the trigger messageId.
+    //
+    // ApprovalIngress serves several producers, so that is a property of the F225
+    // path and NOT of this class. Any producer deriving a draft from untrusted
+    // input must itself establish and validate an authenticated
+    // owner/thread/origin binding before calling this ingress; the exemption below
+    // assumes that binding rather than proving it.
     //
     // Without the exemption this rejected precisely the sessions that need it most.
     // A session-handoff proposal anchors on the message that triggered the

--- a/packages/api/src/domains/approval-hub/ApprovalIngress.ts
+++ b/packages/api/src/domains/approval-hub/ApprovalIngress.ts
@@ -219,24 +219,28 @@ export class ApprovalIngress {
     const origin = await this.deps.messageStore.getById(draft.originRef.messageId);
     if (!origin || origin.deletedAt || origin._tombstone) throw new Error('Approval origin message not found');
     if (origin.threadId !== draft.originRef.threadId) throw new Error('Approval origin message thread mismatch');
-    // Cross-tenant isolation rests on the assertion ABOVE: the origin must live in
-    // the thread the draft names. What remains here is a narrower question — who
-    // may have authored a row inside that thread — and a system pseudo-user
-    // speaking in your own thread is not another tenant.
+    // Cross-tenant isolation here is a CONJUNCTION of two parts, and neither part
+    // is sufficient on its own (@codex-luna's review, rounds 2-4):
     //
-    // State that precisely (@codex-luna's review): the CALLER invariant is the
-    // AUTHENTICATED ORIGIN BINDING, not the threadId comparison. This class does
-    // perform that comparison; what it cannot verify is whether the originRef it
-    // was handed — threadId, and the ownerUserId compared below — came from an
-    // authenticated record at all. On the F225 session-handoff path they do: that
-    // producer derives them from an authenticated InvocationRecord, and a request
-    // body cannot rewrite them.
+    //   (1) CALLER: originRef.threadId / .messageId and ownerUserId must be bound
+    //       to an authenticated record. This class CANNOT verify that binding.
+    //   (2) THIS CLASS: the assertion above checks that the origin message really
+    //       does live in the thread the draft names.
     //
-    // ApprovalIngress serves several producers, so that is a property of the F225
+    // (2) alone proves nothing about tenancy — a draft naming a thread of its own
+    // choosing satisfies the comparison trivially. It carries weight only because
+    // (1) fixes which thread may be named. On the F225 session-handoff path (1)
+    // holds: that producer derives all three from an authenticated
+    // InvocationRecord, and a request body cannot rewrite them.
+    //
+    // ApprovalIngress serves several producers, so (1) is a property of the F225
     // path and NOT of this class. Any producer deriving a draft from untrusted
-    // input must itself establish and validate an authenticated
-    // owner/thread/origin binding before calling this ingress; the exemption below
-    // assumes that binding rather than proving it.
+    // input must itself establish and validate that binding before calling this
+    // ingress; the exemption below assumes (1) rather than proving it.
+    //
+    // Given (1) AND (2), what the comparison below still decides is narrower: who
+    // may have authored a row inside an already-verified thread — and a system
+    // pseudo-user speaking in that thread is not another tenant.
     //
     // Without the exemption this rejected precisely the sessions that need it most.
     // A session-handoff proposal anchors on the message that triggered the

--- a/packages/api/src/domains/approval-hub/ApprovalIngress.ts
+++ b/packages/api/src/domains/approval-hub/ApprovalIngress.ts
@@ -224,6 +224,14 @@ export class ApprovalIngress {
     // authored a row inside that thread — and a system pseudo-user speaking in your
     // own thread is not another tenant.
     //
+    // Read that precisely (砚砚 review): the threadId equality is a CALLER
+    // invariant, not an authorization check this class performs on an arbitrary
+    // draft. It holds today because the only producer of this draft builds it from
+    // an authenticated InvocationRecord — request bodies cannot rewrite threadId,
+    // userId or the trigger messageId. A future producer that derives a draft from
+    // untrusted input must re-establish that binding itself; the exemption below
+    // assumes it rather than proving it.
+    //
     // Without the exemption this rejected precisely the sessions that need it most.
     // A session-handoff proposal anchors on the message that triggered the
     // invocation, and for any long-running session that message IS the scheduler's

--- a/packages/api/test/approval-hub/approval-ingress.test.js
+++ b/packages/api/test/approval-hub/approval-ingress.test.js
@@ -130,10 +130,7 @@ describe('ApprovalIngress', () => {
     const harness = makeHarness({ userId: 'user-2', catId: null });
     const store = new FakePublicationStore();
 
-    await assert.rejects(
-      () => harness.ingress.publish(makeDraft(), store),
-      /Approval origin message owner mismatch/,
-    );
+    await assert.rejects(() => harness.ingress.publish(makeDraft(), store), /Approval origin message owner mismatch/);
   });
 
   // isSystemUserMessage requires BOTH a system userId AND a system/null catId, so
@@ -143,10 +140,7 @@ describe('ApprovalIngress', () => {
     const harness = makeHarness({ userId: 'scheduler', catId: 'codex-sol' });
     const store = new FakePublicationStore();
 
-    await assert.rejects(
-      () => harness.ingress.publish(makeDraft(), store),
-      /Approval origin message owner mismatch/,
-    );
+    await assert.rejects(() => harness.ingress.publish(makeDraft(), store), /Approval origin message owner mismatch/);
   });
 
   it('persists one card, commits its exact envelope, then broadcasts', async () => {

--- a/packages/api/test/approval-hub/approval-ingress.test.js
+++ b/packages/api/test/approval-hub/approval-ingress.test.js
@@ -41,7 +41,7 @@ class FakePublicationStore {
   }
 }
 
-function appendOrigin(messageStore) {
+function appendOrigin(messageStore, authorOverrides = {}) {
   messageStore.append({
     userId: ownerUserId,
     catId: null,
@@ -49,6 +49,7 @@ function appendOrigin(messageStore) {
     mentions: [],
     timestamp: 1_721_111_110_000,
     threadId: originRef.threadId,
+    ...authorOverrides,
   });
   const stored = messageStore.getByThread(originRef.threadId, 1)[0];
   stored.id = originRef.messageId;
@@ -76,9 +77,9 @@ function makeDraft(overrides = {}) {
   };
 }
 
-function makeHarness() {
+function makeHarness(originAuthorOverrides = {}) {
   const messageStore = new MessageStore();
-  appendOrigin(messageStore);
+  appendOrigin(messageStore, originAuthorOverrides);
   const broadcasts = [];
   const userEvents = [];
   const socketManager = {
@@ -100,6 +101,54 @@ function findApprovalCard(messageStore) {
 }
 
 describe('ApprovalIngress', () => {
+  // F167 — a session-handoff proposal anchors on the message that triggered the
+  // invocation, and for a long-running session that message IS the scheduler's
+  // wake row ("持球唤醒"), persisted under the `scheduler` system pseudo-user with
+  // `catId: null`. A bare `origin.userId !== ownerUserId` check therefore rejected
+  // exactly the sessions most in need of a handoff: every attempt driven by a
+  // timer wake failed with "Approval origin message owner mismatch", while the
+  // same proposal from an A2A-triggered turn (userId = the real owner) succeeded.
+  //
+  // The cross-user protection does not live in this comparison — the preceding
+  // threadId assertion already pins the origin to the caller's own thread. What
+  // this one adds is a rule about WHO may author a row inside that thread, and a
+  // system pseudo-user speaking in your own thread is not another tenant.
+  it('accepts a scheduler-authored origin in the owner thread', async () => {
+    const harness = makeHarness({ userId: 'scheduler', catId: null });
+    const store = new FakePublicationStore();
+
+    const envelope = await harness.ingress.publish(makeDraft(), store);
+
+    assert.equal(store.publication.state, 'anchored');
+    assert.equal(envelope.approvalCardRef.threadId, 'source-thread');
+  });
+
+  // The exemption must not become a hole. A different HUMAN owner is a genuine
+  // cross-tenant anchor and stays rejected — without this, the fix above would be
+  // indistinguishable from deleting the check.
+  it('still rejects an origin authored by another human user', async () => {
+    const harness = makeHarness({ userId: 'user-2', catId: null });
+    const store = new FakePublicationStore();
+
+    await assert.rejects(
+      () => harness.ingress.publish(makeDraft(), store),
+      /Approval origin message owner mismatch/,
+    );
+  });
+
+  // isSystemUserMessage requires BOTH a system userId AND a system/null catId, so
+  // a cat-authored row wearing a system userId is not a system message. Pinning it
+  // here keeps the exemption tied to that predicate rather than to the userId alone.
+  it('rejects a system userId carried by a cat-authored message', async () => {
+    const harness = makeHarness({ userId: 'scheduler', catId: 'codex-sol' });
+    const store = new FakePublicationStore();
+
+    await assert.rejects(
+      () => harness.ingress.publish(makeDraft(), store),
+      /Approval origin message owner mismatch/,
+    );
+  });
+
   it('persists one card, commits its exact envelope, then broadcasts', async () => {
     const harness = makeHarness();
     const store = new FakePublicationStore();


### PR DESCRIPTION
## The bug

`propose_session_handoff` returned `500 Approval origin message owner mismatch` **deterministically** — three consecutive calls, not a transient fault.

The asymmetry is what made it look like a flaky server rather than a rule:

| Trigger for the invocation | origin `userId` | handoff |
|---|---|---|
| scheduler wake row (持球唤醒) | `scheduler` | ✗ 500 |
| A2A cross-thread delivery | real owner | ✓ works |

**So the sessions that need handoff most — the long-running ones, driven by timers, carrying the heaviest context — were the only ones that could never hand off.**

## Root cause

A handoff proposal anchors its approval card on the message that triggered the invocation:

```ts
// callback-propose-session-handoff-routes.ts
const originMessageId = record.originTriggerMessageId ?? record.a2aTriggerMessageId;
```

For a long-running session that message *is* the scheduler's wake row. Read back from the store before changing any code:

```json
{ "userId": "scheduler", "catId": null, "threadId": "thread_mslv8bbw8pbazsz2" }
```

The thread belongs to `default-user`, so `ApprovalIngress.validateOrigin` passed the threadId assertion and then failed `origin.userId !== draft.ownerUserId`.

## Why this is a bug, not the check working

The userId comparison was not protecting what it appeared to protect. Isolation on this path is a **conjunction**: the caller binds `originRef` to an authenticated `InvocationRecord` (fixing which thread may be named), and this class checks the stored origin is consistent with it. What the userId comparison additionally decided was only *who may have authored a row inside an already-verified thread* — and a system pseudo-user speaking in your own thread is not another tenant.

## Fix

Reuse the store layer's existing predicate rather than deriving a second definition:

```ts
if (origin.userId !== draft.ownerUserId && !isSystemUserMessage(origin)) { throw ... }
```

`isSystemUserMessage` requires **both** a system userId (`scheduler`/`system`) **and** a system/null catId, so a cat-authored row wearing a system userId stays rejected. Two parallel definitions of "is this the system" is how they start to drift.

## Tests — three, not one

The second and third exist so this fix **cannot degrade into "delete the check"**:

1. 🔴→🟢 a scheduler-authored origin in the owner thread is accepted
2. 🟢 an origin authored by another **human** user is still rejected
3. 🟢 `userId=scheduler` carried by a **cat-authored** message is still rejected

RED was observed first, and confirmed red *for the right reason*:

```
✖ accepts a scheduler-authored origin in the owner thread
  Error: Approval origin message owner mismatch
      at ApprovalIngress.validateOrigin (ApprovalIngress.js:175:19)
```

| Scope | Before | After |
|---|---|---|
| `approval-ingress.test.js` | 15/16 (1 red) | **16/16** |
| `approval-hub/*.test.js` | — | **299/299** |
| `session-handoff-*` + `propose-session-handoff-route` | — | **54/54** |

The pre-existing `rejects ... cross-owner origins` case stays green throughout — direct evidence the cross-user protection was not weakened.

## Review provenance

Reviewed by **@codex-luna** (Maine Coon — cross-family, non-author) across four rounds. Final verdict on `e5b6b1c96`: **APPROVE, no P1/P2/P3**, with independent verification (build, 60/60, 299/299, F225 route 10/10, `git diff --check`) and a mechanical `non_comment_changed_lines=0` check on the comment-only increments.

Commits are **not** amended — each of the reviewer's verdicts stays anchored to the SHA it was given for:

- `7d4870898` fix + tests — APPROVE
- `7843fb6fa` boundary comment — APPROVE + P3
- `2bad996bc` review credit + scope — APPROVE + P3
- `bd609336d` caller-invariant attribution — APPROVE + P3
- `e5b6b1c96` isolation stated once as a conjunction — **APPROVE, converged**

Three of those rounds landed on the same sentence. The reason was the shape of the fix, not the difficulty of the claim: the comment stated the same security argument three times in prose, so each round corrected the quoted instance and left its paraphrases standing. The final commit states it once, as numbered parts, so there is no second site for it to drift.

## Scope

Behaviour change is one condition in `ApprovalIngress.validateOrigin`. No schema migration, no new wire, no external contract change. The other four commits are comment-only.

**Merge is not authorized by this author line** — merge-gate is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)