### PR TITLE
fix(#839): remove trace capture scope filters; distinguish execution from delivery truth

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -698,26 +698,32 @@ export async function* routeParallel(
         }
       }
 
-      // F257: fire-and-forget injection trace persist (pipeline-aware).
-      // Uses the full pipeline traces (session + turn) captured above — no v0
-      // collectTrace re-invocation, no scope filtering. All hooks that fired in
-      // the pipeline are recorded as per-hook ObservedSegments.
+      // #839: fire-and-forget injection trace persist (pipeline-aware).
+      // Per-hook execution telemetry from pipeline traces; aggregate
+      // delivery sizes from the actual route-assembled content.
       // Skip if cat is already cancelled (avoid phantom trace for turns that never happen).
       const preTraceSignal = signalForCat?.(catId) ?? signal;
       try {
         const traceStore = getTraceStore();
         if (traceStore && !preTraceSignal?.aborted) {
           const traceTurnId = crypto.randomUUID();
-          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0);
+          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
+          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapCtx, mcpInstructions]
+            .filter(Boolean)
+            .join('\n\n');
+          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0, {
+            session: staticIdentity,
+            turn: traceTurnContent,
+          });
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
           const summary = buildTraceSummary(trace, traceMeta);
           const detail = buildTraceDetail(trace, traceMeta);
           traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F257] injection trace persist failed (fire-and-forget)');
+            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
           });
         }
       } catch {
-        /* F257: trace collection must never break invocation */
+        /* trace collection must never break invocation */
       }
 
       let prompt: string;

--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -47,8 +47,12 @@ import type { PreparedProactiveMemoryNudge } from '../../../../memory/ProactiveM
 import { mergePushRecallPresentations, triggerRecallCorrelation } from '../../../../memory/recall-correlation-hook.js';
 import { drainCapturedTraces } from '../../../../prompt-hooks/PipelinePromptBuilder.js';
 import { getTraceStore } from '../../../../prompt-hooks/trace-bootstrap.js';
-// F237: Injection trace (v0 — fire-and-forget observability)
-import { buildTraceDetail, buildTraceSummary, collectTrace } from '../../../../prompt-hooks/trace-collector.js';
+// F237→F257: Injection trace — pipeline-aware (per-hook granularity)
+import {
+  buildTraceDetail,
+  buildTraceSummary,
+  collectTraceFromPipeline,
+} from '../../../../prompt-hooks/trace-collector.js';
 import { assembleContext } from '../../context/ContextAssembler.js';
 import {
   buildInvocationContext,
@@ -527,9 +531,14 @@ export async function* routeParallel(
       const staticIdentity = hasNativeL0
         ? buildStaticIdentityPackOnly(catId, { packBlocks })
         : buildStaticIdentity(catId, { mcpAvailable, packBlocks });
+      // F257: for native L0 cats, also run pipeline session-init for full trace
+      // coverage. The pipeline prompt output is discarded — delivery uses L0 compiler.
+      if (hasNativeL0) {
+        buildStaticIdentity(catId, { mcpAvailable, packBlocks });
+      }
       // F237: drain session trace IMMEDIATELY — before any await that could let
       // another parallel cat overwrite the module-global capture buffer.
-      drainCapturedTraces();
+      const pipelineSessionTrace = drainCapturedTraces();
       // F041: inject HTTP callback only when MCP is NOT actually available (fallback)
       const mcpInstructions = needsMcpInjection(mcpAvailable, catConfig?.clientId)
         ? buildMcpCallbackInstructions({
@@ -609,7 +618,7 @@ export async function* routeParallel(
         .filter(Boolean)
         .join('\n\n');
       // F237: drain turn trace IMMEDIATELY — same race-safety as session drain above.
-      drainCapturedTraces();
+      const pipelineTurnTrace = drainCapturedTraces();
 
       // F237 Phase 2: Pipeline trace capture drained above (lines 250, 322) to prevent
       // stale module-global buffer in concurrent Promise.all execution. Persistence is
@@ -689,36 +698,26 @@ export async function* routeParallel(
         }
       }
 
-      // F237: fire-and-forget injection trace persist (v0 — observability only)
-      // Placed after bootstrapCtx so per-turn trace covers ALL route-level
-      // injected system/control content (invocation + mode prompt + bootstrap + MCP).
+      // F257: fire-and-forget injection trace persist (pipeline-aware).
+      // Uses the full pipeline traces (session + turn) captured above — no v0
+      // collectTrace re-invocation, no scope filtering. All hooks that fired in
+      // the pipeline are recorded as per-hook ObservedSegments.
       // Skip if cat is already cancelled (avoid phantom trace for turns that never happen).
       const preTraceSignal = signalForCat?.(catId) ?? signal;
       try {
         const traceStore = getTraceStore();
         if (traceStore && !preTraceSignal?.aborted) {
           const traceTurnId = crypto.randomUUID();
-          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
-          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapCtx, mcpInstructions]
-            .filter(Boolean)
-            .join('\n\n---\n\n');
-          const collected = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
-            mcpAvailable,
-            packBlocks,
-          });
+          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0);
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
-          const summary = buildTraceSummary(collected, traceMeta);
-          const detail = buildTraceDetail(collected, traceMeta);
+          const summary = buildTraceSummary(trace, traceMeta);
+          const detail = buildTraceDetail(trace, traceMeta);
           traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+            log.warn({ err, threadId, catId }, '[F257] injection trace persist failed (fire-and-forget)');
           });
         }
-        // v0 collectTrace → buildStaticIdentity(annotateSegments: true) re-populates
-        // the module-global capturedSessionTrace without draining. Clear it so the next
-        // invocation (especially native-L0 pack-only) doesn't persist stale session traces.
-        if (deps.injectionTraceStore) drainCapturedTraces();
       } catch {
-        /* F237: trace collection must never break invocation */
+        /* F257: trace collection must never break invocation */
       }
 
       let prompt: string;

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -136,8 +136,12 @@ import type { PreparedProactiveMemoryNudge } from '../../../../memory/ProactiveM
 import { mergePushRecallPresentations, triggerRecallCorrelation } from '../../../../memory/recall-correlation-hook.js';
 import { drainCapturedTraces } from '../../../../prompt-hooks/PipelinePromptBuilder.js';
 import { getTraceStore } from '../../../../prompt-hooks/trace-bootstrap.js';
-// F237: Injection trace (v0 — fire-and-forget observability)
-import { buildTraceDetail, buildTraceSummary, collectTrace } from '../../../../prompt-hooks/trace-collector.js';
+// F237→F257: Injection trace — pipeline-aware (per-hook granularity)
+import {
+  buildTraceDetail,
+  buildTraceSummary,
+  collectTraceFromPipeline,
+} from '../../../../prompt-hooks/trace-collector.js';
 import { assembleContext } from '../../context/ContextAssembler.js';
 import {
   buildInvocationContext,
@@ -1163,9 +1167,15 @@ export async function* routeSerial(
       const staticIdentity = hasNativeL0
         ? buildStaticIdentityPackOnly(catId, { packBlocks })
         : buildStaticIdentity(catId, { mcpAvailable, packBlocks });
+      // F257: for native L0 cats, the delivery uses the L0 compiler file, but
+      // the pipeline must still run session-init so the harness has full trace
+      // coverage of all hooks (L+S+B+C). The pipeline prompt output is discarded.
+      if (hasNativeL0) {
+        buildStaticIdentity(catId, { mcpAvailable, packBlocks });
+      }
       // F237: drain session trace synchronously — before any await between
       // buildStaticIdentity and buildInvocationContext (race-safety for parallel reuse).
-      drainCapturedTraces();
+      const pipelineSessionTrace = drainCapturedTraces();
       // L0-budget-defense PR-B-impl (ADR-038 件套 ④): staging is NOT prepended
       // to staticIdentity here. Cloud R2 P1 #2237 L1099: folding staging into
       // staticIdentity breaks ADR-038 "每轮注入生效" contract on resumed
@@ -1288,7 +1298,7 @@ export async function* routeSerial(
         .filter(Boolean)
         .join('\n\n');
       // F237: drain turn trace synchronously — no yield between build and drain.
-      drainCapturedTraces();
+      const pipelineTurnTrace = drainCapturedTraces();
       const continuityCapsule = buildCapsuleFromRouteState({
         threadId,
         catId: catId as string,
@@ -1359,34 +1369,24 @@ export async function* routeSerial(
         }
       }
 
-      // F237: fire-and-forget injection trace persist (v0 — observability only)
-      // Placed after bootstrapContext so per-turn trace covers ALL route-level
-      // injected system/control content (invocation + mode prompt + bootstrap + MCP).
+      // F257: fire-and-forget injection trace persist (pipeline-aware).
+      // Uses the full pipeline traces (session + turn) captured above — no v0
+      // collectTrace re-invocation, no scope filtering. All hooks that fired in
+      // the pipeline are recorded as per-hook ObservedSegments.
       try {
         const traceStore = getTraceStore();
         if (traceStore) {
           const traceTurnId = crypto.randomUUID();
-          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
-          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapContext, mcpInstructions]
-            .filter(Boolean)
-            .join('\n\n---\n\n');
-          const trace = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
-            mcpAvailable,
-            packBlocks,
-          });
+          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0);
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
           const summary = buildTraceSummary(trace, traceMeta);
           const detail = buildTraceDetail(trace, traceMeta);
           traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+            log.warn({ err, threadId, catId }, '[F257] injection trace persist failed (fire-and-forget)');
           });
         }
-        // v0 collectTrace → buildStaticIdentity(annotateSegments: true) re-populates
-        // the module-global capturedSessionTrace without draining. Clear it so the next
-        // invocation (especially native-L0 pack-only) doesn't persist stale session traces.
-        if (deps.injectionTraceStore) drainCapturedTraces();
       } catch {
-        /* F237: trace collection must never break invocation */
+        /* F257: trace collection must never break invocation */
       }
 
       let deliveryBoundaryId: string | undefined;

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -1369,24 +1369,30 @@ export async function* routeSerial(
         }
       }
 
-      // F257: fire-and-forget injection trace persist (pipeline-aware).
-      // Uses the full pipeline traces (session + turn) captured above — no v0
-      // collectTrace re-invocation, no scope filtering. All hooks that fired in
-      // the pipeline are recorded as per-hook ObservedSegments.
+      // #839: fire-and-forget injection trace persist (pipeline-aware).
+      // Per-hook execution telemetry from pipeline traces; aggregate
+      // delivery sizes from the actual route-assembled content.
       try {
         const traceStore = getTraceStore();
         if (traceStore) {
           const traceTurnId = crypto.randomUUID();
-          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0);
+          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
+          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapContext, mcpInstructions]
+            .filter(Boolean)
+            .join('\n\n');
+          const trace = collectTraceFromPipeline(pipelineSessionTrace.session, pipelineTurnTrace.turn, hasNativeL0, {
+            session: staticIdentity,
+            turn: traceTurnContent,
+          });
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
           const summary = buildTraceSummary(trace, traceMeta);
           const detail = buildTraceDetail(trace, traceMeta);
           traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F257] injection trace persist failed (fire-and-forget)');
+            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
           });
         }
       } catch {
-        /* F257: trace collection must never break invocation */
+        /* trace collection must never break invocation */
       }
 
       let deliveryBoundaryId: string | undefined;

--- a/packages/api/src/domains/prompt-hooks/PipelinePromptBuilder.ts
+++ b/packages/api/src/domains/prompt-hooks/PipelinePromptBuilder.ts
@@ -116,12 +116,11 @@ export function drainCapturedTraces(): { session: PipelineResult | null; turn: P
 export function buildStaticIdentityViaHookPipeline(catId: CatId, options?: StaticIdentityOptions): string {
   const { prompt, trace } = buildStaticIdentityViaHookPipelineWithTrace(catId, options);
   // AC-P2-8: capture for invocation-layer persistence.
-  // Scope to S-prefix hooks only — non-delivered hooks (L/B/C/N) must not appear
-  // as ObservedSegments in the trace, since they were filtered from the prompt.
-  capturedSessionTrace = {
-    patches: trace.patches.filter((p) => SCOPE_S.test(p.hookId)),
-    events: trace.events.filter((ev) => SCOPE_S.test(ev.hookId)),
-  };
+  // Capture the FULL pipeline result — all hooks that executed, regardless of
+  // which subset was delivered to the model. The prompt output is scoped (S-only
+  // for session, D-only for turn), but the trace records everything the pipeline
+  // ran so the harness (F257) has complete lifecycle observability.
+  capturedSessionTrace = trace;
 
   if (options?.annotateSegments) {
     const registry = getCachedRegistry();
@@ -168,12 +167,11 @@ export function buildStaticIdentityViaHookPipelineWithTrace(
 export function buildInvocationContextViaHookPipeline(context: InvocationContext): string {
   const { prompt, trace } = buildInvocationContextViaHookPipelineWithTrace(context);
   // AC-P2-8: capture for invocation-layer persistence.
-  // Scope to D-prefix hooks only — non-delivered hooks (R/N) must not appear
-  // as ObservedSegments in the trace, since they were filtered from the prompt.
-  capturedTurnTrace = {
-    patches: trace.patches.filter((p) => SCOPE_D.test(p.hookId)),
-    events: trace.events.filter((ev) => SCOPE_D.test(ev.hookId)),
-  };
+  // Capture the FULL pipeline result — all hooks that executed (D+R+N),
+  // regardless of which subset was delivered to the model. Prompt output is
+  // scoped to D-only, but the trace records everything the pipeline ran so
+  // the harness (F257) has complete lifecycle observability.
+  capturedTurnTrace = trace;
 
   // F229: Concierge duty section — not yet a pipeline hook.
   // Legacy SystemPromptBuilder places concierge between D17 and D18 (before D21

--- a/packages/api/src/domains/prompt-hooks/trace-collector.ts
+++ b/packages/api/src/domains/prompt-hooks/trace-collector.ts
@@ -226,7 +226,29 @@ export function buildTraceDetail(
 }
 
 // ---------------------------------------------------------------------------
-// F257: Pipeline-aware trace collection
+// Pipeline-aware trace collection (#839: full hook observability)
+// ---------------------------------------------------------------------------
+//
+// Two distinct truths:
+//   1. EXECUTION — which hooks fired in the pipeline, what they produced.
+//      Recorded as per-hook ObservedSegments (segmentId = hookId).
+//      A hook with status='observed' means the pipeline executed it AND it
+//      produced content. It does NOT mean that content reached the model —
+//      prompt output is scoped per legacy builder (S-only for session,
+//      D-only for turn). Hooks outside the delivery scope (L/B/C for
+//      session, R/N for turn) execute for trace but their content is
+//      filtered from the prompt.
+//
+//   2. DELIVERY — what was actually assembled and passed to the model.
+//      Recorded in StageDeliveryDecision (channel, contentAssembled) and
+//      the aggregate content hashes/sizes (sessionContentHash, etc.).
+//      When deliveredContent is provided by the route layer, these
+//      reflect the real delivered bytes, not pipeline patch sums.
+//
+// The old v0 collectTrace() conflated both: it re-ran buildStaticIdentity
+// (annotateSegments=true) to get S-prefix segment detail, then used the
+// route-assembled content for aggregate sizing. This new function keeps
+// both truths separate.
 // ---------------------------------------------------------------------------
 
 /**
@@ -252,33 +274,63 @@ function pipelineEventsToSegments(result: PipelineResult, stage: InjectionStage)
 /**
  * Collect trace from HookPipeline results.
  *
- * F257: reads directly from the pipeline's trace events, giving per-hook
+ * Reads directly from the pipeline's trace events, giving per-hook
  * granularity for ALL hooks (L+S+B+C+D+R+N). Unlike v0 `collectTrace()`
  * which re-runs buildStaticIdentity(annotateSegments=true) and only sees
  * S-prefix hooks, this captures whatever the pipeline actually executed.
+ *
+ * @param deliveredContent - Actual content assembled by the route layer and
+ *   passed to the model. When provided, aggregate sizes/hashes reflect what
+ *   was delivered (delivery truth), not what the pipeline produced. When
+ *   omitted, falls back to pipeline patch sums (execution truth).
  */
 export function collectTraceFromPipeline(
   sessionResult: PipelineResult | null,
   turnResult: PipelineResult | null,
   hasNativeL0: boolean,
+  deliveredContent?: { session?: string; turn?: string },
 ): CollectedTrace {
   const startMs = performance.now();
 
   const sessionSegments = sessionResult ? pipelineEventsToSegments(sessionResult, 'session-init') : [];
   const turnSegments = turnResult ? pipelineEventsToSegments(turnResult, 'per-turn') : [];
 
-  const sessionCharCount = sessionResult ? sessionResult.patches.reduce((sum, p) => sum + p.content.length, 0) : 0;
-  const turnCharCount = turnResult ? turnResult.patches.reduce((sum, p) => sum + p.content.length, 0) : 0;
+  // Aggregate sizes: prefer delivered content (delivery truth) over pipeline
+  // patch sums (execution truth). The route layer may add/filter content
+  // beyond what the pipeline produced (mode prompt, bootstrap, MCP, etc.).
+  const sessionText = deliveredContent?.session;
+  const turnText = deliveredContent?.turn;
 
-  const sessionTokenEstimate = sessionResult
-    ? sessionResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0)
-    : 0;
-  const turnTokenEstimate = turnResult ? turnResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0) : 0;
+  const sessionCharCount =
+    sessionText != null
+      ? sessionText.length
+      : sessionResult
+        ? sessionResult.patches.reduce((sum, p) => sum + p.content.length, 0)
+        : 0;
+  const turnCharCount =
+    turnText != null
+      ? turnText.length
+      : turnResult
+        ? turnResult.patches.reduce((sum, p) => sum + p.content.length, 0)
+        : 0;
+
+  const sessionTokenEstimate =
+    sessionText != null
+      ? estimateTokens(sessionText)
+      : sessionResult
+        ? sessionResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0)
+        : 0;
+  const turnTokenEstimate =
+    turnText != null
+      ? estimateTokens(turnText)
+      : turnResult
+        ? turnResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0)
+        : 0;
 
   const delivery: StageDeliveryDecision[] = [
     {
       stage: 'session-init',
-      contentAssembled: sessionSegments.some((s) => s.status === 'observed'),
+      contentAssembled: sessionCharCount > 0,
       channel: hasNativeL0 ? 'native-l0' : 'message-prepend',
       reason: hasNativeL0
         ? 'Pipeline ran all hooks; delivery via native L0 compiler (file/instructions)'
@@ -286,18 +338,22 @@ export function collectTraceFromPipeline(
     },
     {
       stage: 'per-turn',
-      contentAssembled: turnSegments.some((s) => s.status === 'observed'),
+      contentAssembled: turnCharCount > 0,
       channel: 'message-prepend',
       reason: 'Per-turn context assembled for message-prepend',
     },
   ];
 
-  const sessionContentHash =
-    sessionResult && sessionCharCount > 0
-      ? hashContent(sessionResult.patches.map((p) => p.content).join('\n\n'))
-      : null;
-  const turnContentHash =
-    turnResult && turnCharCount > 0 ? hashContent(turnResult.patches.map((p) => p.content).join('\n\n')) : null;
+  let sessionContentHash: string | null = null;
+  if (sessionCharCount > 0) {
+    const raw = sessionText ?? sessionResult?.patches.map((p) => p.content).join('\n\n');
+    if (raw) sessionContentHash = hashContent(raw);
+  }
+  let turnContentHash: string | null = null;
+  if (turnCharCount > 0) {
+    const raw = turnText ?? turnResult?.patches.map((p) => p.content).join('\n\n');
+    if (raw) turnContentHash = hashContent(raw);
+  }
 
   return {
     segments: [...sessionSegments, ...turnSegments],

--- a/packages/api/src/domains/prompt-hooks/trace-collector.ts
+++ b/packages/api/src/domains/prompt-hooks/trace-collector.ts
@@ -21,6 +21,7 @@ import type {
 } from '@cat-cafe/shared';
 import { estimateTokens } from '../../utils/token-counter.js';
 import { buildStaticIdentity, type StaticIdentityOptions } from '../cats/services/context/SystemPromptBuilder.js';
+import type { PipelineResult } from './HookPipeline.js';
 
 export function hashContent(content: string): string {
   return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 16);
@@ -221,5 +222,92 @@ export function buildTraceDetail(
     turnCharCount: trace.turnCharCount,
     turnTokenEstimate: trace.turnTokenEstimate,
     segments: trace.segments,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// F257: Pipeline-aware trace collection
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert pipeline events to ObservedSegments.
+ * Each pipeline TraceEvent becomes one per-hook segment — fired hooks are
+ * 'observed' (with content data from matching patch), skipped/disabled are 'absent'.
+ */
+function pipelineEventsToSegments(result: PipelineResult, stage: InjectionStage): ObservedSegment[] {
+  const patchMap = new Map(result.patches.map((p) => [p.hookId, p]));
+  return result.events.map((event) => {
+    const patch = event.status === 'fired' ? patchMap.get(event.hookId) : undefined;
+    return {
+      segmentId: event.hookId,
+      stage,
+      status: patch ? ('observed' as const) : ('absent' as const),
+      contentHash: patch ? hashContent(patch.content) : null,
+      charCount: patch?.content.length ?? 0,
+      tokenEstimate: patch ? estimateTokens(patch.content) : 0,
+    };
+  });
+}
+
+/**
+ * Collect trace from HookPipeline results.
+ *
+ * F257: reads directly from the pipeline's trace events, giving per-hook
+ * granularity for ALL hooks (L+S+B+C+D+R+N). Unlike v0 `collectTrace()`
+ * which re-runs buildStaticIdentity(annotateSegments=true) and only sees
+ * S-prefix hooks, this captures whatever the pipeline actually executed.
+ */
+export function collectTraceFromPipeline(
+  sessionResult: PipelineResult | null,
+  turnResult: PipelineResult | null,
+  hasNativeL0: boolean,
+): CollectedTrace {
+  const startMs = performance.now();
+
+  const sessionSegments = sessionResult ? pipelineEventsToSegments(sessionResult, 'session-init') : [];
+  const turnSegments = turnResult ? pipelineEventsToSegments(turnResult, 'per-turn') : [];
+
+  const sessionCharCount = sessionResult ? sessionResult.patches.reduce((sum, p) => sum + p.content.length, 0) : 0;
+  const turnCharCount = turnResult ? turnResult.patches.reduce((sum, p) => sum + p.content.length, 0) : 0;
+
+  const sessionTokenEstimate = sessionResult
+    ? sessionResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0)
+    : 0;
+  const turnTokenEstimate = turnResult ? turnResult.patches.reduce((sum, p) => sum + estimateTokens(p.content), 0) : 0;
+
+  const delivery: StageDeliveryDecision[] = [
+    {
+      stage: 'session-init',
+      contentAssembled: sessionSegments.some((s) => s.status === 'observed'),
+      channel: hasNativeL0 ? 'native-l0' : 'message-prepend',
+      reason: hasNativeL0
+        ? 'Pipeline ran all hooks; delivery via native L0 compiler (file/instructions)'
+        : 'Pipeline ran all hooks; delivery via message-prepend',
+    },
+    {
+      stage: 'per-turn',
+      contentAssembled: turnSegments.some((s) => s.status === 'observed'),
+      channel: 'message-prepend',
+      reason: 'Per-turn context assembled for message-prepend',
+    },
+  ];
+
+  const sessionContentHash =
+    sessionResult && sessionCharCount > 0
+      ? hashContent(sessionResult.patches.map((p) => p.content).join('\n\n'))
+      : null;
+  const turnContentHash =
+    turnResult && turnCharCount > 0 ? hashContent(turnResult.patches.map((p) => p.content).join('\n\n')) : null;
+
+  return {
+    segments: [...sessionSegments, ...turnSegments],
+    delivery,
+    sessionContentHash,
+    turnContentHash,
+    sessionCharCount,
+    sessionTokenEstimate,
+    turnCharCount,
+    turnTokenEstimate,
+    durationMs: performance.now() - startMs,
   };
 }

--- a/packages/api/test/dual-path-strict-equality.test.js
+++ b/packages/api/test/dual-path-strict-equality.test.js
@@ -163,10 +163,11 @@ describe('Pipeline equivalence regression (AC-P2-14)', () => {
     const first = ppb.drainCapturedTraces();
     assert.ok(first.session, 'Session trace should be captured');
     assert.ok(first.session.events.length > 0, 'Session events captured');
-    // All captured events should be S-prefix (scope filtering)
-    for (const ev of first.session.events) {
-      assert.ok(/^S\d/.test(ev.hookId), `Captured session event ${ev.hookId} should be S-prefix`);
-    }
+    // F257: captured trace now includes ALL session-init hooks (L+S+B+C),
+    // not just S-prefix — full pipeline observability for the harness.
+    const prefixes = new Set(first.session.events.map((ev) => ev.hookId[0]));
+    assert.ok(prefixes.has('S'), 'Session trace should include S-prefix hooks');
+    assert.ok(prefixes.has('L'), 'Session trace should include L-prefix hooks (full pipeline)');
     // Second drain returns null (buffer cleared)
     const second = ppb.drainCapturedTraces();
     assert.equal(second.session, null, 'Buffer cleared after drain');

--- a/packages/api/test/hook-segment-coverage.test.js
+++ b/packages/api/test/hook-segment-coverage.test.js
@@ -304,10 +304,11 @@ describe('Hook segment coverage (AC-P2-14)', () => {
     const first = ppb.drainCapturedTraces();
     assert.ok(first.session, 'Session trace should be captured');
     assert.ok(first.session.events.length > 0, 'Session events captured');
-    // All captured events should be S-prefix (scope filtering)
-    for (const ev of first.session.events) {
-      assert.ok(/^S\d/.test(ev.hookId), `Captured session event ${ev.hookId} should be S-prefix`);
-    }
+    // F257: captured trace now includes ALL session-init hooks (L+S+B+C),
+    // not just S-prefix — full pipeline observability for the harness.
+    const prefixes = new Set(first.session.events.map((ev) => ev.hookId[0]));
+    assert.ok(prefixes.has('S'), 'Session trace should include S-prefix hooks');
+    assert.ok(prefixes.has('L'), 'Session trace should include L-prefix hooks (full pipeline)');
     // Second drain returns null (buffer cleared)
     const second = ppb.drainCapturedTraces();
     assert.equal(second.session, null, 'Buffer cleared after drain');


### PR DESCRIPTION
## Summary

Fixes the "暂无 Tracing 记录" problem in the console segment lifeline by removing SCOPE_S/SCOPE_D regex filters that filtered trace capture to only S-prefix (session) and D-prefix (turn) hooks — a migration artifact from the F237 prompt-hook pipeline (#839, PR #1075).

**Lineage**: #839 (F237 prompt-hook pipeline) → PR #1075 (pipeline migration) → this fix

### What changed

1. **Trace capture scope filters removed** — `PipelinePromptBuilder.ts` no longer filters `capturedSessionTrace`/`capturedTurnTrace` through SCOPE_S/SCOPE_D. All pipeline hooks (L+S+B+C+D+R+N) are now captured for trace observability.

2. **Execution truth vs delivery truth** — New `collectTraceFromPipeline()` in `trace-collector.ts` separates two concerns:
   - **Execution truth**: per-hook `ObservedSegment` entries record what the pipeline executed (all prefixes)
   - **Delivery truth**: aggregate sizes/hashes use `deliveredContent` from the route layer (what the model actually receives), not pipeline patch sums

3. **Route layer integration** — `route-serial.ts` and `route-parallel.ts` pass `staticIdentity` (session) and assembled turn content (`invocationContext + modePrompt + bootstrap + mcpInstructions`) as `deliveredContent` to the trace collector.

4. **Native L0 safety** — For native L0 cats, `buildStaticIdentity()` runs for trace-only purpose. Pipeline execution is side-effect-free: it produces patches/events in memory but doesn't mutate external state. The L0 compiler subprocess handles actual delivery independently.

### Scope filters preserved for output

SCOPE_S and SCOPE_D constants remain in PipelinePromptBuilder.ts and continue to filter **prompt output** — session output includes only S-prefix patches, turn output includes only D-prefix patches. This is correct behavior; the fix only removes filtering from the **trace capture** layer.

## Test plan

- [x] `dual-path-strict-equality.test.js` updated: verifies captured trace includes both S and L prefix hooks
- [x] `hook-segment-coverage.test.js` updated: same assertion
- [x] All 18 tests pass (segment coverage + scope filtering + trace capture)
- [x] Type check clean (`tsc --noEmit`)
- [x] Biome check clean (warnings only, no errors)
- [ ] Regression tests for: native-L0 vs non-native, session vs turn stages, deliveredContent sizing accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)