### PR TITLE
fix(codex): stop recursive context-window shrink on resume

### DIFF
--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -39,6 +39,7 @@ import { shouldTakeAction } from '../../../../../config/session-strategy.js';
 import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import type { ISessionSealer } from '../../session/SessionSealer.js';
 import type { ISessionChainStore } from '../../stores/ports/SessionChainStore.js';
+import { upsertCapacityPinRecoveryNote } from '../../stores/ports/SessionChainStore.js';
 import {
   type AgentContextBinding,
   type AgentContextCapability,
@@ -257,14 +258,22 @@ export async function applyActiveSessionCapacityPin(options: {
   if (recoveryNote !== '') {
     await sessionChainStore.appendCapacityPinProvenance(active.id, recoveryNote);
   }
+  // #1382 review P1: build the returned snapshot from the CURRENT stored pin
+  // — the linearization point of the atomic writes above. A concurrent
+  // smaller shrink must shape this invocation's returned view too, not just
+  // the store (probe: stored 150000 while the caller still returned 200000).
+  const currentRecord = await sessionChainStore.get(active.id);
+  const currentPin = currentRecord?.capacityPin;
+  if (currentPin && isUsableCapacityPin(currentPin) && currentPin.windowTokens < existingPin.windowTokens) {
+    existingPin = currentPin;
+  }
   // Canonical evidence provenance: the recovery note appears exactly once,
   // whether it was already persisted on the stored pin or is fresh to this
-  // invocation. The stored pin (merged atomically above) and the returned
+  // invocation, and a jittered report number replaces the older note in
+  // place. The stored pin (merged atomically above) and the returned
   // snapshot share this single deduplicated form.
   const evidenceProvenance =
-    recoveryNote !== '' && !existingPin.provenance.includes(recoveryNote)
-      ? `${existingPin.provenance}${recoveryNote}`
-      : existingPin.provenance;
+    recoveryNote !== '' ? upsertCapacityPinRecoveryNote(existingPin.provenance, recoveryNote) : existingPin.provenance;
   return snapshotWithCapacity(snapshot, {
     windowTokens: existingPin.windowTokens,
     inputCeilingTokens: existingPin.inputCeilingTokens,

--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -208,18 +208,19 @@ export async function applyActiveSessionCapacityPin(options: {
     );
   }
 
-  // #1382 maintainer P1: persist the recovery hint on the STORED pin
-  // (deduplicated) — the returned snapshot is per-invocation while the Hub and
-  // digests read the session record. Numeric pin fields never change here.
+  // #1382 maintainer P1: persist the recovery hint on the STORED pin — the
+  // returned snapshot is per-invocation while the Hub and digests read the
+  // session record. The note is merged atomically against the CURRENT stored
+  // pin: writing back this caller's stale pin object could undo a concurrent
+  // shrink (lost-update race). Dedup lives in the store operation.
   const recoveryNote = pinBelowCarrierReport
     ? `; carrier now reports ${freshReport.toLocaleString()} tokens — seal the session to recover if this pin was polluted`
     : '';
-  const hintAlreadyPersisted = existingPin.provenance.includes('seal the session to recover');
-  if (!isUsableCapacityPin(active.capacityPin) || (recoveryNote !== '' && !hintAlreadyPersisted)) {
-    await sessionChainStore.update(active.id, {
-      capacityPin: { ...existingPin, provenance: `${existingPin.provenance}${recoveryNote}` },
-      updatedAt: Date.now(),
-    });
+  if (!isUsableCapacityPin(active.capacityPin)) {
+    await sessionChainStore.update(active.id, { capacityPin: existingPin, updatedAt: Date.now() });
+  }
+  if (recoveryNote !== '') {
+    await sessionChainStore.appendCapacityPinProvenance(active.id, recoveryNote);
   }
   return snapshotWithCapacity(snapshot, {
     windowTokens: existingPin.windowTokens,

--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -174,12 +174,41 @@ export async function applyActiveSessionCapacityPin(options: {
 
   if (!existingPin) {
     if (!resolvedPin) return snapshot;
-    await sessionChainStore.update(active.id, { capacityPin: resolvedPin, updatedAt: Date.now() });
+    // #1382 maintainer P1: even first-pin establishment goes through the
+    // atomic shrink-only write — a concurrent invocation may have landed a
+    // smaller pin between our read and this write.
+    const applied = await sessionChainStore.shrinkCapacityPin(active.id, resolvedPin);
+    const currentPin = applied?.capacityPin;
+    if (currentPin && isUsableCapacityPin(currentPin) && currentPin.windowTokens < snapshot.capacity.windowTokens) {
+      return snapshotWithCapacity(snapshot, {
+        windowTokens: currentPin.windowTokens,
+        inputCeilingTokens: currentPin.inputCeilingTokens,
+        source: currentPin.source,
+        provenance: `${currentPin.provenance}; session-pinned (shrink allowed, expansion requires rollover)`,
+        actionable: currentPin.actionable,
+      });
+    }
     return snapshot;
   }
 
   if (resolvedPin && resolvedPin.windowTokens <= existingPin.windowTokens) {
-    await sessionChainStore.update(active.id, { capacityPin: resolvedPin, updatedAt: Date.now() });
+    // #1382 maintainer P1: the numeric shrink applies atomically against the
+    // CURRENT stored pin — two concurrent shrink candidates must never
+    // reorder into an expansion (delayed 180K must not overwrite a landed
+    // 150K).
+    const applied = await sessionChainStore.shrinkCapacityPin(active.id, resolvedPin);
+    const currentPin = applied?.capacityPin;
+    if (currentPin && isUsableCapacityPin(currentPin) && currentPin.windowTokens < resolvedPin.windowTokens) {
+      // A concurrent smaller shrink won the race — clamp this invocation's
+      // view to the stricter stored pin, not the candidate we prepared.
+      return snapshotWithCapacity(snapshot, {
+        windowTokens: currentPin.windowTokens,
+        inputCeilingTokens: currentPin.inputCeilingTokens,
+        source: currentPin.source,
+        provenance: `${currentPin.provenance}; session-pinned (shrink allowed, expansion requires rollover)`,
+        actionable: currentPin.actionable,
+      });
+    }
     return snapshotWithCapacity(snapshot, snapshot.capacity);
   }
 
@@ -217,7 +246,13 @@ export async function applyActiveSessionCapacityPin(options: {
     ? `; carrier now reports ${freshReport.toLocaleString()} tokens — seal the session to recover if this pin was polluted`
     : '';
   if (!isUsableCapacityPin(active.capacityPin)) {
-    await sessionChainStore.update(active.id, { capacityPin: existingPin, updatedAt: Date.now() });
+    // Same one-way fence for the upgrade materialization: a concurrent usable
+    // pin that constrains harder must survive.
+    const applied = await sessionChainStore.shrinkCapacityPin(active.id, existingPin);
+    const currentPin = applied?.capacityPin;
+    if (currentPin && isUsableCapacityPin(currentPin) && currentPin.windowTokens < existingPin.windowTokens) {
+      existingPin = currentPin;
+    }
   }
   if (recoveryNote !== '') {
     await sessionChainStore.appendCapacityPinProvenance(active.id, recoveryNote);

--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -222,15 +222,19 @@ export async function applyActiveSessionCapacityPin(options: {
   if (recoveryNote !== '') {
     await sessionChainStore.appendCapacityPinProvenance(active.id, recoveryNote);
   }
+  // Canonical evidence provenance: the recovery note appears exactly once,
+  // whether it was already persisted on the stored pin or is fresh to this
+  // invocation. The stored pin (merged atomically above) and the returned
+  // snapshot share this single deduplicated form.
+  const evidenceProvenance =
+    recoveryNote !== '' && !existingPin.provenance.includes(recoveryNote)
+      ? `${existingPin.provenance}${recoveryNote}`
+      : existingPin.provenance;
   return snapshotWithCapacity(snapshot, {
     windowTokens: existingPin.windowTokens,
     inputCeilingTokens: existingPin.inputCeilingTokens,
     source: existingPin.source,
-    provenance: `${existingPin.provenance}; session-pinned (shrink allowed, expansion requires rollover)${
-      pinBelowCarrierReport
-        ? `; carrier now reports ${freshReport.toLocaleString()} tokens — seal the session to recover if this pin was polluted`
-        : ''
-    }`,
+    provenance: `${evidenceProvenance}; session-pinned (shrink allowed, expansion requires rollover)`,
     actionable: existingPin.actionable,
   });
 }

--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -189,7 +189,12 @@ export async function applyActiveSessionCapacityPin(options: {
   // it must not auto-expand. Surface the recoverable state; expansion still
   // requires an explicit seal/rollover.
   const freshReport = snapshot.lastReportedWindowTokens;
-  const pinBelowCarrierReport = resolvedPin && freshReport != null && freshReport >= resolvedPin.windowTokens;
+  // #1382 maintainer P1: compare the RAW report against the ACTIVE pin, never
+  // the resolved candidate — KNOWN_MIN floor-raising (or a manual member cap)
+  // can lift resolvedPin above the raw report and silently suppress a
+  // legitimate recovery hint. Strict >: a report equal to the pin agrees with
+  // it and proves nothing recoverable.
+  const pinBelowCarrierReport = freshReport != null && freshReport > existingPin.windowTokens;
   if (pinBelowCarrierReport) {
     log.warn(
       {
@@ -203,8 +208,18 @@ export async function applyActiveSessionCapacityPin(options: {
     );
   }
 
-  if (!isUsableCapacityPin(active.capacityPin)) {
-    await sessionChainStore.update(active.id, { capacityPin: existingPin, updatedAt: Date.now() });
+  // #1382 maintainer P1: persist the recovery hint on the STORED pin
+  // (deduplicated) — the returned snapshot is per-invocation while the Hub and
+  // digests read the session record. Numeric pin fields never change here.
+  const recoveryNote = pinBelowCarrierReport
+    ? `; carrier now reports ${freshReport.toLocaleString()} tokens — seal the session to recover if this pin was polluted`
+    : '';
+  const hintAlreadyPersisted = existingPin.provenance.includes('seal the session to recover');
+  if (!isUsableCapacityPin(active.capacityPin) || (recoveryNote !== '' && !hintAlreadyPersisted)) {
+    await sessionChainStore.update(active.id, {
+      capacityPin: { ...existingPin, provenance: `${existingPin.provenance}${recoveryNote}` },
+      updatedAt: Date.now(),
+    });
   }
   return snapshotWithCapacity(snapshot, {
     windowTokens: existingPin.windowTokens,

--- a/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invocation-capacity-snapshot.ts
@@ -5,7 +5,18 @@
  * assembly, lifecycle checks, and provider-native controls consume that same
  * snapshot. A trusted carrier report may lower it during the invocation. The
  * active session persists that resolved capacity and may shrink, but cannot
- * expand until session rollover.
+ * expand until session rollover — not even when a later report exceeds the
+ * pin, because that state cannot distinguish a polluted pin (#1381) from a
+ * genuine provider shrink followed by genuine recovery. Polluted pins recover
+ * explicitly via seal/rollover; the recoverable state is surfaced in the pin
+ * provenance and logs.
+ *
+ * #1381: the snapshot carries two distinct quantities. `nativeWindowTokens` is
+ * the raw provider window owned by member configuration and is the only value
+ * a provider may inject as its native window; `capacity` is the effective
+ * usable capacity that carrier reports and the session pin constrain one-way.
+ * Codex reports `native * effective_context_window_percent`, so feeding the
+ * effective value back as native recursed (258400 → 245480 → 233206 → …).
  */
 
 import {
@@ -25,6 +36,7 @@ import {
 } from '../../../../../config/context-capacity.js';
 import { resolveEffectiveOpenCodeModel } from '../../../../../config/opencode-model.js';
 import { shouldTakeAction } from '../../../../../config/session-strategy.js';
+import { createModuleLogger } from '../../../../../infrastructure/logger.js';
 import type { ISessionSealer } from '../../session/SessionSealer.js';
 import type { ISessionChainStore } from '../../stores/ports/SessionChainStore.js';
 import {
@@ -47,6 +59,8 @@ const UNRESOLVED_CAPABILITY: AgentContextCapability = {
   reason: 'service did not declare a concrete context capability',
 };
 
+const log = createModuleLogger('invocation-capacity-snapshot');
+
 export interface InvocationCapacitySnapshot {
   readonly capacity: ResolvedContextCapacity;
   readonly capability: AgentContextCapability;
@@ -55,6 +69,23 @@ export interface InvocationCapacitySnapshot {
   /** Immutable resolver inputs captured at this invocation boundary. */
   readonly memberWindowTokens: number | null;
   readonly model: string | undefined;
+  /**
+   * #1381: raw/native provider window owned by member configuration (manual or
+   * catalog source), captured before any session pin or carrier report applies.
+   * This is the ONLY value a provider may inject as its native window; the
+   * effective/pinned `capacity.windowTokens` must never feed back as native.
+   * `null` means this invocation has no config-owned native window (capacity is
+   * report-derived or unresolved) and the provider must not inject one.
+   */
+  readonly nativeWindowTokens: number | null;
+  /**
+   * #1381: raw carrier-reported window applied during this invocation, before
+   * any resolver floor adjustment. Used to surface (never auto-expand) a
+   * session pin sitting below the currently reported capacity — that state may
+   * be pre-fix feedback-loop pollution, and recovery stays explicit via
+   * seal/rollover.
+   */
+  readonly lastReportedWindowTokens?: number;
 }
 
 export interface AuthoritativeContextUsage {
@@ -102,6 +133,15 @@ function snapshotWithCapacity(
  * cache. The current invocation may replace it with a smaller resolved value;
  * a larger value remains clamped until the old session is sealed and a new
  * active record is created.
+ *
+ * #1381 recovery semantics: a pin polluted by the pre-fix native/effective
+ * feedback loop is indistinguishable from a genuine provider shrink — in both
+ * cases a later carrier report can exceed the pin — so a larger report must
+ * NEVER auto-expand the pin (that would bypass the rollover gate). Recovery
+ * of polluted pins stays explicit: seal/roll over the session (#1313 manual
+ * seal), after which the fresh session adopts the reported capacity. When a
+ * fresh carrier report does exceed the pin, the state is surfaced observably
+ * (log + provenance) so the operator knows a seal will recover capacity.
  */
 export async function applyActiveSessionCapacityPin(options: {
   snapshot: InvocationCapacitySnapshot;
@@ -143,6 +183,26 @@ export async function applyActiveSessionCapacityPin(options: {
     return snapshotWithCapacity(snapshot, snapshot.capacity);
   }
 
+  // #1381: a fresh carrier report above the pin is observable evidence that the
+  // pin may have been polluted by the pre-fix feedback loop — but it is equally
+  // consistent with a genuine provider shrink followed by genuine recovery, so
+  // it must not auto-expand. Surface the recoverable state; expansion still
+  // requires an explicit seal/rollover.
+  const freshReport = snapshot.lastReportedWindowTokens;
+  const pinBelowCarrierReport = resolvedPin && freshReport != null && freshReport >= resolvedPin.windowTokens;
+  if (pinBelowCarrierReport) {
+    log.warn(
+      {
+        catId,
+        threadId,
+        sessionId: active.id,
+        pinnedTokens: existingPin.windowTokens,
+        freshReportTokens: freshReport,
+      },
+      'session capacity pin is below the carrier-reported window; if polluted by the pre-#1381 feedback loop, seal the session to recover (expansion requires rollover)',
+    );
+  }
+
   if (!isUsableCapacityPin(active.capacityPin)) {
     await sessionChainStore.update(active.id, { capacityPin: existingPin, updatedAt: Date.now() });
   }
@@ -150,7 +210,11 @@ export async function applyActiveSessionCapacityPin(options: {
     windowTokens: existingPin.windowTokens,
     inputCeilingTokens: existingPin.inputCeilingTokens,
     source: existingPin.source,
-    provenance: `${existingPin.provenance}; session-pinned (shrink allowed, expansion requires rollover)`,
+    provenance: `${existingPin.provenance}; session-pinned (shrink allowed, expansion requires rollover)${
+      pinBelowCarrierReport
+        ? `; carrier now reports ${freshReport.toLocaleString()} tokens — seal the session to recover if this pin was polluted`
+        : ''
+    }`,
     actionable: existingPin.actionable,
   });
 }
@@ -211,6 +275,10 @@ export function applyReportedWindowToInvocationSnapshot(options: {
   if (!snapshot.capability.reportsRuntimeWindow || reportedWindowSize == null) return snapshot;
   return {
     ...snapshot,
+    // #1381: keep the RAW report as provider evidence for polluted-pin
+    // observability; the resolver may floor-adjust the capacity, but the
+    // pin-below-report check keys on what the carrier actually reported.
+    lastReportedWindowTokens: reportedWindowSize,
     capacity: resolveContextCapacity({
       catId,
       memberWindowTokens: snapshot.memberWindowTokens,
@@ -278,6 +346,14 @@ export function resolveInvocationCapacitySnapshot(options: {
     ...(binding ? { binding } : {}),
     memberWindowTokens,
     model,
+    // #1381: only member configuration (manual/catalog) owns a native window.
+    // A report-derived or unresolved capacity has no raw value to inject —
+    // feeding the effective number back as Codex's native model_context_window
+    // is the recursive shrink this field exists to prevent.
+    nativeWindowTokens:
+      resolvedCapacity.source === 'manual' || resolvedCapacity.source === 'catalog'
+        ? resolvedCapacity.windowTokens
+        : null,
   };
 }
 

--- a/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
+++ b/packages/api/src/domains/cats/services/agents/invocation/invoke-single-cat.ts
@@ -2843,7 +2843,14 @@ export async function* invokeSingleCat(deps: InvocationDeps, params: InvocationP
 
     const baseOptions: AgentServiceOptions = {
       callbackEnv,
-      ...(invocationCapacitySnapshot ? { contextCapacity: invocationCapacitySnapshot.capacity } : {}),
+      ...(invocationCapacitySnapshot
+        ? {
+            contextCapacity: invocationCapacitySnapshot.capacity,
+            // #1381: native window for provider-native injection is owned by
+            // member config, captured pre-pin; may be null (no injection).
+            contextNativeWindowTokens: invocationCapacitySnapshot.nativeWindowTokens,
+          }
+        : {}),
       ...(reasoningEffortOverride ? { reasoningEffortOverride } : {}),
       ...(requestedServiceTier ? { requestedServiceTier } : {}),
       ...(accountEnv ? { accountEnv } : {}),

--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -1123,9 +1123,23 @@ export class CodexAgentService implements AgentService {
     const reasoningArgs = buildCodexReasoningArgs(effortLevel);
     const sandboxConfigArgs = ['--config', `sandbox_mode=${toTomlString(sandboxMode)}`];
     const approvalArgs = ['--config', `approval_policy="${approvalPolicy}"`];
-    const contextWindow = this.carrierMode === 'exec_json' ? options?.contextCapacity?.windowTokens : undefined;
+    // #1381: inject the config-owned RAW/NATIVE window, never the
+    // effective/pinned capacity — Codex reports back
+    // `native * effective_context_window_percent`, so injecting the pinned
+    // value recursed (258400 → 245480 → 233206 → …). An explicit null means
+    // this invocation has no config-owned window (report/pin-derived) and
+    // nothing may be injected; undefined is a legacy caller without an
+    // invocation snapshot and keeps the pre-#1381 contextCapacity behavior.
+    const nativeWindowTokens =
+      options?.contextNativeWindowTokens !== undefined
+        ? options.contextNativeWindowTokens
+        : options?.contextCapacity?.windowTokens;
+    const contextWindow =
+      this.carrierMode === 'exec_json' && nativeWindowTokens != null && nativeWindowTokens > 0
+        ? nativeWindowTokens
+        : undefined;
     const contextWindowArgs: string[] =
-      contextWindow && contextWindow > 0
+      contextWindow != null
         ? [
             '--config',
             `model_context_window=${contextWindow}`,

--- a/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
@@ -7,7 +7,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { CatId, HybridProgress, SessionPolicySnapshot, SessionRecord } from '@cat-cafe/shared';
+import type { CatId, HybridProgress, SessionCapacityPin, SessionPolicySnapshot, SessionRecord } from '@cat-cafe/shared';
 import type { StoreReadOptions } from './StoreReadOptions.js';
 import { throwIfStoreReadAborted } from './StoreReadOptions.js';
 
@@ -131,6 +131,15 @@ export interface ISessionChainStore {
    * or null when nothing was written.
    */
   appendCapacityPinProvenance(id: string, note: string): SessionRecord | null | Promise<SessionRecord | null>;
+  /**
+   * #1382 maintainer P1: atomically apply a shrink-only capacity pin — the
+   * candidate is written only when no usable pin is stored or its windowTokens
+   * is <= the CURRENT stored pin's. A stored smaller constraint is never
+   * overwritten by a delayed larger candidate (one-way pin invariant).
+   * Returns the record as it stands after the atomic decision, or null when
+   * the session does not exist.
+   */
+  shrinkCapacityPin(id: string, candidate: SessionCapacityPin): SessionRecord | null | Promise<SessionRecord | null>;
   /** F118: List IDs of all sessions currently in 'sealing' status (for global reaper). */
   listSealingSessions(): string[] | Promise<string[]>;
 }
@@ -499,6 +508,25 @@ export class SessionChainStore implements ISessionChainStore {
     // Merge onto the CURRENT stored pin — never a caller-stale copy, so a
     // concurrent shrink is never undone (synchronous store = atomic here).
     record.capacityPin = { ...pin, provenance: `${pin.provenance}${note}` };
+    record.updatedAt = Date.now();
+    return record;
+  }
+
+  shrinkCapacityPin(id: string, candidate: SessionCapacityPin): SessionRecord | null {
+    const record = this.records.get(id);
+    if (!record) return null;
+    const current = record.capacityPin;
+    if (
+      current &&
+      Number.isFinite(current.windowTokens) &&
+      current.windowTokens > 0 &&
+      candidate.windowTokens > current.windowTokens
+    ) {
+      // A smaller constraint is already stored — never expand (synchronous
+      // store = the compare-and-write is atomic here).
+      return record;
+    }
+    record.capacityPin = candidate;
     record.updatedAt = Date.now();
     return record;
   }

--- a/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
@@ -123,6 +123,14 @@ export interface ISessionChainStore {
   getByChainKey(chainKey: string): SessionRecord | null | Promise<SessionRecord | null>;
   /** Atomically increment compressionCount and return the new value. Returns null if session not found. */
   incrementCompressionCount(id: string): number | null | Promise<number | null>;
+  /**
+   * #1382 maintainer P1: atomically merge a provenance note into the STORED
+   * capacityPin without copying caller-stale numeric fields — a concurrent
+   * pin shrink must never be undone by a delayed provenance write. Dedup:
+   * no-op when the exact note is already present. Returns the updated record,
+   * or null when nothing was written.
+   */
+  appendCapacityPinProvenance(id: string, note: string): SessionRecord | null | Promise<SessionRecord | null>;
   /** F118: List IDs of all sessions currently in 'sealing' status (for global reaper). */
   listSealingSessions(): string[] | Promise<string[]>;
 }
@@ -481,6 +489,18 @@ export class SessionChainStore implements ISessionChainStore {
     record.compressionCount += 1;
     record.updatedAt = Date.now();
     return record.compressionCount;
+  }
+
+  appendCapacityPinProvenance(id: string, note: string): SessionRecord | null {
+    const record = this.records.get(id);
+    if (!record?.capacityPin) return null;
+    const pin = record.capacityPin;
+    if (typeof pin.provenance !== 'string' || pin.provenance.includes(note)) return null;
+    // Merge onto the CURRENT stored pin — never a caller-stale copy, so a
+    // concurrent shrink is never undone (synchronous store = atomic here).
+    record.capacityPin = { ...pin, provenance: `${pin.provenance}${note}` };
+    record.updatedAt = Date.now();
+    return record;
   }
 
   listSealingSessions(): string[] {

--- a/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/ports/SessionChainStore.ts
@@ -1,4 +1,26 @@
 /**
+ * #1382 review P2: stable identity of the capacity-pin recovery note. A pin
+ * carries at most ONE recovery instruction — when the carrier's reported
+ * number jitters (245480 → 245481), the previous note is replaced in place
+ * rather than appended, so provenance never grows unbounded.
+ */
+export const CAPACITY_PIN_RECOVERY_NOTE_PATTERN =
+  /; carrier now reports [\d,]+ tokens — seal the session to recover if this pin was polluted/;
+
+/**
+ * Upsert the recovery note into a provenance string: exact note already
+ * present → unchanged; an older note with a different report number →
+ * replaced in place; otherwise appended.
+ */
+export function upsertCapacityPinRecoveryNote(provenance: string, note: string): string {
+  if (provenance.includes(note)) return provenance;
+  if (CAPACITY_PIN_RECOVERY_NOTE_PATTERN.test(provenance)) {
+    return provenance.replace(CAPACITY_PIN_RECOVERY_NOTE_PATTERN, note);
+  }
+  return `${provenance}${note}`;
+}
+
+/**
  * Session Chain Store
  * F24: Thread → N Sessions per cat, context health tracking.
  *
@@ -507,7 +529,9 @@ export class SessionChainStore implements ISessionChainStore {
     if (typeof pin.provenance !== 'string' || pin.provenance.includes(note)) return null;
     // Merge onto the CURRENT stored pin — never a caller-stale copy, so a
     // concurrent shrink is never undone (synchronous store = atomic here).
-    record.capacityPin = { ...pin, provenance: `${pin.provenance}${note}` };
+    // upsert = semantic dedup: a jittered report number replaces the previous
+    // note in place instead of growing provenance unbounded.
+    record.capacityPin = { ...pin, provenance: upsertCapacityPinRecoveryNote(pin.provenance, note) };
     record.updatedAt = Date.now();
     return record;
   }

--- a/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
@@ -240,7 +240,16 @@ if not data then return 0 end
 local ok, pin = pcall(cjson.decode, data)
 if not ok or type(pin) ~= 'table' or type(pin['provenance']) ~= 'string' then return 0 end
 if string.find(pin['provenance'], ARGV[1], 1, true) then return 0 end
-pin['provenance'] = pin['provenance'] .. ARGV[1]
+-- #1382 review P2: semantic dedup — a jittered report number replaces the
+-- previous recovery note in place (one pin carries at most one recovery
+-- instruction) instead of growing provenance unbounded.
+local pattern = "; carrier now reports [%d,]+ tokens .-seal the session to recover if this pin was polluted"
+local replaced, count = string.gsub(pin['provenance'], pattern, ARGV[1], 1)
+if count == 0 then
+  pin['provenance'] = pin['provenance'] .. ARGV[1]
+else
+  pin['provenance'] = replaced
+end
 redis.call('HSET', KEYS[1], 'capacityPin', cjson.encode(pin), 'updatedAt', ARGV[2])
 return 1
 `;

--- a/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
@@ -245,6 +245,29 @@ redis.call('HSET', KEYS[1], 'capacityPin', cjson.encode(pin), 'updatedAt', ARGV[
 return 1
 `;
 
+/**
+ * #1382 maintainer P1: atomic shrink-only pin application. The candidate is
+ * written only when no usable pin is stored or its windowTokens is <= the
+ * CURRENT stored pin's — a stored smaller constraint is never overwritten by
+ * a delayed larger candidate. KEYS[1] = detail key; ARGV[1] = candidate JSON;
+ * ARGV[2] = updatedAt. Returns 1 when written, 0 when the stored pin already
+ * constrains harder, -1 when the record is missing.
+ */
+const SHRINK_CAPACITY_PIN_LUA = `
+if redis.call('EXISTS', KEYS[1]) == 0 then return -1 end
+local data = redis.call('HGET', KEYS[1], 'capacityPin')
+if data then
+  local ok, current = pcall(cjson.decode, data)
+  local candidate = cjson.decode(ARGV[1])
+  if ok and type(current) == 'table' and type(current['windowTokens']) == 'number'
+     and current['windowTokens'] > 0 and candidate['windowTokens'] > current['windowTokens'] then
+    return 0
+  end
+end
+redis.call('HSET', KEYS[1], 'capacityPin', ARGV[1], 'updatedAt', ARGV[2])
+return 1
+`;
+
 export class RedisSessionChainStore implements ISessionChainStore {
   private readonly redis: RedisClient;
   private threadIndexReady = false;
@@ -755,6 +778,21 @@ export class RedisSessionChainStore implements ISessionChainStore {
     // script comment) — a concurrent shrink is never undone by stale numerics.
     const result = await this.redis.eval(APPEND_CAPACITY_PIN_PROVENANCE_LUA, 1, detailKey, note, String(Date.now()));
     if ((result as number) !== 1) return null;
+    return this.get(id);
+  }
+
+  async shrinkCapacityPin(id: string, candidate: SessionCapacityPin): Promise<SessionRecord | null> {
+    const detailKey = SessionChainKeys.detail(id);
+    // Lua: atomic compare-and-write — the candidate lands only when it does
+    // not expand beyond the CURRENT stored pin (one-way pin invariant).
+    const result = await this.redis.eval(
+      SHRINK_CAPACITY_PIN_LUA,
+      1,
+      detailKey,
+      JSON.stringify(candidate),
+      String(Date.now()),
+    );
+    if ((result as number) < 0) return null;
     return this.get(id);
   }
 

--- a/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
+++ b/packages/api/src/domains/cats/services/stores/redis/RedisSessionChainStore.ts
@@ -226,6 +226,25 @@ redis.call('HSET', KEYS[1], 'updatedAt', ARGV[1])
 return newCount
 `;
 
+/**
+ * #1382 maintainer P1: atomically merge a provenance note into the stored
+ * capacityPin. The script re-reads the CURRENT pin inside the same Redis
+ * execution, so a delayed writer can never undo a concurrent shrink by
+ * writing back a stale pin object. Dedup lives here: an already-present note
+ * is not re-appended. KEYS[1] = detail key; ARGV[1] = note; ARGV[2] =
+ * updatedAt. Returns 1 when appended, 0 when skipped.
+ */
+const APPEND_CAPACITY_PIN_PROVENANCE_LUA = `
+local data = redis.call('HGET', KEYS[1], 'capacityPin')
+if not data then return 0 end
+local ok, pin = pcall(cjson.decode, data)
+if not ok or type(pin) ~= 'table' or type(pin['provenance']) ~= 'string' then return 0 end
+if string.find(pin['provenance'], ARGV[1], 1, true) then return 0 end
+pin['provenance'] = pin['provenance'] .. ARGV[1]
+redis.call('HSET', KEYS[1], 'capacityPin', cjson.encode(pin), 'updatedAt', ARGV[2])
+return 1
+`;
+
 export class RedisSessionChainStore implements ISessionChainStore {
   private readonly redis: RedisClient;
   private threadIndexReady = false;
@@ -728,6 +747,15 @@ export class RedisSessionChainStore implements ISessionChainStore {
     const result = await this.redis.eval(INCR_COMPRESSION_LUA, 1, detailKey, String(Date.now()));
     const code = result as number;
     return code < 0 ? null : code;
+  }
+
+  async appendCapacityPinProvenance(id: string, note: string): Promise<SessionRecord | null> {
+    const detailKey = SessionChainKeys.detail(id);
+    // Lua: atomic read-merge-write against the CURRENT stored pin (see the
+    // script comment) — a concurrent shrink is never undone by stale numerics.
+    const result = await this.redis.eval(APPEND_CAPACITY_PIN_PROVENANCE_LUA, 1, detailKey, note, String(Date.now()));
+    if ((result as number) !== 1) return null;
+    return this.get(id);
   }
 
   async listSealingSessions(): Promise<string[]> {

--- a/packages/api/src/domains/cats/services/types.ts
+++ b/packages/api/src/domains/cats/services/types.ts
@@ -460,6 +460,18 @@ export interface AgentServiceOptions {
   sessionId?: string;
   /** #1208: same capacity snapshot used by prompt assembly and lifecycle health. */
   contextCapacity?: AgentContextCapacity;
+  /**
+   * #1381: raw/native provider window owned by member config (manual/catalog),
+   * captured before any session pin or carrier report shrinks the effective
+   * capacity. Providers with nativeWindowControl inject THIS as their native
+   * window (e.g. Codex `model_context_window`), never the effective/pinned
+   * `contextCapacity.windowTokens` — Codex reports back
+   * `native * effective_context_window_percent`, so feeding the effective value
+   * back recursed (258400 → 245480 → 233206 → …).
+   * `null` explicitly means "no config-owned native window; do not inject".
+   * `undefined` is a legacy caller: fall back to `contextCapacity.windowTokens`.
+   */
+  contextNativeWindowTokens?: number | null;
   /** F262: Raw per-thread member effort. Providers validate against the effective model before applying it. */
   reasoningEffortOverride?: CliEffortPreset;
   /** F291: Resolved Codex OAuth requested tier. Undefined means inherit Codex user config. */

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -2213,6 +2213,78 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     );
   });
 
+  test('injects the config-owned native window, not the session-pinned effective capacity (#1381)', async () => {
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({
+      l0CompilerFn: fakeL0Compiler,
+      spawnFn,
+      catId: 'runtime-sol',
+      model: 'gpt-5.6-sol',
+    });
+
+    const promise = collect(
+      service.invoke('hello', {
+        // Effective capacity after the session pin; Codex reports 95% of the
+        // native window, so injecting this back would recurse (258400 → 245480
+        // → 233206 → …). The native injection must use the config-owned value.
+        contextCapacity: { windowTokens: 245480, inputCeilingTokens: 229480, actionable: true },
+        contextNativeWindowTokens: 258400,
+      }),
+    );
+    emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-native-window-1381' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.ok(
+      args.includes('model_context_window=258400'),
+      `native model_context_window must come from member config, got argv: ${JSON.stringify(args)}`,
+    );
+    assert.ok(
+      !args.includes('model_context_window=245480'),
+      'session-pinned effective capacity must never be fed back as the native window',
+    );
+    assert.ok(
+      args.includes('model_auto_compact_token_limit=227392'),
+      'auto-compact limit derives from the native window',
+    );
+  });
+
+  test('skips native window injection when the invocation has no config-owned window (#1381)', async () => {
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({
+      l0CompilerFn: fakeL0Compiler,
+      spawnFn,
+      catId: 'runtime-sol',
+      model: 'gpt-5.6-sol',
+    });
+
+    const promise = collect(
+      service.invoke('hello', {
+        contextCapacity: { windowTokens: 245480, inputCeilingTokens: 229480, actionable: true },
+        // Explicit null: this invocation's capacity is report/pin-derived, so
+        // there is no raw/native value to hand Codex — injecting the effective
+        // capacity would restart the feedback loop.
+        contextNativeWindowTokens: null,
+      }),
+    );
+    emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-no-native-window-1381' }]);
+    await promise;
+
+    const args = spawnFn.mock.calls[0].arguments[1];
+    assert.equal(
+      args.some((arg) => arg.startsWith('model_context_window=')),
+      false,
+      `report-derived capacity must not become a native window: ${JSON.stringify(args)}`,
+    );
+    assert.equal(
+      args.some((arg) => arg.startsWith('model_auto_compact_token_limit=')),
+      false,
+      'no native window means no derived compaction limit either',
+    );
+  });
+
   test('keeps binding-owned model identity ahead of free-form cliConfigArgs', async () => {
     for (const rawOverride of [
       '--model gpt-4o',

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -440,6 +440,13 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
         catId: TEST_CAT_ID,
         l0CompilerFn: fakeL0Compiler,
         spawnFn,
+        // resolveCliCommand probes the binary's existence before spawn even
+        // with an injected spawnFn, and the real codex CLI is absent on CI
+        // runners (codex-agent-service.test.js is not in the public suite, so
+        // only this bridge file hits that gate). Point at the running node
+        // binary — guaranteed resolvable everywhere; the mock spawnFn means
+        // it is never actually executed.
+        cliCommand: process.execPath,
         model: 'gpt-5.6-sol',
         auditLog: { append: async () => {} },
         rawArchive: { append: async () => {}, getPath: () => undefined },

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -1,0 +1,301 @@
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import { catRegistry } from '@cat-cafe/shared';
+
+const TEST_CAT_ID = 'issue-1381-codex-window';
+const MANUAL_WINDOW = 258_400;
+const CODEX_EFFECTIVE_PERCENT = 0.95;
+const EFFECTIVE_WINDOW = Math.floor(MANUAL_WINDOW * CODEX_EFFECTIVE_PERCENT); // 245480
+
+// Codex exec_json reports token_count.model_context_window AFTER applying its
+// effective_context_window_percent to the injected native model_context_window.
+const codexEffectiveReport = (nativeWindow) => Math.floor(nativeWindow * CODEX_EFFECTIVE_PERCENT);
+
+describe('issue #1381: Codex exec_json native/effective context window feedback loop', () => {
+  let resolveInvocationCapacitySnapshot;
+  let applyUsageEvidenceToInvocationSnapshot;
+  let applyActiveSessionCapacityPin;
+  let SessionChainStore;
+  let savedConfigs;
+
+  function registerTestCat(contextWindow = MANUAL_WINDOW, defaultModel = 'gpt-5.6-sol') {
+    catRegistry.reset();
+    catRegistry.register(TEST_CAT_ID, {
+      id: TEST_CAT_ID,
+      name: TEST_CAT_ID,
+      displayName: 'Issue 1381 Test',
+      avatar: '🐱',
+      color: { primary: '#000', secondary: '#fff' },
+      mentionPatterns: ['@issue-1381-codex-window'],
+      clientId: 'openai',
+      accountRef: 'codex-oauth',
+      provider: 'openai',
+      defaultModel,
+      contextWindow,
+      mcpSupport: false,
+      roleDescription: 'test',
+      personality: 'test',
+    });
+  }
+
+  function execJsonService() {
+    return {
+      async *invoke() {},
+      contextCapability() {
+        return {
+          provider: 'openai',
+          carrier: 'exec_json',
+          reportsRuntimeWindow: true,
+          authoritativeUsage: true,
+          usageTelemetry: 'available',
+          nativeWindowControl: true,
+          nativeCompressionControl: true,
+          observesCompression: true,
+          reason: 'test codex exec_json carrier',
+        };
+      },
+    };
+  }
+
+  before(async () => {
+    ({ resolveInvocationCapacitySnapshot, applyUsageEvidenceToInvocationSnapshot, applyActiveSessionCapacityPin } =
+      await import('../dist/domains/cats/services/agents/invocation/invocation-capacity-snapshot.js'));
+    ({ SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js'));
+    savedConfigs = catRegistry.getAllConfigs();
+  });
+
+  after(() => {
+    catRegistry.reset();
+    for (const [id, config] of Object.entries(savedConfigs)) catRegistry.register(id, config);
+  });
+
+  /**
+   * One resume round: resolve member config, apply the session pin, inject the
+   * native window into Codex, observe Codex's effective report, apply the pin
+   * again. Returns the post-report snapshot.
+   */
+  async function runResumeRound(store, threadId, reportOverride) {
+    const resolved = await resolveInvocationCapacitySnapshot({
+      catId: TEST_CAT_ID,
+      service: execJsonService(),
+    });
+    const pinned = await applyActiveSessionCapacityPin({
+      snapshot: resolved,
+      catId: TEST_CAT_ID,
+      threadId,
+      sessionChainStore: store,
+    });
+    // Codex applies its 95% effective factor to whatever native window we
+    // injected; the report must never become the next native window.
+    const report = reportOverride ?? codexEffectiveReport(pinned.nativeWindowTokens);
+    const observed = applyUsageEvidenceToInvocationSnapshot({
+      snapshot: pinned,
+      catId: TEST_CAT_ID,
+      capability: pinned.capability,
+      reportedWindowSize: report,
+    });
+    return applyActiveSessionCapacityPin({
+      snapshot: observed,
+      catId: TEST_CAT_ID,
+      threadId,
+      sessionChainStore: store,
+    });
+  }
+
+  it('keeps the manual-configured native window stable across 12 resumes of the same session', async () => {
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-stability';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-stability',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+
+    // Round 1 establishes the pin: native 258400 → Codex reports 245480.
+    const first = await runResumeRound(store, threadId);
+    assert.equal(first.nativeWindowTokens, MANUAL_WINDOW);
+    assert.equal(first.capacity.windowTokens, EFFECTIVE_WINDOW);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+
+    // Rounds 2..12 must be a fixed point: before the fix each round fed the
+    // effective report back as the next native window (258400 → 245480 →
+    // 233206 → …); now the native window comes from member config every time.
+    for (let round = 2; round <= 12; round += 1) {
+      const snapshot = await runResumeRound(store, threadId);
+      assert.equal(
+        snapshot.nativeWindowTokens,
+        MANUAL_WINDOW,
+        `round ${round}: native model_context_window must stay at the configured ${MANUAL_WINDOW}`,
+      );
+      assert.equal(
+        snapshot.capacity.windowTokens,
+        EFFECTIVE_WINDOW,
+        `round ${round}: effective capacity must stay at ${EFFECTIVE_WINDOW}, not shrink recursively`,
+      );
+      assert.equal(
+        store.get(active.id)?.capacityPin?.windowTokens,
+        EFFECTIVE_WINDOW,
+        `round ${round}: session pin must stay at ${EFFECTIVE_WINDOW}`,
+      );
+    }
+  });
+
+  it('still shrinks the pin when the provider independently reports a genuinely smaller window', async () => {
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-genuine-shrink';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-shrink',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+
+    await runResumeRound(store, threadId);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+
+    // A genuinely independent reduction (e.g. provider/model metadata change),
+    // not the 95% echo of our own injection.
+    const shrunk = await runResumeRound(store, threadId, 200_000);
+    assert.equal(shrunk.capacity.windowTokens, 200_000);
+    assert.equal(shrunk.capacity.source, 'reported');
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+
+    // The shrink persists and does not oscillate back while the provider keeps
+    // reporting the reduced window.
+    const steady = await runResumeRound(store, threadId, 200_000);
+    assert.equal(steady.capacity.windowTokens, 200_000);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+  });
+
+  it('never auto-expands a pin on a larger fresh report — recovery stays explicit via seal/rollover', async () => {
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-recovery';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-recovery',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    // Pin polluted by the old feedback loop (258400 * 0.95^11 ≈ 146973).
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 146_973,
+        inputCeilingTokens: 130_973,
+        source: 'reported',
+        provenance: 'Carrier reported 146,973 tokens (polluted by pre-fix feedback loop)',
+        actionable: true,
+      },
+    });
+
+    // Codex now reports the stable effective window (245480) — larger than the
+    // polluted pin. A larger report cannot distinguish pre-fix pollution from
+    // a genuine shrink followed by genuine recovery, so the pin must NOT
+    // auto-expand; the recoverable state is surfaced in the provenance.
+    const clamped = await runResumeRound(store, threadId);
+    assert.equal(clamped.capacity.windowTokens, 146_973);
+    assert.match(clamped.capacity.provenance, /session-pinned/);
+    assert.match(clamped.capacity.provenance, /seal the session to recover/);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 146_973);
+
+    // Explicit recovery: sealing the session ends the pin; the fresh session
+    // adopts the carrier-reported capacity on its first invocation.
+    store.update(active.id, { status: 'sealed' });
+    const fresh = store.create({
+      cliSessionId: 'cli-issue-1381-recovered',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    const recovered = await runResumeRound(store, threadId);
+    assert.equal(recovered.capacity.windowTokens, EFFECTIVE_WINDOW);
+    assert.equal(store.get(fresh.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+  });
+
+  it('does not expand a genuinely shrunk pin when the provider later reports a larger window', async () => {
+    // 砚砚 review counterexample: genuine provider shrink to 200K, then a later
+    // report of 245480. The larger report is genuine independent evidence, but
+    // expansion past the pin remains gated on rollover.
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-genuine-then-larger';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-genuine-then-larger',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+
+    await runResumeRound(store, threadId, 200_000);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+
+    const later = await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
+    assert.equal(later.capacity.windowTokens, 200_000);
+    assert.match(later.capacity.provenance, /session-pinned/);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+  });
+
+  it('does not expand a pin from a floor-raised catalog value without raw provider proof', async () => {
+    // claude-fable-5: KNOWN_MIN floor raises a stale 200K CLI report to 1M in
+    // the resolver, but the raw report never proved 1M — the pin must not
+    // expand on that basis.
+    registerTestCat(undefined, 'claude-fable-5');
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-floor';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-floor',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 200_000,
+        inputCeilingTokens: 184_000,
+        source: 'reported',
+        provenance: 'Carrier reported 200,000 tokens',
+        actionable: true,
+      },
+    });
+
+    const recovered = await runResumeRound(store, threadId, 200_000);
+    assert.equal(recovered.capacity.windowTokens, 200_000);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+  });
+
+  it('keeps expansion gated on rollover when no fresh carrier report exists', async () => {
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-no-report';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-no-report',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+
+    await runResumeRound(store, threadId);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+
+    // Member raises the manual cap mid-session; without a carrier report the
+    // active session must NOT expand — rollover semantics are preserved.
+    registerTestCat(400_000);
+    const resolved = await resolveInvocationCapacitySnapshot({
+      catId: TEST_CAT_ID,
+      service: execJsonService(),
+    });
+    const pinned = await applyActiveSessionCapacityPin({
+      snapshot: resolved,
+      catId: TEST_CAT_ID,
+      threadId,
+      sessionChainStore: store,
+    });
+    assert.equal(pinned.capacity.windowTokens, EFFECTIVE_WINDOW);
+    assert.match(pinned.capacity.provenance, /session-pinned/);
+    assert.equal(pinned.nativeWindowTokens, 400_000);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+  });
+});

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -212,13 +212,18 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     // deduplicated and without touching the numeric pin.
     const storedPin = store.get(active.id)?.capacityPin;
     assert.match(storedPin?.provenance, /carrier now reports 245,480 tokens — seal the session to recover/);
-    await runResumeRound(store, threadId);
+    const secondRound = await runResumeRound(store, threadId);
     const persistedPin = store.get(active.id)?.capacityPin;
     assert.equal(persistedPin?.windowTokens, 146_973);
     assert.equal(
       persistedPin?.provenance?.match(/seal the session to recover/g)?.length,
       1,
       'recovery hint must be persisted once, not re-appended every round',
+    );
+    assert.equal(
+      secondRound.capacity.provenance.match(/seal the session to recover/g)?.length,
+      1,
+      'the returned snapshot must carry the hint exactly once on repeat rounds',
     );
 
     // Explicit recovery: sealing the session ends the pin; the fresh session

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -36,7 +36,8 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       ...(accountRef ? { accountRef } : {}),
       provider: 'openai',
       defaultModel,
-      contextWindow,
+      // null = Auto mode (no manual member window; catalog/report-owned).
+      ...(contextWindow === null ? {} : { contextWindow }),
       mcpSupport: false,
       roleDescription: 'test',
       personality: 'test',
@@ -206,6 +207,20 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     assert.match(clamped.capacity.provenance, /seal the session to recover/);
     assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 146_973);
 
+    // Maintainer P1: the hint must also land on the STORED pin (the Hub and
+    // digests read the session record, not the per-invocation snapshot),
+    // deduplicated and without touching the numeric pin.
+    const storedPin = store.get(active.id)?.capacityPin;
+    assert.match(storedPin?.provenance, /carrier now reports 245,480 tokens — seal the session to recover/);
+    await runResumeRound(store, threadId);
+    const persistedPin = store.get(active.id)?.capacityPin;
+    assert.equal(persistedPin?.windowTokens, 146_973);
+    assert.equal(
+      persistedPin?.provenance?.match(/seal the session to recover/g)?.length,
+      1,
+      'recovery hint must be persisted once, not re-appended every round',
+    );
+
     // Explicit recovery: sealing the session ends the pin; the fresh session
     // adopts the carrier-reported capacity on its first invocation.
     store.update(active.id, { status: 'sealed' });
@@ -241,13 +256,51 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     assert.equal(later.capacity.windowTokens, 200_000);
     assert.match(later.capacity.provenance, /session-pinned/);
     assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+    // The larger raw report exceeds the active pin → the recovery hint is
+    // persisted on the stored record (the pin itself stays clamped).
+    assert.match(store.get(active.id)?.capacityPin?.provenance, /seal the session to recover/);
+  });
+
+  it('gates the recovery hint on the raw report vs the active pin (manual cap + floor-raised candidate)', async () => {
+    // Maintainer P1 exact counterexample: manual 258400 + claude-fable-5 +
+    // active pin 200000 + raw report 245480. The KNOWN_MIN floor lifts the
+    // resolver candidate past the raw report (manual branch → 258400), so the
+    // old predicate (report >= resolvedPin) silently produced no hint. The pin
+    // correctly stays 200000; the hint must fire because the RAW report
+    // exceeds the ACTIVE pin.
+    registerTestCat(undefined, 'claude-fable-5');
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-floor-manual';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-floor-manual',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 200_000,
+        inputCeilingTokens: 184_000,
+        source: 'reported',
+        provenance: 'Carrier reported 200,000 tokens',
+        actionable: true,
+      },
+    });
+
+    const clamped = await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
+    assert.equal(clamped.capacity.windowTokens, 200_000);
+    assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+    assert.match(store.get(active.id)?.capacityPin?.provenance, /seal the session to recover/);
   });
 
   it('does not expand a pin from a floor-raised catalog value without raw provider proof', async () => {
-    // claude-fable-5: KNOWN_MIN floor raises a stale 200K CLI report to 1M in
-    // the resolver, but the raw report never proved 1M — the pin must not
-    // expand on that basis.
-    registerTestCat(undefined, 'claude-fable-5');
+    // claude-fable-5 in Auto mode (no manual member window): KNOWN_MIN floor
+    // raises any raw report below 1M to 1M in the resolver — the resolved
+    // candidate therefore exceeds the active 200K pin in BOTH controls, so
+    // only the raw report can distinguish them. Positive: raw 245480 > pin →
+    // hint persisted. Negative: raw 200000 == pin → no hint. In neither case
+    // may the pin expand on the floor-raised value.
+    registerTestCat(null, 'claude-fable-5');
     const store = new SessionChainStore();
     const threadId = 'thread-issue-1381-floor';
     const active = store.create({
@@ -266,9 +319,36 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       },
     });
 
-    const recovered = await runResumeRound(store, threadId, 200_000);
-    assert.equal(recovered.capacity.windowTokens, 200_000);
+    const positive = await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
+    assert.equal(positive.capacity.windowTokens, 200_000);
     assert.equal(store.get(active.id)?.capacityPin?.windowTokens, 200_000);
+    assert.match(store.get(active.id)?.capacityPin?.provenance, /seal the session to recover/);
+
+    // Negative control on a fresh session: raw report equal to the pin proves
+    // nothing recoverable even after floor-raising — no hint may appear.
+    registerTestCat(null, 'claude-fable-5');
+    const controlStore = new SessionChainStore();
+    const controlThreadId = 'thread-issue-1381-floor-control';
+    const control = controlStore.create({
+      cliSessionId: 'cli-issue-1381-floor-control',
+      threadId: controlThreadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    controlStore.update(control.id, {
+      capacityPin: {
+        windowTokens: 200_000,
+        inputCeilingTokens: 184_000,
+        source: 'reported',
+        provenance: 'Carrier reported 200,000 tokens',
+        actionable: true,
+      },
+    });
+
+    const negative = await runResumeRound(controlStore, controlThreadId, 200_000);
+    assert.equal(negative.capacity.windowTokens, 200_000);
+    assert.equal(controlStore.get(control.id)?.capacityPin?.windowTokens, 200_000);
+    assert.doesNotMatch(controlStore.get(control.id)?.capacityPin?.provenance, /seal the session to recover/);
   });
 
   it('keeps expansion gated on rollover when no fresh carrier report exists', async () => {

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -408,6 +408,58 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     );
   });
 
+  it('never reorders concurrent shrinks into an expansion (200K pin, 150K lands, delayed 180K)', async () => {
+    // Maintainer P1 probe, one level up from the provenance merge: invocation
+    // A reads pin 200000 and prepares a genuine shrink to 180000; invocation
+    // B's smaller shrink to 150000 lands first; A's delayed write must not
+    // restore 180000. Final pin stays 150000 and A's returned view clamps.
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-shrink-reorder';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-shrink-reorder',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 200_000,
+        inputCeilingTokens: 184_000,
+        source: 'reported',
+        provenance: 'Carrier reported 200,000 tokens',
+        actionable: true,
+      },
+    });
+
+    const atomicShrink = store.shrinkCapacityPin.bind(store);
+    store.shrinkCapacityPin = (id, candidate) => {
+      if (candidate.windowTokens === 180_000) {
+        // Invocation B's smaller shrink lands while A is paused at the write.
+        store.update(id, {
+          capacityPin: {
+            windowTokens: 150_000,
+            inputCeilingTokens: 134_000,
+            source: 'reported',
+            provenance: 'Carrier reported 150,000 tokens',
+            actionable: true,
+          },
+          updatedAt: Date.now(),
+        });
+      }
+      return atomicShrink(id, candidate);
+    };
+
+    const shrunk = await runResumeRound(store, threadId, 180_000);
+    const finalPin = store.get(active.id)?.capacityPin;
+    assert.equal(finalPin?.windowTokens, 150_000, 'delayed 180K must not overwrite the concurrent 150K');
+    assert.equal(
+      shrunk.capacity.windowTokens,
+      150_000,
+      "the losing invocation's returned view clamps to the stored smaller pin",
+    );
+  });
+
   it('keeps expansion gated on rollover when no fresh carrier report exists', async () => {
     registerTestCat();
     const store = new SessionChainStore();

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -452,7 +452,10 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       const sessionKey = `user-1:${TEST_CAT_ID}:${threadId}`;
       const deps = {
         registry: {
-          create: () => ({ invocationId: `inv-bridge-${++invocationCounter}`, callbackToken: `tok-${invocationCounter}` }),
+          create: () => ({
+            invocationId: `inv-bridge-${++invocationCounter}`,
+            callbackToken: `tok-${invocationCounter}`,
+          }),
           verify: async () => ({ ok: false, reason: 'unknown_invocation' }),
         },
         sessionManager: {
@@ -535,10 +538,7 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
           msgs.some((m) => m.type === 'done'),
           `round ${round}: invocation must complete`,
         );
-        assert.ok(
-          !msgs.some((m) => m.type === 'error'),
-          `round ${round}: invocation must not error`,
-        );
+        assert.ok(!msgs.some((m) => m.type === 'error'), `round ${round}: invocation must not error`);
         assert.equal(
           store.get(active.id)?.capacityPin?.windowTokens,
           EFFECTIVE_WINDOW,

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -351,6 +351,58 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     assert.doesNotMatch(controlStore.get(control.id)?.capacityPin?.provenance, /seal the session to recover/);
   });
 
+  it('merges the persisted recovery hint onto the current pin — a concurrent shrink is never undone', async () => {
+    // Maintainer P1 interleaving probe: invocation A reads active pin 200000
+    // and pauses at the recovery-note write for raw report 245480; invocation
+    // B lands a genuine shrink to 150000; A's delayed write must NOT restore
+    // the stale 200000. The final pin stays 150000 with the hint present
+    // exactly once.
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-lost-update';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-lost-update',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 200_000,
+        inputCeilingTokens: 184_000,
+        source: 'reported',
+        provenance: 'Carrier reported 200,000 tokens',
+        actionable: true,
+      },
+    });
+
+    const atomicAppend = store.appendCapacityPinProvenance.bind(store);
+    store.appendCapacityPinProvenance = (id, note) => {
+      // Invocation B's genuine shrink lands while A is paused at the note write.
+      store.update(id, {
+        capacityPin: {
+          windowTokens: 150_000,
+          inputCeilingTokens: 134_000,
+          source: 'reported',
+          provenance: 'Carrier reported 150,000 tokens',
+          actionable: true,
+        },
+        updatedAt: Date.now(),
+      });
+      return atomicAppend(id, note);
+    };
+
+    await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
+    const finalPin = store.get(active.id)?.capacityPin;
+    assert.equal(finalPin?.windowTokens, 150_000, 'delayed note write must not undo the concurrent shrink');
+    assert.match(finalPin?.provenance, /carrier now reports 245,480 tokens — seal the session to recover/);
+    assert.equal(
+      finalPin?.provenance?.match(/seal the session to recover/g)?.length,
+      1,
+      'recovery hint must be present exactly once',
+    );
+  });
+
   it('keeps expansion gated on rollover when no fresh carrier report exists', async () => {
     registerTestCat();
     const store = new SessionChainStore();

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -655,7 +655,18 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       if (bridgeGlobalConfigRoot) await rm(bridgeGlobalConfigRoot, { recursive: true, force: true });
     });
 
-    it('keeps the injected Codex argv window at the configured native window across 12 bridge resumes', async () => {
+    async function withAmbientCodexCarrier(ambientCarrier, run) {
+      const savedCarrier = process.env.CAT_CAFE_CODEX_CARRIER;
+      process.env.CAT_CAFE_CODEX_CARRIER = ambientCarrier;
+      try {
+        return await run();
+      } finally {
+        if (savedCarrier === undefined) delete process.env.CAT_CAFE_CODEX_CARRIER;
+        else process.env.CAT_CAFE_CODEX_CARRIER = savedCarrier;
+      }
+    }
+
+    async function runProductionBridge() {
       // No accountRef: the bridge drives real invoke-single-cat account
       // resolution, which hard-fails on a bound account that does not exist in
       // the isolated global config. Template openai variants also leave
@@ -678,6 +689,10 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       const spawnFn = mock.fn(() => currentProc);
       const service = new CodexAgentService({
         catId: TEST_CAT_ID,
+        // This regression owns the exec_json production bridge. Never let a
+        // supported ambient app_server setting bypass the injected spawnFn
+        // and erase the 12-resume proof.
+        carrierMode: 'exec_json',
         l0CompilerFn: fakeL0Compiler,
         spawnFn,
         // resolveCliCommand probes the binary's existence before spawn even
@@ -792,6 +807,16 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
           `round ${round}: session pin must stay at ${EFFECTIVE_WINDOW}, not shrink recursively`,
         );
       }
-    });
+    }
+
+    for (const ambientCarrier of ['app_server', 'exec_json']) {
+      it(
+        `keeps the injected Codex argv window at the configured native window across 12 bridge resumes ` +
+          `with ambient ${ambientCarrier}`,
+        async () => {
+          await withAmbientCodexCarrier(ambientCarrier, runProductionBridge);
+        },
+      );
+    }
   });
 });

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -397,7 +397,7 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       return atomicAppend(id, note);
     };
 
-    await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
+    const returned = await runResumeRound(store, threadId, EFFECTIVE_WINDOW);
     const finalPin = store.get(active.id)?.capacityPin;
     assert.equal(finalPin?.windowTokens, 150_000, 'delayed note write must not undo the concurrent shrink');
     assert.match(finalPin?.provenance, /carrier now reports 245,480 tokens — seal the session to recover/);
@@ -406,6 +406,57 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       1,
       'recovery hint must be present exactly once',
     );
+    // 太阳猫 review P1: the returned snapshot must be built from the current
+    // (post-race) pin too — not the caller's stale 200000 read.
+    assert.equal(returned.capacity.windowTokens, 150_000, 'returned view must reflect the concurrent shrink');
+    assert.equal(
+      returned.capacity.provenance.match(/seal the session to recover/g)?.length,
+      1,
+      'returned provenance carries the hint exactly once',
+    );
+  });
+
+  it('keeps exactly one recovery instruction per pin when the larger report number jitters', async () => {
+    // 太阳猫 review P2: exact-string dedup treats 245480 → 245481 as different
+    // notes and appends twice. The recovery instruction must be a stable
+    // singleton — the latest report number replaces the previous note in
+    // place, on both the stored pin and the returned snapshot.
+    registerTestCat();
+    const store = new SessionChainStore();
+    const threadId = 'thread-issue-1381-hint-jitter';
+    const active = store.create({
+      cliSessionId: 'cli-issue-1381-hint-jitter',
+      threadId,
+      catId: TEST_CAT_ID,
+      userId: 'user-1',
+    });
+    store.update(active.id, {
+      capacityPin: {
+        windowTokens: 146_973,
+        inputCeilingTokens: 130_973,
+        source: 'reported',
+        provenance: 'Carrier reported 146,973 tokens (polluted by pre-fix feedback loop)',
+        actionable: true,
+      },
+    });
+
+    await runResumeRound(store, threadId, 245_480);
+    const jittered = await runResumeRound(store, threadId, 245_481);
+    const storedPin = store.get(active.id)?.capacityPin;
+    assert.equal(storedPin?.windowTokens, 146_973);
+    assert.equal(
+      storedPin?.provenance?.match(/seal the session to recover/g)?.length,
+      1,
+      'a jittered report must replace the note in place, not append a second one',
+    );
+    assert.match(storedPin?.provenance, /245,481/, 'the stored note carries the latest report number');
+    assert.doesNotMatch(storedPin?.provenance, /245,480/, 'the stale report number is replaced');
+    assert.equal(
+      jittered.capacity.provenance.match(/seal the session to recover/g)?.length,
+      1,
+      'returned snapshot carries exactly one recovery instruction',
+    );
+    assert.match(jittered.capacity.provenance, /245,481/);
   });
 
   it('never reorders concurrent shrinks into an expansion (200K pin, 150K lands, delayed 180K)', async () => {

--- a/packages/api/test/issue-1381-codex-context-window.test.js
+++ b/packages/api/test/issue-1381-codex-context-window.test.js
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
-import { after, before, describe, it } from 'node:test';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { after, before, describe, it, mock } from 'node:test';
 import { catRegistry } from '@cat-cafe/shared';
 
 const TEST_CAT_ID = 'issue-1381-codex-window';
@@ -18,7 +23,7 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
   let SessionChainStore;
   let savedConfigs;
 
-  function registerTestCat(contextWindow = MANUAL_WINDOW, defaultModel = 'gpt-5.6-sol') {
+  function registerTestCat(contextWindow = MANUAL_WINDOW, defaultModel = 'gpt-5.6-sol', accountRef = 'codex-oauth') {
     catRegistry.reset();
     catRegistry.register(TEST_CAT_ID, {
       id: TEST_CAT_ID,
@@ -28,7 +33,7 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
       color: { primary: '#000', secondary: '#fff' },
       mentionPatterns: ['@issue-1381-codex-window'],
       clientId: 'openai',
-      accountRef: 'codex-oauth',
+      ...(accountRef ? { accountRef } : {}),
       provider: 'openai',
       defaultModel,
       contextWindow,
@@ -297,5 +302,249 @@ describe('issue #1381: Codex exec_json native/effective context window feedback 
     assert.match(pinned.capacity.provenance, /session-pinned/);
     assert.equal(pinned.nativeWindowTokens, 400_000);
     assert.equal(store.get(active.id)?.capacityPin?.windowTokens, EFFECTIVE_WINDOW);
+  });
+
+  /**
+   * 太阳猫 review P2: the pure snapshot/pin rounds above never cross the
+   * production bridge — deleting the `contextNativeWindowTokens` pass-through
+   * in invoke-single-cat would not turn them red. This suite drives the full
+   * loop per resume round: route-level resolve + pre-pin → invokeSingleCat →
+   * real CodexAgentService argv construction (mock spawn) → Codex's effective
+   * token_count report (injected contextSnapshotResolver) → post-usage
+   * re-pin in the real SessionChainStore.
+   */
+  describe('production bridge: invokeSingleCat → CodexAgentService argv/report/pin loop', () => {
+    const CLI_THREAD_ID = 't-issue-1381-bridge';
+    let invokeSingleCat;
+    let CodexAgentService;
+    let fakeL0Compiler;
+    let bridgeGlobalConfigRoot;
+    let savedGlobalConfigRoot;
+    let savedHome;
+
+    function createMockProcess() {
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const emitter = new EventEmitter();
+      const originalEmit = emitter.emit.bind(emitter);
+      emitter.emit = (event, ...args) => {
+        const emitted = originalEmit(event, ...args);
+        if (event === 'exit') {
+          process.nextTick(() => originalEmit('close', ...args));
+        }
+        return emitted;
+      };
+      const proc = {
+        stdout,
+        stderr,
+        stdin: { write: () => true, end: () => {}, on: () => proc.stdin },
+        // invoke-single-cat passes a liveness probe; spawnCli checks pid
+        // liveness via signal-0, so the mock needs a pid that actually exists.
+        // Signals still route through the mocked kill(), and cli-spawn's
+        // process.on('exit') SIGKILL guard is neutralized by childExited.
+        pid: process.pid,
+        exitCode: null,
+        kill: mock.fn(() => {
+          process.nextTick(() => {
+            if (!stdout.destroyed) stdout.end();
+            emitter.emit('exit', null, 'SIGTERM');
+          });
+          return true;
+        }),
+        on: (event, listener) => {
+          emitter.on(event, listener);
+          return proc;
+        },
+        once: (event, listener) => {
+          emitter.once(event, listener);
+          return proc;
+        },
+        _emitter: emitter,
+      };
+      return proc;
+    }
+
+    function emitCodexEvents(proc, events) {
+      for (const event of events) {
+        proc.stdout.write(`${JSON.stringify(event)}\n`);
+      }
+      setImmediate(() => {
+        proc.stdout.end();
+        proc._emitter.emit('exit', 0, null);
+      });
+    }
+
+    async function waitFor(condition, label) {
+      const deadline = Date.now() + 10_000;
+      while (!condition()) {
+        if (Date.now() > deadline) throw new Error(`timed out waiting for ${label}`);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+    }
+
+    function parseInjectedNativeWindow(args) {
+      for (const arg of args) {
+        const match = /^model_context_window=(\d+)$/.exec(arg);
+        if (match) return Number(match[1]);
+      }
+      return null;
+    }
+
+    async function collect(iterable) {
+      const msgs = [];
+      for await (const msg of iterable) msgs.push(msg);
+      return msgs;
+    }
+
+    before(async () => {
+      ({ invokeSingleCat } = await import('../dist/domains/cats/services/agents/invocation/invoke-single-cat.js'));
+      ({ CodexAgentService } = await import('../dist/domains/cats/services/agents/providers/CodexAgentService.js'));
+      ({ fakeL0Compiler } = await import('./helpers/fake-l0-compiler.js'));
+      savedGlobalConfigRoot = process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+      savedHome = process.env.HOME;
+      bridgeGlobalConfigRoot = await mkdtemp(join(tmpdir(), 'issue-1381-bridge-global-'));
+      process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = bridgeGlobalConfigRoot;
+      process.env.HOME = bridgeGlobalConfigRoot;
+    });
+
+    after(async () => {
+      if (savedGlobalConfigRoot === undefined) delete process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT;
+      else process.env.CAT_CAFE_GLOBAL_CONFIG_ROOT = savedGlobalConfigRoot;
+      if (savedHome === undefined) delete process.env.HOME;
+      else process.env.HOME = savedHome;
+      if (bridgeGlobalConfigRoot) await rm(bridgeGlobalConfigRoot, { recursive: true, force: true });
+    });
+
+    it('keeps the injected Codex argv window at the configured native window across 12 bridge resumes', async () => {
+      // No accountRef: the bridge drives real invoke-single-cat account
+      // resolution, which hard-fails on a bound account that does not exist in
+      // the isolated global config. Template openai variants also leave
+      // accountRef undefined.
+      registerTestCat(undefined, undefined, null);
+      const store = new SessionChainStore();
+      const threadId = 'thread-issue-1381-bridge';
+      // cliSessionId matches the Codex thread_id emitted below so the
+      // session_init binding takes the same-session path every round.
+      const active = store.create({
+        cliSessionId: CLI_THREAD_ID,
+        threadId,
+        catId: TEST_CAT_ID,
+        userId: 'user-1',
+      });
+
+      let currentProc = null;
+      let currentReport = 0;
+      let invocationCounter = 0;
+      const spawnFn = mock.fn(() => currentProc);
+      const service = new CodexAgentService({
+        catId: TEST_CAT_ID,
+        l0CompilerFn: fakeL0Compiler,
+        spawnFn,
+        model: 'gpt-5.6-sol',
+        auditLog: { append: async () => {} },
+        rawArchive: { append: async () => {}, getPath: () => undefined },
+        // Simulates Codex's own token_count bookkeeping: whatever native window
+        // was injected on argv comes back multiplied by the effective percent.
+        contextSnapshotResolver: async () => ({ contextUsedTokens: 1_000, contextWindowTokens: currentReport }),
+      });
+
+      const sessionMap = new Map();
+      const sessionKey = `user-1:${TEST_CAT_ID}:${threadId}`;
+      const deps = {
+        registry: {
+          create: () => ({ invocationId: `inv-bridge-${++invocationCounter}`, callbackToken: `tok-${invocationCounter}` }),
+          verify: async () => ({ ok: false, reason: 'unknown_invocation' }),
+        },
+        sessionManager: {
+          get: async () => sessionMap.get(sessionKey),
+          getOrCreate: async () => ({}),
+          store: async (_userId, _catId, _threadId, sessionId) => {
+            sessionMap.set(sessionKey, sessionId);
+          },
+          delete: async () => {
+            sessionMap.delete(sessionKey);
+          },
+          resolveWorkingDirectory: () => '/tmp/test',
+        },
+        threadStore: null,
+        apiUrl: 'http://127.0.0.1:3004',
+        sessionChainStore: store,
+      };
+
+      for (let round = 1; round <= 12; round += 1) {
+        // route-serial.ts production sequence: resolve member config → apply the
+        // active session pin → invoke with the pinned snapshot.
+        const resolved = await resolveInvocationCapacitySnapshot({ catId: TEST_CAT_ID, service });
+        const pinnedSnapshot = await applyActiveSessionCapacityPin({
+          snapshot: resolved,
+          catId: TEST_CAT_ID,
+          threadId,
+          userId: 'user-1',
+          sessionChainStore: store,
+        });
+
+        currentProc = createMockProcess();
+        const promise = collect(
+          invokeSingleCat(deps, {
+            catId: TEST_CAT_ID,
+            service,
+            prompt: `bridge resume round ${round}`,
+            userId: 'user-1',
+            threadId,
+            isLastCat: true,
+            capacitySnapshot: pinnedSnapshot,
+            // Production contract for codex exec_json resumes: the continuity
+            // handshake resolves 'unknown', so the route must supply a prompt
+            // rebuild callback (route-serial passes one; without it the
+            // invocation throws context_continuity_cold_rebuild_unavailable).
+            rebuildPromptAfterSessionSeal: async () => `bridge resume round ${round} (rebuilt)`,
+          }),
+        );
+        // Always drive the mocked CLI to completion before asserting — an
+        // assertion thrown while the generator still waits for stdout would
+        // leave the invocation timeout timer pending and hang the test process.
+        let injected = null;
+        let roundError = null;
+        try {
+          await waitFor(() => spawnFn.mock.calls.length === round, `codex spawn for round ${round}`);
+          const args = spawnFn.mock.calls[round - 1].arguments[1];
+          injected = parseInjectedNativeWindow(args);
+          currentReport = codexEffectiveReport(injected ?? MANUAL_WINDOW);
+          emitCodexEvents(currentProc, [
+            { type: 'thread.started', thread_id: CLI_THREAD_ID },
+            { type: 'turn.completed', usage: { input_tokens: 1_000, output_tokens: 50 } },
+          ]);
+        } catch (err) {
+          roundError = err;
+          try {
+            currentProc.stdout.end();
+            currentProc._emitter.emit('exit', 1, null);
+          } catch {
+            /* best-effort stream teardown */
+          }
+        }
+        const msgs = await promise;
+        if (roundError) throw roundError;
+        assert.equal(
+          injected,
+          MANUAL_WINDOW,
+          `round ${round}: argv must inject the config-owned native window ${MANUAL_WINDOW}, ` +
+            'never the effective/pinned capacity (the pre-#1381 recursion)',
+        );
+        assert.ok(
+          msgs.some((m) => m.type === 'done'),
+          `round ${round}: invocation must complete`,
+        );
+        assert.ok(
+          !msgs.some((m) => m.type === 'error'),
+          `round ${round}: invocation must not error`,
+        );
+        assert.equal(
+          store.get(active.id)?.capacityPin?.windowTokens,
+          EFFECTIVE_WINDOW,
+          `round ${round}: session pin must stay at ${EFFECTIVE_WINDOW}, not shrink recursively`,
+        );
+      }
+    });
   });
 });

--- a/packages/api/test/redis-session-chain-store.test.js
+++ b/packages/api/test/redis-session-chain-store.test.js
@@ -104,6 +104,71 @@ describe('RedisSessionChainStore', { skip: redisIsolationSkipReason(REDIS_URL) }
     assert.ok(record.createdAt > 0);
   });
 
+  it('#1382 shrinkCapacityPin never lets a delayed larger candidate undo a smaller pin', async (t) => {
+    if (!connected) return t.skip('Redis not connected');
+    const record = await store.create(BASE_INPUT);
+    const pin = (windowTokens, inputCeilingTokens) => ({
+      windowTokens,
+      inputCeilingTokens,
+      source: 'reported',
+      provenance: `Carrier reported ${windowTokens.toLocaleString()} tokens`,
+      actionable: true,
+    });
+
+    // First write lands (no usable pin stored yet).
+    await store.shrinkCapacityPin(record.id, pin(200_000, 184_000));
+    assert.equal((await store.get(record.id))?.capacityPin?.windowTokens, 200_000);
+
+    // Maintainer probe ordering: the 150K constraint lands, then the delayed
+    // 180K candidate must be refused by the Lua compare-and-write.
+    await store.shrinkCapacityPin(record.id, pin(150_000, 134_000));
+    await store.shrinkCapacityPin(record.id, pin(180_000, 164_000));
+    const final = (await store.get(record.id))?.capacityPin;
+    assert.equal(final?.windowTokens, 150_000, 'delayed larger candidate must not overwrite the smaller pin');
+    assert.equal(final?.provenance, 'Carrier reported 150,000 tokens');
+
+    // Equal candidate still lands (refreshes provenance), smaller lands too.
+    await store.shrinkCapacityPin(record.id, pin(150_000, 134_000));
+    await store.shrinkCapacityPin(record.id, pin(120_000, 104_000));
+    assert.equal((await store.get(record.id))?.capacityPin?.windowTokens, 120_000);
+
+    // Missing record → null, and no hash may be created as a side effect.
+    assert.equal(await store.shrinkCapacityPin('missing-session-id', pin(150_000, 134_000)), null);
+    assert.equal(await store.get('missing-session-id'), null);
+  });
+
+  it('#1382 appendCapacityPinProvenance merges onto the current pin and dedups', async (t) => {
+    if (!connected) return t.skip('Redis not connected');
+    const record = await store.create(BASE_INPUT);
+    const note = '; carrier now reports 245,480 tokens — seal the session to recover if this pin was polluted';
+    const pin = (windowTokens, inputCeilingTokens) => ({
+      windowTokens,
+      inputCeilingTokens,
+      source: 'reported',
+      provenance: `Carrier reported ${windowTokens.toLocaleString()} tokens`,
+      actionable: true,
+    });
+
+    // The shrink lands before the delayed note write: the note must merge
+    // onto the CURRENT 150K pin, never restoring the stale 200K object.
+    await store.update(record.id, { capacityPin: pin(200_000, 184_000) });
+    await store.update(record.id, { capacityPin: pin(150_000, 134_000) });
+    await store.appendCapacityPinProvenance(record.id, note);
+    let current = (await store.get(record.id))?.capacityPin;
+    assert.equal(current?.windowTokens, 150_000);
+    assert.ok(current?.provenance?.includes('seal the session to recover'));
+
+    // Dedup: the identical note is not re-appended.
+    await store.appendCapacityPinProvenance(record.id, note);
+    current = (await store.get(record.id))?.capacityPin;
+    assert.equal(current?.provenance?.match(/seal the session to recover/g)?.length, 1);
+
+    // No stored pin → null, nothing written.
+    const bare = await store.create({ ...BASE_INPUT, cliSessionId: 'cli-sess-bare' });
+    assert.equal(await store.appendCapacityPinProvenance(bare.id, note), null);
+    assert.equal((await store.get(bare.id))?.capacityPin, undefined);
+  });
+
   it('#1329 atomically creates one unbound logical node and binds it later', async () => {
     const input = {
       threadId: 'thread-logical',

--- a/packages/api/test/redis-session-chain-store.test.js
+++ b/packages/api/test/redis-session-chain-store.test.js
@@ -163,6 +163,16 @@ describe('RedisSessionChainStore', { skip: redisIsolationSkipReason(REDIS_URL) }
     current = (await store.get(record.id))?.capacityPin;
     assert.equal(current?.provenance?.match(/seal the session to recover/g)?.length, 1);
 
+    // Semantic dedup: a jittered report number replaces the note in place —
+    // one pin carries at most one recovery instruction.
+    const jitteredNote = '; carrier now reports 245,481 tokens — seal the session to recover if this pin was polluted';
+    await store.appendCapacityPinProvenance(record.id, jitteredNote);
+    current = (await store.get(record.id))?.capacityPin;
+    assert.equal(current?.windowTokens, 150_000);
+    assert.equal(current?.provenance?.match(/seal the session to recover/g)?.length, 1);
+    assert.ok(current?.provenance?.includes('245,481'), 'latest report number wins');
+    assert.ok(!current?.provenance?.includes('245,480'), 'stale report number replaced');
+
     // No stored pin → null, nothing written.
     const bare = await store.create({ ...BASE_INPUT, cliSessionId: 'cli-sess-bare' });
     assert.equal(await store.appendCapacityPinProvenance(bare.id, note), null);

--- a/packages/api/test/route-strategies.test.js
+++ b/packages/api/test/route-strategies.test.js
@@ -453,15 +453,14 @@ describe('routeParallel collaboration continuity', () => {
 
   it('includes continuity capsule in threshold seal payload for parallel invocations', async () => {
     const { routeParallel } = await import('../dist/domains/cats/services/agents/routing/route-parallel.js');
-    const activeRecord = {
-      id: 'sess-parallel-seal',
+    const { SessionChainStore } = await import('../dist/domains/cats/services/stores/ports/SessionChainStore.js');
+    const sessionChainStore = new SessionChainStore();
+    const activeRecord = sessionChainStore.create({
+      cliSessionId: 'cli-parallel-seal',
       catId: 'codex',
       threadId: 'thread-parallel-seal',
       userId: 'user1',
-      seq: 0,
-      status: 'active',
-      compressionCount: 0,
-    };
+    });
     const service = {
       contextCapability() {
         return {
@@ -495,12 +494,7 @@ describe('routeParallel collaboration continuity', () => {
     };
     const deps = createMockDeps({ codex: service });
     deps.invocationDeps.sessionManager.delete = async () => {};
-    deps.invocationDeps.sessionChainStore = {
-      getChain: async () => [activeRecord],
-      getActive: async () => activeRecord,
-      update: async () => activeRecord,
-      create: async () => activeRecord,
-    };
+    deps.invocationDeps.sessionChainStore = sessionChainStore;
     deps.invocationDeps.sessionSealer = {
       requestSeal: async () => ({ accepted: true, status: 'sealing' }),
       finalize: async () => {},
@@ -531,7 +525,7 @@ describe('routeParallel collaboration continuity', () => {
     assert.equal(payload.continuityCapsule.threadId, 'thread-parallel-seal');
     assert.equal(payload.continuityCapsule.catId, 'codex');
     assert.equal(payload.continuityCapsule.mode, 'parallel');
-    assert.equal(payload.continuityCapsule.seal.sessionId, 'sess-parallel-seal');
+    assert.equal(payload.continuityCapsule.seal.sessionId, activeRecord.id);
   });
 });
 


### PR DESCRIPTION
## PR Type

- [x] 🐛 Patch — Bug fix, typo, test gap (no Feature Doc needed)
- [ ] ✨ Feature — New capability or behavior change (requires Feature Doc)
- [ ] 📋 Protocol — Rules, skills, workflow changes (the doc IS the contribution)

## Related Issue

Closes #1381

## What

Breaks the recursive Codex context-window feedback loop by splitting the two quantities that were being fed into each other:

- **Native/raw window** (`InvocationCapacitySnapshot.nativeWindowTokens`): owned by member configuration (manual/catalog), captured once per invocation before any pin or report applies. `CodexAgentService` injects exactly this as `model_context_window` (explicit `null` = no config-owned window = no injection; legacy callers without a snapshot keep the old `contextCapacity` behavior). The native window therefore stays stable across resumes.
- **Effective/pinned capacity** (`capacity`): still constrained one-way by trusted carrier reports and the shrink-only session pin. Genuine provider shrink events and rollover semantics are preserved — a later *larger* report never auto-expands a pin, because it cannot distinguish a polluted pin from a genuine shrink followed by genuine recovery.

**Recovery for already-polluted pins** is explicit, not silent: seal/roll over the session (manual seal from #1313), and the fresh session adopts the carrier-reported capacity on its first invocation. When a fresh carrier report exceeds the active pin, the recoverable state is surfaced via `log.warn` and a pin-provenance note ("seal the session to recover if this pin was polluted"), without mutating state.

## Why

Codex exec_json applies its `effective_context_window_percent` (95%) to the injected native `model_context_window` and reports the smaller effective value. Clowder resolved that report as authoritative over the manual setting, pinned it shrink-only, and injected the pin back as the next invocation's native window — a deterministic 5% recursion per resume (258400 → 245480 → 233206 → … → <100K) while the saved member setting never changed.

## Tradeoff

- Runtime-window evidence and session pinning are NOT disabled; they still protect users when providers genuinely lower a model limit.
- No second resolver or pin system: one new snapshot field + one new invoke option, consumed only by the Codex exec_json injection site.
- Active polluted sessions are not silently expanded; recovery is an explicit operator seal with an observable hint.
- Settings/Session UI presentation of configured-vs-effective remains with #1343/#1345; this PR carries the distinction in provenance/diagnostics only.

## Test Evidence

Red→green TDD; the fix rounds ran on `ec48cb062`, the review-follow-up bridge regression runs on HEAD `b28c1de65`.

- [x] **Same-session 12-resume regression** (new `packages/api/test/issue-1381-codex-context-window.test.js`): drives the full `native config → provider effective report → session pin → next native config` loop across 12 resumes; native window stays at the manual 258400 every round and the pin reaches a fixed point at the effective 245480 instead of recursing.
- [x] **Genuine independent shrink preserved**: report drops to 200000 → pin shrinks and stays; no oscillation.
- [x] **No auto-expansion on larger fresh reports** (review counterexample): genuine shrink to 200K followed by a 245480 report keeps the pin at 200K; polluted pin (146973) likewise stays clamped, with the recoverable state visible in the provenance; explicit seal + rollover adopts the reported capacity.
- [x] **Floor-raised catalog values** (e.g. stale CLI report raised by `KNOWN_MIN_CONTEXT_WINDOWS`) never expand a pin.
- [x] **Production-bridge 12-resume regression** (review P2 follow-up, same test file, `production bridge` suite): each resume round drives the real `route-serial` sequence — resolve + pre-pin → `invokeSingleCat` → real `CodexAgentService` argv construction (mock spawn) → Codex's effective `token_count` report (injected `contextSnapshotResolver`) → post-usage re-pin in the real `SessionChainStore`. Asserts the spawned argv's `model_context_window` stays at the config-owned native 258400 across all 12 rounds. **RED proof**: with the `contextNativeWindowTokens` pass-through in `invoke-single-cat.ts` removed, this test fails at round 2 (`argv must inject the config-owned native window 258400`) because the legacy `contextCapacity` fallback injects the pinned 245480 and the recursion resumes; the snapshot/pin-only tests stay green without the bridge, which was exactly the gap.
- [x] **Codex argv tests** (`codex-agent-service.test.js`): injected `model_context_window` comes from the config-owned native window, not the pinned effective capacity; report/pin-derived capacity with explicit `null` native window injects nothing; auto-compact limit derives from the native window.
- [x] **Existing suites green**: invocation-capacity-snapshot, codex-agent-service, invoke-single-cat, session-policy-snapshot, context-window-sizes, kimi, opencode, gemini, token-usage, codex-session-context-snapshot, codex-carrier-truth — 426/426 pass. After the bridge-test commit: issue-1381 + codex-agent-service + invoke-single-cat + invocation-capacity-snapshot re-run green, 249/249.
- [x] **Public quality gate**: `pnpm gate` runs build/tsc/lint/checks green; the full public test step fails only `test/prompt-capture.test.js` AC-G10 ×3, which is **pre-existing on `origin/main`**: the identical 3 failures reproduce on a clean checkout of base `8fd4824cb` (same ~1.1s poll-window timeouts). Those tests import only `prompt-capture-bridge/store` and do not touch any file changed here. Evidence available on request.

## Coordination

Implementation owner: Kimi Code cat (local cross-model handoff from 砚砚).
Review constraint adopted pre-HEAD: 砚砚's genuine-shrink counterexample removed the auto-recovery branch in favor of explicit seal/rollover recovery.
Independent reviewer after this stable HEAD (`ec48cb062`): Sun cat, with Tabby cat as fallback.

[小开/k3🐾]

### Latest OWNER P1 follow-up — exact HEAD `e76ca6a261245993e857947a96492b9651ceb323`

- [x] **Session-store contract migration RED→GREEN**: at `0eb6a1e7b`, the exact route test failed with `TypeError: sessionChainStore.shrinkCapacityPin is not a function`. The route fixture now uses the real `SessionChainStore`, so it exercises the canonical atomic `shrinkCapacityPin` / `appendCapacityPinProvenance` boundary instead of a partial JS structural double. Exact test passes 1/1; full route file passes 124/124. Static caller audit found both production stores already conform and no other route-level capacity-pin double missing this contract. No whole-pin fallback or optional-call bypass was added.
- [x] **Ambient carrier isolation RED→GREEN**: at `0eb6a1e7b`, forcing `CAT_CAFE_CODEX_CARRIER=app_server` timed out at round 1 because the service bypassed the mock exec-json spawn. The bridge now passes `carrierMode: exec_json` explicitly and restores the ambient variable after each case. It completes all 12 rounds under ambient `app_server` and all 12 rounds under ambient `exec_json`; issue suite passes 12/12.
- [x] **Targeted evidence**: invocation capacity 13/13, Codex service 86/86, invoke capacity/window subset 2/2, route 124/124, affected public-runner focus 136/136.
- [x] **Redis production contract**: 45/45 on a temporary non-persistent Redis instance bound only to authorized dev port 6398 (DB 15); port 6399 was never accessed.
- [x] **Quality gate**: API build and Biome exit 0; `git diff --check` clean. Full public suite completes 21,008 tests with 20,910 pass / 95 skip and only the same three pre-existing `prompt-capture.test.js` AC-G10 poll-window failures already reproduced on base `8fd4824cb`; the former route-strategies TypeError is gone.

[小狸/gpt-5.6-sol🐾]