### PR TITLE
fix(codex): allow safe Playwright reads without approval UI

### DIFF
--- a/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
+++ b/packages/api/src/domains/cats/services/agents/providers/CodexAgentService.ts
@@ -405,6 +405,43 @@ function toTomlString(value: string): string {
   return `"${escaped}"`;
 }
 
+const CODEX_NONINTERACTIVE_PLAYWRIGHT_APPROVED_TOOLS = [
+  'browser_navigate',
+  'browser_navigate_back',
+  'browser_tabs',
+] as const;
+
+function isOfficialPlaywrightMcpServer(server: {
+  name: string;
+  source: string;
+  command?: string;
+  args?: readonly string[];
+}): boolean {
+  if (server.name !== 'playwright' || server.source !== 'external') return false;
+  const launchSignature = [server.command ?? '', ...(server.args ?? [])].join(' ');
+  return /(?:^|\s)@playwright\/mcp(?:@[^\s]+)?(?:\s|$)/.test(launchSignature);
+}
+
+function appendNoninteractivePlaywrightApprovalPolicy(
+  args: string[],
+  tomlName: string,
+  server: { name: string; source: string; command?: string; args?: readonly string[] },
+  approvalSurface: CodexApprovalSurface,
+): void {
+  if (approvalSurface !== 'unavailable' || !isOfficialPlaywrightMcpServer(server)) return;
+
+  // Codex's `writes` mode trusts the official MCP readOnlyHint annotation while
+  // keeping input/click/evaluate/upload tools approval-gated. Playwright marks
+  // navigation and its mixed tabs tool as actions, although they only mutate
+  // browser-local state, so approve exactly those narrow tools. Do not broaden
+  // this to arbitrary external MCPs or page-interaction tools: this host cannot
+  // surface their confirmation prompts today.
+  args.push('--config', `mcp_servers.${tomlName}.default_tools_approval_mode="writes"`);
+  for (const tool of CODEX_NONINTERACTIVE_PLAYWRIGHT_APPROVED_TOOLS) {
+    args.push('--config', `mcp_servers.${tomlName}.tools.${tool}.approval_mode="approve"`);
+  }
+}
+
 const CODEX_SIGNATURE_BOUNDARY_INSTRUCTION =
   'Codex output boundary: do not append the cat signature to commentary/progress messages; append it exactly once, only at the end of the final response.';
 
@@ -624,6 +661,7 @@ function writeCodexMcpEnvWrapper(spec: {
 async function buildCatCafeMcpArgs(
   callbackEnv?: Record<string, string>,
   workingDirectory?: string,
+  approvalSurface?: CodexApprovalSurface,
 ): Promise<{ args: string[]; bearerEnv: Record<string, string>; declaredServerNames?: readonly string[] }> {
   if (!callbackEnv) return { args: [], bearerEnv: {} };
 
@@ -881,6 +919,8 @@ async function buildCatCafeMcpArgs(
             const value = callbackEnv[key];
             if (value) args.push('--config', `mcp_servers.${tomlName}.env.${key}=${toTomlString(value)}`);
           }
+        } else {
+          if (approvalSurface) appendNoninteractivePlaywrightApprovalPolicy(args, tomlName, s, approvalSurface);
         }
       }
       resolved = true;
@@ -1235,7 +1275,7 @@ export class CodexAgentService implements AgentService {
       declaredServerNames: declaredMcpServerNames,
     } = readOnly
       ? { args: [], bearerEnv: {}, declaredServerNames: [] as readonly string[] }
-      : await buildCatCafeMcpArgs(mcpCallbackEnv, options?.workingDirectory);
+      : await buildCatCafeMcpArgs(mcpCallbackEnv, options?.workingDirectory, this.approvalSurface);
     const gitRepoArgs = readOnly ? [] : buildGitRepoArgs(options?.workingDirectory);
     // User-defined CLI args from the member editor (#567) — passed as-is, no implicit wrapping.
     // Each entry is split by whitespace (e.g. "--config model_reasoning_effort=\"low\"").

--- a/packages/api/test/codex-agent-service.test.js
+++ b/packages/api/test/codex-agent-service.test.js
@@ -638,6 +638,137 @@ describe('CodexAgentService Tests (CLI mode)', { concurrency: false }, () => {
     }
   });
 
+  test('unavailable approval surface auto-approves only safe official Playwright navigation tools', async () => {
+    const runtimeRoot = makeTempDir('.tmp-codex-playwright-policy-root-');
+    const projectDir = makeTempDir('.tmp-codex-playwright-policy-project-');
+    const proc = createMockProcess();
+    const spawnFn = createMockSpawnFn(proc);
+    const service = new CodexAgentService({
+      l0CompilerFn: fakeL0Compiler,
+      spawnFn,
+      model: 'gpt-5.3-codex',
+      approvalSurface: 'unavailable',
+    });
+
+    try {
+      writeMcpDistStubs(runtimeRoot, ['index.js']);
+      writeCapabilitiesConfig(runtimeRoot, [
+        {
+          id: 'playwright',
+          type: 'mcp',
+          globalEnabled: true,
+          source: 'external',
+          mcpServer: { command: 'npx', args: ['-y @playwright/mcp@latest'] },
+        },
+      ]);
+
+      await withRuntimeRootEnv(runtimeRoot, async () => {
+        const promise = collect(
+          service.invoke('inspect a page', {
+            workingDirectory: projectDir,
+            callbackEnv: {
+              CAT_CAFE_INVOCATION_ID: 'inv-playwright-policy',
+              CAT_CAFE_CALLBACK_TOKEN: 'tok-playwright-policy',
+              CAT_CAFE_CAT_ID: 'codex',
+            },
+          }),
+        );
+        emitCodexEvents(proc, [{ type: 'thread.started', thread_id: 't-playwright-policy' }]);
+        await promise;
+
+        const args = spawnFn.mock.calls[0].arguments[1];
+        assert.ok(
+          args.includes('mcp_servers.playwright.default_tools_approval_mode="writes"'),
+          'annotated read-only Playwright tools should run without an unavailable confirmation surface',
+        );
+        for (const tool of ['browser_navigate', 'browser_navigate_back', 'browser_tabs']) {
+          assert.ok(
+            args.includes(`mcp_servers.playwright.tools.${tool}.approval_mode="approve"`),
+            `${tool} should be treated as safe browser-local navigation`,
+          );
+        }
+        for (const tool of ['browser_click', 'browser_type', 'browser_fill_form', 'browser_file_upload']) {
+          assert.ok(
+            !args.some((arg) => arg.includes(`mcp_servers.playwright.tools.${tool}.approval_mode="approve"`)),
+            `${tool} must remain approval-gated`,
+          );
+        }
+      });
+    } finally {
+      rmSync(runtimeRoot, { recursive: true, force: true });
+      rmSync(projectDir, { recursive: true, force: true });
+    }
+  });
+
+  test('Playwright approval fast path rejects lookalike servers and stays off with an interactive surface', async () => {
+    for (const fixture of [
+      {
+        label: 'lookalike',
+        approvalSurface: 'unavailable',
+        command: 'node',
+        args: ['untrusted-playwright.js'],
+      },
+      {
+        label: 'interactive',
+        approvalSurface: 'interactive',
+        command: 'npx',
+        args: ['-y', '@playwright/mcp@latest'],
+      },
+    ]) {
+      const runtimeRoot = makeTempDir(`.tmp-codex-playwright-${fixture.label}-root-`);
+      const projectDir = makeTempDir(`.tmp-codex-playwright-${fixture.label}-project-`);
+      const proc = createMockProcess();
+      const spawnFn = createMockSpawnFn(proc);
+      const service = new CodexAgentService({
+        l0CompilerFn: fakeL0Compiler,
+        spawnFn,
+        model: 'gpt-5.3-codex',
+        approvalSurface: fixture.approvalSurface,
+      });
+
+      try {
+        writeMcpDistStubs(runtimeRoot, ['index.js']);
+        writeCapabilitiesConfig(runtimeRoot, [
+          {
+            id: 'playwright',
+            type: 'mcp',
+            globalEnabled: true,
+            source: 'external',
+            mcpServer: { command: fixture.command, args: fixture.args },
+          },
+        ]);
+
+        await withRuntimeRootEnv(runtimeRoot, async () => {
+          const promise = collect(
+            service.invoke(`inspect a page (${fixture.label})`, {
+              workingDirectory: projectDir,
+              callbackEnv: {
+                CAT_CAFE_INVOCATION_ID: `inv-playwright-${fixture.label}`,
+                CAT_CAFE_CALLBACK_TOKEN: `tok-playwright-${fixture.label}`,
+                CAT_CAFE_CAT_ID: 'codex',
+              },
+            }),
+          );
+          emitCodexEvents(proc, [{ type: 'thread.started', thread_id: `t-playwright-${fixture.label}` }]);
+          await promise;
+
+          const args = spawnFn.mock.calls[0].arguments[1];
+          assert.ok(
+            !args.some((arg) => arg.startsWith('mcp_servers.playwright.default_tools_approval_mode=')),
+            `${fixture.label} server must retain the normal approval policy`,
+          );
+          assert.ok(
+            !args.some((arg) => arg.startsWith('mcp_servers.playwright.tools.')),
+            `${fixture.label} server must not receive safe-navigation overrides`,
+          );
+        });
+      } finally {
+        rmSync(runtimeRoot, { recursive: true, force: true });
+        rmSync(projectDir, { recursive: true, force: true });
+      }
+    }
+  });
+
   test('Codex MCP config suppresses external entry with unsupported transport as disabled dummy', async () => {
     // #1072 fix: external entry with managed name but unsupported transport
     // resolves as disabled (transport unsupported for this provider). The

--- a/packages/api/test/codex-app-server-pooling.test.js
+++ b/packages/api/test/codex-app-server-pooling.test.js
@@ -204,6 +204,10 @@ test('pooled Codex materializes ordered MCP overlays without duplicate TOML tabl
     'mcp_servers.cat-cafe.default_tools_approval_mode="approve"',
     '--config',
     'mcp_servers.cat-cafe.env.CAT_CAFE_CREDENTIAL_FILE="/tmp/session.json"',
+    '--config',
+    'mcp_servers.playwright.default_tools_approval_mode="writes"',
+    '--config',
+    'mcp_servers.playwright.tools.browser_navigate.approval_mode="approve"',
   ]);
 
   assert.deepEqual(config, {
@@ -214,6 +218,10 @@ test('pooled Codex materializes ordered MCP overlays without duplicate TOML tabl
         enabled: true,
         default_tools_approval_mode: 'approve',
         env: { CAT_CAFE_CREDENTIAL_FILE: '/tmp/session.json' },
+      },
+      playwright: {
+        default_tools_approval_mode: 'writes',
+        tools: { browser_navigate: { approval_mode: 'approve' } },
       },
     },
   });


### PR DESCRIPTION
## Why

Clowder Codex invocations currently expose no interactive MCP confirmation surface. External Playwright therefore reports even browser_tabs(list) and browser_navigate as user rejected before Chromium opens.

## Change

- Recognize only the external server named playwright whose launch signature contains the official @playwright/mcp package.
- Set its default tool approval mode to writes so upstream readOnlyHint annotations are honored.
- Approve only browser_navigate, browser_navigate_back, and browser_tabs because Playwright classifies these browser-local navigation operations as actions.
- Leave click, type, fill, evaluate, upload, dialog, keyboard, and other page-interaction tools approval-gated.
- Apply the exception only when approvalSurface is unavailable; interactive hosts retain their normal policy.
- Preserve the same nested policy through pooled app-server thread config.

## Verification

- RED then GREEN: codex-agent-service.test.js, 88/88 passed.
- codex-app-server-pooling.test.js, 8/8 passed.
- pnpm check passed with Python 3.11 selected for the existing TTS test contract.
- pnpm lint passed; only pre-existing Web warnings remain.
- Latest-main gate passed rebase, dependency refresh, full build, and TypeScript checks. Its public-test selector is currently blocked by an expired Redis exclusion dated 2026-08-31. Full mode is independently blocked by existing private-fixture/F254 baseline failures; neither touches this diff.
- Convention graph command was attempted, but this public checkout has no @cat-cafe/convention-graph workspace package.

## Risk boundary

This is a narrow permission-policy change. It does not auto-approve page interaction or arbitrary external MCP servers, and lookalike/interactive-surface negative fixtures fail closed.