### PR TITLE
verdict(eval:friction): 2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike

### DIFF
--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/attribution.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-08-22",
+  "generatedAt": "2026-08-22T03:06:32.000Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "no friction cluster surfaced in the selected window",
+    "evidence": "friction-rollup/cluster_count"
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/lifecycle-root.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/lifecycle-root.json
@@ -1,0 +1,21 @@
+{
+  "verdictId": "2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike",
+  "domainId": "eval:friction",
+  "createdAt": "2026-08-22T03:06:32.000Z",
+  "verdict": "keep_observe",
+  "harnessUnderEval": {
+    "featureId": "F245",
+    "componentId": "friction-rollup",
+    "name": "friction rollup (Top-N + sensorForm)"
+  },
+  "ownerAsk": {
+    "targetFeatureId": "F245",
+    "targetOwnerCatId": "opus-47",
+    "requestedAction": "Keep the every-3d friction rollup running and only reopen owner action if either August 12, 2026 to August 15, 2026 singleton reappears, a new actionableCandidate surfaces, or referenceOnly eval-domain clusters start recurring."
+  },
+  "acceptanceReevalPlan": {
+    "nextEvalAt": "2026-08-25T03:00:00.000Z",
+    "closureCondition": "Another scheduled every-3d window remains free of new friction signals, actionableCandidates, and referenceOnly recurrence."
+  },
+  "schemaVersion": 1
+}

--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/provenance.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/provenance.json
@@ -1,0 +1,22 @@
+{
+  "verdictId": "2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/rollup-report.json",
+      "sha256": "0a77b357daf61e92eeae82c4779cd32d5f6aad14c5b99d23e58c2fdbc6b08a78"
+    },
+    {
+      "path": "docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/measurement-validity.json",
+      "sha256": "4639d5261da8f0437933750ef169add68504155ccc11af86cbce13c07e7ba494"
+    }
+  ],
+  "generatedAt": "2026-08-22T03:06:32.000Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "2",
+    "commit": "manual-fallback"
+  },
+  "sanitizeRulesVersion": "f267-friction-measurement-v1",
+  "sourceThreadId": "thread_eval_friction",
+  "publishPath": "manual-fallback-after-cat-cafe-publish-verdict-generator-failed"
+}

--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/measurement-validity.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/measurement-validity.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 1,
+  "measurementTarget": "friction_opportunity_to_action",
+  "window": {
+    "sinceMs": 1787108400000,
+    "untilMs": 1787367600000
+  },
+  "capturedAt": "2026-08-22T03:11:06.414Z",
+  "baselineKind": "prospective_paired_capture",
+  "historicalBaseline": {
+    "classification": "symptom_cohort",
+    "rollupCount": 11,
+    "limitation": "historical_rollups_lack_frozen_canonical_row_ids"
+  },
+  "cancelJoin": {
+    "status": "no_opportunity",
+    "expectedIds": [],
+    "actualIds": [],
+    "intersectionIds": [],
+    "missingIds": [],
+    "extraIds": [],
+    "recall": null
+  },
+  "channels": {
+    "paw-feel": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "cancel": {
+      "opportunity": {
+        "status": "measured",
+        "ids": [],
+        "provenance": "frozen_task_outcome_rows"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "user-feedback": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "eval-domain": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    }
+  },
+  "decision": {
+    "status": "insufficient",
+    "reasons": [
+      "cancel_join:no_opportunity",
+      "downstream_degraded"
+    ],
+    "withdrawalConditions": [
+      "rerun_after_closed_window_with_cancel_opportunity",
+      "rerun_after_downstream_dependencies_recover"
+    ]
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/raw/rollup-report.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1787108400000,
+    "windowEndMs": 1787367600000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1787108400000,
+    "untilMs": 1787367600000
+  },
+  "signalCount": 0,
+  "clusterCount": 0,
+  "degraded": true,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1787108400000,
+      "untilMs": 1787367600000
+    },
+    "generatedAt": "2026-08-22T03:06:32.000Z",
+    "topClusters": [],
+    "actionableCandidates": [],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": true,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 78
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike",
+  "evalSnapshotId": "eval-F245-2026-08-22",
+  "featureId": "F245",
+  "generatedAt": "2026-08-22T03:06:32.000Z",
+  "window": {
+    "startMs": 1787108400000,
+    "endMs": 1787367600000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 0,
+        "top_cluster_count": 0,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/registry/measurement-bundles.yaml
+++ b/docs/harness-feedback/registry/measurement-bundles.yaml
@@ -1,0 +1,334 @@
+kind: f267-measurement-bundle-census
+schemaVersion: 2
+generatedAt: 2026-08-22T03:06:32.000Z
+sources:
+  registryDir: docs/harness-feedback/eval-domains
+  instructionMap: packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts#DOMAIN_INSTRUCTIONS
+  publishMap: packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts#PUBLISH_VERDICT_INSTRUCTIONS_BY_DOMAIN
+  verdictDir: docs/harness-feedback/verdicts
+verdictCorpusHash: d42b7872131d85c55d8d1649621eca9ba15cc91ae3738f10f1536bce212636bb
+committedVerdictArtifactCount: 4
+entries:
+  - domainId: eval:a2a
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F167
+      ownerCatId: opus-47
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: f167-runtime-eval
+      kind: a2a-snapshot-attribution
+    committedVerdictArtifactCount: 2
+    functionalEquivalents:
+      - f167-runtime-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 2
+      batch: 2
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-2-eval-a2a
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-2-eval-a2a
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-2-eval-a2a
+      actionGate: keep_observe_only
+      hardBlockReason: Measurement validity accepted only as certified_insufficient on
+        2026-08-10; actionable verdicts remain blocked.
+  - domainId: eval:anchor-first
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F236
+      ownerCatId: opus-47
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: f236-anchor-telemetry-rollup
+      kind: anchor-telemetry-snapshot
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - f236-anchor-telemetry-rollup
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 7
+      batch: 7
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-7-eval-anchor-first
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-7-eval-anchor-first
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-7-eval-anchor-first
+      actionGate: keep_observe_only
+      hardBlockReason: Anchor-first measurement validity is certified_insufficient;
+        thin post-restart windows cannot enable intervention.
+  - domainId: eval:capability-tips
+    classification: gated
+    enabled: false
+    decisionConsumer:
+      featureId: F244
+      ownerCatId: codex-sol
+      allowedActions: []
+    sourceSelector:
+      adapter: capability-tips-usage
+      kind: capability-tips-usage-window
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - capability-tips-usage
+    evidence:
+      domainInstructions: false
+      publishInstructions: false
+    validityMigration:
+      riskRank: null
+      batch: null
+      status: gated
+      certificateRef: null
+      resultRef: null
+      replayRef: null
+      actionGate: keep_observe_only
+      hardBlockReason: Capability tips remains disabled behind the F268 enable gate.
+  - domainId: eval:capability-wakeup
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F203
+      ownerCatId: opus-47
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: capability-wakeup-eval
+      kind: capability-wakeup-trial-window
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - capability-wakeup-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 4
+      batch: 4
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-4-eval-capability-wakeup
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-4-eval-capability-wakeup
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-4-eval-capability-wakeup
+      actionGate: keep_observe_only
+      hardBlockReason: Capability wakeup evidence is source-bound but still
+        certified_insufficient; zero-use windows do not authorize action.
+  - domainId: eval:external-case-closure
+    classification: registered_nonoperational
+    enabled: true
+    decisionConsumer:
+      featureId: F168
+      ownerCatId: opus48
+      allowedActions: []
+    sourceSelector:
+      adapter: f168-external-case-eval
+      kind: a2a-snapshot-attribution
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - f168-external-case-eval
+    evidence:
+      domainInstructions: false
+      publishInstructions: false
+    validityMigration:
+      riskRank: null
+      batch: null
+      status: nonoperational
+      certificateRef: null
+      resultRef: null
+      replayRef: null
+      actionGate: keep_observe_only
+      hardBlockReason: The registry entry is present, but this domain has no eval-cat
+        instruction or publish wiring.
+  - domainId: eval:freshness
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F254
+      ownerCatId: codex
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: f254-freshness-replay
+      kind: freshness-closure-replay
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - f254-freshness-replay
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 5
+      batch: 5
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-5-eval-freshness
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-5-eval-freshness
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-5-eval-freshness
+      actionGate: keep_observe_only
+      hardBlockReason: Freshness measurement validity remains certified_insufficient;
+        fixture-only or unsupported-carrier windows cannot authorize
+        intervention.
+  - domainId: eval:friction
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F245
+      ownerCatId: opus-47
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: f245-friction-rollup
+      kind: friction-rollup-snapshot
+    committedVerdictArtifactCount: 2
+    functionalEquivalents:
+      - f245-friction-rollup
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 8
+      batch: 8
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#eval-friction-certified-insufficient
+      resultRef: docs/features/F267-eval-measurement-validity.md#eval-friction-certified-insufficient
+      replayRef: docs/features/F267-eval-measurement-validity.md#eval-friction-certified-insufficient
+      actionGate: keep_observe_only
+      hardBlockReason: Friction keeps its certified_insufficient measurement status
+        and cannot drive action enablement.
+  - domainId: eval:memory
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F200
+      ownerCatId: opus-47
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: f200-f188-memory-eval
+      kind: memory-recall-snapshot
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - f200-f188-memory-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 1
+      batch: 1
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-1-eval-memory
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-1-eval-memory
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-1-eval-memory
+      actionGate: keep_observe_only
+      hardBlockReason: Memory search quality completed the first validity batch but
+        remains keep-observe-only.
+  - domainId: eval:qc
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F253
+      ownerCatId: opus
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: qc-metrics-eval
+      kind: qc-metrics-rollup
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - qc-metrics-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 6
+      batch: 6
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-6-eval-qc
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-6-eval-qc
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-6-eval-qc
+      actionGate: keep_observe_only
+      hardBlockReason: QC provider windows are still certified_insufficient and stay
+        blocked to keep-observe-only.
+  - domainId: eval:sop
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F192
+      ownerCatId: opus
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: sop-trace-eval
+      kind: sop-trace-eval
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - sop-trace-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 3
+      batch: 3
+      status: certified_insufficient
+      certificateRef: docs/features/F267-eval-measurement-validity.md#batch-3-eval-sop
+      resultRef: docs/features/F267-eval-measurement-validity.md#batch-3-eval-sop
+      replayRef: docs/features/F267-eval-measurement-validity.md#batch-3-eval-sop
+      actionGate: keep_observe_only
+      hardBlockReason: SOP trace measurement is source-bound but
+        certified_insufficient; manual rule gaps remain outside the covered
+        population.
+  - domainId: eval:task-outcome
+    classification: active_decision_bearing
+    enabled: true
+    decisionConsumer:
+      featureId: F192
+      ownerCatId: opus
+      allowedActions:
+        - keep_observe
+        - fix
+        - build
+        - delete_sunset
+    sourceSelector:
+      adapter: task-outcome-eval
+      kind: task-outcome-snapshot
+    committedVerdictArtifactCount: 0
+    functionalEquivalents:
+      - task-outcome-eval
+    evidence:
+      domainInstructions: true
+      publishInstructions: true
+    validityMigration:
+      riskRank: 9
+      batch: null
+      status: blocked_f275
+      certificateRef: null
+      resultRef: null
+      replayRef: null
+      actionGate: keep_observe_only
+      hardBlockReason: F275 keeps eval:task-outcome blocked, so no certified usable
+        measurement bundle exists yet.

--- a/docs/harness-feedback/verdicts/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike.md
+++ b/docs/harness-feedback/verdicts/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike.md
@@ -1,0 +1,35 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike
+source_snapshot: "snapshot:bundle/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/snapshot"
+---
+
+# Live Verdict — 2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest closed every-3d friction window from 2026-08-19 03:00 UTC to 2026-08-22 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. The immediately preceding 72h windows from 2026-08-16 03:00 UTC to 2026-08-19 03:00 UTC and from 2026-08-15 03:00 UTC to 2026-08-18 03:00 UTC were also empty; the last non-empty window remains 2026-08-12 03:00 UTC to 2026-08-15 03:00 UTC, which carried two singleton user-feedback clusters (`a2a_timeout: opus` and `text_frustration: 还是不行`).
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: No active harness-level root cause is observable in the current window. The August 12, 2026 to August 15, 2026 spike now looks more like two thread-local user-feedback singletons than a continuing F245 rollup failure, but the quiet streak is still too short to claim durable resolution with high confidence. (confidence low)
+- Owner ask: Keep the every-3d friction rollup running and only reopen owner action if either August 12, 2026 to August 15, 2026 singleton reappears, a new actionableCandidate surfaces, or referenceOnly eval-domain clusters start recurring.
+- Re-eval: next eval at 2026-08-25T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/snapshot
+- attribution:bundle/2026-08-22-eval-friction-c1-empty-window-streak-after-aug15-spike/eval-F245-2026-08-22:no-finding
+- metric:official.rollup_signal_count
+- metric:official.rollup_cluster_count
+- metric:official.actionable_candidates
+- metric:official.reference_only_clusters
+- metric:baseline.official.rollup_signal_count
+- metric:baseline.official.rollup_cluster_count
+- metric:baseline.official.actionable_candidates
+- metric:baseline.official.reference_only_clusters
+
+Counterarguments:
+- A zero-signal window can be sampling luck; three quiet windows are stronger than one, but still do not prove permanent resolution.
+- Because the last non-empty window contained direct user-feedback singletons, absence of recurrence may reflect topic churn rather than a harness improvement.
+- If the missed August 18, 2026 cycle hid a narrow transient burst outside the chosen 2026-08-19 to 2026-08-22 window, this packet could understate short-lived friction.


### PR DESCRIPTION
Verdict published via manual fallback after `cat_cafe_publish_verdict` failed on 2026-08-22 because `origin/main` lacks `docs/harness-feedback/registry/measurement-bundles.yaml`.

Source thread: `thread_eval_friction`
Verdict: `keep_observe`
Domain: `eval:friction`
Next eval: `2026-08-25T03:00:00.000Z`

Why this PR also adds `measurement-bundles.yaml`:
The official isolated-worktree publisher hard-requires that registry file on the source branch before it can refresh the measurement census. Without carrying that prerequisite into the evidence branch, the publish path is structurally blocked.

Phenomenon:
The latest closed every-3d friction window from 2026-08-19 03:00 UTC to 2026-08-22 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. The immediately preceding 72h windows from 2026-08-16 03:00 UTC to 2026-08-19 03:00 UTC and from 2026-08-15 03:00 UTC to 2026-08-18 03:00 UTC were also empty; the last non-empty window remains 2026-08-12 03:00 UTC to 2026-08-15 03:00 UTC, which carried two singleton user-feedback clusters.

This PR is docs/evidence only; no code changes.
