### PR TITLE
feat(skills): add grill-with-docs workflow

### DIFF
--- a/cat-cafe-skills/BOOTSTRAP.md
+++ b/cat-cafe-skills/BOOTSTRAP.md
@@ -21,6 +21,9 @@ co-creation docs → co-creation-docs → direct push | merge-gate(docs PR)
 | `guide-authoring` | 编排场景引导 YAML / registry / 标签契约 | — |
 | `guide-interaction` | 判断是否需要交互引导，并按 Guide Matched/Pending/Active 等状态驱动回复 | — |
 | `collaborative-thinking` | brainstorm/多猫讨论/收敛 | — |
+| `grill-with-docs` | 把方案拷问与 glossary/ADR 沉淀组合成一次设计会话 | — |
+| `grilling` | 用 design tree/frontier 轮次拷问方案并确认 shared understanding | — |
+| `domain-modeling` | 统一领域术语、更新 CONTEXT.md，并仅为关键取舍记录 ADR | — |
 | `expert-panel` | 专家辩论团/竞品分析/技术趋势/showcase | — |
 | `writing-plans` | 写实施计划 | ① impl |
 | `co-creation-docs` | 共创型 docs-only 落盘：按冲突/治理/可逆性选择 direct push 或 PR | — |

--- a/cat-cafe-skills/domain-modeling/ADR-FORMAT.md
+++ b/cat-cafe-skills/domain-modeling/ADR-FORMAT.md
@@ -1,0 +1,47 @@
+# ADR Format
+
+ADRs live in `docs/adr/` and use sequential numbering: `0001-slug.md`, `0002-slug.md`, etc.
+
+Create the `docs/adr/` directory lazily — only when the first ADR is needed.
+
+## Template
+
+```md
+# {Short title of the decision}
+
+{1-3 sentences: what's the context, what did we decide, and why.}
+```
+
+That's it. An ADR can be a single paragraph. The value is in recording *that* a decision was made and *why* — not in filling out sections.
+
+## Optional sections
+
+Only include these when they add genuine value. Most ADRs won't need them.
+
+- **Status** frontmatter (`proposed | accepted | deprecated | superseded by ADR-NNNN`) — useful when decisions are revisited
+- **Considered Options** — only when the rejected alternatives are worth remembering
+- **Consequences** — only when non-obvious downstream effects need to be called out
+
+## Numbering
+
+Scan `docs/adr/` for the highest existing number and increment by one.
+
+## When to offer an ADR
+
+All three of these must be true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will look at the code and wonder "why on earth did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If a decision is easy to reverse, skip it — you'll just reverse it. If it's not surprising, nobody will wonder why. If there was no real alternative, there's nothing to record beyond "we did the obvious thing."
+
+### What qualifies
+
+- **Architectural shape.** "We're using a monorepo." "The write model is event-sourced, the read model is projected into Postgres."
+- **Integration patterns between contexts.** "Ordering and Billing communicate via domain events, not synchronous HTTP."
+- **Technology choices that carry lock-in.** Database, message bus, auth provider, deployment target. Not every library — just the ones that would take a quarter to swap out.
+- **Boundary and scope decisions.** "Customer data is owned by the Customer context; other contexts reference it by ID only." The explicit no-s are as valuable as the yes-s.
+- **Deliberate deviations from the obvious path.** "We're using manual SQL instead of an ORM because X." Anything where a reasonable reader would assume the opposite. These stop the next engineer from "fixing" something that was deliberate.
+- **Constraints not visible in the code.** "We can't use AWS because of compliance requirements." "Response times must be under 200ms because of the partner API contract."
+- **Rejected alternatives when the rejection is non-obvious.** If you considered GraphQL and picked REST for subtle reasons, record it — otherwise someone will suggest GraphQL again in six months.

--- a/cat-cafe-skills/domain-modeling/CONTEXT-FORMAT.md
+++ b/cat-cafe-skills/domain-modeling/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/cat-cafe-skills/domain-modeling/LICENSE
+++ b/cat-cafe-skills/domain-modeling/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cat-cafe-skills/domain-modeling/PROVENANCE.md
+++ b/cat-cafe-skills/domain-modeling/PROVENANCE.md
@@ -1,0 +1,13 @@
+# Provenance
+
+- Upstream repository: <https://github.com/mattpocock/skills>
+- Upstream path: `skills/engineering/domain-modeling`
+- Pinned revision: `8b78b531ab965735c5dc74f6f7a219e1e37326df`
+- License: MIT
+- Imported: 2026-08-15
+
+## Clowder adaptation
+
+- Added Clowder routing boundaries, output contract, examples, common mistakes, and next-skill guidance.
+- Made target-repository governance and document conventions override the upstream default paths and formats.
+- Preserved inline glossary updates, code cross-checking, lazy file creation, and the three-part ADR threshold.

--- a/cat-cafe-skills/domain-modeling/SKILL.md
+++ b/cat-cafe-skills/domain-modeling/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: domain-modeling
+tips_exempt: documentation discipline routed by explicit modeling requests and the skill manifest
+description: >
+  主动建立和校准项目领域模型，并把已确认的语言与少量关键决策写回仓库。
+  Use when: 讨论代码库术语、统一 bounded-context 语言、创建或修改 CONTEXT.md、或记录真正必要的 ADR。
+  Not for: 只读取 glossary、实现细节文档、普通代码修改、容易逆转或没有真实取舍的决定。
+  Output: 按仓库约定更新的 CONTEXT.md / CONTEXT-MAP.md + 仅在三条件同时成立时创建的 ADR。
+  GOTCHA: CONTEXT.md 只能是领域 glossary；写文件前先服从目标仓库既有路径、frontmatter 和文档约定。
+triggers:
+  - "领域建模"
+  - "统一术语"
+  - "CONTEXT.md"
+  - "写 ADR"
+---
+
+# Domain Modeling
+
+Actively sharpen the project's domain model while designing: challenge conflicting terms, invent edge-case scenarios, compare claims with code, and record language or decisions when they crystallize.
+
+Merely reading `CONTEXT.md` for vocabulary is not this skill. Use it when the model itself is changing.
+
+## Resolve the Repository Convention First
+
+Before writing, read the repository governance and existing documentation structure. Existing canonical glossary/ADR locations, naming, numbering, frontmatter, or feature-truth rules override the defaults below.
+
+Default for a single-context repository:
+
+```text
+/
+├── CONTEXT.md
+├── docs/
+│   └── adr/
+└── src/
+```
+
+If `CONTEXT-MAP.md` exists, use it to locate multiple contexts and place context-specific glossaries or ADRs accordingly. Create files lazily: only when the first resolved term or qualifying decision exists.
+
+## During the Session
+
+### Challenge the glossary
+
+When the user's language conflicts with the canonical glossary, surface the conflict immediately and ask which meaning is intended.
+
+### Sharpen fuzzy language
+
+When a term is vague or overloaded, propose one precise canonical term and explicitly list the meanings it replaces or excludes.
+
+### Test concrete scenarios
+
+Probe relationships with concrete edge cases. Scenarios should force clarity about concept boundaries, ownership, identity, lifecycle, and failure behavior.
+
+### Cross-check with code
+
+When a claim describes current behavior, inspect the relevant code. If code and proposed model disagree, report the contradiction rather than silently choosing one.
+
+### Update the glossary inline
+
+Once a term is resolved, update the canonical `CONTEXT.md` immediately using [CONTEXT-FORMAT.md](./CONTEXT-FORMAT.md), adapted to repository conventions.
+
+`CONTEXT.md` is a glossary only. It must not become a spec, scratchpad, implementation guide, or decision log.
+
+### Offer ADRs sparingly
+
+Create or offer an ADR only when all three conditions hold:
+
+1. **Hard to reverse** — changing the decision later has meaningful cost.
+2. **Surprising without context** — a future reader is likely to question why it was chosen.
+3. **A real tradeoff** — credible alternatives existed and were rejected for specific reasons.
+
+If any condition is absent, skip the ADR. Use [ADR-FORMAT.md](./ADR-FORMAT.md), adapted to repository conventions.
+
+## 正反灰例
+
+- 正例：同一个“account”在需求和代码里分别代表 Customer 与 User，需要选定语言和边界。
+- 正例：跨 context 的集成方式难以逆转、违反直觉且有真实替代方案，需要记录原因。
+- 反例：只需查 `CONTEXT.md` 理解一个已有术语；直接读取即可。
+- 反例：记录函数参数、表结构或重试算法；这些属于 spec/implementation docs。
+- 灰例：一个重要但容易回滚的命名选择可以写入 glossary，但不应写 ADR。
+
+## Common Mistakes
+
+| 错误 | 后果 | 修正 |
+|---|---|---|
+| 强行创建根目录 `CONTEXT.md` | 破坏多 context 或仓库真相源 | 先查 `CONTEXT-MAP.md` 与项目约定 |
+| glossary 记录实现细节 | 领域语言被版本细节污染 | 只定义领域概念与禁用同义词 |
+| 用户描述与代码冲突时默认信一边 | 旧实现或新认知被悄悄覆盖 | 展示证据，让冲突成为显式决策 |
+| 为所有决定写 ADR | ADR 失去信噪比 | 三个门槛缺一不可 |
+| 自创文档格式 | 触发项目治理或索引漂移 | 既有规范优先，模板仅为默认值 |
+
+## 下一步
+
+需要系统追问时与 `grilling` 组合为 `grill-with-docs`；模型确认后再进入 `writing-plans`。

--- a/cat-cafe-skills/domain-modeling/agents/openai.yaml
+++ b/cat-cafe-skills/domain-modeling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Domain Modeling"
+  short_description: "Build and sharpen a domain model"

--- a/cat-cafe-skills/grill-with-docs/LICENSE
+++ b/cat-cafe-skills/grill-with-docs/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cat-cafe-skills/grill-with-docs/PROVENANCE.md
+++ b/cat-cafe-skills/grill-with-docs/PROVENANCE.md
@@ -1,0 +1,13 @@
+# Provenance
+
+- Upstream repository: <https://github.com/mattpocock/skills>
+- Upstream path: `skills/engineering/grill-with-docs`
+- Pinned revision: `8b78b531ab965735c5dc74f6f7a219e1e37326df`
+- License: MIT
+- Imported: 2026-08-15
+
+## Clowder adaptation
+
+- Replaced upstream slash-command wording with explicit Clowder skill loading.
+- Added routing boundaries, output contract, examples, common mistakes, and dependency handoff.
+- Preserved the upstream role as the composition of `grilling` and `domain-modeling`.

--- a/cat-cafe-skills/grill-with-docs/SKILL.md
+++ b/cat-cafe-skills/grill-with-docs/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: grill-with-docs
+tips_exempt: explicit opt-in facilitation skill; discoverability is provided by the skill manifest
+description: >
+  把方案拷问与领域文档沉淀组合成一次设计会话。
+  Use when: 用户要求 "grill with docs"、边追问边统一术语、或把关键取舍沉淀为 glossary/ADR。
+  Not for: 普通问答、已经定稿的执行计划、直接实现代码、只需纯口头 stress-test 的讨论。
+  Output: 经确认的 design tree + 按需更新的 CONTEXT.md / ADR。
+  GOTCHA: 这是组合 skill；必须显式加载 grilling 与 domain-modeling，不能把它们当斜杠命令。
+disable-model-invocation: true
+triggers:
+  - "grill with docs"
+  - "带文档拷问"
+  - "边追问边写 ADR"
+  - "把方案问透并沉淀"
+---
+
+# Grill with Docs
+
+这不是第三套访谈方法，而是两个 skill 的组合入口：
+
+- [`grilling`](../grilling/SKILL.md)：建立 design tree，逐轮解决当前可回答的决策 frontier。
+- [`domain-modeling`](../domain-modeling/SKILL.md)：校准领域语言，并在结论形成时更新 glossary；只为真正值得保留的取舍写 ADR。
+
+## 流程
+
+1. **先加载两个依赖 skill。** 在提出第一轮问题前，完整读取并遵守 `grilling` 与 `domain-modeling`。
+2. **先查事实。** 读取现有 `CONTEXT.md` / `CONTEXT-MAP.md`、ADR、需求和相关代码；能从环境确认的事实不丢给用户。
+3. **按 design tree 追问。** 每轮只问当前 frontier，并为每个问题给出明确推荐。
+4. **边收敛边沉淀。** 术语一旦明确，按仓库约定更新 glossary；决策同时满足 ADR 三条件时才写 ADR。
+5. **明确确认再实现。** 文档是讨论过程的记录，不代表获准实现。frontier 为空后，请用户确认 shared understanding；确认前不进入代码实现。
+
+## 正反灰例
+
+- 正例：一个新系统方案同时存在术语冲突、边界选择与难以逆转的架构取舍。
+- 正例：用户希望“把这个设计问透，并把以后需要记住的原因写下来”。
+- 反例：用户只想快速比较两个库，不要求建立完整决策树或修改文档。
+- 反例：需求和 ADR 已定，只差拆 implementation steps；使用 `writing-plans`。
+- 灰例：只说“grill me”时默认使用 `grilling`；只有明确要求文档沉淀时才使用本组合 skill。
+
+## Common Mistakes
+
+| 错误 | 后果 | 修正 |
+|---|---|---|
+| 执行 `/grilling` 或 `/domain-modeling` 字符串 | Clowder 不把 slash command 当 skill 调度 | 显式加载两个 skill |
+| 把用户当代码搜索器 | 决策被环境事实污染 | 自己读代码、文档和工具输出 |
+| 每个选择都写 ADR | 决策日志变成噪音 | 严格执行 domain-modeling 的三条件门槛 |
+| glossary 混入实现细节 | 术语真相源失焦 | `CONTEXT.md` 只保留领域语言 |
+| 用户未确认就开始实现 | 把访谈误当授权 | 停在 shared-understanding checkpoint |
+
+## 下一步
+
+shared understanding 经用户确认后，再按任务性质进入 `writing-plans` 或 `feat-lifecycle`。

--- a/cat-cafe-skills/grill-with-docs/agents/openai.yaml
+++ b/cat-cafe-skills/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "Grill a design and write its docs"
+policy:
+  allow_implicit_invocation: false

--- a/cat-cafe-skills/grilling/LICENSE
+++ b/cat-cafe-skills/grilling/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cat-cafe-skills/grilling/PROVENANCE.md
+++ b/cat-cafe-skills/grilling/PROVENANCE.md
@@ -1,0 +1,13 @@
+# Provenance
+
+- Upstream repository: <https://github.com/mattpocock/skills>
+- Upstream path: `skills/productivity/grilling`
+- Pinned revision: `8b78b531ab965735c5dc74f6f7a219e1e37326df`
+- License: MIT
+- Imported: 2026-08-15
+
+## Clowder adaptation
+
+- Added Clowder routing boundaries, output contract, examples, common mistakes, and next-skill guidance.
+- Reworded environment fact-finding to use available tools or delegation without assuming a specific sub-agent interface.
+- Preserved the design-tree, frontier-round, recommendation, and explicit-confirmation methodology.

--- a/cat-cafe-skills/grilling/SKILL.md
+++ b/cat-cafe-skills/grilling/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: grilling
+tips_exempt: facilitation skill routed by explicit user language and the skill manifest
+description: >
+  用分层决策树持续 stress-test 一个计划、决定或想法。
+  Use when: 用户说 "grill me"、要求拷问方案、找出隐含假设、或在行动前把关键决策问透。
+  Not for: 普通事实问答、已经定稿的执行、代码实现、需要同步写 glossary/ADR 的会话。
+  Output: 带推荐答案的 frontier 问题轮次 + 经用户确认的 shared understanding。
+  GOTCHA: 环境事实由 agent 自己查；用户只负责取舍。每轮问完整的当前 frontier，但不要提前问依赖尚未解决的问题。
+triggers:
+  - "grill me"
+  - "拷问我的方案"
+  - "把这个想法问透"
+  - "stress-test"
+---
+
+# Grilling
+
+Interview the user relentlessly until you reach a shared understanding. Map the discussion as a **design tree**: every decision branches into the decisions that depend on it.
+
+## Work the Frontier in Rounds
+
+The **frontier** is every decision whose prerequisites are already settled: the questions you can ask now without guessing at answers you have not heard yet.
+
+For each round:
+
+1. Recompute the frontier from the latest answers and discovered facts.
+2. Ask every currently unblocked decision in one numbered round.
+3. Give a clear recommended answer for every question; the user still owns the decision.
+4. Wait for the user's answers before opening the next frontier.
+
+Format each question like this:
+
+```md
+❓ **Q1 — <question title>**: <question body and concrete choices>
+
+➡️ **Recommendation:** <recommended answer and the decisive tradeoff>
+```
+
+A question whose answer depends on another question still open in this round belongs to a later round.
+
+## Facts Are the Agent's Job
+
+When a frontier question needs a fact from the environment, inspect the filesystem, code, docs, or available tools yourself. If delegation is available, use it for independent fact-finding without blocking unrelated frontier questions. Do not ask the user for information you can retrieve.
+
+Decisions remain the user's. Separate observations from recommendations so the user can see what is factual and what is a proposed tradeoff.
+
+## Completion Gate
+
+The session is complete only when the frontier is empty: every reachable branch has been visited and no material assumption remains silent. Summarize the resulting design tree and ask the user to confirm shared understanding. Do not implement the design before that explicit confirmation.
+
+## 正反灰例
+
+- 正例：用户有一个方向，但边界、失败模式和优先级尚未明确。
+- 正例：用户希望在写计划前主动找出“我没想到的问题”。
+- 反例：答案能通过一次代码查询直接确定；查完直接回答。
+- 反例：用户已确认方案并要求实现；进入开发流程，不重新开启访谈。
+- 灰例：需要同时维护 glossary/ADR 时，使用 `grill-with-docs` 组合本 skill 与 `domain-modeling`。
+
+## Common Mistakes
+
+| 错误 | 后果 | 修正 |
+|---|---|---|
+| 一次抛出整棵树 | 后续问题建立在未决前提上 | 只问当前 frontier |
+| 只问问题，不给立场 | 把分析成本转嫁给用户 | 每题给推荐与关键 tradeoff |
+| 询问可查询的环境事实 | 用户被迫当检索工具 | 自己查代码、文档和运行环境 |
+| 把推荐写成事实 | 用户看不见取舍边界 | 明确区分 evidence 与 recommendation |
+| frontier 未空就宣布完成 | 隐含假设进入实施 | 重算 design tree，直到无未访问分支 |
+
+## 下一步
+
+用户确认 shared understanding 后，按需进入 `writing-plans`；若还要同步沉淀领域文档，转 `grill-with-docs`。

--- a/cat-cafe-skills/grilling/agents/openai.yaml
+++ b/cat-cafe-skills/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking a round of questions at a time"

--- a/cat-cafe-skills/manifest.yaml
+++ b/cat-cafe-skills/manifest.yaml
@@ -132,6 +132,73 @@ skills:
     sop_step: null
     merged_from: ["brainstorming", "multi-cat-brainstorm", "discussion-convergence"]
 
+  # ── 方案拷问与领域沉淀 ──
+  grill-with-docs:
+    category: "引导与协作"
+    description: >
+      把方案拷问与领域文档沉淀组合成一次设计会话。
+      Use when: 用户要求 "grill with docs"、边追问边统一术语、或把关键取舍沉淀为 glossary/ADR。
+      Not for: 普通问答、已经定稿的执行计划、直接实现代码、只需纯口头 stress-test 的讨论。
+      Output: 经确认的 design tree + 按需更新的 CONTEXT.md / ADR。
+      GOTCHA: 必须显式加载 grilling 与 domain-modeling，不能把它们当斜杠命令。
+    triggers:
+      - "grill with docs"
+      - "带文档拷问"
+      - "边追问边写 ADR"
+      - "把方案问透并沉淀"
+    not_for:
+      - "普通问答"
+      - "已定稿的执行计划"
+      - "直接实现代码"
+      - "纯口头 stress-test"
+    output: "Confirmed design tree + glossary and selective ADR updates"
+    next: ["writing-plans", "feat-lifecycle"]
+    sop_step: null
+
+  grilling:
+    category: "引导与协作"
+    description: >
+      用分层决策树持续 stress-test 一个计划、决定或想法。
+      Use when: 用户说 "grill me"、要求拷问方案、找出隐含假设、或在行动前把关键决策问透。
+      Not for: 普通事实问答、已经定稿的执行、代码实现、需要同步写 glossary/ADR 的会话。
+      Output: 带推荐答案的 frontier 问题轮次 + 经用户确认的 shared understanding。
+      GOTCHA: 环境事实由 agent 自己查；每轮只问完整的当前 frontier。
+    triggers:
+      - "grill me"
+      - "拷问我的方案"
+      - "把这个想法问透"
+      - "stress-test"
+    not_for:
+      - "普通事实问答"
+      - "已定稿的执行"
+      - "代码实现"
+      - "同步写 glossary 或 ADR"
+    output: "Recommended frontier rounds + confirmed shared understanding"
+    next: ["grill-with-docs", "writing-plans"]
+    sop_step: null
+
+  domain-modeling:
+    category: "引导与协作"
+    description: >
+      主动建立和校准项目领域模型，并把已确认的语言与少量关键决策写回仓库。
+      Use when: 讨论代码库术语、统一 bounded-context 语言、创建或修改 CONTEXT.md、或记录真正必要的 ADR。
+      Not for: 只读取 glossary、实现细节文档、普通代码修改、容易逆转或没有真实取舍的决定。
+      Output: 按仓库约定更新的 CONTEXT.md / CONTEXT-MAP.md + 仅在三条件同时成立时创建的 ADR。
+      GOTCHA: CONTEXT.md 只能是领域 glossary；写文件前先服从目标仓库既有文档约定。
+    triggers:
+      - "领域建模"
+      - "统一术语"
+      - "CONTEXT.md"
+      - "写 ADR"
+    not_for:
+      - "只读 glossary"
+      - "实现细节文档"
+      - "普通代码修改"
+      - "trivial reversible decision"
+    output: "Repository-conformant glossary and selective ADR updates"
+    next: ["grill-with-docs", "writing-plans"]
+    sop_step: null
+
   # ── 专家辩论团 ──
   expert-panel:
     category: "引导与协作"

--- a/review-notes/2026-08-15-grill-with-docs-skill-review-request.md
+++ b/review-notes/2026-08-15-grill-with-docs-skill-review-request.md
@@ -1,0 +1,106 @@
+# Review Request: Install grill-with-docs skill family into Clowder
+
+Review-Target-ID: grill-with-docs-skill
+Branch: feat/grill-with-docs-skill
+
+## What
+
+Import and adapt the upstream `grill-with-docs` skill and its required dependencies:
+
+- `cat-cafe-skills/grill-with-docs/`
+- `cat-cafe-skills/grilling/`
+- `cat-cafe-skills/domain-modeling/`
+
+The change registers all three skills in `manifest.yaml` and `BOOTSTRAP.md`, preserves the upstream methodology, replaces unsupported slash-command wording with explicit Clowder skill loading, and records the pinned upstream revision plus MIT license in each skill directory.
+
+## Why
+
+Operator request: “帮我把这个skill安装到CAFF上 skills/engineering/grill-with-docs”，随后明确要求“给clowder也装一个”。 The Clowder copy must be discoverable through the shared skill registry and must not instruct agents to invoke unsupported `/grilling` or `/domain-modeling` commands.
+
+## Original Requirements
+
+> 给clowder也装一个·
+
+- 来源：co-creator dispatch `0001786778913372-000356-8cca2674` (2026-08-15)
+- 上游来源：`mattpocock/skills` at revision `8b78b531ab965735c5dc74f6f7a219e1e37326df`
+- 请对照上述要求判断 Clowder 是否能发现并加载入口及其依赖。
+
+## Tradeoff
+
+Kept the upstream design-tree, frontier-round, glossary, and selective-ADR methodology. Adapted only runtime integration and Clowder routing metadata, adding examples and common-mistake guardrails required by the shared skill quality standard. Installed the dependency closure of three skills rather than copying only the entrypoint, so the entrypoint cannot resolve to missing dependencies.
+
+## Architecture Ownership
+
+Architecture cell: shared skill registry / agent guidance surface
+Map delta: none
+Why: this adds three discoverable guidance skills and their registry entries, but creates no runtime Store, Queue, Router, Adapter, Dispatcher, Binding, API, or data boundary.
+
+Please check:
+
+- the three skill directories are complete and independently discoverable;
+- `grill-with-docs` explicitly composes `grilling` and `domain-modeling` under Clowder loading semantics;
+- the manifest `next` links resolve and the bootstrap registry matches the source directories;
+- provenance, license, and adaptation scope are accurate;
+- no hidden runtime or external-network side effects were introduced.
+
+## Open Questions
+
+### Technical OQ
+
+1. Is the minimal slash-command adaptation correct for Clowder's skill loading semantics?
+2. Are the routing boundaries and `tips_exempt` declarations sufficiently precise to avoid accidental invocation?
+3. Are the imported support templates (`ADR-FORMAT.md`, `CONTEXT-FORMAT.md`) appropriately scoped and licensed?
+
+### Value OQ
+
+无。 This is a reversible shared-skill registry addition; no product behavior, user data, permission boundary, or external contract changes.
+
+## Fresh-Context Findings
+
+Skipped by the `fresh-context-review` trigger table: this is a SKILL.md/metadata-only change with no runtime code, and the formal cross-cat reviewer will inspect the complete diff.
+
+## Next Action
+
+Please perform an independent cross-cat review on the exact pushed HEAD. Return a clear APPROVE or REQUEST-CHANGES verdict with P1/P2/P3 findings. Do not self-approve through the shared GitHub account; record the logical verdict in the PR conversation or thread.
+
+## Review Sandbox
+
+- Path: `/tmp/cat-cafe-review/grill-with-docs-skill/opus`
+- Start Command: no runtime server required; inspect the detached review checkout and run the validation commands below
+- Ports: not applicable (docs/skill-only change; do not start a server)
+
+### Sandbox Bootstrap
+
+```bash
+unset NODE_ENV
+pnpm install --frozen-lockfile
+```
+
+## Self-check Evidence
+
+### Quality Gate Summary
+
+- `check-skills:manifest`: PASS — 57 skills validated; five pre-existing advisory MCP capability warnings.
+- `check-skill-reference-integrity.mjs`: PASS on the real repository graph.
+- `check:skills:surfaces`: PASS — 12 passed, 1 skipped, 0 failed.
+- `check:capability-tips`: PASS — 11 tests passed and the changed skills are explicitly exempt as opt-in facilitation skills.
+- YAML parse probe for manifest and all three `agents/openai.yaml`: PASS.
+- `git diff --check`: PASS.
+- Root artifact check: no media/design artifacts.
+
+### Known Environment Limitations
+
+- Full `pnpm check` was run and failed before any changed-file semantic check because this Windows checkout presents the repository baseline as CRLF: Biome reported 6,351 pre-existing formatting errors across 6,354 files. No formatter or bulk line-ending rewrite was applied.
+- The reference-integrity test fixture could not create temporary Windows symlinks (`EPERM`); its real repository checker passed. This is an environment limitation, not a finding in the imported skill content.
+- `pnpm sync:skills --dry-run` could not run because the Windows checkout exposes `scripts/sync-skills.sh` with CRLF (`$'\r': command not found`). The sync script also intentionally resolves the canonical first worktree, so project-level mounts will be refreshed after this branch lands in canonical main.
+
+## Related Source
+
+- Upstream: `https://github.com/mattpocock/skills/tree/8b78b531ab965735c5dc74f6f7a219e1e37326df/skills/engineering/grill-with-docs`
+- Dependency: `skills/productivity/grilling`
+- Dependency: `skills/engineering/domain-modeling`
+- Adaptation: `cat-cafe-skills/grill-with-docs/PROVENANCE.md`
+- Adaptation: `cat-cafe-skills/grilling/PROVENANCE.md`
+- Adaptation: `cat-cafe-skills/domain-modeling/PROVENANCE.md`
+
+[砚砚/gpt-5.6-sol🐾]


### PR DESCRIPTION
# Review Request: Install grill-with-docs skill family into Clowder

Review-Target-ID: grill-with-docs-skill
Branch: feat/grill-with-docs-skill

## What

Import and adapt the upstream `grill-with-docs` skill and its required dependencies:

- `cat-cafe-skills/grill-with-docs/`
- `cat-cafe-skills/grilling/`
- `cat-cafe-skills/domain-modeling/`

The change registers all three skills in `manifest.yaml` and `BOOTSTRAP.md`, preserves the upstream methodology, replaces unsupported slash-command wording with explicit Clowder skill loading, and records the pinned upstream revision plus MIT license in each skill directory.

## Why

Operator request: “帮我把这个skill安装到CAFF上 skills/engineering/grill-with-docs”，随后明确要求“给clowder也装一个”。 The Clowder copy must be discoverable through the shared skill registry and must not instruct agents to invoke unsupported `/grilling` or `/domain-modeling` commands.

## Original Requirements

> 给clowder也装一个·

- 来源：co-creator dispatch `0001786778913372-000356-8cca2674` (2026-08-15)
- 上游来源：`mattpocock/skills` at revision `8b78b531ab965735c5dc74f6f7a219e1e37326df`
- 请对照上述要求判断 Clowder 是否能发现并加载入口及其依赖。

## Tradeoff

Kept the upstream design-tree, frontier-round, glossary, and selective-ADR methodology. Adapted only runtime integration and Clowder routing metadata, adding examples and common-mistake guardrails required by the shared skill quality standard. Installed the dependency closure of three skills rather than copying only the entrypoint, so the entrypoint cannot resolve to missing dependencies.

## Architecture Ownership

Architecture cell: shared skill registry / agent guidance surface
Map delta: none
Why: this adds three discoverable guidance skills and their registry entries, but creates no runtime Store, Queue, Router, Adapter, Dispatcher, Binding, API, or data boundary.

Please check:

- the three skill directories are complete and independently discoverable;
- `grill-with-docs` explicitly composes `grilling` and `domain-modeling` under Clowder loading semantics;
- the manifest `next` links resolve and the bootstrap registry matches the source directories;
- provenance, license, and adaptation scope are accurate;
- no hidden runtime or external-network side effects were introduced.

## Open Questions

### Technical OQ

1. Is the minimal slash-command adaptation correct for Clowder's skill loading semantics?
2. Are the routing boundaries and `tips_exempt` declarations sufficiently precise to avoid accidental invocation?
3. Are the imported support templates (`ADR-FORMAT.md`, `CONTEXT-FORMAT.md`) appropriately scoped and licensed?

### Value OQ

无。 This is a reversible shared-skill registry addition; no product behavior, user data, permission boundary, or external contract changes.

## Fresh-Context Findings

Skipped by the `fresh-context-review` trigger table: this is a SKILL.md/metadata-only change with no runtime code, and the formal cross-cat reviewer will inspect the complete diff.

## Next Action

Please perform an independent cross-cat review on the exact pushed HEAD. Return a clear APPROVE or REQUEST-CHANGES verdict with P1/P2/P3 findings. Do not self-approve through the shared GitHub account; record the logical verdict in the PR conversation or thread.

## Review Sandbox

- Path: `/tmp/cat-cafe-review/grill-with-docs-skill/opus`
- Start Command: no runtime server required; inspect the detached review checkout and run the validation commands below
- Ports: not applicable (docs/skill-only change; do not start a server)

### Sandbox Bootstrap

```bash
unset NODE_ENV
pnpm install --frozen-lockfile
```

## Self-check Evidence

### Quality Gate Summary

- `check-skills:manifest`: PASS — 57 skills validated; five pre-existing advisory MCP capability warnings.
- `check-skill-reference-integrity.mjs`: PASS on the real repository graph.
- `check:skills:surfaces`: PASS — 12 passed, 1 skipped, 0 failed.
- `check:capability-tips`: PASS — 11 tests passed and the changed skills are explicitly exempt as opt-in facilitation skills.
- YAML parse probe for manifest and all three `agents/openai.yaml`: PASS.
- `git diff --check`: PASS.
- Root artifact check: no media/design artifacts.

### Known Environment Limitations

- Full `pnpm check` was run and failed before any changed-file semantic check because this Windows checkout presents the repository baseline as CRLF: Biome reported 6,351 pre-existing formatting errors across 6,354 files. No formatter or bulk line-ending rewrite was applied.
- The reference-integrity test fixture could not create temporary Windows symlinks (`EPERM`); its real repository checker passed. This is an environment limitation, not a finding in the imported skill content.
- `pnpm sync:skills --dry-run` could not run because the Windows checkout exposes `scripts/sync-skills.sh` with CRLF (`$'\r': command not found`). The sync script also intentionally resolves the canonical first worktree, so project-level mounts will be refreshed after this branch lands in canonical main.

## Related Source

- Upstream: `https://github.com/mattpocock/skills/tree/8b78b531ab965735c5dc74f6f7a219e1e37326df/skills/engineering/grill-with-docs`
- Dependency: `skills/productivity/grilling`
- Dependency: `skills/engineering/domain-modeling`
- Adaptation: `cat-cafe-skills/grill-with-docs/PROVENANCE.md`
- Adaptation: `cat-cafe-skills/grilling/PROVENANCE.md`
- Adaptation: `cat-cafe-skills/domain-modeling/PROVENANCE.md`

[砚砚/gpt-5.6-sol🐾]
