### PR TITLE
fix(build): build Collective Service with the API

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "while true; do NODE_OPTIONS=\"--import $PWD/scripts/sigusr1-guard.mjs${NODE_OPTIONS:+ $NODE_OPTIONS}\" tsx watch --exclude \"dist/**\" --exclude \"../shared/dist/**\" src/index.ts; ec=$?; if [ $ec -eq 0 ] || [ $ec -eq 130 ]; then break; fi; echo \"[api] dev exited ($ec) — auto-restarting in 1s\"; sleep 1; done",
     "verify:sigusr1": "node scripts/verify-sigusr1-guard.mjs",
-    "build": "pnpm --dir ../shared build && pnpm --dir ../collective-connector build && pnpm run build:f247-extension && tsc && node ./scripts/copy-marketplace-catalog-data.mjs && node ../../scripts/check-provider-request-recorder.mjs",
+    "build": "pnpm --dir ../shared build && pnpm --dir ../collective-connector build && pnpm --dir ../collective-service build && pnpm run build:f247-extension && tsc && node ./scripts/copy-marketplace-catalog-data.mjs && node ../../scripts/check-provider-request-recorder.mjs",
     "build:f247-extension": "node scripts/build-f247-personal-chrome-extension.mjs",
     "build:f247-extension:write": "node scripts/build-f247-personal-chrome-extension.mjs --write",
     "audit:codex-protocol": "node ./scripts/audit-codex-app-server-protocol.mjs",

--- a/packages/api/test/build-script-cross-platform.test.js
+++ b/packages/api/test/build-script-cross-platform.test.js
@@ -21,6 +21,7 @@ test('api build uses the public native command without the prepared-artifact wra
   assert.equal(typeof buildScript, 'string');
   assert.doesNotMatch(buildScript, /gate-prepared-artifacts/);
   assert.match(buildScript, /pnpm --dir \.\.\/shared build/);
+  assert.match(buildScript, /pnpm --dir \.\.\/collective-service build/);
   assert.match(buildScript, /node \.\/scripts\/copy-marketplace-catalog-data\.mjs/);
   assert.doesNotMatch(buildScript, /\bmkdir -p\b/);
   assert.doesNotMatch(buildScript, /\bcp\s+src\/marketplace\/catalog-data/);


### PR DESCRIPTION
Clean CI builds the API before running public tests, but the API build omitted Collective Service. This left its CLI artifact absent and made the real-process test time out during startup.

Build Collective Service as part of the API's existing dependency chain and assert that dependency in the public build contract. This also produces the Client artifacts that Service serves.

Validation:

- Started from a fresh checkout with no `packages/collective-service/dist/cli.js`.
- Ran the same shared → MCP server → API build order used by CI. API build produced both Service CLI and Client server artifacts.
- Build/packaging and Service lifecycle tests: 13/13 passed; real process start/stop/recovery passed in 536ms.
- Targeted Biome and `git diff --check` passed.
- Full GitHub CI passed at `062ab83d0953b1e05aa5c04d1c0dcaae197f9118`, including the serial lane, four pure shards, build/lint, public contract checks and Windows smoke. Terra independently approved this exact candidate.

This is a two-file build correction on the current public baseline. The source export fix preserves the canonical dependency command so a later sync retains this change.

Risk: behavior = build regression; data = none; security = no change; contract = API build dependency closure; irreversible = none. Independent review confirmed that this candidate matches the canonical source command.

Related blocked contribution: #1420.

[小星星·砚砚/gpt-6-astra🐾]
