### PR TITLE
verdict(eval:friction): 2026-09-02-eval-friction-c1-empty-window-streak-through-sep01

### DIFF
--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/attribution.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/attribution.json
@@ -1,0 +1,11 @@
+{
+  "verdictId": "2026-09-02-eval-friction-c1-empty-window-streak-through-sep01",
+  "featureId": "F245",
+  "evalSnapshotId": "eval-F245-2026-09-02",
+  "generatedAt": "2026-09-02T03:01:48.000Z",
+  "findings": [],
+  "noFindingRecord": {
+    "reason": "no friction cluster surfaced in the selected window",
+    "evidence": "friction-rollup/cluster_count"
+  }
+}

--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/lifecycle-root.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/lifecycle-root.json
@@ -1,0 +1,21 @@
+{
+  "verdictId": "2026-09-02-eval-friction-c1-empty-window-streak-through-sep01",
+  "domainId": "eval:friction",
+  "createdAt": "2026-09-02T03:01:48.000Z",
+  "verdict": "keep_observe",
+  "harnessUnderEval": {
+    "featureId": "F245",
+    "componentId": "friction-rollup",
+    "name": "friction rollup (Top-N + sensorForm)"
+  },
+  "ownerAsk": {
+    "targetFeatureId": "F245",
+    "targetOwnerCatId": "opus-47",
+    "requestedAction": "Keep the every-3d friction rollup running and only reopen owner action if the August 12, 2026 to August 15, 2026 singleton pair reappears, a new actionableCandidate surfaces, or referenceOnly eval-domain clusters start recurring."
+  },
+  "acceptanceReevalPlan": {
+    "nextEvalAt": "2026-09-04T03:00:00.000Z",
+    "closureCondition": "The next scheduled every-3d window also remains free of new friction signals, actionableCandidates, and referenceOnly recurrence."
+  },
+  "schemaVersion": 1
+}

--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/provenance.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/provenance.json
@@ -1,0 +1,21 @@
+{
+  "verdictId": "2026-09-02-eval-friction-c1-empty-window-streak-through-sep01",
+  "rawInputs": [
+    {
+      "path": "docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/rollup-report.json",
+      "sha256": "3d01568c83936cfe5aca3899335dac4c5efed798a101928278276a8182bcb7c0"
+    },
+    {
+      "path": "docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/measurement-validity.json",
+      "sha256": "0997179caf8b161dbe7895ffb25c8f5af42dfa1f8b762388039868a2a739c690"
+    }
+  ],
+  "generatedAt": "2026-09-02T03:01:48.000Z",
+  "generator": {
+    "name": "eval-friction-live-verdict",
+    "version": "2"
+  },
+  "sanitizeRulesVersion": "f267-friction-measurement-v1",
+  "sourceThreadId": "thread_eval_friction",
+  "sourceMessageId": "0001788317999740-000115-c46c3ce8"
+}

--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/measurement-validity.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/measurement-validity.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 1,
+  "measurementTarget": "friction_opportunity_to_action",
+  "window": {
+    "sinceMs": 1787972400000,
+    "untilMs": 1788231600000
+  },
+  "capturedAt": "2026-09-02T03:01:48.000Z",
+  "baselineKind": "prospective_paired_capture",
+  "historicalBaseline": {
+    "classification": "symptom_cohort",
+    "rollupCount": 11,
+    "limitation": "historical_rollups_lack_frozen_canonical_row_ids"
+  },
+  "cancelJoin": {
+    "status": "no_opportunity",
+    "expectedIds": [],
+    "actualIds": [],
+    "intersectionIds": [],
+    "missingIds": [],
+    "extraIds": [],
+    "recall": null
+  },
+  "channels": {
+    "paw-feel": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "cancel": {
+      "opportunity": {
+        "status": "measured",
+        "ids": [],
+        "provenance": "frozen_task_outcome_rows"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "user-feedback": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    },
+    "eval-domain": {
+      "opportunity": {
+        "status": "unmeasured",
+        "ids": null,
+        "provenance": "canonical_opportunity_source_not_instrumented"
+      },
+      "adapter": {
+        "status": "ok",
+        "emittedIds": [],
+        "provenance": "single_window_adapter_capture"
+      },
+      "aggregate": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_aggregator_output"
+      },
+      "clustered": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "friction_cluster_membership"
+      },
+      "eligibility": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "non_eval_domain_only_cluster_membership"
+      },
+      "actionable": {
+        "ids": [],
+        "excludedIds": [],
+        "provenance": "rollup_actionable_candidate_selection"
+      }
+    }
+  },
+  "decision": {
+    "status": "insufficient",
+    "reasons": [
+      "cancel_join:no_opportunity",
+      "downstream_degraded"
+    ],
+    "withdrawalConditions": [
+      "rerun_after_closed_window_with_cancel_opportunity",
+      "rerun_after_downstream_dependencies_recover"
+    ]
+  }
+}

--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/rollup-report.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/raw/rollup-report.json
@@ -1,0 +1,39 @@
+{
+  "verdictId": "2026-09-02-eval-friction-c1-empty-window-streak-through-sep01",
+  "selector": {
+    "kind": "friction-rollup-snapshot",
+    "windowStartMs": 1787972400000,
+    "windowEndMs": 1788231600000,
+    "topN": 10,
+    "tokenCap": 4000
+  },
+  "window": {
+    "sinceMs": 1787972400000,
+    "untilMs": 1788231600000
+  },
+  "signalCount": 0,
+  "clusterCount": 0,
+  "degraded": true,
+  "droppedChannels": [],
+  "report": {
+    "window": {
+      "sinceMs": 1787972400000,
+      "untilMs": 1788231600000
+    },
+    "generatedAt": "2026-09-02T03:01:48.000Z",
+    "topClusters": [],
+    "actionableCandidates": [],
+    "referenceOnly": [],
+    "tailSummary": {
+      "clusterCount": 0,
+      "signalCount": 0,
+      "byChannel": {}
+    },
+    "degraded": true,
+    "droppedChannels": [],
+    "tokenBudget": {
+      "cap": 4000,
+      "estimated": 78
+    }
+  }
+}

--- a/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/snapshot.json
+++ b/docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/snapshot.json
@@ -1,0 +1,25 @@
+{
+  "verdictId": "2026-09-02-eval-friction-c1-empty-window-streak-through-sep01",
+  "evalSnapshotId": "eval-F245-2026-09-02",
+  "featureId": "F245",
+  "generatedAt": "2026-09-02T03:01:48.000Z",
+  "window": {
+    "startMs": 1787972400000,
+    "endMs": 1788231600000,
+    "durationHours": 72
+  },
+  "components": [
+    {
+      "id": "friction-rollup",
+      "name": "friction rollup (Top-N + sensorForm)",
+      "confidence": "low",
+      "activationCounts": {},
+      "frictionCounts": {
+        "cluster_count": 0,
+        "top_cluster_count": 0,
+        "tail_cluster_count": 0,
+        "tail_signal_count": 0
+      }
+    }
+  ]
+}

--- a/docs/harness-feedback/registry/measurement-bundles.yaml
+++ b/docs/harness-feedback/registry/measurement-bundles.yaml
@@ -1,13 +1,13 @@
 kind: f267-measurement-bundle-census
 schemaVersion: 2
-generatedAt: 2026-08-27T06:35:32Z
+generatedAt: 2026-09-02T03:01:48.000Z
 sources:
   registryDir: docs/harness-feedback/eval-domains
   instructionMap: packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts#DOMAIN_INSTRUCTIONS
   publishMap: packages/api/src/infrastructure/harness-eval/eval-cat-invocation.ts#PUBLISH_VERDICT_INSTRUCTIONS_BY_DOMAIN
   verdictDir: docs/harness-feedback/verdicts
-verdictCorpusHash: f7ee57365b6a410f69841c0bfd3c75ece7c7f26c5b0ec37da1094f6daf623dec
-committedVerdictArtifactCount: 3
+verdictCorpusHash: 09f0e28e8bf0dd0dc1c0fbe69d2fed5c8d3736ed14742ecbe237d6da2d179b2f
+committedVerdictArtifactCount: 4
 entries:
   - domainId: eval:a2a
     classification: active_decision_bearing
@@ -227,7 +227,7 @@ entries:
     sourceSelector:
       adapter: f245-friction-rollup
       kind: friction-rollup-snapshot
-    committedVerdictArtifactCount: 1
+    committedVerdictArtifactCount: 2
     functionalEquivalents:
       - f245-friction-rollup/friction-rollup-snapshot public registry contract
     evidence:

--- a/docs/harness-feedback/verdicts/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01.md
+++ b/docs/harness-feedback/verdicts/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01.md
@@ -1,0 +1,35 @@
+---
+feature_ids: [F245]
+topics: [harness-eval, eval-friction, live-verdict]
+doc_kind: harness-feedback
+feedback_type: live-verdict
+domain_id: eval:friction
+packet_id: 2026-09-02-eval-friction-c1-empty-window-streak-through-sep01
+source_snapshot: "snapshot:bundle/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/snapshot"
+---
+
+# Live Verdict — 2026-09-02-eval-friction-c1-empty-window-streak-through-sep01
+
+- Verdict: `keep_observe`
+- Phenomenon: The latest closed every-3d friction window from 2026-08-29 03:00 UTC to 2026-09-01 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. The two immediately preceding closed 72h windows from 2026-08-26 03:00 UTC to 2026-08-29 03:00 UTC and from 2026-08-23 03:00 UTC to 2026-08-26 03:00 UTC were also empty; the last non-empty window remains 2026-08-12 03:00 UTC to 2026-08-15 03:00 UTC, which carried two singleton user-feedback clusters (`a2a_timeout: opus` and `text_frustration: 还是不行`).
+- Harness: F245/friction-rollup (friction rollup (Top-N + sensorForm))
+- Root cause: No active harness-level root cause is observable in the current window. The August 12, 2026 to August 15, 2026 spike still looks more like two thread-local user-feedback singletons than a continuing F245 rollup failure, but the rollup remains degraded and the quiet streak is still evidence of absence rather than proof of durable resolution. (confidence low)
+- Owner ask: Keep the every-3d friction rollup running and only reopen owner action if the August 12, 2026 to August 15, 2026 singleton pair reappears, a new actionableCandidate surfaces, or referenceOnly eval-domain clusters start recurring.
+- Re-eval: next eval at 2026-09-04T03:00:00.000Z
+
+Evidence:
+- snapshot:bundle/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/snapshot
+- attribution:bundle/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/eval-F245-2026-09-02:no-finding
+- metric:official.rollup_signal_count
+- metric:official.rollup_cluster_count
+- metric:official.actionable_candidates
+- metric:official.reference_only_clusters
+- metric:baseline.official.rollup_signal_count
+- metric:baseline.official.rollup_cluster_count
+- metric:baseline.official.actionable_candidates
+- metric:baseline.official.reference_only_clusters
+
+Counterarguments:
+- Three consecutive empty windows are encouraging, but they still do not prove permanent resolution.
+- Absence of recurrence may reflect topic churn rather than harness improvement.
+- The current rollup remains degraded, so zero surfaced clusters is weaker than a fully non-degraded clean window.


### PR DESCRIPTION
Verdict published for `eval:friction` after the official `cat_cafe_publish_verdict` path failed on missing `scripts/check-verdict-publish-contract.mjs`.

- Verdict: `keep_observe`
- Domain: `eval:friction`
- Phenomenon: The latest closed every-3d friction window from 2026-08-29 03:00 UTC to 2026-09-01 03:00 UTC produced no friction signals, no actionableCandidates, and no referenceOnly clusters. The two immediately preceding closed 72h windows from 2026-08-26 03:00 UTC to 2026-08-29 03:00 UTC and from 2026-08-23 03:00 UTC to 2026-08-26 03:00 UTC were also empty; the last non-empty window remains 2026-08-12 03:00 UTC to 2026-08-15 03:00 UTC, which carried two singleton user-feedback clusters (`a2a_timeout: opus` and `text_frustration: 还是不行`).
- Requested action: Keep the every-3d friction rollup running and only reopen owner action if the August 12, 2026 to August 15, 2026 singleton pair reappears, a new actionableCandidate surfaces, or referenceOnly eval-domain clusters start recurring.
- Source thread: `thread_eval_friction`
- Source message: `0001788317999740-000115-c46c3ce8`

Traceability also lives in `docs/harness-feedback/bundles/2026-09-02-eval-friction-c1-empty-window-streak-through-sep01/provenance.json` via `sourceThreadId`.
