### PR TITLE
fix(trace): persist all 46 pipeline segments instead of S-prefix only

### DIFF
--- a/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-parallel.ts
@@ -47,6 +47,7 @@ import type { PreparedProactiveMemoryNudge } from '../../../../memory/ProactiveM
 import { mergePushRecallPresentations, triggerRecallCorrelation } from '../../../../memory/recall-correlation-hook.js';
 import { drainCapturedTraces } from '../../../../prompt-hooks/PipelinePromptBuilder.js';
 import { getTraceStore } from '../../../../prompt-hooks/trace-bootstrap.js';
+import { buildFromPipeline } from '../../../../prompt-hooks/trace-bridge.js';
 // F237: Injection trace (v0 — fire-and-forget observability)
 import { buildTraceDetail, buildTraceSummary, collectTrace } from '../../../../prompt-hooks/trace-collector.js';
 import { assembleContext } from '../../context/ContextAssembler.js';
@@ -535,7 +536,8 @@ export async function* routeParallel(
         : buildStaticIdentity(catId, { mcpAvailable, packBlocks });
       // F237: drain session trace IMMEDIATELY — before any await that could let
       // another parallel cat overwrite the module-global capture buffer.
-      drainCapturedTraces();
+      // F257: save session pipeline trace for full 46-segment persistence (S+L+B+C).
+      const { session: pipelineSessionTrace } = drainCapturedTraces();
       // F041: inject HTTP callback only when MCP is NOT actually available (fallback)
       const mcpInstructions = needsMcpInjection(mcpAvailable, catConfig?.clientId)
         ? buildMcpCallbackInstructions({
@@ -615,7 +617,8 @@ export async function* routeParallel(
         .filter(Boolean)
         .join('\n\n');
       // F237: drain turn trace IMMEDIATELY — same race-safety as session drain above.
-      drainCapturedTraces();
+      // F257: save turn pipeline trace for full 46-segment persistence (D+R+N).
+      const { turn: pipelineTurnTrace } = drainCapturedTraces();
 
       // F237 Phase 2: Pipeline trace capture drained above (lines 250, 322) to prevent
       // stale module-global buffer in concurrent Promise.all execution. Persistence is
@@ -700,36 +703,49 @@ export async function* routeParallel(
         }
       }
 
-      // F237: fire-and-forget injection trace persist (v0 — observability only)
-      // Placed after bootstrapCtx so per-turn trace covers ALL route-level
-      // injected system/control content (invocation + mode prompt + bootstrap + MCP).
+      // F257: fire-and-forget injection trace persist — pipeline path (all 46 segments).
+      // F237 v0 legacy path kept as fallback when pipeline traces are unavailable.
       // Skip if cat is already cancelled (avoid phantom trace for turns that never happen).
       const preTraceSignal = signalForCat?.(catId) ?? signal;
       try {
         const traceStore = getTraceStore();
         if (traceStore && !preTraceSignal?.aborted) {
           const traceTurnId = crypto.randomUUID();
-          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
-          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapCtx, mcpInstructions]
-            .filter(Boolean)
-            .join('\n\n---\n\n');
-          const collected = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
-            mcpAvailable,
-            packBlocks,
-          });
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
-          const summary = buildTraceSummary(collected, traceMeta);
-          const detail = buildTraceDetail(collected, traceMeta);
-          traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+
+          // F257: prefer pipeline traces — per-segment for ALL hooks (S+L+B+C session, D+R+N turn).
+          // This fixes the 15/46 segment trace gap where S1-S13, B1, C1 were invisible.
+          const pipelineResult = buildFromPipeline(pipelineSessionTrace ?? null, pipelineTurnTrace ?? null, {
+            ...traceMeta,
+            hasNativeL0,
+            sessionFromNativeCompiler: hasNativeL0,
           });
+
+          if (pipelineResult) {
+            traceStore.persist(pipelineResult.summary, pipelineResult.detail).catch((err) => {
+              log.warn({ err, threadId, catId }, '[F257] pipeline trace persist failed (fire-and-forget)');
+            });
+          } else {
+            // Fallback: legacy collectTrace (S-prefix only for session, aggregate for turn)
+            const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
+            const traceTurnContent = [invocationContext, traceModePrompt, bootstrapCtx, mcpInstructions]
+              .filter(Boolean)
+              .join('\n\n---\n\n');
+            const collected = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
+              mcpAvailable,
+              packBlocks,
+            });
+            const summary = buildTraceSummary(collected, traceMeta);
+            const detail = buildTraceDetail(collected, traceMeta);
+            traceStore.persist(summary, detail).catch((err) => {
+              log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+            });
+            // v0 collectTrace re-populates capturedSessionTrace. Clear stale buffer.
+            if (deps.injectionTraceStore) drainCapturedTraces();
+          }
         }
-        // v0 collectTrace → buildStaticIdentity(annotateSegments: true) re-populates
-        // the module-global capturedSessionTrace without draining. Clear it so the next
-        // invocation (especially native-L0 pack-only) doesn't persist stale session traces.
-        if (deps.injectionTraceStore) drainCapturedTraces();
       } catch {
-        /* F237: trace collection must never break invocation */
+        /* F237/F257: trace collection must never break invocation */
       }
 
       let prompt: string;

--- a/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
+++ b/packages/api/src/domains/cats/services/agents/routing/route-serial.ts
@@ -138,6 +138,7 @@ import type { PreparedProactiveMemoryNudge } from '../../../../memory/ProactiveM
 import { mergePushRecallPresentations, triggerRecallCorrelation } from '../../../../memory/recall-correlation-hook.js';
 import { drainCapturedTraces } from '../../../../prompt-hooks/PipelinePromptBuilder.js';
 import { getTraceStore } from '../../../../prompt-hooks/trace-bootstrap.js';
+import { buildFromPipeline } from '../../../../prompt-hooks/trace-bridge.js';
 // F237: Injection trace (v0 — fire-and-forget observability)
 import { buildTraceDetail, buildTraceSummary, collectTrace } from '../../../../prompt-hooks/trace-collector.js';
 import { assembleContext } from '../../context/ContextAssembler.js';
@@ -1203,7 +1204,8 @@ export async function* routeSerial(
         : buildStaticIdentity(catId, { mcpAvailable, packBlocks });
       // F237: drain session trace synchronously — before any await between
       // buildStaticIdentity and buildInvocationContext (race-safety for parallel reuse).
-      drainCapturedTraces();
+      // F257: save session pipeline trace for full 46-segment persistence (S+L+B+C).
+      const { session: pipelineSessionTrace } = drainCapturedTraces();
       // L0-budget-defense PR-B-impl (ADR-038 件套 ④): staging is NOT prepended
       // to staticIdentity here. Cloud R2 P1 #2237 L1099: folding staging into
       // staticIdentity breaks ADR-038 "每轮注入生效" contract on resumed
@@ -1326,7 +1328,8 @@ export async function* routeSerial(
         .filter(Boolean)
         .join('\n\n');
       // F237: drain turn trace synchronously — no yield between build and drain.
-      drainCapturedTraces();
+      // F257: save turn pipeline trace for full 46-segment persistence (D+R+N).
+      const { turn: pipelineTurnTrace } = drainCapturedTraces();
       const continuityCapsule = buildCapsuleFromRouteState({
         threadId,
         catId: catId as string,
@@ -1402,34 +1405,49 @@ export async function* routeSerial(
         }
       }
 
-      // F237: fire-and-forget injection trace persist (v0 — observability only)
-      // Placed after bootstrapContext so per-turn trace covers ALL route-level
-      // injected system/control content (invocation + mode prompt + bootstrap + MCP).
+      // F257: fire-and-forget injection trace persist — pipeline path (all 46 segments).
+      // F237 v0 legacy path kept as fallback when pipeline traces are unavailable.
       try {
         const traceStore = getTraceStore();
         if (traceStore) {
           const traceTurnId = crypto.randomUUID();
-          const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
-          const traceTurnContent = [invocationContext, traceModePrompt, bootstrapContext, mcpInstructions]
-            .filter(Boolean)
-            .join('\n\n---\n\n');
-          const trace = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
-            mcpAvailable,
-            packBlocks,
-          });
           const traceMeta = { turnId: traceTurnId, threadId, catId: catId as string };
-          const summary = buildTraceSummary(trace, traceMeta);
-          const detail = buildTraceDetail(trace, traceMeta);
-          traceStore.persist(summary, detail).catch((err) => {
-            log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+
+          // F257: prefer pipeline traces — per-segment for ALL hooks (S+L+B+C session, D+R+N turn).
+          // This fixes the 15/46 segment trace gap where S1-S13, B1, C1 were invisible.
+          const pipelineResult = buildFromPipeline(pipelineSessionTrace ?? null, pipelineTurnTrace ?? null, {
+            ...traceMeta,
+            hasNativeL0,
+            sessionFromNativeCompiler: hasNativeL0,
           });
+
+          if (pipelineResult) {
+            traceStore.persist(pipelineResult.summary, pipelineResult.detail).catch((err) => {
+              log.warn({ err, threadId, catId }, '[F257] pipeline trace persist failed (fire-and-forget)');
+            });
+          } else {
+            // Fallback: legacy collectTrace (S-prefix only for session, aggregate for turn)
+            const traceModePrompt = modeSystemPromptByCat?.[catId as string] ?? modeSystemPrompt ?? '';
+            const traceTurnContent = [invocationContext, traceModePrompt, bootstrapContext, mcpInstructions]
+              .filter(Boolean)
+              .join('\n\n---\n\n');
+            const trace = collectTrace(catId as string, staticIdentity, traceTurnContent, hasNativeL0, {
+              mcpAvailable,
+              packBlocks,
+            });
+            const summary = buildTraceSummary(trace, traceMeta);
+            const detail = buildTraceDetail(trace, traceMeta);
+            traceStore.persist(summary, detail).catch((err) => {
+              log.warn({ err, threadId, catId }, '[F237] injection trace persist failed (fire-and-forget)');
+            });
+            // v0 collectTrace → buildStaticIdentity(annotateSegments: true) re-populates
+            // the module-global capturedSessionTrace without draining. Clear it so the next
+            // invocation doesn't persist stale session traces.
+            if (deps.injectionTraceStore) drainCapturedTraces();
+          }
         }
-        // v0 collectTrace → buildStaticIdentity(annotateSegments: true) re-populates
-        // the module-global capturedSessionTrace without draining. Clear it so the next
-        // invocation (especially native-L0 pack-only) doesn't persist stale session traces.
-        if (deps.injectionTraceStore) drainCapturedTraces();
       } catch {
-        /* F237: trace collection must never break invocation */
+        /* F237/F257: trace collection must never break invocation */
       }
 
       let deliveryBoundaryId: string | undefined;

--- a/packages/api/src/domains/prompt-hooks/trace-bridge.ts
+++ b/packages/api/src/domains/prompt-hooks/trace-bridge.ts
@@ -1,0 +1,189 @@
+/**
+ * F257 Trace Persistence Bridge
+ *
+ * Converts pipeline-produced PipelineResult (per-hook TraceEvent[])
+ * into v0 InjectionTraceSummary / InjectionTraceDetail formats
+ * consumed by InjectionTraceStore.
+ *
+ * Fixes the 15/46 segment trace gap: the legacy collectTrace() path
+ * only covers S-prefix session segments and per-turn aggregate. This
+ * bridge converts the full pipeline result (all 46 hooks) to v0 format.
+ *
+ * When pipeline traces are unavailable (e.g., legacy path without
+ * pipeline), callers fall back to the existing collectTrace() path.
+ */
+
+import { createHash } from 'node:crypto';
+import type {
+  DeliveryChannel,
+  InjectionTraceDetail,
+  InjectionTraceSummary,
+  ObservedSegment,
+  StageDeliveryDecision,
+} from '@cat-cafe/shared';
+import type { PipelineResult } from './HookPipeline.js';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface TraceBridgeMeta {
+  turnId: string;
+  sessionId?: string;
+  threadId: string;
+  catId: string;
+  hasNativeL0: boolean;
+  /**
+   * When true, the session result comes from the native L0 compiler's
+   * manifest (L1-L7), so the delivery channel is 'native-l0'.
+   */
+  sessionFromNativeCompiler?: boolean;
+}
+
+/**
+ * Build v0 InjectionTraceSummary + InjectionTraceDetail from pipeline results.
+ *
+ * Returns null when both session and turn results are null (no pipeline
+ * traces captured — caller should fall back to collectTrace path).
+ */
+export function buildFromPipeline(
+  sessionResult: PipelineResult | null,
+  turnResult: PipelineResult | null,
+  meta: TraceBridgeMeta,
+): { summary: InjectionTraceSummary; detail: InjectionTraceDetail } | null {
+  if (!sessionResult && !turnResult) return null;
+
+  const sessionSegments = sessionResult ? eventsToSegments(sessionResult, 'session-init') : [];
+  const turnSegments = turnResult ? eventsToSegments(turnResult, 'per-turn') : [];
+  const allSegments = [...sessionSegments, ...turnSegments];
+
+  const observed = allSegments.filter((s) => s.status === 'observed');
+  const absent = allSegments.filter((s) => s.status === 'absent');
+
+  const sessionTokens = sumTokens(sessionSegments);
+  const turnTokens = sumTokens(turnSegments);
+  const sessionChars = sumChars(sessionResult);
+  const turnChars = sumChars(turnResult);
+
+  const delivery = buildDelivery(sessionResult, turnResult, meta.hasNativeL0, meta.sessionFromNativeCompiler ?? false);
+  const timestamp = Date.now();
+
+  const summary: InjectionTraceSummary = {
+    turnId: meta.turnId,
+    ...(meta.sessionId ? { sessionId: meta.sessionId } : {}),
+    threadId: meta.threadId,
+    catId: meta.catId,
+    timestamp,
+    segments: allSegments,
+    delivery,
+    totalCharCount: sessionChars + turnChars,
+    totalTokenEstimate: sessionTokens + turnTokens,
+    totalSegmentsObserved: observed.length,
+    totalSegmentsAbsent: absent.length,
+    durationMs: 0, // Pipeline doesn't track duration; 0 = not measured
+  };
+
+  const detail: InjectionTraceDetail = {
+    turnId: meta.turnId,
+    threadId: meta.threadId,
+    catId: meta.catId,
+    timestamp,
+    sessionContentHash: assembledContentHash(sessionResult),
+    turnContentHash: assembledContentHash(turnResult),
+    sessionCharCount: sessionChars,
+    sessionTokenEstimate: sessionTokens,
+    turnCharCount: turnChars,
+    turnTokenEstimate: turnTokens,
+    segments: allSegments,
+  };
+
+  return { summary, detail };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type InjectionStage = 'session-init' | 'per-turn';
+
+/**
+ * Convert pipeline TraceEvent[] to v0 ObservedSegment[].
+ *
+ * Maps pipeline statuses to v0 binary: fired → 'observed', everything else → 'absent'.
+ */
+function eventsToSegments(result: PipelineResult, stage: InjectionStage): ObservedSegment[] {
+  const patchMap = new Map(result.patches.map((p) => [p.hookId, p]));
+  return result.events.map((ev): ObservedSegment => {
+    if (ev.status === 'fired') {
+      const patch = patchMap.get(ev.hookId);
+      return {
+        segmentId: ev.hookId,
+        stage,
+        status: 'observed',
+        contentHash: ev.contentHash,
+        charCount: patch?.content.length ?? 0,
+        tokenEstimate: ev.tokenEstimate,
+      };
+    }
+    // skipped, disabled, or observed-without-content → absent
+    return {
+      segmentId: ev.hookId,
+      stage,
+      status: 'absent',
+      contentHash: null,
+      charCount: 0,
+      tokenEstimate: 0,
+    };
+  });
+}
+
+function sumTokens(segments: ObservedSegment[]): number {
+  return segments.reduce((acc, s) => acc + s.tokenEstimate, 0);
+}
+
+function sumChars(result: PipelineResult | null): number {
+  if (!result) return 0;
+  return result.patches.reduce((acc, p) => acc + p.content.length, 0);
+}
+
+/**
+ * Hash assembled patch content matching HookPipeline.assemblePatches semantics:
+ * patches in manifest order, joined with '\n\n'.
+ */
+function assembledContentHash(result: PipelineResult | null): string | null {
+  if (!result || result.patches.length === 0) return null;
+  const combined = result.patches.map((p) => p.content).join('\n\n');
+  return createHash('sha256').update(combined).digest('hex').slice(0, 16);
+}
+
+function buildDelivery(
+  sessionResult: PipelineResult | null,
+  turnResult: PipelineResult | null,
+  hasNativeL0: boolean,
+  sessionFromNativeCompiler: boolean,
+): StageDeliveryDecision[] {
+  const sessionChannel: DeliveryChannel = sessionFromNativeCompiler
+    ? 'native-l0'
+    : hasNativeL0
+      ? 'pack-only'
+      : 'message-prepend';
+  const sessionReason = sessionFromNativeCompiler
+    ? 'Pipeline bridge: L1-L7 delivered via native L0 compiler artifact'
+    : hasNativeL0
+      ? 'Pipeline bridge: pack-only for native L0'
+      : 'Pipeline bridge: content assembled for message-prepend';
+  return [
+    {
+      stage: 'session-init' as InjectionStage,
+      contentAssembled: sessionResult !== null && sessionResult.patches.length > 0,
+      channel: sessionChannel,
+      reason: sessionReason,
+    },
+    {
+      stage: 'per-turn' as InjectionStage,
+      contentAssembled: turnResult !== null && turnResult.patches.length > 0,
+      channel: 'message-prepend',
+      reason: 'Pipeline bridge: per-turn content assembled',
+    },
+  ];
+}

--- a/packages/api/test/trace-bridge.test.ts
+++ b/packages/api/test/trace-bridge.test.ts
@@ -1,0 +1,193 @@
+/**
+ * F257: trace-bridge.ts — pipeline → v0 trace conversion tests
+ *
+ * Verifies that buildFromPipeline correctly converts PipelineResult
+ * (all 46 hooks) into v0 InjectionTraceSummary + InjectionTraceDetail,
+ * fixing the 15/46 segment trace gap.
+ */
+import { describe, expect, it } from 'vitest';
+import type { PipelineResult } from '../src/domains/prompt-hooks/HookPipeline.js';
+import { buildFromPipeline } from '../src/domains/prompt-hooks/trace-bridge.js';
+
+function makeFiredEvent(hookId: string, stage: 'session-init' | 'per-turn') {
+  return {
+    hookId,
+    stage,
+    timestamp: Date.now(),
+    status: 'fired' as const,
+    version: 1,
+    contentHash: `hash-${hookId}`,
+    tokenEstimate: 100,
+  };
+}
+
+function makeSkippedEvent(hookId: string, stage: 'session-init' | 'per-turn') {
+  return {
+    hookId,
+    stage,
+    timestamp: Date.now(),
+    status: 'skipped' as const,
+    reasonCode: 'condition-false',
+    reason: 'Resolver returned false',
+  };
+}
+
+function makeDisabledEvent(hookId: string, stage: 'session-init' | 'per-turn') {
+  return {
+    hookId,
+    stage,
+    timestamp: Date.now(),
+    status: 'disabled' as const,
+    disabledBy: 'operator' as const,
+  };
+}
+
+function makePatch(hookId: string, content: string) {
+  return { hookId, content, order: 100 };
+}
+
+describe('buildFromPipeline', () => {
+  it('returns null when both results are null', () => {
+    expect(
+      buildFromPipeline(null, null, {
+        turnId: 't1',
+        threadId: 'th1',
+        catId: 'cat1',
+        hasNativeL0: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('converts all session hooks (S+L+B+C) to segments', () => {
+    const sessionResult: PipelineResult = {
+      events: [
+        makeFiredEvent('S1', 'session-init'),
+        makeFiredEvent('S2', 'session-init'),
+        makeSkippedEvent('S3', 'session-init'),
+        makeFiredEvent('L1', 'session-init'),
+        makeFiredEvent('L2', 'session-init'),
+        makeFiredEvent('B1', 'session-init'),
+        makeDisabledEvent('C1', 'session-init'),
+      ],
+      patches: [
+        makePatch('S1', 'content-S1'),
+        makePatch('S2', 'content-S2'),
+        makePatch('L1', 'content-L1'),
+        makePatch('L2', 'content-L2'),
+        makePatch('B1', 'content-B1'),
+      ],
+    };
+
+    const result = buildFromPipeline(sessionResult, null, {
+      turnId: 't1',
+      threadId: 'th1',
+      catId: 'cat1',
+      hasNativeL0: false,
+    });
+
+    expect(result).not.toBeNull();
+    const { summary, detail } = result!;
+
+    // All 7 hooks should appear as segments
+    expect(summary.segments).toHaveLength(7);
+    expect(detail.segments).toHaveLength(7);
+
+    // S1, S2, L1, L2, B1 = observed (fired)
+    expect(summary.totalSegmentsObserved).toBe(5);
+    // S3, C1 = absent (skipped/disabled)
+    expect(summary.totalSegmentsAbsent).toBe(2);
+
+    // Verify segment IDs include non-S-prefix hooks (the fix!)
+    const segmentIds = summary.segments.map((s) => s.segmentId);
+    expect(segmentIds).toContain('L1');
+    expect(segmentIds).toContain('L2');
+    expect(segmentIds).toContain('B1');
+    expect(segmentIds).toContain('C1');
+  });
+
+  it('converts all turn hooks (D+R+N) to segments', () => {
+    const turnResult: PipelineResult = {
+      events: [
+        makeFiredEvent('D1', 'per-turn'),
+        makeFiredEvent('D2', 'per-turn'),
+        makeSkippedEvent('D5', 'per-turn'),
+        makeFiredEvent('R1', 'per-turn'),
+        makeFiredEvent('N1', 'per-turn'),
+      ],
+      patches: [
+        makePatch('D1', 'content-D1'),
+        makePatch('D2', 'content-D2'),
+        makePatch('R1', 'content-R1'),
+        makePatch('N1', 'content-N1'),
+      ],
+    };
+
+    const result = buildFromPipeline(null, turnResult, {
+      turnId: 't1',
+      threadId: 'th1',
+      catId: 'cat1',
+      hasNativeL0: false,
+    });
+
+    expect(result).not.toBeNull();
+    const { summary } = result!;
+
+    expect(summary.segments).toHaveLength(5);
+    expect(summary.totalSegmentsObserved).toBe(4);
+    expect(summary.totalSegmentsAbsent).toBe(1);
+
+    // R1 and N1 should be present (not just D-prefix)
+    const segmentIds = summary.segments.map((s) => s.segmentId);
+    expect(segmentIds).toContain('R1');
+    expect(segmentIds).toContain('N1');
+  });
+
+  it('combines session and turn traces into one summary', () => {
+    const sessionResult: PipelineResult = {
+      events: [makeFiredEvent('S1', 'session-init'), makeFiredEvent('L1', 'session-init')],
+      patches: [makePatch('S1', 'session-content'), makePatch('L1', 'l1-content')],
+    };
+    const turnResult: PipelineResult = {
+      events: [makeFiredEvent('D1', 'per-turn')],
+      patches: [makePatch('D1', 'turn-content')],
+    };
+
+    const result = buildFromPipeline(sessionResult, turnResult, {
+      turnId: 't1',
+      threadId: 'th1',
+      catId: 'cat1',
+      hasNativeL0: false,
+    });
+
+    expect(result).not.toBeNull();
+    const { summary, detail } = result!;
+
+    // 2 session + 1 turn = 3 total segments
+    expect(summary.segments).toHaveLength(3);
+    expect(summary.totalSegmentsObserved).toBe(3);
+    expect(summary.totalSegmentsAbsent).toBe(0);
+
+    // Detail should have correct per-stage char counts
+    expect(detail.sessionCharCount).toBeGreaterThan(0);
+    expect(detail.turnCharCount).toBeGreaterThan(0);
+  });
+
+  it('sets native-l0 delivery channel when sessionFromNativeCompiler is true', () => {
+    const sessionResult: PipelineResult = {
+      events: [makeFiredEvent('L1', 'session-init')],
+      patches: [makePatch('L1', 'native-content')],
+    };
+
+    const result = buildFromPipeline(sessionResult, null, {
+      turnId: 't1',
+      threadId: 'th1',
+      catId: 'cat1',
+      hasNativeL0: true,
+      sessionFromNativeCompiler: true,
+    });
+
+    expect(result).not.toBeNull();
+    const sessionDelivery = result!.summary.delivery.find((d) => d.stage === 'session-init');
+    expect(sessionDelivery?.channel).toBe('native-l0');
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `drainCapturedTraces()` in `route-serial.ts` (line 1206) and `route-parallel.ts` (line 538) discarded pipeline trace data without saving it. Persistence fell back to legacy `collectTrace()` which only covers S-prefix session segments and per-turn aggregate — leaving 15/46 segments (S1-S13, B1, C1) with zero trace data.
- **Fix**: Capture the `PipelineResult` from each drain call and convert it to v0 `InjectionTraceSummary`/`InjectionTraceDetail` via a new `trace-bridge.ts` module. Legacy `collectTrace()` path kept as fallback.
- **New file**: `packages/api/src/domains/prompt-hooks/trace-bridge.ts` — `buildFromPipeline()` converts per-hook `TraceEvent[]` arrays to v0 `ObservedSegment[]` format with correct stage labeling, token/char accounting, and delivery channel metadata.

## Changes

| File | What |
|------|------|
| `route-serial.ts` | Capture drain results → pipeline-first persistence with legacy fallback |
| `route-parallel.ts` | Same pattern, abort-signal guard preserved |
| `trace-bridge.ts` (new) | `buildFromPipeline()` — pipeline → v0 trace format converter |
| `trace-bridge.test.ts` (new) | 5 tests: session-only, turn-only, combined, null inputs, native-L0 channel |

## Test plan

- [x] `vitest run trace-bridge.test.ts` — 5/5 pass
- [x] Biome check passes (imports sorted, formatting applied)
- [ ] Integration: verify trace data appears for B1, C1, S1-S13 segments in a real invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)