### PR TITLE
verdict(eval:friction): 2026-08-15-eval-friction-c1-mixed-actionable-singletons

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/attribution.json
@@ -1,0 +1,36 @@
+{
+  "verdictId": "2026-08-15-eval-friction-c1-mixed-actionable-singletons",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-08-15",
+  "generatedAt": "2026-08-15T03:09:02.052Z",
+  "findings": [
+    {
+      "id": "FR-2026-08-15-c03def938f44",
+      "relatedFeature": "F245",
+      "frictionSignal": {
+        "type": "friction.cluster_c03def938f44",
+        "severity": "high",
+        "confidence": 0.7,
+        "detectedAt": "2026-08-15T03:09:02.052Z"
+      },
+      "attribution": {
+        "primaryLayer": "needs_investigation",
+        "evidence": [
+          {
+            "type": "counter",
+            "anchor": "friction-rollup/cluster_c03def938f44",
+            "excerpt": "cluster 'a2a_timeout: opus' count=1 severity=high sensorForms=[reason]"
+          }
+        ]
+      },
+      "proposedAction": [
+        {
+          "action": "triage-top-friction-cluster",
+          "target": "F245/friction-rollup",
+          "rationale": "Highest-ranked friction cluster in the window — eval cat assigns the 7-class root cause in the verdict before handoff."
+        }
+      ],
+      "status": "open"
+    }
+  ]
+}

--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/lifecycle-root.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/lifecycle-root.json
@@ -1,0 +1,21 @@
+{
+  "verdictId": "2026-08-15-eval-friction-c1-mixed-actionable-singletons",
+  "domainId": "eval:friction",
+  "createdAt": "2026-08-15T03:04:49Z",
+  "verdict": "fix",
+  "harnessUnderEval": {
+    "featureId": "F245",
+    "componentId": "friction-rollup",
+    "name": "friction rollup (Top-N + sensorForm)"
+  },
+  "ownerAsk": {
+    "targetFeatureId": "F245",
+    "targetOwnerCatId": "opus-47",
+    "requestedAction": "Triage both current actionable singleton clusters at the F245 rollup layer: keep the F156/session-recovery repair open because the direct-channel '还是不行' complaint recurred, and inspect the new high-severity a2a_timeout: opus singleton to decide whether it is transient environment drift or a separately owned repair thread."
+  },
+  "acceptanceReevalPlan": {
+    "nextEvalAt": "2026-08-18T03:00:00.000Z",
+    "closureCondition": "Close this finding only after a subsequent every-3d window returns zero actionableCandidates, or the recurring direct-channel complaint is eliminated and the Opus timeout singleton is shown to be transient and non-recurring."
+  },
+  "schemaVersion": 1
+}

--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/provenance.json
@@ -1,0 +1,29 @@
+{
+  "verdictId": "2026-08-15-eval-friction-c1-mixed-actionable-singletons",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/rollup-report.json",
+      "sha256": "f08507431ab9d2c36c277f25e6488a9ba619fb146c443f80bfdec24756cebc42"
+    },
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/measurement-validity.json",
+      "sha256": "de6e862b0bb2894f2a513db3e654fef5ec154fb44f6772906592b5d65877a78a"
+    }
+  ],
+  "generatedAt": "2026-08-15T03:09:02.052Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "2"
+  },
+  "sanitizeRulesVersion": "f267-friction-measurement-v1",
+  "sourceThreadId": "thread_eval_friction",
+  "sourceMessageId": "0001786762799726-000047-24c21855",
+  "sourceRefs": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1786503600000,
+    "windowEndMs": 1786762800000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "publishFallback": "manual-worktree"
+}

--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/measurement-validity.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/measurement-validity.json
@@ -1,0 +1,180 @@
+{
+  "schemaVersion": 1,
+  "measurementTarget": "friction_opportunity_to_action",
+  "window": {
+    "sinceMs": 1786503600000,
+    "untilMs": 1786762800000
+  },
+  "capturedAt": "2026-08-15T03:09:02.052Z",
+  "baselineKind": "prospective_paired_capture",
+  "historicalBaseline": {
+    "classification": "symptom_cohort",
+    "rollupCount": 11,
+    "limitation": "historical_rollups_lack_frozen_canonical_row_ids"
+  },
+  "cancelJoin": {
+    "status": "no_opportunity",
+    "expectedIds": [],
+    "actualIds": [],
+    "intersectionIds": [],
+    "missingIds": [],
+    "extraIds": [],
+    "recall": null
+  },
+  "channels": {
+    "paw-feel": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "cancel": {
+      "opportunity": {
+        "status": "measured",
+        "ids": [],
+        "provenance": "frozen_task_outcome_rows"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "user-feedback": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [
+          "user-feedback:fi_msrr7ie3g99v4y4b",
+          "user-feedback:fi_msrrjlhao784v88j"
+        ],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [
+          "user-feedback:fi_msrr7ie3g99v4y4b",
+          "user-feedback:fi_msrrjlhao784v88j"
+        ],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [
+          "user-feedback:fi_msrr7ie3g99v4y4b",
+          "user-feedback:fi_msrrjlhao784v88j"
+        ],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [
+          "user-feedback:fi_msrr7ie3g99v4y4b",
+          "user-feedback:fi_msrrjlhao784v88j"
+        ],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [
+          "user-feedback:fi_msrr7ie3g99v4y4b",
+          "user-feedback:fi_msrrjlhao784v88j"
+        ],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "eval-domain": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    }
+  },
+  "decision": {
+    "status": "insufficient",
+    "reasons": [
+      "cancel_join:no_opportunity",
+      "downstream_degraded"
+    ],
+    "withdrawalConditions": [
+      "rerun_after_closed_window_with_cancel_opportunity",
+      "rerun_after_downstream_dependencies_recover"
+    ]
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/raw/rollup-report.json
@@ -1,0 +1,143 @@
+{
+  "verdictId": "2026-08-15-eval-friction-c1-mixed-actionable-singletons",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1786503600000,
+    "windowEndMs": 1786762800000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1786503600000,
+    "untilMs": 1786762800000
+  },
+  "signalCount": 2,
+  "clusterCount": 2,
+  "degraded": true,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1786503600000,
+      "untilMs": 1786762800000
+    },
+    "generatedAt": "2026-08-15T03:09:02.052Z",
+    "topClusters": [
+      {
+        "clusterId": "c03def938f44",
+        "representative": "a2a_timeout: opus",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msrrjlhao784v88j",
+            "rawRef": "fi_msrrjlhao784v88j",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "high"
+      },
+      {
+        "clusterId": "cd494b7db6bf",
+        "representative": "text_frustration: 还是不行",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msrr7ie3g99v4y4b",
+            "rawRef": "fi_msrr7ie3g99v4y4b",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "medium"
+      }
+    ],
+    "actionableCandidates": [
+      {
+        "clusterId": "c03def938f44",
+        "representative": "a2a_timeout: opus",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msrrjlhao784v88j",
+            "rawRef": "fi_msrrjlhao784v88j",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "high",
+        "actionability": "actionable_candidate",
+        "followupDraft": {
+          "clusterId": "c03def938f44",
+          "title": "Investigate friction cluster: a2a_timeout: opus",
+          "summary": "a2a_timeout: opus",
+          "evidenceRefs": [
+            "fi_msrrjlhao784v88j"
+          ],
+          "reportingMode": "final-only"
+        },
+        "referenceOnlyEvidenceRefs": []
+      },
+      {
+        "clusterId": "cd494b7db6bf",
+        "representative": "text_frustration: 还是不行",
+        "channels": [
+          "user-feedback"
+        ],
+        "count": 1,
+        "members": [
+          {
+            "signalId": "user-feedback:fi_msrr7ie3g99v4y4b",
+            "rawRef": "fi_msrr7ie3g99v4y4b",
+            "channel": "user-feedback"
+          }
+        ],
+        "method": "rule",
+        "sensorForms": [
+          "reason"
+        ],
+        "severity": "medium",
+        "actionability": "actionable_candidate",
+        "followupDraft": {
+          "clusterId": "cd494b7db6bf",
+          "title": "Investigate friction cluster: text_frustration: 还是不行",
+          "summary": "text_frustration: 还是不行",
+          "evidenceRefs": [
+            "fi_msrr7ie3g99v4y4b"
+          ],
+          "reportingMode": "final-only"
+        },
+        "referenceOnlyEvidenceRefs": []
+      }
+    ],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": true,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 501
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/snapshot.json
@@ -1,0 +1,27 @@
+{
+  "verdictId": "2026-08-15-eval-friction-c1-mixed-actionable-singletons",
+  "evalSnapshotId": "eval-F245-2026-08-15",
+  "featureId": "F245",
+  "generatedAt": "2026-08-15T03:09:02.052Z",
+  "window": {
+    "startMs": 1786503600000,
+    "endMs": 1786762800000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 2,
+        "top_cluster_count": 2,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0,
+        "cluster_c03def938f44": 1,
+        "cluster_cd494b7db6bf": 1
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/verdicts/2026-08-15-eval-friction-c1-mixed-actionable-singletons.md
+++ b/docs/harness-feedback/verdicts/2026-08-15-eval-friction-c1-mixed-actionable-singletons.md
@@ -1,0 +1,35 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-08-15-eval-friction-c1-mixed-actionable-singletons
+source_snapshot: "snapshot:bundle/2026-08-15-eval-friction-c1-mixed-actionable-singletons/snapshot"
+---
+
+# Live Verdict — 2026-08-15-eval-friction-c1-mixed-actionable-singletons
+
+- Verdict: `fix`
+- Phenomenon: The current every-3d friction window from 2026-08-12 03:00 UTC to 2026-08-15 03:00 UTC produced two Top-N user-feedback singleton clusters, and both remain actionable. One repeats the direct-channel '还是不行' complaint on the post-F156 chat visibility path, while the other is a new high-severity a2a_timeout: opus singleton in a separate thread.
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: Primary evidence still points to an execution_gap on the direct-channel/session recovery path because the same '还是不行' friction recurred after prior repair work; the separate a2a_timeout: opus singleton may instead be environment_drift, so this mixed window is routed at the F245 rollup owner level with medium confidence. (confidence medium)
+- Owner ask: Triage both current actionable singleton clusters at the F245 rollup layer: keep the F156/session-recovery repair open because the direct-channel '还是不行' complaint recurred, and inspect the new high-severity a2a_timeout: opus singleton to decide whether it is transient environment drift or a separately owned repair thread.
+- Re-eval: next eval at 2026-08-18T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-08-15-eval-friction-c1-mixed-actionable-singletons/snapshot
+- attribution:bundle/2026-08-15-eval-friction-c1-mixed-actionable-singletons/FR-2026-08-15-c03def938f44
+- metric:official.rollup_signal_count
+- metric:official.rollup_cluster_count
+- metric:official.actionable_candidates
+- metric:official.reference_only_clusters
+- metric:baseline.official.rollup_signal_count
+- metric:baseline.official.rollup_cluster_count
+- metric:baseline.official.actionable_candidates
+- metric:baseline.official.reference_only_clusters
+
+Counterarguments:
+- Both current clusters are singletons on one channel, so the apparent regression could still be noise rather than a durable friction trend.
+- The high-severity Opus timeout may be transient provider instability, which would make a fix verdict too aggressive if it does not recur.
+- Because the two actionable clusters come from different threads and likely different mechanisms, a domain-level mixed verdict may over-group unrelated issues.


### PR DESCRIPTION
Verdict published for `eval:friction` after the official `cat_cafe_publish_verdict` path failed on missing `measurement-bundles.yaml`.

- Verdict: `fix`
- Domain: `eval:friction`
- Phenomenon: The August 12, 2026 03:00 UTC to August 15, 2026 03:00 UTC window produced two actionable singleton user-feedback clusters: a recurring direct-channel `还是不行` complaint on the post-F156 chat visibility path, and a new high-severity `a2a_timeout: opus` singleton.
- Requested action: Triage both current actionable singleton clusters at the F245 rollup layer: keep the F156/session-recovery repair open because the direct-channel complaint recurred, and inspect the new high-severity `a2a_timeout: opus` singleton to decide whether it is transient environment drift or a separately owned repair thread.
- Source thread: `thread_eval_friction`
- Source message: `0001786762799726-000047-24c21855`

Traceability also lives in `docs/harness-feedback/bundles/2026-08-15-eval-friction-c1-mixed-actionable-singletons/provenance.json` via `sourceThreadId`.
