### PR TITLE
ci(F308): audit public test exclusions for v0.13

### DIFF
--- a/packages/api/config/public-test-exclusions.json
+++ b/packages/api/config/public-test-exclusions.json
@@ -1,23 +1,22 @@
 {
-  "version": 1,
+  "version": 2,
   "entries": [
     {
       "id": "redis",
       "match": "redis-",
       "category": "source_only",
-      "reason": "Redis isolation and persistence tests are internal harness coverage, not part of the public gate.",
+      "reason": "Public CI resource availability is the contract under test; a local isolated Redis pass does not prove safe public re-admission.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "task-progress-store",
-      "match": "task-progress-store",
-      "category": "source_only",
-      "reason": "Task progress store behavior depends on internal persistence surfaces not exported to the public gate.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "resource_contract",
+        "matchedFileCount": 62,
+        "matchedFilesHash": "414a329e11828b5b202777c4b0560e7e8e7328292f6cb065551d691286c8a7f4"
+      }
     },
     {
       "id": "session-strategy-phase3",
@@ -26,88 +25,83 @@
       "reason": "Phase 3 session strategy assertions cover internal rollout behavior outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "signal-article-store",
-      "match": "signal-article-store",
-      "category": "source_only",
-      "reason": "Signal article store cases exercise source-only data plumbing not guaranteed in the public export.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "cursor-store-atomicity",
-      "match": "cursor-store-atomicity",
-      "category": "source_only",
-      "reason": "Atomic cursor store checks cover internal durability mechanics not enforced by the public gate.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "4127534522f418733c8f19179cb88aec40ce3fe4bcb1657842cd393bd5516d91"
+      }
     },
     {
       "id": "workflow-sop-store",
       "match": "workflow-sop-store",
       "category": "source_only",
-      "reason": "Workflow SOP store tests rely on internal governance persistence surfaces excluded from the public gate.",
+      "reason": "The bounded public audit discovered no matching test file; retain only until the explicit inventory recheck completes.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-08",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "pending_bounded_recheck",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "f2bb4b4bfdab922a8169ff8df9d041e0d694b636be18fa81ce58850ba264e0c8"
+      }
     },
     {
       "id": "codex-agent-service",
       "match": "codex-agent-service",
       "category": "source_only",
-      "reason": "Codex agent runtime service tests depend on internal carrier/harness wiring outside the public gate.",
+      "reason": "The bounded public audit reached its 120-second cap; retain only until a completed public recheck replaces this evidence.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-09-08",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "pending_bounded_recheck",
+        "matchedFileCount": 2,
+        "matchedFilesHash": "bb6f15490d1f0a407ece89b4a005c9fbea371b0d2b57e3d3ce080c9b27f08113"
+      }
     },
     {
       "id": "kimi-agent-service",
       "match": "kimi-agent-service",
       "category": "source_only",
-      "reason": "Kimi agent service coverage is internal runtime behavior, not public gate contract.",
+      "reason": "Kimi agent service coverage depends on internal runtime behavior outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "claude-settings-hooks",
-      "match": "claude-settings-hooks\\.test",
-      "category": "private_fixture",
-      "reason": "Claude settings hook assertions depend on private runtime fixtures unavailable in public export.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "game-store",
-      "match": "game-store\\.test",
-      "category": "private_fixture",
-      "reason": "Game store tests rely on non-exported local fixtures and are kept out of the public gate.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "02431627c6e84d1a89123586fe6c450c068adb377918637e8eb8046fdd18d7b1"
+      }
     },
     {
       "id": "memory-tests",
       "match": "test/memory/",
       "category": "source_only",
-      "reason": "Memory package tests cover internal recall/index behavior outside the public gate promise.",
+      "reason": "The public audit found source/public gaps in operational lessons, fixtures, seeds, aliases, prompts, and project skeletons; the group is not a re-admission candidate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "cross-cat-context",
-      "match": "cross-cat-context\\.test",
-      "category": "source_only",
-      "reason": "Cross-cat context routing is internal collaboration harness behavior, not public gate surface.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 243,
+        "matchedFilesHash": "4953141167946fe4c413f545d503c37bb24794f4877b8f4a3693c79323f2e026"
+      }
     },
     {
       "id": "thread-wiring",
@@ -116,16 +110,32 @@
       "reason": "Thread wiring assertions cover internal callback plumbing outside the public gate contract.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "1751f3af4a52c290eb6e669004d487bbf4b53a2325a42e50f7489b3f9a85b580"
+      }
     },
     {
       "id": "integration-wiring",
       "match": "integration/wiring\\.test",
       "category": "source_only",
-      "reason": "Integration wiring checks depend on internal connection topology not exported to public gate.",
+      "reason": "Integration wiring checks depend on internal connection topology not exported to the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "7a1f58932ffd3615c1d498f55a647da6b1620fc35bcce76ef409817ec9bc2480"
+      }
     },
     {
       "id": "shared-state-wiring",
@@ -134,7 +144,15 @@
       "reason": "Shared-state wiring is internal runtime glue not part of the public gate guarantee.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "0df9171f74a61605fcb0ad7ec7c9a1246afe814ff04adb8015bdb763ae4a5b2d"
+      }
     },
     {
       "id": "signal-fetcher-launchd",
@@ -143,52 +161,32 @@
       "reason": "launchd-specific signal fetcher coverage depends on private macOS fixtures and stays internal.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "2fa8886467effb9d39d17159a09d6598eab910e3a048def6455ab300f5b46636"
+      }
     },
     {
       "id": "reflection-capsule-m3",
       "match": "reflection-capsule-m3",
       "category": "source_only",
-      "reason": "Reflection capsule M3 tests cover internal memory/harness behavior outside the public gate.",
+      "reason": "Reflection capsule M3 tests cover internal memory and harness behavior outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "workspace-project-context",
-      "match": "workspace-project-context\\.test",
-      "category": "source_only",
-      "reason": "Workspace project context assertions depend on source-only repo structure and local project wiring.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "projects-setup",
-      "match": "projects-setup\\.test",
-      "category": "source_only",
-      "reason": "Project setup tests cover internal bootstrap flows not guaranteed in the public gate.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "projects-mkdir",
-      "match": "projects-mkdir\\.test",
-      "category": "source_only",
-      "reason": "Project directory creation coverage depends on source-only filesystem conventions.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "governance-status",
-      "match": "governance-status\\.test",
-      "category": "source_only",
-      "reason": "Governance status assertions are source-owned workflow coverage, not public gate behavior.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "24dbca913f9baef4c217077bf21014f6e0c8b9c3564b9f3ace72f1f16d830de1"
+      }
     },
     {
       "id": "pack-integration",
@@ -197,34 +195,15 @@
       "reason": "Pack integration coverage exercises internal source packaging rules outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "project-setup-flow",
-      "match": "project-setup-flow\\.test",
-      "category": "source_only",
-      "reason": "Project setup flow behavior is internal bootstrap coverage, not public gate contract.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "expedition-bootstrap",
-      "match": "expedition-bootstrap\\.test",
-      "category": "source_only",
-      "reason": "Expedition bootstrap coverage depends on source-owned harness flows not exported publicly.",
-      "owner": "@zts212653",
-      "introducedBy": "78f3bc57c",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "rules-route",
-      "match": "rules-route\\.test",
-      "category": "source_only",
-      "reason": "Rules route assertions depend on source-only rule artifacts stripped from public export.",
-      "owner": "@zts212653",
-      "introducedBy": "4243948da",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "e863ecc16f456dc0e0ac9150ae1cc72a0953fc0c5d79a1f2b2449992c8652b4e"
+      }
     },
     {
       "id": "root-md-slim",
@@ -233,7 +212,15 @@
       "reason": "Root markdown slim tests rely on source-specific Chinese anchors not preserved in public export.",
       "owner": "@zts212653",
       "introducedBy": "7a300704a",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "b96b750f224f1d09b5eaa2225d325005e0bf56dbe9766d86dd8c9a05e0cbb496"
+      }
     },
     {
       "id": "audit-cc-system-prompt",
@@ -242,7 +229,15 @@
       "reason": "System prompt audit depends on internal L0 prompt assets not shipped in public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "4669091edc31419467913df55953f3bd2e734e9a4e313b4bef808ea128094332"
+      }
     },
     {
       "id": "f188-cold-start-fixtures",
@@ -251,7 +246,15 @@
       "reason": "F188 cold-start fixture coverage depends on internal fixture files absent from public export.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "647ec3b74409c18f828424d0e3a60b79f221797fefbc0d3265b3eb6de891a524"
+      }
     },
     {
       "id": "f188-harness-consistency",
@@ -260,52 +263,49 @@
       "reason": "F188 harness consistency checks rely on internal fixtures and remain source-only.",
       "owner": "@zts212653",
       "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "orphan-chrome-cleaner",
-      "match": "orphan-chrome-cleaner\\.test",
-      "category": "private_fixture",
-      "reason": "Orphan Chrome cleaner assertions are sensitive to local path sanitization and private fixtures.",
-      "owner": "@zts212653",
-      "introducedBy": "e9bb56052",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "f203-phase-i-opencode-l0",
-      "match": "f203-phase-i-opencode-l0\\.test",
-      "category": "source_only",
-      "reason": "F203 opencode L0 coverage depends on internal runtime files not exported publicly.",
-      "owner": "@zts212653",
-      "introducedBy": "9c4f26fde",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "73cee6542191fe3929a475b31b0eba71919b12e07d7c444244ea3a8819072a8e"
+      }
     },
     {
       "id": "f236-cc-anchor-hook",
       "match": "f236-cc-anchor-hook\\.test",
       "category": "source_only",
-      "reason": "F236 cc anchor hook coverage imports the source-only root .claude hook implementation that is not part of the public export.",
+      "reason": "F236 anchor-hook coverage imports a source-only root hook implementation absent from the public export.",
       "owner": "@zts212653",
       "introducedBy": "68dd499d9",
-      "expiresOn": "2026-08-31"
-    },
-    {
-      "id": "github-schedule-factories",
-      "match": "github-schedule-factories\\.test",
-      "category": "source_only",
-      "reason": "GitHub schedule factory assertions are source-owned public-sync governance coverage, not runtime gate behavior.",
-      "owner": "@zts212653",
-      "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "dbafee0ca7d55a3a08f1e9d72c479a1999128b08f6b29c729317d8280ff2cde0"
+      }
     },
     {
       "id": "harness-eval-hub-read-model",
       "match": "harness-eval/eval-hub-read-model\\.test",
       "category": "source_only",
-      "reason": "Eval hub read-model coverage exercises source-owned harness governance surfaces outside the public gate.",
+      "reason": "Eval Hub read-model coverage exercises source-owned governance surfaces outside the public gate.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "826b543cdb5eb370ec6b80ee8d5ad7414b101a1881585a8bc76cfcc9b9fb7713"
+      }
     },
     {
       "id": "harness-eval-merge-gate-provenance-contract",
@@ -314,25 +314,49 @@
       "reason": "Merge-gate provenance contract tests are source-owned governance coverage, not public runtime behavior.",
       "owner": "@zts212653",
       "introducedBy": "bd8823b99",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "source_dependency_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "3e730c3767c5de435fa700a4a4926f3b75c3de1fc13d1b691c5fe62d488c9d0c"
+      }
     },
     {
       "id": "harness-eval-design-gate-private-evidence",
       "match": "harness-eval/design-gate-episode-source-provider-private-evidence\\.test",
       "category": "private_fixture",
-      "reason": "The committed design-gate episode proof consumes home-only source maps and review provenance; the self-contained provider contract remains in the public suite.",
+      "reason": "The committed design-gate episode proof consumes home-only source maps and review provenance; its self-contained provider contract remains public.",
       "owner": "@zts212653",
       "introducedBy": "a21fd7682",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 1,
+        "matchedFilesHash": "8f27390a06280fe0cbd2d28692d66b847bab29fc45231a7817cb50a5f247de28"
+      }
     },
     {
       "id": "f254-private-evidence-contracts",
       "match": "f254-(?:freshness-instruction-private-evidence|freshness-replay-provider|manual-reminder-scope|provider-native-freshness)\\.test",
       "category": "private_fixture",
-      "reason": "F254 document evidence, replay, scope, and native-provider checks require home-only archives, owner provenance, or carrier credentials; public runtime behavior is covered independently.",
+      "reason": "F254 evidence, replay, scope, and native-provider checks require home-only archives, owner provenance, or carrier credentials; public runtime behavior is covered independently.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 4,
+        "matchedFilesHash": "d1eb54b87cc4db5903184b69b5743cceef36b6c9d2a609594f1fcaadee0789c6"
+      }
     },
     {
       "id": "harness-eval-private-registry",
@@ -341,34 +365,66 @@
       "reason": "These Eval Hub governance checks require the home-only measurement registry and historical evidence archive, not public product state.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 4,
+        "matchedFilesHash": "aa2cc08b3e4cd6befd518b8293d1e79fc2702cf996381efed852df876cd59d69"
+      }
     },
     {
       "id": "harness-eval-private-measurement-evidence",
       "match": "harness-eval/(?:friction-measurement-bundle|measurement-independent-rejudge(?:-adjudication|-judgment)?)\\.test",
       "category": "private_fixture",
-      "reason": "Friction measurement and rejudge checks consume private certificates, verdicts, and replay artifacts that are deliberately absent from the public export.",
+      "reason": "Friction measurement and rejudge checks consume private certificates, verdicts, and replay artifacts deliberately absent from public export.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 4,
+        "matchedFilesHash": "2fefb759ec45a303e710a01fc3475c061ee1977d4cefde21fedeb4394805fd60"
+      }
     },
     {
       "id": "harness-eval-private-verdict-publication",
       "match": "harness-eval/publish-verdict-(?:capability-wakeup(?:-owner-scope)?|freshness|friction|measurement-validity-gate|memory|pipeline|task-outcome(?:-writeback-guard)?)\\.test",
       "category": "private_fixture",
-      "reason": "Verdict publication checks require home-owned task, memory, and measurement evidence stores; they are governance coverage rather than a public runtime contract.",
+      "reason": "Verdict publication checks require home-owned task, memory, and measurement evidence stores; they are governance coverage rather than public runtime contract.",
       "owner": "@zts212653",
       "introducedBy": "bfa9e2c8f",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 9,
+        "matchedFilesHash": "0c0d80f3d4f94431a26b151478f8beed27527783d335186604a61627b7a9f4de"
+      }
     },
     {
       "id": "harness-eval-private-legacy-reeval-cases",
       "match": "harness-eval/legacy-reeval-case-(?:hub|migration)\\.test",
       "category": "private_fixture",
-      "reason": "Legacy stable-case migration and Hub projection assertions consume the home-only historical verdict archive and migration manifest, which are deliberately absent from the public export.",
+      "reason": "Legacy stable-case migration and Hub projection assertions consume a home-only historical verdict archive and migration manifest.",
       "owner": "@zts212653",
       "introducedBy": "7121c7dec",
-      "expiresOn": "2026-08-31"
+      "expiresOn": "2026-10-01",
+      "audit": {
+        "reviewedOn": "2026-09-01",
+        "sourceHead": "b741f42fdbbb4484a54cde7eadca08b3b11652e3",
+        "publicHead": "182d8ec9abc87ff7905441dca0575aab9787ee8f",
+        "status": "private_fixture_failure",
+        "matchedFileCount": 2,
+        "matchedFilesHash": "5156289dd54012e2deb82e432e13df85d39af2bbdc967e4499a266a82a95547a"
+      }
     }
   ]
 }

--- a/packages/api/scripts/resolve-public-test-files.mjs
+++ b/packages/api/scripts/resolve-public-test-files.mjs
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { readdir, readFile } from 'node:fs/promises';
 import { posix, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -7,6 +8,22 @@ const DEFAULT_CONFIG_PATH = resolve(
   'config/public-test-exclusions.json',
 );
 export const DEFAULT_POLICY_TIMEZONE = 'America/Los_Angeles';
+
+export function stablePublicTestSha256(value) {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+export function publicTestSelectionHash(selectedFiles) {
+  return stablePublicTestSha256({ selectedFiles: [...selectedFiles].sort() });
+}
+
+export function publicTestExclusionMatchHash(matchedFiles) {
+  return stablePublicTestSha256({ matchedFiles: [...matchedFiles].sort() });
+}
+
+export function publicTestExclusionRegistryHash(registry) {
+  return stablePublicTestSha256({ version: registry.version, entries: registry.entries });
+}
 
 function isNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
@@ -56,13 +73,29 @@ export async function loadPublicTestExclusions(options = {}) {
 }
 
 const REQUIRED_ENTRY_FIELDS = ['id', 'match', 'category', 'reason', 'owner', 'introducedBy', 'expiresOn'];
+const REQUIRED_AUDIT_FIELDS = [
+  'reviewedOn',
+  'sourceHead',
+  'publicHead',
+  'status',
+  'matchedFileCount',
+  'matchedFilesHash',
+];
 const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const SHA_PATTERN = /^[a-f0-9]{40}$/;
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const AUDIT_STATUSES = new Set([
+  'resource_contract',
+  'source_dependency_failure',
+  'private_fixture_failure',
+  'pending_bounded_recheck',
+]);
 
 function assertRegistryShape(registry) {
   if (!registry || typeof registry !== 'object') {
     throw new Error('public test exclusion registry must be an object');
   }
-  if (registry.version !== 1) {
+  if (registry.version !== 2) {
     throw new Error(`unsupported public test exclusion registry version: ${registry.version}`);
   }
   if (!Array.isArray(registry.entries)) {
@@ -100,6 +133,43 @@ function assertEntryExpiresOnFormat(entry) {
   }
 }
 
+function assertAuditDate(audit, entry) {
+  if (!ISO_DATE_PATTERN.test(audit.reviewedOn)) {
+    throw new Error(
+      `public test exclusion "${entry.id}" audit.reviewedOn must be in YYYY-MM-DD format, got: ${audit.reviewedOn}`,
+    );
+  }
+  const parsed = new Date(`${audit.reviewedOn}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== audit.reviewedOn) {
+    throw new Error(`public test exclusion "${entry.id}" audit.reviewedOn is not a valid calendar date`);
+  }
+}
+
+function assertEntryAudit(entry) {
+  const audit = entry.audit;
+  if (!audit || typeof audit !== 'object' || Array.isArray(audit)) {
+    throw new Error(`public test exclusion "${entry.id}" is missing required audit object`);
+  }
+  for (const field of REQUIRED_AUDIT_FIELDS) {
+    if (audit[field] === undefined || audit[field] === null || audit[field] === '') {
+      throw new Error(`public test exclusion "${entry.id}" audit is missing required field: ${field}`);
+    }
+  }
+  assertAuditDate(audit, entry);
+  if (!SHA_PATTERN.test(audit.sourceHead) || !SHA_PATTERN.test(audit.publicHead)) {
+    throw new Error(`public test exclusion "${entry.id}" audit sourceHead/publicHead must be full 40-character SHAs`);
+  }
+  if (!AUDIT_STATUSES.has(audit.status)) {
+    throw new Error(`public test exclusion "${entry.id}" audit status is invalid: ${audit.status}`);
+  }
+  if (!Number.isSafeInteger(audit.matchedFileCount) || audit.matchedFileCount <= 0) {
+    throw new Error(`public test exclusion "${entry.id}" audit matchedFileCount must be a positive integer`);
+  }
+  if (!SHA256_PATTERN.test(audit.matchedFilesHash)) {
+    throw new Error(`public test exclusion "${entry.id}" audit matchedFilesHash must be a SHA-256 hex digest`);
+  }
+}
+
 function compileEntryPattern(entry) {
   try {
     return new RegExp(entry.match);
@@ -112,10 +182,17 @@ function assertEntryAgainstFilesystem(entry, pattern, allTestFiles, today) {
   if (entry.expiresOn < today) {
     throw new Error(`public test exclusion "${entry.id}" is expired (${entry.expiresOn} < ${today})`);
   }
-  const hasMatch = allTestFiles.some((file) => pattern.test(file));
-  if (!hasMatch) {
+  const matchedFiles = allTestFiles.filter((file) => pattern.test(file)).sort();
+  if (matchedFiles.length === 0) {
     throw new Error(`public test exclusion "${entry.id}" matches no current test files`);
   }
+  const actualHash = publicTestExclusionMatchHash(matchedFiles);
+  if (entry.audit.matchedFileCount !== matchedFiles.length || entry.audit.matchedFilesHash !== actualHash) {
+    throw new Error(
+      `public test exclusion "${entry.id}" audited match inventory drift (expected ${entry.audit.matchedFileCount}/${entry.audit.matchedFilesHash}, got ${matchedFiles.length}/${actualHash})`,
+    );
+  }
+  return matchedFiles;
 }
 
 export function validatePublicTestExclusions(registry, options = {}) {
@@ -129,13 +206,14 @@ export function validatePublicTestExclusions(registry, options = {}) {
   for (const entry of registry.entries) {
     assertEntryFields(entry);
     assertEntryExpiresOnFormat(entry);
+    assertEntryAudit(entry);
     if (seenIds.has(entry.id)) {
       throw new Error(`duplicate public test exclusion id: ${entry.id}`);
     }
     seenIds.add(entry.id);
     const pattern = compileEntryPattern(entry);
-    assertEntryAgainstFilesystem(entry, pattern, allTestFiles, today);
-    compiledEntries.push({ ...entry, regex: pattern });
+    const matchedFiles = assertEntryAgainstFilesystem(entry, pattern, allTestFiles, today);
+    compiledEntries.push({ ...entry, regex: pattern, matchedFiles });
   }
 
   // Backward-compatible default return is the registry; compiled patterns are
@@ -198,12 +276,24 @@ export function selectFocusedPublicTestFiles(result, rawFocus = '') {
   return requested;
 }
 
+export function buildPublicTestManifest(result, selectedFiles = result.selectedFiles) {
+  const selected = [...selectedFiles].sort();
+  const excluded = [...result.excludedFiles].sort();
+  return {
+    schemaVersion: 1,
+    selectedFiles: selected,
+    excludedFiles: excluded,
+    selectionHash: publicTestSelectionHash(selected),
+    exclusionRegistryHash: publicTestExclusionRegistryHash(result.registry),
+  };
+}
+
 async function main() {
   const format = process.argv.includes('--json') ? 'json' : 'plain';
   const result = await resolvePublicTestFiles();
   const selectedFiles = selectFocusedPublicTestFiles(result, process.env.CAT_CAFE_PUBLIC_TEST_FOCUS);
   if (format === 'json') {
-    process.stdout.write(JSON.stringify({ ...result, selectedFiles }, null, 2));
+    process.stdout.write(JSON.stringify({ ...result, ...buildPublicTestManifest(result, selectedFiles) }, null, 2));
     return;
   }
   process.stdout.write(selectedFiles.join('\n'));

--- a/packages/api/test/public-test-exclusions-validation.test.js
+++ b/packages/api/test/public-test-exclusions-validation.test.js
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { readdir } from 'node:fs/promises';
+import { dirname, posix, resolve } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(__dirname, '..');
+const resolverModuleUrl = pathToFileURL(resolve(packageRoot, 'scripts/resolve-public-test-files.mjs')).href;
+const AUDIT_SOURCE_HEAD = 'b741f42fdbbb4484a54cde7eadca08b3b11652e3';
+const AUDIT_PUBLIC_HEAD = '182d8ec9abc87ff7905441dca0575aab9787ee8f';
+
+function auditFor(matchedFiles) {
+  const normalized = [...matchedFiles].sort();
+  return {
+    reviewedOn: '2026-09-01',
+    sourceHead: AUDIT_SOURCE_HEAD,
+    publicHead: AUDIT_PUBLIC_HEAD,
+    status: 'source_dependency_failure',
+    matchedFileCount: normalized.length,
+    matchedFilesHash: createHash('sha256')
+      .update(JSON.stringify({ matchedFiles: normalized }))
+      .digest('hex'),
+  };
+}
+
+async function listTestFiles(rootDir, relDir = '') {
+  const dir = resolve(rootDir, relDir);
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const relPath = relDir ? posix.join(relDir, entry.name) : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...(await listTestFiles(rootDir, relPath)));
+      continue;
+    }
+    if (entry.isFile() && relPath.endsWith('.test.js')) {
+      files.push(posix.join('test', relPath));
+    }
+  }
+  return files.sort();
+}
+
+test('validator rejects malformed, expired, or zero-match exclusion entries', async () => {
+  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
+  const allTestFiles = await listTestFiles(resolve(packageRoot, 'test'));
+
+  assert.throws(
+    () =>
+      validatePublicTestExclusions(
+        {
+          version: 2,
+          entries: [
+            {
+              id: 'missing-owner',
+              match: 'governance-status\\.test',
+              category: 'source_only',
+              reason: 'missing owner should fail',
+              introducedBy: 'deadbeef0',
+              expiresOn: '2026-07-31',
+              audit: auditFor(['test/governance-status.test.js']),
+            },
+          ],
+        },
+        { allTestFiles, today: '2026-06-16' },
+      ),
+    /owner/i,
+  );
+
+  assert.throws(
+    () =>
+      validatePublicTestExclusions(
+        {
+          version: 2,
+          entries: [
+            {
+              id: 'expired',
+              match: 'governance-status\\.test',
+              category: 'source_only',
+              reason: 'expired should fail',
+              owner: '@zts212653',
+              introducedBy: 'deadbeef1',
+              expiresOn: '2026-06-01',
+              audit: auditFor(['test/governance-status.test.js']),
+            },
+          ],
+        },
+        { allTestFiles, today: '2026-06-16' },
+      ),
+    /expired/i,
+  );
+
+  assert.throws(
+    () =>
+      validatePublicTestExclusions(
+        {
+          version: 2,
+          entries: [
+            {
+              id: 'zero-match',
+              match: 'this-test-does-not-exist\\.test',
+              category: 'source_only',
+              reason: 'stale entry should fail',
+              owner: '@zts212653',
+              introducedBy: 'deadbeef2',
+              expiresOn: '2026-07-31',
+              audit: auditFor(['test/governance-status.test.js']),
+            },
+          ],
+        },
+        { allTestFiles, today: '2026-06-16' },
+      ),
+    /matches no current test/i,
+  );
+});
+
+test('validator rejects non-ISO YYYY-MM-DD expiresOn formats (codex #2326 P2)', async () => {
+  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
+  const allTestFiles = await listTestFiles(resolve(packageRoot, 'test'));
+
+  for (const [id, expiresOn, expectedError] of [
+    ['loose-format-no-zero-pad', '2026-6-23', /YYYY-MM-DD/i],
+    ['word-sentinel', 'never', /YYYY-MM-DD/i],
+    ['slash-separator', '2026/06/23', /YYYY-MM-DD/i],
+    ['invalid-calendar-date', '2026-13-99', /valid calendar date/i],
+  ]) {
+    assert.throws(
+      () =>
+        validatePublicTestExclusions(
+          {
+            version: 2,
+            entries: [
+              {
+                id,
+                match: 'governance-status\\.test',
+                category: 'source_only',
+                reason: 'invalid exclusion expiry must fail closed',
+                owner: '@zts212653',
+                introducedBy: 'deadbeef3',
+                expiresOn,
+                audit: auditFor(['test/governance-status.test.js']),
+              },
+            ],
+          },
+          { allTestFiles, today: '2026-06-16' },
+        ),
+      expectedError,
+    );
+  }
+});
+
+test('validator requires a v2 audit for every live exclusion', async () => {
+  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
+
+  assert.throws(
+    () =>
+      validatePublicTestExclusions(
+        {
+          version: 2,
+          entries: [
+            {
+              id: 'missing-audit',
+              match: 'governance-status\\.test',
+              category: 'source_only',
+              reason: 'an exclusion without evidence must fail closed',
+              owner: '@zts212653',
+              introducedBy: 'deadbeef7',
+              expiresOn: '2026-10-01',
+            },
+          ],
+        },
+        { allTestFiles: ['test/governance-status.test.js'], today: '2026-09-01' },
+      ),
+    /audit/i,
+  );
+});
+
+test('validator rejects an audited exclusion when its matched test inventory drifts', async () => {
+  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
+  const baselineFiles = ['test/governance-status.test.js'];
+  const entry = {
+    id: 'audited-inventory',
+    match: 'governance-status',
+    category: 'source_only',
+    reason: 'the audit must bind to the exact public candidate inventory',
+    owner: '@zts212653',
+    introducedBy: 'deadbeef8',
+    expiresOn: '2026-10-01',
+    audit: auditFor(baselineFiles),
+  };
+
+  assert.doesNotThrow(() =>
+    validatePublicTestExclusions(
+      { version: 2, entries: [entry] },
+      { allTestFiles: baselineFiles, today: '2026-09-01' },
+    ),
+  );
+  assert.throws(
+    () =>
+      validatePublicTestExclusions(
+        { version: 2, entries: [entry] },
+        {
+          allTestFiles: [...baselineFiles, 'test/governance-status-replay.test.js'],
+          today: '2026-09-01',
+        },
+      ),
+    /audited match inventory/i,
+  );
+});

--- a/packages/api/test/public-test-exclusions.test.js
+++ b/packages/api/test/public-test-exclusions.test.js
@@ -11,39 +11,22 @@ const resolverModuleUrl = pathToFileURL(resolve(packageRoot, 'scripts/resolve-pu
 
 const RECONCILED_EXCLUSIONS = [
   'redis-',
-  'task-progress-store',
   'session-strategy-phase3',
-  'signal-article-store',
-  'cursor-store-atomicity',
   'workflow-sop-store',
   'codex-agent-service',
   'kimi-agent-service',
-  'claude-settings-hooks\\.test',
-  'game-store\\.test',
   'test/memory/',
-  'cross-cat-context\\.test',
   'thread-wiring\\.test',
   'integration/wiring\\.test',
-  'antigravity-cdp-client\\.test',
   'shared-state-wiring\\.test',
   'signal-fetcher-launchd',
   'reflection-capsule-m3',
-  'workspace-project-context\\.test',
-  'projects-setup\\.test',
-  'projects-mkdir\\.test',
-  'governance-status\\.test',
   'pack-integration\\.test',
-  'project-setup-flow\\.test',
-  'expedition-bootstrap\\.test',
-  'rules-route\\.test',
   'root-md-slim\\.test',
   'audit-cc-system-prompt\\.test',
   'f188-cold-start-fixtures\\.test',
   'f188-harness-consistency\\.test',
-  'orphan-chrome-cleaner\\.test',
-  'f203-phase-i-opencode-l0\\.test',
   'f236-cc-anchor-hook\\.test',
-  'github-schedule-factories\\.test',
   'harness-eval/eval-hub-read-model\\.test',
   'harness-eval/merge-gate-provenance-contract\\.test',
   'harness-eval/design-gate-episode-source-provider-private-evidence\\.test',
@@ -76,11 +59,43 @@ function applyReconciledSelection(files) {
   return files.filter((file) => patterns.every((pattern) => !pattern.test(file))).sort();
 }
 
-test('registry preserves metadata for reconciled exclusions and drops retired ones', async () => {
+test('registry retains only audited exclusions and drops re-admitted cases', async () => {
   const { loadPublicTestExclusions } = await import(resolverModuleUrl);
   const registry = await loadPublicTestExclusions({ configPath: registryPath });
 
-  assert.equal(registry.version, 1);
+  assert.equal(registry.version, 2);
+  assert.equal(registry.entries.length, RECONCILED_EXCLUSIONS.length);
+  for (const entry of registry.entries) {
+    assert.deepEqual(entry.audit.sourceHead, 'b741f42fdbbb4484a54cde7eadca08b3b11652e3');
+    assert.deepEqual(entry.audit.publicHead, '182d8ec9abc87ff7905441dca0575aab9787ee8f');
+    assert.match(entry.audit.reviewedOn, /^2026-09-01$/);
+    assert.match(entry.audit.matchedFilesHash, /^[a-f0-9]{64}$/);
+    assert.ok(entry.audit.matchedFileCount > 0);
+  }
+  for (const id of [
+    'task-progress-store',
+    'signal-article-store',
+    'cursor-store-atomicity',
+    'claude-settings-hooks',
+    'game-store',
+    'cross-cat-context',
+    'workspace-project-context',
+    'projects-setup',
+    'projects-mkdir',
+    'governance-status',
+    'project-setup-flow',
+    'expedition-bootstrap',
+    'rules-route',
+    'orphan-chrome-cleaner',
+    'f203-phase-i-opencode-l0',
+    'github-schedule-factories',
+  ]) {
+    assert.equal(
+      registry.entries.some((entry) => entry.id === id),
+      false,
+      `${id} must be re-admitted`,
+    );
+  }
   assert.equal(
     registry.entries.some((entry) => entry.match === 'antigravity-cdp-client\\.test'),
     false,
@@ -152,7 +167,9 @@ test('resolver excludes private evidence consumers but keeps self-contained publ
 });
 
 test('focused public selection accepts only explicit files from the live selected suite', async () => {
-  const { resolvePublicTestFiles, selectFocusedPublicTestFiles } = await import(resolverModuleUrl);
+  const { buildPublicTestManifest, resolvePublicTestFiles, selectFocusedPublicTestFiles } = await import(
+    resolverModuleUrl
+  );
   const resolved = await resolvePublicTestFiles({
     packageRoot,
     configPath: registryPath,
@@ -174,6 +191,16 @@ test('focused public selection accepts only explicit files from the live selecte
     () => selectFocusedPublicTestFiles(resolved, 'test/cicd-router.test.js,test/cicd-router.test.js'),
     /duplicate/,
   );
+
+  const fullManifest = buildPublicTestManifest(resolved);
+  const focusedManifest = buildPublicTestManifest(
+    resolved,
+    selectFocusedPublicTestFiles(resolved, 'test/cicd-router.test.js,test/system-prompt-builder.test.js'),
+  );
+  assert.match(fullManifest.selectionHash, /^[a-f0-9]{64}$/);
+  assert.match(fullManifest.exclusionRegistryHash, /^[a-f0-9]{64}$/);
+  assert.notEqual(fullManifest.selectionHash, focusedManifest.selectionHash);
+  assert.deepEqual(fullManifest.selectedFiles, [...resolved.selectedFiles].sort());
 });
 
 test('resolver re-admits capabilities-route once the product regression is fixed', async () => {
@@ -216,174 +243,4 @@ test('default expiry date helper falls back to the repo policy timezone when env
       process.env.TZ = previousHostTimezone;
     }
   }
-});
-
-test('validator rejects malformed, expired, or zero-match exclusion entries', async () => {
-  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
-  const allTestFiles = await listTestFiles(resolve(packageRoot, 'test'));
-
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'missing-owner',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'missing owner should fail',
-              introducedBy: 'deadbeef0',
-              expiresOn: '2026-07-31',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /owner/i,
-  );
-
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'expired',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'expired should fail',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef1',
-              expiresOn: '2026-06-01',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /expired/i,
-  );
-
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'zero-match',
-              match: 'this-test-does-not-exist\\.test',
-              category: 'source_only',
-              reason: 'stale entry should fail',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef2',
-              expiresOn: '2026-07-31',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /matches no current test/i,
-  );
-});
-
-test('validator rejects non-ISO YYYY-MM-DD expiresOn formats (codex #2326 P2)', async () => {
-  const { validatePublicTestExclusions } = await import(resolverModuleUrl);
-  const allTestFiles = await listTestFiles(resolve(packageRoot, 'test'));
-
-  // Non-strict format: zero-padding missing — lexicographic compare would
-  // still let it through ("2026-6-23" > "2026-06-16") so format check matters.
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'loose-format-no-zero-pad',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'YYYY-M-D should fail strict format check',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef3',
-              expiresOn: '2026-6-23',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /YYYY-MM-DD/i,
-  );
-
-  // Word-form sentinel that lexicographic compare would happily let through
-  // ("never" > "2026-06-16" lexicographically).
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'word-sentinel',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'sentinel like never should fail strict format check',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef4',
-              expiresOn: 'never',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /YYYY-MM-DD/i,
-  );
-
-  // Slash separators
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'slash-separator',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'YYYY/MM/DD should fail strict format check',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef5',
-              expiresOn: '2026/06/23',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /YYYY-MM-DD/i,
-  );
-
-  // Syntactically YYYY-MM-DD but semantically invalid calendar date — Date()
-  // will roll 13/99 into a future month, lexicographic compare would accept.
-  assert.throws(
-    () =>
-      validatePublicTestExclusions(
-        {
-          version: 1,
-          entries: [
-            {
-              id: 'invalid-calendar-date',
-              match: 'governance-status\\.test',
-              category: 'source_only',
-              reason: 'rolled-over date should fail',
-              owner: '@zts212653',
-              introducedBy: 'deadbeef6',
-              expiresOn: '2026-13-99',
-            },
-          ],
-        },
-        { allTestFiles, today: '2026-06-16' },
-      ),
-    /valid calendar date/i,
-  );
 });


### PR DESCRIPTION
## Why

The v0.13.0 release gate must not renew every expired public-test exclusion by date alone. PR #1423 does exactly that for all 41 entries, so it is not safe to merge.

This candidate ports the audited F308 disposition onto the exact current public main:

- re-admit 16 test groups whose public dependencies are now present;
- retain 25 source-only groups with owner, reason, expiry, source/public audit heads, exact matched-file count, and SHA-256 inventory hash;
- fail closed when a retained pattern matches a different inventory;
- keep focused and sharded public-test selection bound to the same registry hash.

No runtime product code changes in this PR. This is release integrity work for v0.13.0.

## Verification

- `pnpm check` — pass
- native public gate — 22,039 tests; 21,935 pass; 0 fail; 104 contract skips; 1,456.6 s
- focused exclusion tests — 12/12 pass after the test-only file split
- desktop tests — 196/196 pass
- official shared/MCP/API/Web builds — pass
- `git diff --check` — pass

The only post-full-gate delta is a mechanical split of the same exclusion-validator assertions into a second file to satisfy the 350-line hard limit. GitHub required CI will rerun the exact PR HEAD.

## External PR custody

PR #1423 remains open and is not merged or closed by this change. Maintainer verdict is BLOCK: its blanket renewal would re-exclude 16 runnable groups and it has no linked accepted issue. Any close or supersession action remains a separate CVO decision.

[小太阳·砚砚/GPT-5.6 Sol🐾]