### PR TITLE
fix(F253): add qc-metrics-rollup sourceRefs to publish-verdict MCP schema

### DIFF
--- a/packages/mcp-server/src/tools/publish-verdict-tool.ts
+++ b/packages/mcp-server/src/tools/publish-verdict-tool.ts
@@ -265,6 +265,28 @@ const anchorTelemetrySourceRefsShape = z
   })
   .describe('eval:anchor-first sourceRefs — replayable anchor telemetry rollup window selector.');
 
+/**
+ * F253 Phase C — qc-metrics-rollup sourceRefs. Replayable weekly rollup
+ * window selector: the provider resolves to the QC metrics snapshot
+ * (findingYield / falsePositiveRate / reviewerDelta / postMergeBugRate).
+ * Phase C bootstrap returns zero-baseline (no live review telemetry wired
+ * yet) — structurally real, values zero. Generator writes the rollup
+ * snapshot + attribution + provenance into the bundle.
+ *
+ * KEEP IN SYNC: packages/api/.../publish-verdict/validation.ts
+ * validateQcMetricsSelector + qc-metrics-provider.ts QcMetricsSelector.
+ */
+const qcMetricsSourceRefsShape = z
+  .object({
+    kind: z.literal('qc-metrics-rollup'),
+    windowStartMs: z.number().finite().describe('Inclusive epoch ms window start for QC metrics rollup.'),
+    windowEndMs: z
+      .number()
+      .finite()
+      .describe('Exclusive epoch ms window end for QC metrics rollup. Must be > windowStartMs.'),
+  })
+  .describe('eval:qc sourceRefs — replayable weekly QC metrics rollup window selector.');
+
 const sourceRefsShape = z
   .union([
     a2aSourceRefsShape,
@@ -274,9 +296,10 @@ const sourceRefsShape = z
     sopSourceRefsShape,
     frictionRollupSourceRefsShape,
     anchorTelemetrySourceRefsShape,
+    qcMetricsSourceRefsShape,
   ])
   .describe(
-    'Discriminated union by `kind` field. a2a kind is default (backward compat); capability-wakeup-trial-window kind wired in PR-2; memory-recall-snapshot kind wired in F192 memory wire-up; task-outcome-snapshot kind wired in task-outcome PR; sop-trace-eval kind wired in F192 sop-wiring; friction-rollup-snapshot kind wired in F245 PR1b; anchor-telemetry-snapshot kind wired in F236 Track-2.',
+    'Discriminated union by `kind` field. a2a kind is default (backward compat); capability-wakeup-trial-window kind wired in PR-2; memory-recall-snapshot kind wired in F192 memory wire-up; task-outcome-snapshot kind wired in task-outcome PR; sop-trace-eval kind wired in F192 sop-wiring; friction-rollup-snapshot kind wired in F245 PR1b; anchor-telemetry-snapshot kind wired in F236 Track-2; qc-metrics-rollup kind wired in F253 Phase C.',
   );
 
 export const publishVerdictInputSchema = {
@@ -348,6 +371,11 @@ type PublishVerdictToolInput = {
         kind: 'anchor-telemetry-snapshot';
         windowStartMs: number;
         windowEndMs: number;
+      }
+    | {
+        kind: 'qc-metrics-rollup';
+        windowStartMs: number;
+        windowEndMs: number;
       };
   agentKeyCatId?: string | undefined;
 };
@@ -377,7 +405,7 @@ export const publishVerdictTools = [
       'Use after your analysis converges to a verdict for your assigned eval domain. ' +
       'Pass the complete VerdictHandoffPacket + sourceRefs (shape depends on your domain — see your eval cat invocation instructions for the exact selector shape). ' +
       'The handler validates schema, dispatches to the per-domain generator inside an isolated git worktree, commits + pushes the branch verdict/auto/<domain-slug>/<verdict-id>, and opens an auto-PR. Returns { commitSha, prUrl }. ' +
-      'GOTCHA: wired domains: eval:a2a (snapshot/attribution YAML basenames) + eval:capability-wakeup (replayable trial-window selector) + eval:memory (memory-recall-snapshot selector) + eval:sop (sop-trace-eval replayable SOP trace selector) + eval:task-outcome (task-outcome-snapshot replay window) + eval:friction (friction-rollup-snapshot replay window) + eval:anchor-first (anchor-telemetry-snapshot rollup window). Unregistered domains return 501. ' +
+      'GOTCHA: wired domains: eval:a2a (snapshot/attribution YAML basenames) + eval:capability-wakeup (replayable trial-window selector) + eval:memory (memory-recall-snapshot selector) + eval:sop (sop-trace-eval replayable SOP trace selector) + eval:task-outcome (task-outcome-snapshot replay window) + eval:friction (friction-rollup-snapshot replay window) + eval:anchor-first (anchor-telemetry-snapshot rollup window) + eval:qc (qc-metrics-rollup replayable weekly window selector). Unregistered domains return 501. ' +
       'GOTCHA: catId must match the registered eval cat for the domain (or its OQ-20 Redis override); 403 not_allowed otherwise. ' +
       'GOTCHA: DO NOT run git push/commit/add yourself; this tool owns the publish lifecycle.',
     inputSchema: publishVerdictInputSchema,

--- a/packages/mcp-server/test/publish-verdict-tool-schema.test.js
+++ b/packages/mcp-server/test/publish-verdict-tool-schema.test.js
@@ -382,4 +382,60 @@ describe('cat_cafe_publish_verdict MCP schema (砚砚 R1 Q3: discriminated union
     });
     assert.ok(!result.success, 'missing gitState.branch should fail min(1)');
   });
+
+  // F253 Phase C — qc-metrics-rollup kind (this PR).
+  // Regression fixture: eval:qc weekly fire was rejected with -32602 because
+  // the MCP sourceRefs union was missing this member while the API side
+  // (validation.ts / qc-generator-adapter.ts) was already wired.
+  it('accepts qc-metrics-rollup sourceRefs (eval:qc wire-up)', () => {
+    const result = schema.safeParse({
+      domainId: 'eval:qc',
+      packet: { ...validPacket, domainId: 'eval:qc' },
+      sourceRefs: {
+        kind: 'qc-metrics-rollup',
+        windowStartMs: 1786838400000,
+        windowEndMs: 1787443200000,
+      },
+    });
+    assert.ok(result.success, `expected accept, got: ${JSON.stringify(result)}`);
+  });
+
+  it('accepts qc-metrics-rollup with the exact 2026-08-23 weekly fire window', () => {
+    // 2026-08-16T00:00:00Z → 2026-08-23T00:00:00Z (7d)
+    const result = schema.safeParse({
+      domainId: 'eval:qc',
+      packet: { ...validPacket, domainId: 'eval:qc' },
+      sourceRefs: {
+        kind: 'qc-metrics-rollup',
+        windowStartMs: 1786838400000,
+        windowEndMs: 1787443200000,
+      },
+    });
+    assert.ok(result.success, 'real weekly window should pass MCP schema');
+  });
+
+  it('rejects qc-metrics-rollup with non-finite windowStartMs', () => {
+    const result = schema.safeParse({
+      domainId: 'eval:qc',
+      packet: { ...validPacket, domainId: 'eval:qc' },
+      sourceRefs: {
+        kind: 'qc-metrics-rollup',
+        windowStartMs: 'not-a-number',
+        windowEndMs: 1787443200000,
+      },
+    });
+    assert.ok(!result.success, 'non-finite windowStartMs should fail');
+  });
+
+  it('rejects qc-metrics-rollup with missing windowEndMs', () => {
+    const result = schema.safeParse({
+      domainId: 'eval:qc',
+      packet: { ...validPacket, domainId: 'eval:qc' },
+      sourceRefs: {
+        kind: 'qc-metrics-rollup',
+        windowStartMs: 1786838400000,
+      },
+    });
+    assert.ok(!result.success, 'missing windowEndMs should fail required');
+  });
 });


### PR DESCRIPTION
## What

`cat_cafe_publish_verdict` MCP tool rejects `eval:qc` verdicts with `-32602 Input validation error`: the `sourceRefs` discriminated union in `packages/mcp-server/src/tools/publish-verdict-tool.ts` is missing the `qc-metrics-rollup` member.

## Why

F253 Phase C wired the eval:qc domain end-to-end on the API side (`validation.ts` `isQcMetricsSourceRefs` / `validateQcMetricsSelector`, `qc-metrics-provider.ts`, `qc-generator-adapter.ts`, `types.ts` union) and registered it in `PUBLISH_VERDICT_INSTRUCTIONS_BY_DOMAIN`, but the MCP tool schema was never updated. The weekly eval:qc fire (2026-08-23, thread_eval_qc) hit the Zod union rejection before the request could reach the API route — the domain could never publish a verdict through the sanctioned tool.

## Fix

- Add `qcMetricsSourceRefsShape` (kind + finite windowStartMs/windowEndMs) to the sourceRefs union + inferred tool input type + tool GOTCHA description.
- 4 regression tests in `publish-verdict-tool-schema.test.js`, including the exact real weekly window from this week's fire (2026-08-16T00:00Z → 2026-08-23T00:00Z).

## Verification

- `pnpm build` clean.
- `publish-verdict-tool-schema.test.js`: 28/28 pass (4 new qc tests).
- Full suite: 477/484 pass; the 7 failures are pre-existing Windows-environment failures in `file-tools.test.js` / `shell-tools.test.js` (symlink EPERM, path resolution) unrelated to this diff.

Thread-Context: threadId=thread_eval_qc catId=opus

[宪宪/deepseek-v4-pro🐾]