### PR TITLE
fix(session-chain): give peer lifecycle actions equal visual weight

### DIFF
--- a/packages/web/src/components/SessionChainPanel.tsx
+++ b/packages/web/src/components/SessionChainPanel.tsx
@@ -569,7 +569,13 @@ export function SessionChainPanel({
                 )}
                 {/* Context health bar (already shows % internally, no duplicate text) */}
                 {health && <ContextHealthBar catId={session.catId} health={health} />}
-                <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                {/* Lifecycle actions act on this session's own state. Linkage (bind) is a
+                    separate row below because it changes WHICH runtime session this card
+                    points at, not this session's state. */}
+                <div
+                  data-testid={`session-lifecycle-actions-${session.id}`}
+                  className="mt-1 flex flex-wrap items-center gap-1.5"
+                >
                   {session.cliSessionId && (
                     <button
                       type="button"
@@ -581,7 +587,7 @@ export function SessionChainPanel({
                           ? '请先停止该 Agent，再压缩原生上下文'
                           : '请求 provider 原生压缩并保留 Clowder AI continuity'
                       }
-                      className="rounded border border-cafe-subtle px-2 py-0.5 text-micro text-cafe-secondary hover:bg-cafe-surface-elevated disabled:cursor-not-allowed disabled:opacity-50"
+                      className="rounded border border-cafe-subtle px-2 py-0.5 text-micro text-cafe-secondary hover:bg-[var(--console-hover-bg)] disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {compactingSessionId === session.id ? '压缩中…' : '原生压缩'}
                     </button>
@@ -589,13 +595,7 @@ export function SessionChainPanel({
                   <button
                     type="button"
                     data-testid={`seal-session-${session.id}`}
-                    className="rounded border border-[var(--_accent-20)] px-2 py-0.5 text-micro text-[var(--color-cafe-accent)] hover:bg-[var(--_accent-5)] disabled:cursor-not-allowed disabled:opacity-50"
-                    style={
-                      {
-                        '--_accent-20': 'color-mix(in oklch, var(--color-cafe-accent) 20%, transparent)',
-                        '--_accent-5': 'color-mix(in oklch, var(--color-cafe-accent) 5%, transparent)',
-                      } as React.CSSProperties
-                    }
+                    className="rounded border border-cafe-subtle px-2 py-0.5 text-micro text-cafe-secondary hover:bg-[var(--console-hover-bg)] disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={() => void handleSeal(session.id)}
                     disabled={sealingSessionId !== null || isStale || invocationIsActive}
                     title={invocationIsActive ? '请先停止该 Agent，再封存会话' : '封存当前会话；下次激活将使用新会话'}

--- a/packages/web/src/components/__tests__/session-chain-panel.test.ts
+++ b/packages/web/src/components/__tests__/session-chain-panel.test.ts
@@ -172,6 +172,38 @@ describe('F24: SessionChainPanel', () => {
     });
   });
 
+  it('gives peer lifecycle actions the same visual weight and keeps linkage out of that row', async () => {
+    mockSessionsResponse([
+      {
+        id: 's-codex',
+        cliSessionId: 'native-1',
+        catId: 'codex',
+        seq: 0,
+        status: 'active',
+        messageCount: 4,
+        createdAt: Date.now(),
+      },
+    ]);
+    renderPanel('thread-1');
+    await flushFetch();
+
+    const row = container.querySelector('[data-testid="session-lifecycle-actions-s-codex"]');
+    const compact = container.querySelector('[data-testid="compact-native-session-s-codex"]') as HTMLButtonElement;
+    const seal = container.querySelector('[data-testid="seal-session-s-codex"]') as HTMLButtonElement;
+    expect(row).not.toBeNull();
+    expect(row?.contains(compact)).toBe(true);
+    expect(row?.contains(seal)).toBe(true);
+
+    // Native compaction and seal are peer actions on the same session's lifecycle,
+    // so neither may outrank the other visually.
+    expect(seal.className).toBe(compact.className);
+    expect(seal.getAttribute('style')).toBeNull();
+
+    // bind changes WHICH runtime session this card points at, not this session's
+    // lifecycle, so it stays outside the lifecycle row.
+    expect(row?.textContent).not.toContain('bind');
+  });
+
   it('seals an idle active session and refreshes the chain', async () => {
     mockSessionsResponse([
       { id: 's1', catId: 'opus', seq: 0, status: 'active', messageCount: 5, createdAt: Date.now() },
@@ -1395,7 +1427,17 @@ describe('F24: SessionChainPanel', () => {
 
     it('does not emit any of the legacy hardcoded color tokens', async () => {
       mockSessionsResponse([
-        { id: 's1', catId: 'codex', seq: 0, status: 'active', messageCount: 1, createdAt: Date.now() },
+        // cliSessionId present so the native-compact action actually renders — without it
+        // this guard silently skipped that button's classes.
+        {
+          id: 's1',
+          cliSessionId: 'native-1',
+          catId: 'codex',
+          seq: 0,
+          status: 'active',
+          messageCount: 1,
+          createdAt: Date.now(),
+        },
         { id: 's2', catId: 'gemini', seq: 1, status: 'active', messageCount: 1, createdAt: Date.now() },
         { id: 's3', catId: 'opus-45', seq: 2, status: 'active', messageCount: 1, createdAt: Date.now() },
         { id: 's4', catId: 'gpt52', seq: 3, status: 'active', messageCount: 1, createdAt: Date.now() },


### PR DESCRIPTION
## What

`原生压缩` and `封存当前会话` are peer actions on the same session's lifecycle and render side by side in one row — but seal carried an accent outline and accent text while native compaction stayed neutral. Nothing about the two justifies ranking one above the other, and the accent treatment made seal read as the card's primary command.

- align seal to the neutral treatment native compaction already uses
- label the lifecycle row so its membership is assertable
- **fix a token violation and the blind spot that hid it** (below)

Linkage stays deliberately outside this row: `bind` changes *which* runtime session the card points at, not this session's lifecycle.

## Token violation found while matching the two buttons

This panel's own guard — `does not emit any of the legacy hardcoded color tokens` — bans `bg-cafe-surface-elevated`. The native-compact button introduced in #1434 shipped with `hover:bg-cafe-surface-elevated`.

The guard never caught it because **its fixture omits `cliSessionId`, so that button never rendered**. Copying its classes onto seal is what exposed the rule.

Both buttons now use this panel's sanctioned `--console-hover-bg`, and the guard's fixture renders native compaction so the rule actually covers it going forward.

## Rebuilt from scratch on current main

The previous HEAD is gone — this is not a patch on top of it. Both P1s from the last review are accepted and dropped, not argued:

- **P1 — identity/linkage modeled as a lifecycle peer.** Dropped entirely. `bind` keeps its own row, the `/` action grammar is gone, and no linkage action was moved. #1434 landing `原生压缩` made the intended hierarchy explicit: the lifecycle row now genuinely holds two peers, and this PR only equalizes those two.
- **P1 — unapproved mixed-language contract.** Dropped entirely. Every visible label stays Chinese; nothing was translated or shortened, and no test asserts a concatenated visible string.

## On the requested evidence

The earlier evidence request targeted a **layout regrouping**. That regrouping no longer exists. This revision changes no layout, no DOM order, no element nesting, and no copy — it changes `className` on two buttons plus one `data-testid` on the existing wrapper. Wrapping, horizontal overflow, touch-target geometry, keyboard activation, and focus return are therefore byte-identical to current `main`; there is no delta for a screenshot to show.

If you still want captured evidence on this HEAD, say so and I will build the fixture page — I did not want to produce screenshots asserting a difference this diff does not create.

## Verification

- `session-chain-panel.test.ts` + `SessionChainPanel-viewSession.test.ts`: **72 passing**
- new peer-weight test asserts both lifecycle actions carry identical `className` and that seal no longer carries an inline `style`
- **red→green verified**: reverting native-compact to `bg-cafe-surface-elevated` turns the legacy-token guard red on the new fixture; restoring `--console-hover-bg` turns it green
- `tsc --noEmit` on `packages/web`: clean
- `biome check` on both files: no new diagnostics (26 warnings, all pre-existing, none in changed ranges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)