### PR TITLE
ci(public): renew audited exclusion cohort

### DIFF
--- a/packages/api/config/public-test-exclusions.json
+++ b/packages/api/config/public-test-exclusions.json
@@ -8,7 +8,7 @@
       "reason": "Redis isolation and persistence tests are internal harness coverage, not part of the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "task-progress-store",
@@ -17,7 +17,7 @@
       "reason": "Task progress store behavior depends on internal persistence surfaces not exported to the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "session-strategy-phase3",
@@ -26,7 +26,7 @@
       "reason": "Phase 3 session strategy assertions cover internal rollout behavior outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "signal-article-store",
@@ -35,7 +35,7 @@
       "reason": "Signal article store cases exercise source-only data plumbing not guaranteed in the public export.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "cursor-store-atomicity",
@@ -44,7 +44,7 @@
       "reason": "Atomic cursor store checks cover internal durability mechanics not enforced by the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "workflow-sop-store",
@@ -53,7 +53,7 @@
       "reason": "Workflow SOP store tests rely on internal governance persistence surfaces excluded from the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "codex-agent-service",
@@ -62,7 +62,7 @@
       "reason": "Codex agent runtime service tests depend on internal carrier/harness wiring outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "kimi-agent-service",
@@ -71,7 +71,7 @@
       "reason": "Kimi agent service coverage is internal runtime behavior, not public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "claude-settings-hooks",
@@ -80,7 +80,7 @@
       "reason": "Claude settings hook assertions depend on private runtime fixtures unavailable in public export.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "game-store",
@@ -89,7 +89,7 @@
       "reason": "Game store tests rely on non-exported local fixtures and are kept out of the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "memory-tests",
@@ -98,7 +98,7 @@
       "reason": "Memory package tests cover internal recall/index behavior outside the public gate promise.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "cross-cat-context",
@@ -107,7 +107,7 @@
       "reason": "Cross-cat context routing is internal collaboration harness behavior, not public gate surface.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "thread-wiring",
@@ -116,7 +116,7 @@
       "reason": "Thread wiring assertions cover internal callback plumbing outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "integration-wiring",
@@ -125,7 +125,7 @@
       "reason": "Integration wiring checks depend on internal connection topology not exported to public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "shared-state-wiring",
@@ -134,7 +134,7 @@
       "reason": "Shared-state wiring is internal runtime glue not part of the public gate guarantee.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "signal-fetcher-launchd",
@@ -143,7 +143,7 @@
       "reason": "launchd-specific signal fetcher coverage depends on private macOS fixtures and stays internal.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "reflection-capsule-m3",
@@ -152,7 +152,7 @@
       "reason": "Reflection capsule M3 tests cover internal memory/harness behavior outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "workspace-project-context",
@@ -161,7 +161,7 @@
       "reason": "Workspace project context assertions depend on source-only repo structure and local project wiring.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "projects-setup",
@@ -170,7 +170,7 @@
       "reason": "Project setup tests cover internal bootstrap flows not guaranteed in the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "projects-mkdir",
@@ -179,7 +179,7 @@
       "reason": "Project directory creation coverage depends on source-only filesystem conventions.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "governance-status",
@@ -188,7 +188,7 @@
       "reason": "Governance status assertions are source-owned workflow coverage, not public gate behavior.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "pack-integration",
@@ -197,7 +197,7 @@
       "reason": "Pack integration coverage exercises internal source packaging rules outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "project-setup-flow",
@@ -206,7 +206,7 @@
       "reason": "Project setup flow behavior is internal bootstrap coverage, not public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "expedition-bootstrap",
@@ -215,7 +215,7 @@
       "reason": "Expedition bootstrap coverage depends on source-owned harness flows not exported publicly.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "rules-route",
@@ -224,7 +224,7 @@
       "reason": "Rules route assertions depend on source-only rule artifacts stripped from public export.",
       "owner": "@zts212653",
       "introducedBy": "4243948da",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "root-md-slim",
@@ -233,7 +233,7 @@
       "reason": "Root markdown slim tests rely on source-specific Chinese anchors not preserved in public export.",
       "owner": "@zts212653",
       "introducedBy": "7a300704a",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "audit-cc-system-prompt",
@@ -242,7 +242,7 @@
       "reason": "System prompt audit depends on internal L0 prompt assets not shipped in public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "f188-cold-start-fixtures",
@@ -251,7 +251,7 @@
       "reason": "F188 cold-start fixture coverage depends on internal fixture files absent from public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "f188-harness-consistency",
@@ -260,7 +260,7 @@
       "reason": "F188 harness consistency checks rely on internal fixtures and remain source-only.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "orphan-chrome-cleaner",
@@ -269,7 +269,7 @@
       "reason": "Orphan Chrome cleaner assertions are sensitive to local path sanitization and private fixtures.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "f203-phase-i-opencode-l0",
@@ -278,7 +278,7 @@
       "reason": "F203 opencode L0 coverage depends on internal runtime files not exported publicly.",
       "owner": "@zts212653",
       "introducedBy": "9c4f26fde",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "f236-cc-anchor-hook",
@@ -287,7 +287,7 @@
       "reason": "F236 cc anchor hook coverage imports the source-only root .claude hook implementation that is not part of the public export.",
       "owner": "@zts212653",
       "introducedBy": "68dd499d9",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "github-schedule-factories",
@@ -296,7 +296,7 @@
       "reason": "GitHub schedule factory assertions are source-owned public-sync governance coverage, not runtime gate behavior.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-hub-read-model",
@@ -305,7 +305,7 @@
       "reason": "Eval hub read-model coverage exercises source-owned harness governance surfaces outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-merge-gate-provenance-contract",
@@ -314,7 +314,7 @@
       "reason": "Merge-gate provenance contract tests are source-owned governance coverage, not public runtime behavior.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-design-gate-private-evidence",
@@ -323,7 +323,7 @@
       "reason": "The committed design-gate episode proof consumes home-only source maps and review provenance; the self-contained provider contract remains in the public suite.",
       "owner": "@zts212653",
       "introducedBy": "a21fd7682",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "f254-private-evidence-contracts",
@@ -332,7 +332,7 @@
       "reason": "F254 document evidence, replay, scope, and native-provider checks require home-only archives, owner provenance, or carrier credentials; public runtime behavior is covered independently.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-private-registry",
@@ -341,7 +341,7 @@
       "reason": "These Eval Hub governance checks require the home-only measurement registry and historical evidence archive, not public product state.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-private-measurement-evidence",
@@ -350,7 +350,7 @@
       "reason": "Friction measurement and rejudge checks consume private certificates, verdicts, and replay artifacts that are deliberately absent from the public export.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-private-verdict-publication",
@@ -359,7 +359,7 @@
       "reason": "Verdict publication checks require home-owned task, memory, and measurement evidence stores; they are governance coverage rather than a public runtime contract.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     },
     {
       "id": "harness-eval-private-legacy-reeval-cases",
@@ -368,7 +368,7 @@
       "reason": "Legacy stable-case migration and Hub projection assertions consume the home-only historical verdict archive and migration manifest, which are deliberately absent from the public export.",
       "owner": "@zts212653",
       "introducedBy": "7121c7dec",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-30"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- extend the existing 41 audited public-test exclusions from 2026-08-31 to 2026-09-30
- keep the exclusion selection, match patterns, categories, owners, reasons, and provenance unchanged
- preserve fail-closed expiry while giving the existing source-only/private-fixture cohort a bounded maintenance window

## Verification

- full serial public-test suite passed (24m52s)
- Windows smoke, build, lint, public contract surfaces, and public-test plan passed
- fork-side exact-HEAD cross-review approved
- diff is limited to packages/api/config/public-test-exclusions.json